### PR TITLE
⬆️ Maintenance: Upgrade UV to 0.6.x

### DIFF
--- a/.github/workflows/ci-pact-master.yml
+++ b/.github/workflows/ci-pact-master.yml
@@ -28,7 +28,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
       - name: checkout source branch
         uses: actions/checkout@v4

--- a/.github/workflows/ci-testing-deploy.yml
+++ b/.github/workflows/ci-testing-deploy.yml
@@ -359,7 +359,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/web/server/requirements/ci.txt"
       - name: show system version
@@ -407,7 +407,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/web/server/requirements/ci.txt"
       - name: show system version
@@ -449,7 +449,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/web/server/requirements/ci.txt"
       - name: show system version
@@ -491,7 +491,7 @@ jobs:
         - name: install uv
           uses: astral-sh/setup-uv@v5
           with:
-            version: "0.5.x"
+            version: "0.6.x"
             enable-cache: false
             cache-dependency-glob: "**/web/server/requirements/ci.txt"
         - name: show system version
@@ -536,7 +536,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/storage/requirements/ci.txt"
       - name: show system version
@@ -583,7 +583,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/agent/requirements/ci.txt"
       - name: show system version
@@ -628,7 +628,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/api/tests/requirements.txt"
       - name: show system version
@@ -670,7 +670,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/api-server/requirements/ci.txt"
       - name: show system version
@@ -718,7 +718,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/autoscaling/requirements/ci.txt"
       - name: show system version
@@ -763,7 +763,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/catalog/requirements/ci.txt"
       - name: show system version
@@ -814,7 +814,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/clusters-keeper/requirements/ci.txt"
       - name: show system version
@@ -870,7 +870,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/datcore-adapter/requirements/ci.txt"
       - name: show system version
@@ -921,7 +921,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/director/requirements/ci.txt"
       - name: show system version
@@ -972,7 +972,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/director-v2/requirements/ci.txt"
       - name: show system version
@@ -1023,7 +1023,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/aws-library/requirements/ci.txt"
       - name: show system version
@@ -1068,7 +1068,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/dask-task-models-library/requirements/ci.txt"
       - name: show system version
@@ -1113,7 +1113,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/dask-sidecar/requirements/ci.txt"
       - name: show system version
@@ -1158,7 +1158,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/payments/requirements/ci.txt"
       - name: show system version
@@ -1203,7 +1203,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/dynamic-scheduler/requirements/ci.txt"
       - name: show system version
@@ -1248,7 +1248,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/resource-usage-tracker/requirements/ci.txt"
       - name: show system version
@@ -1303,7 +1303,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/dynamic-sidecar/requirements/ci.txt"
       - name: show system version
@@ -1348,7 +1348,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/efs-guardian/requirements/ci.txt"
       - name: show system version
@@ -1404,7 +1404,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/ci/helpers/requirements.txt"
       - name: show system version
@@ -1439,7 +1439,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/postgres-database/requirements/ci.txt"
       - name: show system version
@@ -1484,7 +1484,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/notifications-library/requirements/ci.txt"
       - name: show system version
@@ -1529,7 +1529,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/service-integration/requirements/ci.txt"
       - name: show system version
@@ -1574,7 +1574,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/service-library/requirements/ci*.txt"
       - name: show system version
@@ -1619,7 +1619,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/settings-library/requirements/ci.txt"
       - name: show system version
@@ -1664,7 +1664,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/models-library/requirements/ci.txt"
       - name: show system version
@@ -1707,11 +1707,6 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: install uv
         uses: yezz123/setup-uv@v4
-      - uses: actions/cache@v4
-        id: cache-uv
-        with:
-          path: ~/.cache/uv
-          key: ${{ runner.os }}-${{ github.job }}-python-${{ matrix.python }}-uv
       - name: show system version
         run: ./ci/helpers/show_system_versions.bash
       - name: install
@@ -1749,7 +1744,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/notifications-library/requirements/ci.txt"
       - name: show system version
@@ -1796,7 +1791,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/simcore-sdk/requirements/ci.txt"
       - name: show system version
@@ -1900,7 +1895,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/web/server/requirements/ci.txt"
       - name: load docker images
@@ -1964,7 +1959,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/web/server/requirements/ci.txt"
       - name: load docker images
@@ -2028,7 +2023,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/director-v2/requirements/ci.txt"
       - name: load docker images
@@ -2101,7 +2096,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/director-v2/requirements/ci.txt"
       - name: load docker images
@@ -2167,7 +2162,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/dynamic-sidecar/requirements/ci.txt"
       - name: load docker images
@@ -2232,7 +2227,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/docker-api-proxy/requirements/ci.txt"
       - name: load docker images
@@ -2296,7 +2291,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/simcore-sdk/requirements/ci.txt"
       - name: load docker images
@@ -2384,7 +2379,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/public-api/requirements/ci.txt"
       - name: load docker images
@@ -2444,7 +2439,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/swarm-deploy/requirements/ci.txt"
       - name: load docker images
@@ -2515,7 +2510,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/e2e/requirements/requirements.txt"
       - name: load docker images
@@ -2580,7 +2575,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/e2e-playwright/requirements/ci.txt"
       - name: expose github runtime for buildx
@@ -2642,7 +2637,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/environment-setup/requirements/ci.txt"
       - name: show system version
@@ -2702,7 +2697,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
           cache-dependency-glob: "**/e2e-playwright/requirements/ci.txt"
       # FIXME: Workaround for https://github.com/actions/download-artifact/issues/249

--- a/.github/workflows/ci-testing-pull-request.yml
+++ b/.github/workflows/ci-testing-pull-request.yml
@@ -41,7 +41,7 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.6.x"
           enable-cache: false
       - name: checkout source branch
         uses: actions/checkout@v4

--- a/packages/postgres-database/docker/Dockerfile
+++ b/packages/postgres-database/docker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/packages/postgres-database/scripts/erd/Dockerfile
+++ b/packages/postgres-database/scripts/erd/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/packages/service-integration/Dockerfile
+++ b/packages/service-integration/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/requirements/tools/Dockerfile
+++ b/requirements/tools/Dockerfile
@@ -9,7 +9,7 @@
 #
 #
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/scripts/erd/Dockerfile
+++ b/scripts/erd/Dockerfile
@@ -8,7 +8,7 @@
 #
 
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/scripts/maintenance/migrate_project/Dockerfile
+++ b/scripts/maintenance/migrate_project/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:3.11.9-buster

--- a/scripts/openapi/oas_resolver/Dockerfile
+++ b/scripts/openapi/oas_resolver/Dockerfile
@@ -2,7 +2,7 @@
 # Usage:
 # docker build . -t oas_resolver
 # docker run -v /path/to/api:/input -v /path/to/compiled/file:/output oas_resolver /input/path/to/openapi.yaml /output/output_file.yaml
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:3.6-alpine

--- a/scripts/pydeps-docker/Dockerfile
+++ b/scripts/pydeps-docker/Dockerfile
@@ -9,7 +9,7 @@
 #
 #
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian

--- a/services/api-server/Dockerfile
+++ b/services/api-server/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/autoscaling/Dockerfile
+++ b/services/autoscaling/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/clusters-keeper/Dockerfile
+++ b/services/clusters-keeper/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM --platform=${TARGETPLATFORM} python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/datcore-adapter/Dockerfile
+++ b/services/datcore-adapter/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/director-v2/Dockerfile
+++ b/services/director-v2/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/director/Dockerfile
+++ b/services/director/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/efs-guardian/Dockerfile
+++ b/services/efs-guardian/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/invitations/Dockerfile
+++ b/services/invitations/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/migration/Dockerfile
+++ b/services/migration/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/resource-usage-tracker/Dockerfile
+++ b/services/resource-usage-tracker/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -2,7 +2,7 @@
 
 # Define arguments in the global scope
 ARG PYTHON_VERSION="3.11.9"
-ARG UV_VERSION="0.5"
+ARG UV_VERSION="0.6"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 # we docker image is built based on debian
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->
  
This pull request updates the `uv` dependency version across multiple CI workflows to ensure compatibility with the latest features and improvements. The changes involve upgrading from version `0.5.x` to `0.6.x` in several `jobs` configurations within the `.github/workflows` directory.

### Dependency Upgrades:
* [`.github/workflows/ci-pact-master.yml`](diffhunk://#diff-5d849c811be153c45b50f3a97e7b7db4b515f9823cdd69106137765f237037f6L31-R31): Updated `uv` version to `0.6.x` in the `install uv` step.
* [`.github/workflows/ci-testing-deploy.yml`](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L362-R362): Updated `uv` version to `0.6.x` in multiple `install uv` steps across various job configurations, ensuring consistency throughout the workflow. [[1]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L362-R362) [[2]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L410-R410) [[3]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L452-R452) [[4]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L494-R494) [[5]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L539-R539) [[6]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L586-R586) [[7]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L631-R631) [[8]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L673-R673) [[9]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L721-R721) [[10]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L766-R766) [[11]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L817-R817) [[12]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L873-R873) [[13]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L924-R924) [[14]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L975-R975) [[15]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1026-R1026) [[16]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1071-R1071) [[17]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1116-R1116) [[18]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1161-R1161) [[19]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1206-R1206) [[20]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1251-R1251) [[21]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1306-R1306) [[22]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1351-R1351) [[23]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1407-R1407) [[24]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1442-R1442) [[25]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1487-R1487) [[26]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1532-R1532) [[27]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1577-R1577) [[28]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1622-R1622) [[29]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1667-R1667) [[30]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1752-R1747) [[31]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1799-R1794) [[32]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1903-R1898) [[33]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1967-R1962) [[34]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L2031-R2026) [[35]](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L2104-R2099)

### Cache Configuration Cleanup:
* [`.github/workflows/ci-testing-deploy.yml`](diffhunk://#diff-9b5d06fc85e79182a6a8e352fea2c8f992876b2617bb2c246946fd78128daff9L1710-L1714): Removed redundant `actions/cache` configuration for caching `uv` dependencies, simplifying the workflow.    Upgrade dependencies.

### Copilot instructions
- ensure it uses f-string formatting

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s

<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
