### PR TITLE
🐛 Add missing `AsyncJob`'s name

### DIFF
--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc_interfaces_async_jobs.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc_interfaces_async_jobs.py
@@ -108,7 +108,8 @@ async def async_job_rpc_server(  # noqa: C901
 
             return [
                 AsyncJobGet(
-                    job_id=TypeAdapter(AsyncJobId).validate_python(t.get_name())
+                    job_id=TypeAdapter(AsyncJobId).validate_python(t.get_name()),
+                    job_name="fake_job_name",
                 )
                 for t in self.tasks
             ]
@@ -117,7 +118,7 @@ async def async_job_rpc_server(  # noqa: C901
             assert job_id_data
             job_id = faker.uuid4(cast_to=None)
             self.tasks.append(asyncio.create_task(_slow_task(), name=f"{job_id}"))
-            return AsyncJobGet(job_id=job_id)
+            return AsyncJobGet(job_id=job_id, job_name="fake_job_name")
 
         async def setup(self) -> None:
             for m in (self.status, self.cancel, self.result):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Fix `service_library` tests adding the missing `AsyncJob`'s name.

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

```
cd packages/service-libraries
pytest tests/rabbitmq/test_rabbitmq_rpc_interfaces_async_jobs.py
```

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
