### PR TITLE
🎨 Replaces built-in JSON serialization with common_library utilities

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,9 +26,8 @@ This document provides guidelines and best practices for using GitHub Copilot in
 
 ### Json serialization
 
-- Use `json_loads` from `common_library.json_serialization` instead of `json.dumps` / `json.loads`.
-- Prefer Pydantic model methods (e.g., `model.model_dump_json()`) for serialization/deserialization.
-- Avoid using the built-in `json` module for these tasks.
+- Generally use `json_dumps`/`json_loads` from `common_library.json_serialization` to built-in `json.dumps` / `json.loads`.
+- Prefer Pydantic model methods (e.g., `model.model_dump_json()`) for serialization.
 
 
 ## Node.js-Specific Instructions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,14 @@ This document provides guidelines and best practices for using GitHub Copilot in
 - ensure we use `fastapi` >0.100 compatible code
 - use f-string formatting
 
+
+### Json serialization
+
+- Use `json_loads` from `common_library.json_serialization` instead of `json.dumps` / `json.loads`.
+- Prefer Pydantic model methods (e.g., `model.model_dump_json()`) for serialization/deserialization.
+- Avoid using the built-in `json` module for these tasks.
+
+
 ## Node.js-Specific Instructions
 
 - Use ES6+ syntax and features.

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/io.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/io.py
@@ -3,6 +3,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Annotated, Any, TypeAlias
 
+from common_library.json_serialization import json_loads
 from models_library.basic_regex import MIME_TYPE_RE
 from models_library.generics import DictModel
 from models_library.services_types import ServicePortKey
@@ -160,7 +161,7 @@ class TaskOutputData(DictModel[ServicePortKey, PortValue]):
             with suppress(json.JSONDecodeError):
                 # NOTE: The suppression here is ok, since if the data is empty,
                 # there will be a validation error anyway
-                data = json.loads(output_data_file.read_text())
+                data = json_loads(output_data_file.read_text())
 
         for output_key, output_params in schema.items():
             if isinstance(output_params, FilePortSchema):

--- a/packages/models-library/src/models_library/function_services_catalog/_settings.py
+++ b/packages/models-library/src/models_library/function_services_catalog/_settings.py
@@ -1,11 +1,12 @@
 import json
 import os
 
+from common_library.json_serialization import json_loads
 from pydantic_settings import BaseSettings
 
 # Expects env var: FUNCTION_SERVICES_AUTHORS='{"OM":{"name": ...}, "EN":{...} }'
 try:
-    AUTHORS = json.loads(os.environ.get("FUNCTION_SERVICES_AUTHORS", "{}"))
+    AUTHORS = json_loads(os.environ.get("FUNCTION_SERVICES_AUTHORS", "{}"))
 except json.decoder.JSONDecodeError:
     AUTHORS = {}
 

--- a/packages/models-library/src/models_library/service_settings_labels.py
+++ b/packages/models-library/src/models_library/service_settings_labels.py
@@ -27,7 +27,9 @@ from .service_settings_nat_rule import NATRule
 from .services_resources import DEFAULT_SINGLE_SERVICE_NAME
 
 _BaseConfig = ConfigDict(
-    extra="forbid", arbitrary_types_allowed=True, ignored_types=(cached_property,)
+    extra="forbid",
+    arbitrary_types_allowed=True,
+    ignored_types=(cached_property,),
 )
 
 

--- a/packages/models-library/src/models_library/utils/change_case.py
+++ b/packages/models-library/src/models_library/utils/change_case.py
@@ -4,11 +4,9 @@
 Example of usage in pydantic:
 
 [...]
-    class Config:
-        extra = Extra.forbid
-        alias_generator = snake_to_camel  # <--------
-        json_loads = json_loads
-        json_dumps = json_dumps
+    model_config = ConfigDict(
+        alias_generator=snake_to_camel, # <-- note
+    )
 
 """
 

--- a/packages/models-library/src/models_library/utils/change_case.py
+++ b/packages/models-library/src/models_library/utils/change_case.py
@@ -1,4 +1,4 @@
-""" String convesion
+"""String convesion
 
 
 Example of usage in pydantic:
@@ -7,10 +7,11 @@ Example of usage in pydantic:
     class Config:
         extra = Extra.forbid
         alias_generator = snake_to_camel  # <--------
-        json_loads = orjson.loads
+        json_loads = json_loads
         json_dumps = json_dumps
 
 """
+
 # Partially taken from  https://github.com/autoferrit/python-change-case/blob/master/change_case/change_case.py#L131
 import re
 from typing import Final

--- a/packages/models-library/src/models_library/utils/labels_annotations.py
+++ b/packages/models-library/src/models_library/utils/labels_annotations.py
@@ -1,14 +1,13 @@
-""" Image labels annotations
+"""Image labels annotations
 
 osparc expects the service configuration (in short: config) attached to the service's image as label annotations.
 This module defines how this config is serialized/deserialized to/from docker labels annotations
 """
 
-import json
 from json.decoder import JSONDecodeError
 from typing import Any, TypeAlias
 
-from common_library.json_serialization import json_dumps
+from common_library.json_serialization import json_dumps, json_loads
 
 LabelsAnnotationsDict: TypeAlias = dict[str, str | float | bool | None]
 
@@ -57,7 +56,7 @@ def from_labels(
     for key, label in labels.items():
         if key.startswith(f"{prefix_key}."):
             try:
-                value = json.loads(label)  # type: ignore
+                value = json_loads(label)  # type: ignore
             except JSONDecodeError:
                 value = label
 

--- a/packages/models-library/src/models_library/utils/labels_annotations.py
+++ b/packages/models-library/src/models_library/utils/labels_annotations.py
@@ -56,7 +56,7 @@ def from_labels(
     for key, label in labels.items():
         if key.startswith(f"{prefix_key}."):
             try:
-                value = json_loads(label)  # type: ignore
+                value = json_loads(label)
             except JSONDecodeError:
                 value = label
 

--- a/packages/models-library/src/models_library/utils/nodes.py
+++ b/packages/models-library/src/models_library/utils/nodes.py
@@ -1,10 +1,10 @@
 import hashlib
-import json
 import logging
 from collections.abc import Callable, Coroutine
 from copy import deepcopy
 from typing import Any
 
+from common_library.json_serialization import json_dumps
 from pydantic import BaseModel, TypeAdapter
 
 from ..projects import Project
@@ -67,6 +67,6 @@ async def compute_node_hash(
     # now create the hash
     # WARNING: Here we cannot change to json_serialization.json_dumps because if would create a different dump string and therefore a different hash
     # NOTE that these hashes might have been already stored elsewhere
-    block_string = json.dumps(resolved_payload, sort_keys=True).encode("utf-8")
+    block_string = json_dumps(resolved_payload, sort_keys=True).encode("utf-8")
     raw_hash = hashlib.sha256(block_string)
     return raw_hash.hexdigest()

--- a/packages/models-library/src/models_library/utils/nodes.py
+++ b/packages/models-library/src/models_library/utils/nodes.py
@@ -1,10 +1,10 @@
 import hashlib
+import json
 import logging
 from collections.abc import Callable, Coroutine
 from copy import deepcopy
 from typing import Any
 
-from common_library.json_serialization import json_dumps
 from pydantic import BaseModel, TypeAdapter
 
 from ..projects import Project
@@ -67,6 +67,6 @@ async def compute_node_hash(
     # now create the hash
     # WARNING: Here we cannot change to json_serialization.json_dumps because if would create a different dump string and therefore a different hash
     # NOTE that these hashes might have been already stored elsewhere
-    block_string = json_dumps(resolved_payload, sort_keys=True).encode("utf-8")
+    block_string = json.dumps(resolved_payload, sort_keys=True).encode("utf-8")
     raw_hash = hashlib.sha256(block_string)
     return raw_hash.hexdigest()

--- a/packages/models-library/src/models_library/utils/nodes.py
+++ b/packages/models-library/src/models_library/utils/nodes.py
@@ -64,8 +64,8 @@ async def compute_node_hash(
             if payload is not None:
                 resolved_payload[port_type][port_key] = payload
 
-    # now create the hash
     # WARNING: Here we cannot change to json_serialization.json_dumps because if would create a different dump string and therefore a different hash
+    # typically test_node_ports_v2_serialization_v2.py::test_dump will fail if you do this change.
     # NOTE that these hashes might have been already stored elsewhere
     block_string = json.dumps(resolved_payload, sort_keys=True).encode("utf-8")
     raw_hash = hashlib.sha256(block_string)

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -5,10 +5,10 @@
 - Every product has a front-end with exactly the same name
 """
 
-import json
 from typing import Literal
 
 import sqlalchemy as sa
+from common_library.json_serialization import json_dumps
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql import func
 from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
@@ -114,7 +114,7 @@ class ProductLoginSettingsDict(TypedDict, total=False):
 
 # NOTE: defaults affects migration!!
 LOGIN_SETTINGS_DEFAULT = ProductLoginSettingsDict()  # = {}
-_LOGIN_SETTINGS_SERVER_DEFAULT = json.dumps(LOGIN_SETTINGS_DEFAULT)
+_LOGIN_SETTINGS_SERVER_DEFAULT = json_dumps(LOGIN_SETTINGS_DEFAULT)
 
 
 #

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/s3.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/s3.py
@@ -5,8 +5,8 @@ from typing import Final
 
 import aiofiles
 import httpx
+import orjson
 from aws_library.s3 import MultiPartUploadLinks
-from common_library.json_serialization import json_loads
 from fastapi import status
 from models_library.api_schemas_storage.storage_schemas import (
     ETag,
@@ -71,7 +71,7 @@ async def upload_file_part(
     assert response.status_code == status.HTTP_200_OK
     assert response.headers
     assert "Etag" in response.headers
-    received_e_tag = json_loads(response.headers["Etag"])
+    received_e_tag = orjson.loads(response.headers["Etag"])
     print(
         f"--> completed upload {this_file_chunk_size=} of {file=}, [{part_index + 1}/{num_parts}], {received_e_tag=}"
     )

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/s3.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/s3.py
@@ -5,8 +5,8 @@ from typing import Final
 
 import aiofiles
 import httpx
-import orjson
 from aws_library.s3 import MultiPartUploadLinks
+from common_library.json_serialization import json_loads
 from fastapi import status
 from models_library.api_schemas_storage.storage_schemas import (
     ETag,
@@ -71,7 +71,7 @@ async def upload_file_part(
     assert response.status_code == status.HTTP_200_OK
     assert response.headers
     assert "Etag" in response.headers
-    received_e_tag = orjson.loads(response.headers["Etag"])
+    received_e_tag = json_loads(response.headers["Etag"])
     print(
         f"--> completed upload {this_file_chunk_size=} of {file=}, [{part_index + 1}/{num_parts}], {received_e_tag=}"
     )

--- a/packages/service-integration/src/service_integration/cli/_config.py
+++ b/packages/service-integration/src/service_integration/cli/_config.py
@@ -1,10 +1,10 @@
-import json
 from pathlib import Path
 from typing import Annotated, Final
 
 import rich
 import typer
 import yaml
+from common_library.json_serialization import json_loads
 from models_library.utils.labels_annotations import LabelsAnnotationsDict
 from pydantic import BaseModel
 
@@ -57,7 +57,7 @@ def _create_config_from_compose_spec(
             rich.print(f"Creating {output_path} ...", end="")
 
             with output_path.open("wt") as fh:
-                data = json.loads(
+                data = json_loads(
                     model.model_dump_json(by_alias=True, exclude_none=True)
                 )
                 yaml.safe_dump(data, fh, sort_keys=False)

--- a/packages/service-integration/src/service_integration/pytest_plugin/docker_integration.py
+++ b/packages/service-integration/src/service_integration/pytest_plugin/docker_integration.py
@@ -18,6 +18,7 @@ import docker
 import jsonschema
 import pytest
 import yaml
+from common_library.json_serialization import json_loads
 from docker.errors import APIError
 from docker.models.containers import Container
 
@@ -206,7 +207,7 @@ def convert_to_simcore_labels(image_labels: dict) -> dict:
     io_simcore_labels = {}
     for key, value in image_labels.items():
         if str(key).startswith("io.simcore."):
-            simcore_label = json.loads(value)
+            simcore_label = json_loads(value)
             simcore_keys = list(simcore_label.keys())
             assert len(simcore_keys) == 1
             simcore_key = simcore_keys[0]

--- a/packages/service-library/src/servicelib/aiohttp/rest_middlewares.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_middlewares.py
@@ -3,7 +3,6 @@
 SEE  https://gist.github.com/amitripshtos/854da3f4217e3441e8fceea85b0cbd91
 """
 
-import json
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any, Union
@@ -12,7 +11,7 @@ from aiohttp import web
 from aiohttp.web_request import Request
 from aiohttp.web_response import StreamResponse
 from common_library.error_codes import create_error_code
-from common_library.json_serialization import json_dumps
+from common_library.json_serialization import json_dumps, json_loads
 from models_library.rest_error import ErrorGet, ErrorItemType, LogMessageType
 
 from ..logging_errors import create_troubleshotting_log_kwargs
@@ -107,7 +106,7 @@ def error_middleware_factory(
             err.content_type = MIMETYPE_APPLICATION_JSON
             if err.text:
                 try:
-                    payload = json.loads(err.text)
+                    payload = json_loads(err.text)
                     if not is_enveloped_from_map(payload):
                         payload = wrap_as_envelope(data=payload)
                         err.text = json_dumps(payload)

--- a/packages/service-library/src/servicelib/rest_responses.py
+++ b/packages/service-library/src/servicelib/rest_responses.py
@@ -2,6 +2,8 @@ import json
 from collections.abc import Mapping
 from typing import Any
 
+from common_library.json_serialization import json_loads
+
 _ENVELOPE_KEYS = ("data", "error")
 
 
@@ -11,7 +13,7 @@ def is_enveloped_from_map(payload: Mapping) -> bool:
 
 def is_enveloped_from_text(text: str) -> bool:
     try:
-        payload = json.loads(text)
+        payload = json_loads(text)
     except json.decoder.JSONDecodeError:
         return False
     return is_enveloped_from_map(payload)

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/dbmanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/dbmanager.py
@@ -2,6 +2,8 @@ import json
 import logging
 
 import sqlalchemy as sa
+from common_library.json_serialization import json_loads
+
 from models_library.projects import ProjectID
 from models_library.users import UserID
 from pydantic import TypeAdapter
@@ -85,7 +87,7 @@ class DBManager:
         )
         _logger.debug(message)
 
-        node_configuration = json.loads(json_configuration)
+        node_configuration = json_loads(json_configuration)
         async with (
             DBContextManager(self._db_engine) as engine,
             engine.begin() as connection,

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/dbmanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/dbmanager.py
@@ -1,8 +1,7 @@
-import json
 import logging
 
 import sqlalchemy as sa
-from common_library.json_serialization import json_loads
+from common_library.json_serialization import json_dumps, json_loads
 
 from models_library.projects import ProjectID
 from models_library.users import UserID
@@ -118,7 +117,7 @@ class DBManager:
             engine.connect() as connection,
         ):
             node = await _get_node_from_db(project_id, node_uuid, connection)
-            node_json_config = json.dumps(
+            node_json_config = json_dumps(
                 {
                     "schema": node.schema,
                     "inputs": node.inputs,

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/file_io_utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 from collections.abc import AsyncGenerator, Coroutine
 from contextlib import AsyncExitStack
@@ -17,6 +16,7 @@ from aiohttp import (
     ClientSession,
     RequestInfo,
 )
+from common_library.json_serialization import json_loads
 from models_library.api_schemas_storage.storage_schemas import (
     ETag,
     FileUploadSchema,
@@ -143,8 +143,7 @@ class ProgressData:
 
 @runtime_checkable
 class LogRedirectCB(Protocol):
-    async def __call__(self, log: str) -> None:
-        ...
+    async def __call__(self, log: str) -> None: ...
 
 
 async def _file_chunk_writer(
@@ -276,7 +275,7 @@ async def _session_put(
         assert response.status == status.HTTP_200_OK  # nosec
         assert response.headers  # nosec
         assert "Etag" in response.headers  # nosec
-        etag: str = json.loads(response.headers["Etag"])
+        etag: str = json_loads(response.headers["Etag"])
         return etag
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/serialization_v2.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/serialization_v2.py
@@ -1,11 +1,10 @@
 import functools
-import json
 import logging
 from pprint import pformat
 from typing import Any
 
 import pydantic
-from common_library.json_serialization import json_dumps
+from common_library.json_serialization import json_dumps, json_loads
 from models_library.projects_nodes_io import NodeID
 from models_library.utils.nodes import compute_node_hash
 from packaging import version
@@ -50,7 +49,7 @@ async def load(
     port_config_str: str = await db_manager.get_ports_configuration_from_node_uuid(
         project_id, node_uuid
     )
-    port_cfg = json.loads(port_config_str)
+    port_cfg = json_loads(port_config_str)
 
     log.debug(f"{port_cfg=}")  # pylint: disable=logging-fstring-interpolation
     if any(k not in port_cfg for k in NODE_REQUIRED_KEYS):

--- a/packages/simcore-sdk/tests/unit/conftest.py
+++ b/packages/simcore-sdk/tests/unit/conftest.py
@@ -27,7 +27,7 @@ def node_uuid() -> str:
     return str(uuid4())
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 async def mock_db_manager(
     monkeypatch,
     project_id: str,

--- a/services/api-server/src/simcore_service_api_server/models/_utils_pydantic.py
+++ b/services/api-server/src/simcore_service_api_server/models/_utils_pydantic.py
@@ -1,14 +1,8 @@
 from copy import deepcopy
 
-from common_library.json_serialization import json_dumps, json_loads
 from pydantic import GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core.core_schema import CoreSchema
-
-
-class BaseConfig:
-    json_loads = json_loads
-    json_dumps = json_dumps
 
 
 class UriSchema:

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/redis.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/redis.py
@@ -1,5 +1,4 @@
-import json
-
+from common_library.json_serialization import json_dumps
 from fastapi import FastAPI
 
 from ..core.settings import ApplicationSettings
@@ -14,7 +13,7 @@ def create_lock_key_and_value(app: FastAPI) -> tuple[str, str]:
             "dynamic",
             *app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NODE_LABELS,
         ]
-        lock_value = json.dumps(
+        lock_value = json_dumps(
             {
                 "node_labels": app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NODE_LABELS
             }
@@ -24,7 +23,7 @@ def create_lock_key_and_value(app: FastAPI) -> tuple[str, str]:
             "computational",
             f"{app_settings.AUTOSCALING_DASK.DASK_MONITORING_URL}",
         ]
-        lock_value = json.dumps(
+        lock_value = json_dumps(
             {"scheduler_url": f"{app_settings.AUTOSCALING_DASK.DASK_MONITORING_URL}"}
         )
     lock_key = ":".join(f"{k}" for k in lock_key_parts)

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_ec2.py
@@ -1,14 +1,12 @@
-""" Free helper functions for AWS API
+"""Free helper functions for AWS API"""
 
-"""
-
-import json
 import logging
 from collections import OrderedDict
 from collections.abc import Callable
 from textwrap import dedent
 
 from aws_library.ec2 import AWSTagKey, AWSTagValue, EC2InstanceType, EC2Tags, Resources
+from common_library.json_serialization import json_dumps
 
 from .._meta import VERSION
 from ..core.errors import ConfigurationError, TaskBestFittingInstanceNotFoundError
@@ -23,12 +21,12 @@ def get_ec2_tags_dynamic(app_settings: ApplicationSettings) -> EC2Tags:
     return {
         AWSTagKey("io.simcore.autoscaling.version"): AWSTagValue(f"{VERSION}"),
         AWSTagKey("io.simcore.autoscaling.monitored_nodes_labels"): AWSTagValue(
-            json.dumps(
+            json_dumps(
                 app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NODE_LABELS
             )
         ),
         AWSTagKey("io.simcore.autoscaling.monitored_services_labels"): AWSTagValue(
-            json.dumps(
+            json_dumps(
                 app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_SERVICE_LABELS
             )
         ),

--- a/services/catalog/src/simcore_service_catalog/clients/director.py
+++ b/services/catalog/src/simcore_service_catalog/clients/director.py
@@ -1,6 +1,5 @@
 import asyncio
 import functools
-import json
 import logging
 import urllib.parse
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -9,7 +8,7 @@ from pprint import pformat
 from typing import Any, Final
 
 import httpx
-from common_library.json_serialization import json_dumps
+from common_library.json_serialization import json_dumps, json_loads
 from fastapi import FastAPI, HTTPException
 from fastapi_lifespan_manager import State
 from models_library.api_schemas_directorv2.services import ServiceExtras
@@ -221,7 +220,7 @@ class DirectorClient:
         _logger.debug("Compiling service extras from labels %s", pformat(labels))
 
         if _SERVICE_RUNTIME_SETTINGS in labels:
-            service_settings: list[dict[str, Any]] = json.loads(
+            service_settings: list[dict[str, Any]] = json_loads(
                 labels[_SERVICE_RUNTIME_SETTINGS]
             )
             for entry in service_settings:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import functools
+import json
 from pathlib import Path
 from typing import Any, Final
 
@@ -8,7 +9,6 @@ import arrow
 import yaml
 from aws_library.ec2 import EC2InstanceBootSpecific, EC2InstanceData, EC2Tags
 from aws_library.ec2._models import CommandStr
-from common_library.json_serialization import json_dumps
 from common_library.serialization import model_dump_with_secrets
 from fastapi.encoders import jsonable_encoder
 from models_library.api_schemas_clusters_keeper.clusters import (
@@ -80,7 +80,7 @@ def _prepare_environment_variables(
         return f"[{entries_as_str}]"
 
     def _convert_to_env_dict(entries: dict[str, Any]) -> str:
-        return f"'{json_dumps(jsonable_encoder(entries))}'"
+        return f"'{json.dumps(jsonable_encoder(entries))}'"
 
     assert app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES  # nosec
 

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/clusters.py
@@ -1,7 +1,6 @@
 import base64
 import datetime
 import functools
-import json
 from pathlib import Path
 from typing import Any, Final
 
@@ -9,6 +8,7 @@ import arrow
 import yaml
 from aws_library.ec2 import EC2InstanceBootSpecific, EC2InstanceData, EC2Tags
 from aws_library.ec2._models import CommandStr
+from common_library.json_serialization import json_dumps
 from common_library.serialization import model_dump_with_secrets
 from fastapi.encoders import jsonable_encoder
 from models_library.api_schemas_clusters_keeper.clusters import (
@@ -80,7 +80,7 @@ def _prepare_environment_variables(
         return f"[{entries_as_str}]"
 
     def _convert_to_env_dict(entries: dict[str, Any]) -> str:
-        return f"'{json.dumps(jsonable_encoder(entries))}'"
+        return f"'{json_dumps(jsonable_encoder(entries))}'"
 
     assert app_settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES  # nosec
 

--- a/services/clusters-keeper/tests/unit/test_utils_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_utils_clusters.py
@@ -181,7 +181,7 @@ def test_create_deploy_cluster_stack_script(
         "WORKERS_EC2_INSTANCES_CUSTOM_TAGS",
     ]
     assert all(
-        re.search(rf"{i}=\'{{(\".+\":\s\".*\")+}}\'", deploy_script)
+        re.search(rf"{i}=\'{{(\".+\":\s*\".*\")+}}\'", deploy_script)
         for i in dict_settings
     )
 

--- a/services/clusters-keeper/tests/unit/test_utils_clusters.py
+++ b/services/clusters-keeper/tests/unit/test_utils_clusters.py
@@ -181,7 +181,7 @@ def test_create_deploy_cluster_stack_script(
         "WORKERS_EC2_INSTANCES_CUSTOM_TAGS",
     ]
     assert all(
-        re.search(rf"{i}=\'{{(\".+\":\s*\".*\")+}}\'", deploy_script)
+        re.search(rf"{i}=\'{{(\".+\":\s\".*\")+}}\'", deploy_script)
         for i in dict_settings
     )
 

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 import os
 import socket
@@ -12,6 +11,7 @@ from typing import Final, cast
 from uuid import uuid4
 
 from aiodocker import Docker
+from common_library.json_serialization import json_dumps
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
 from dask_task_models_library.container_tasks.errors import ServiceRuntimeError
 from dask_task_models_library.container_tasks.io import FileUrl, TaskOutputData
@@ -95,7 +95,7 @@ class ComputationalSidecar:
         # NOTE: temporary solution until new version is created
         for task in download_tasks:
             await task
-        input_data_file.write_text(json.dumps(local_input_data_file))
+        input_data_file.write_text(json_dumps(local_input_data_file))
 
         await self._publish_sidecar_log("All the input data were downloaded.")
 

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -20,6 +20,7 @@ from unittest import mock
 import distributed
 import fsspec
 import pytest
+from common_library.json_serialization import json_dumps
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
 from dask_task_models_library.container_tasks.errors import ServiceRuntimeError
 from dask_task_models_library.container_tasks.events import (
@@ -363,7 +364,14 @@ def sleeper_task(
         log_file_url=log_file_url,
         expected_output_data=expected_output_data,
         expected_logs=[
-            '{"input_1": 23, "input_23": "a string input", "the_input_43": 15.0, "the_bool_input_54": false}',
+            json_dumps(
+                {
+                    "input_1": 23,
+                    "input_23": "a string input",
+                    "the_input_43": 15.0,
+                    "the_bool_input_54": False,
+                }
+            ),
             "This is the file contents of file #'001'",
             "This is the file contents of file #'002'",
             "This is the file contents of file #'003'",

--- a/services/dask-sidecar/tests/unit/test_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_tasks.py
@@ -414,7 +414,7 @@ def sidecar_task(
 
 @pytest.fixture()
 def failing_ubuntu_task(
-    sidecar_task: Callable[..., ServiceExampleParam]
+    sidecar_task: Callable[..., ServiceExampleParam],
 ) -> ServiceExampleParam:
     return sidecar_task(command=["/bin/bash", "-c", "some stupid failing command"])
 
@@ -444,7 +444,7 @@ def mocked_get_image_labels(
 ) -> mock.Mock:
     assert "json_schema_extra" in ServiceMetaDataPublished.model_config
     labels: ImageLabels = TypeAdapter(ImageLabels).validate_python(
-        ServiceMetaDataPublished.model_config["json_schema_extra"]["examples"][0],
+        ServiceMetaDataPublished.model_json_schema()["examples"][0],
     )
     labels.integration_version = f"{integration_version}"
     return mocker.patch(

--- a/services/director-v2/src/simcore_service_director_v2/models/dynamic_services_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/dynamic_services_scheduler.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from collections.abc import Mapping
 from datetime import datetime
@@ -10,6 +9,7 @@ from uuid import UUID
 
 import arrow
 from common_library.error_codes import ErrorCodeStr
+from common_library.json_serialization import json_dumps
 from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceCreate
 from models_library.api_schemas_directorv2.dynamic_services_service import (
     CommonServiceDetails,
@@ -504,7 +504,7 @@ class SchedulerData(CommonServiceDetails, DynamicSidecarServiceLabels):
             "product_name": service.product_name,
             "paths_mapping": simcore_service_labels.paths_mapping,
             "callbacks_mapping": simcore_service_labels.callbacks_mapping,
-            "compose_spec": json.dumps(simcore_service_labels.compose_spec),
+            "compose_spec": json_dumps(simcore_service_labels.compose_spec),
             "container_http_entry": simcore_service_labels.container_http_entry,
             "restart_policy": simcore_service_labels.restart_policy,
             "dynamic_sidecar_network_name": names_helper.dynamic_sidecar_network_name,
@@ -541,7 +541,7 @@ class SchedulerData(CommonServiceDetails, DynamicSidecarServiceLabels):
         # compose_spec needs to be json encoded before encoding it to json
         # and storing it in the label
         return self.model_copy(
-            update={"compose_spec": json.dumps(self.compose_spec)},
+            update={"compose_spec": json_dumps(self.compose_spec)},
             deep=True,
         ).model_dump_json()
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -9,7 +9,6 @@ loads(dumps(my_object))
 """
 
 import asyncio
-import json
 import logging
 import traceback
 from collections.abc import Callable
@@ -21,6 +20,7 @@ from typing import Any, Final, cast
 import dask.typing
 import distributed
 from aiohttp import ClientResponseError
+from common_library.json_serialization import json_dumps
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
 from dask_task_models_library.container_tasks.errors import TaskCancelledError
 from dask_task_models_library.container_tasks.io import (
@@ -162,11 +162,11 @@ class DaskClient:
                 _logger.info(
                     "Connection to %s succeeded [%s]",
                     f"dask-scheduler at {endpoint}",
-                    json.dumps(attempt.retry_state.retry_object.statistics),
+                    json_dumps(attempt.retry_state.retry_object.statistics),
                 )
                 _logger.info(
                     "Scheduler info:\n%s",
-                    json.dumps(backend.client.scheduler_info(), indent=2),
+                    json_dumps(backend.client.scheduler_info(), indent=2),
                 )
                 return instance
         # this is to satisfy pylance

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects_networks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects_networks.py
@@ -1,7 +1,6 @@
-import json
-
 import sqlalchemy as sa
 from aiopg.sa.result import RowProxy
+from common_library.json_serialization import json_loads
 from models_library.projects import ProjectID
 from models_library.projects_networks import NetworksWithAliases, ProjectsNetworks
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -33,7 +32,7 @@ class ProjectsNetworksRepository(BaseRepository):
         )
 
         async with self.db_engine.acquire() as conn:
-            row_data = json.loads(projects_networks_to_insert.model_dump_json())
+            row_data = json_loads(projects_networks_to_insert.model_dump_json())
             insert_stmt = pg_insert(projects_networks).values(**row_data)
             upsert_snapshot = insert_stmt.on_conflict_do_update(
                 constraint=projects_networks.primary_key, set_=row_data

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_thin.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/api_client/_thin.py
@@ -1,6 +1,6 @@
-import json
 from typing import Any
 
+from common_library.json_serialization import json_dumps
 from fastapi import FastAPI, status
 from httpx import Response, Timeout
 from models_library.services_creation import CreateServiceMetricsAdditionalParams
@@ -123,7 +123,7 @@ class ThinSidecarsClient(BaseThinClient):  # pylint: disable=too-many-public-met
     async def get_containers_name(
         self, dynamic_sidecar_endpoint: AnyHttpUrl, *, dynamic_sidecar_network_name: str
     ) -> Response:
-        filters = json.dumps(
+        filters = json_dumps(
             {
                 "network": dynamic_sidecar_network_name,
                 "exclude": SUFFIX_EGRESS_PROXY_NAME,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_api/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_api/_core.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import re
 from collections.abc import Mapping
@@ -98,7 +97,7 @@ def _to_snake_case(string: str) -> str:
 
 
 async def create_service_and_get_id(
-    create_service_data: AioDockerServiceSpec | dict[str, Any]
+    create_service_data: AioDockerServiceSpec | dict[str, Any],
 ) -> ServiceId:
     # NOTE: ideally the argument should always be AioDockerServiceSpec
     # but for that we need get_dynamic_proxy_spec to return that type
@@ -108,13 +107,13 @@ async def create_service_and_get_id(
         )
         kwargs = {_to_snake_case(k): v for k, v in kwargs.items()}
 
-        logging.debug("Creating service with\n%s", json.dumps(kwargs, indent=1))
+        logging.debug("Creating service with\n%s", json_dumps(kwargs, indent=1))
         service_start_result = await client.services.create(**kwargs)
 
         log.debug(
             "Started service %s with\n%s",
             service_start_result,
-            json.dumps(kwargs, indent=1),
+            json_dumps(kwargs, indent=1),
         )
 
     if "ID" not in service_start_result:

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/settings.py
@@ -1,9 +1,8 @@
-import json
 import logging
 from collections import deque
 from typing import Any, cast
 
-from common_library.json_serialization import json_loads
+from common_library.json_serialization import json_dumps, json_loads
 from models_library.basic_types import EnvVarKey, PortInt
 from models_library.boot_options import BootOption
 from models_library.docker import (
@@ -375,7 +374,7 @@ def _patch_target_service_into_env_vars(
 
     def _format_env_var(env_var: str, destination_container: list[str]) -> str:
         var_name, var_payload = env_var.split("=")
-        json_encoded = json.dumps(
+        json_encoded = json_dumps(
             {"destination_containers": destination_container, "env_var": var_payload}
         )
         return f"{var_name}={json_encoded}"

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/settings.py
@@ -3,6 +3,7 @@ import logging
 from collections import deque
 from typing import Any, cast
 
+from common_library.json_serialization import json_loads
 from models_library.basic_types import EnvVarKey, PortInt
 from models_library.boot_options import BootOption
 from models_library.docker import (
@@ -156,11 +157,15 @@ def update_service_params_from_settings(
     container_spec = create_service_params["task_template"]["ContainerSpec"]
     # set labels for CPU and Memory limits, for both service and container labels
     # NOTE: cpu-limit is a float not NanoCPUs!!
-    container_spec["Labels"][
-        f"{to_simcore_runtime_docker_label_key('cpu-limit')}"
-    ] = str(
-        float(create_service_params["task_template"]["Resources"]["Limits"]["NanoCPUs"])
-        / (1 * 10**9)
+    container_spec["Labels"][f"{to_simcore_runtime_docker_label_key('cpu-limit')}"] = (
+        str(
+            float(
+                create_service_params["task_template"]["Resources"]["Limits"][
+                    "NanoCPUs"
+                ]
+            )
+            / (1 * 10**9)
+        )
     )
     create_service_params["labels"][
         f"{to_simcore_runtime_docker_label_key('cpu-limit')}"
@@ -401,7 +406,7 @@ def _get_boot_options(
     if boot_options_encoded is None:
         return None
 
-    boot_options = json.loads(boot_options_encoded)["boot-options"]
+    boot_options = json_loads(boot_options_encoded)["boot-options"]
     log.debug("got boot_options=%s", boot_options)
     return {k: BootOption.model_validate(v) for k, v in boot_options.items()}
 
@@ -443,13 +448,13 @@ async def get_labels_for_involved_services(
     # paths_mapping express how to map dynamic-sidecar paths to the compose-spec volumes
     # where the service expects to find its certain folders
 
-    labels_for_involved_services: dict[
-        str, SimcoreServiceLabels
-    ] = await _extract_osparc_involved_service_labels(
-        catalog_client=catalog_client,
-        service_key=service_key,
-        service_tag=service_tag,
-        service_labels=simcore_service_labels,
+    labels_for_involved_services: dict[str, SimcoreServiceLabels] = (
+        await _extract_osparc_involved_service_labels(
+            catalog_client=catalog_client,
+            service_key=service_key,
+            service_tag=service_tag,
+            service_labels=simcore_service_labels,
+        )
     )
     logging.info("labels_for_involved_services=%s", labels_for_involved_services)
     return labels_for_involved_services

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
@@ -1,10 +1,10 @@
 # pylint: disable=relative-beyond-top-level
 
 import asyncio
-import json
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
+from common_library.json_serialization import json_loads
 from fastapi import FastAPI
 from models_library.api_schemas_long_running_tasks.base import ProgressPercent
 from models_library.products import ProductName
@@ -565,7 +565,7 @@ async def prepare_services_environment(
             scheduler_data.key, scheduler_data.version
         )
     )
-    service_outputs_labels = json.loads(
+    service_outputs_labels = json_loads(
         simcore_service_labels.model_dump().get("io.simcore.outputs", "{}")
     ).get("outputs", {})
     _logger.debug(

--- a/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_thin.py
+++ b/services/director-v2/tests/unit/test_modules_dynamic_sidecar_client_api_thin.py
@@ -1,11 +1,11 @@
 # pylint:disable=unused-argument
 # pylint:disable=redefined-outer-name
 
-import json
 from collections.abc import AsyncIterable, Callable
 from typing import Any
 
 import pytest
+from common_library.json_serialization import json_dumps
 from faker import Faker
 from fastapi import FastAPI, status
 from httpx import Response
@@ -182,7 +182,7 @@ async def test_get_containers_name(
 ) -> None:
     mock_response = Response(status.HTTP_200_OK)
 
-    encoded_filters = json.dumps(
+    encoded_filters = json_dumps(
         {
             "network": dynamic_sidecar_network_name,
             "exclude": SUFFIX_EGRESS_PROXY_NAME,

--- a/services/director/src/simcore_service_director/producer.py
+++ b/services/director/src/simcore_service_director/producer.py
@@ -1,6 +1,5 @@
 import asyncio
 import contextlib
-import json
 import logging
 import re
 from datetime import timedelta
@@ -13,7 +12,7 @@ import aiodocker.networks
 import arrow
 import httpx
 import tenacity
-from common_library.json_serialization import json_loads
+from common_library.json_serialization import json_dumps, json_loads
 from fastapi import FastAPI, status
 from packaging.version import Version
 from servicelib.async_utils import run_sequentially_in_context
@@ -315,7 +314,7 @@ async def _create_docker_service_params(
         _check_setting_correctness(param)
         # replace %service_uuid% by the given uuid
         if str(param["value"]).find("%service_uuid%") != -1:
-            dummy_string = json.dumps(param["value"])
+            dummy_string = json_dumps(param["value"])
             dummy_string = dummy_string.replace("%service_uuid%", node_uuid)
             param["value"] = json_loads(dummy_string)
 

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -8,6 +8,7 @@ from typing import Any, Final, cast
 
 import httpx
 from aiocache import Cache, SimpleMemoryCache  # type: ignore[import-untyped]
+from common_library.json_serialization import json_loads
 from fastapi import FastAPI, status
 from servicelib.async_utils import cancel_wait_task
 from servicelib.background_task import create_periodic_task
@@ -380,7 +381,7 @@ async def get_image_labels(
     request_result, headers = await registry_request(
         app, path=path, method="GET", use_cache=not update_cache
     )
-    v1_compatibility_key = json.loads(request_result["history"][0]["v1Compatibility"])
+    v1_compatibility_key = json_loads(request_result["history"][0]["v1Compatibility"])
     container_config: dict[str, Any] = v1_compatibility_key.get(
         "container_config", v1_compatibility_key["config"]
     )
@@ -413,7 +414,7 @@ async def get_image_details(
         if not key.startswith("io.simcore."):
             continue
         try:
-            label_data = json.loads(labels[key])
+            label_data = json_loads(labels[key])
             for label_key in label_data:
                 image_details[label_key] = label_data[label_key]
         except json.decoder.JSONDecodeError:
@@ -483,7 +484,7 @@ async def list_interactive_service_dependencies(
     dependency_keys = []
     if DEPENDENCIES_LABEL_KEY in image_labels:
         try:
-            dependencies = json.loads(image_labels[DEPENDENCIES_LABEL_KEY])
+            dependencies = json_loads(image_labels[DEPENDENCIES_LABEL_KEY])
             dependency_keys = [
                 {"key": dependency["key"], "tag": dependency["tag"]}
                 for dependency in dependencies

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/frontend/routes/_index.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/frontend/routes/_index.py
@@ -1,7 +1,5 @@
-import json
-
 import httpx
-from common_library.json_serialization import json_loads
+from common_library.json_serialization import json_dumps, json_loads
 from fastapi import FastAPI
 from models_library.projects_nodes_io import NodeID
 from nicegui import APIRouter, app, ui
@@ -120,7 +118,7 @@ def _get_clean_hashable(model: TrackedServiceModel) -> dict:
 
 def _get_hash(items: list[tuple[NodeID, TrackedServiceModel]]) -> int:
     return hash(
-        json.dumps([(f"{key}", _get_clean_hashable(model)) for key, model in items])
+        json_dumps([(f"{key}", _get_clean_hashable(model)) for key, model in items])
     )
 
 

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/frontend/routes/_index.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/frontend/routes/_index.py
@@ -1,6 +1,7 @@
 import json
 
 import httpx
+from common_library.json_serialization import json_loads
 from fastapi import FastAPI
 from models_library.projects_nodes_io import NodeID
 from nicegui import APIRouter, app, ui
@@ -39,7 +40,7 @@ def _render_service_details(node_id: NodeID, service: TrackedServiceModel) -> No
             service.dynamic_service_start.product_name,
         )
         service_status = (
-            json.loads(service.service_status) if service.service_status else {}
+            json_loads(service.service_status) if service.service_status else {}
         )
         dict_to_render["Service State"] = (
             "label",

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/frontend/routes/_service.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/frontend/routes/_service.py
@@ -1,6 +1,7 @@
 import json
 
 import httpx
+from common_library.json_serialization import json_loads
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
     DynamicServiceStop,
 )
@@ -89,7 +90,7 @@ async def service_details(node_id: NodeID):
 
         scheduler_internals = service_model.model_dump(mode="json")
         service_status = scheduler_internals.pop("service_status", "{}")
-        service_status = json.loads("{}" if service_status == "" else service_status)
+        service_status = json_loads("{}" if service_status == "" else service_status)
         dynamic_service_start = scheduler_internals.pop("dynamic_service_start")
 
         ui.markdown("**Service Status**")

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/frontend/routes/_service.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/api/frontend/routes/_service.py
@@ -1,7 +1,5 @@
-import json
-
 import httpx
-from common_library.json_serialization import json_loads
+from common_library.json_serialization import json_dumps, json_loads
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
     DynamicServiceStop,
 )
@@ -94,13 +92,13 @@ async def service_details(node_id: NodeID):
         dynamic_service_start = scheduler_internals.pop("dynamic_service_start")
 
         ui.markdown("**Service Status**")
-        ui.code(json.dumps(service_status, indent=2), language="json")
+        ui.code(json_dumps(service_status, indent=2), language="json")
 
         ui.markdown("**Scheduler Internals**")
-        ui.code(json.dumps(scheduler_internals, indent=2), language="json")
+        ui.code(json_dumps(scheduler_internals, indent=2), language="json")
 
         ui.markdown("**Start Parameters**")
-        ui.code(json.dumps(dynamic_service_start, indent=2), language="json")
+        ui.code(json_dumps(dynamic_service_start, indent=2), language="json")
 
         ui.markdown("**Raw serialized data (the one used to render the above**")
         ui.code(service_model.model_dump_json(indent=2), language="json")

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/rest/containers.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/api/rest/containers.py
@@ -1,10 +1,10 @@
 # pylint: disable=too-many-arguments
 
-import json
 import logging
 from asyncio import Lock
 from typing import Annotated, Any, Final
 
+from common_library.json_serialization import json_loads
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import Path as PathParam
 from fastapi import Query, Request, status
@@ -234,7 +234,7 @@ async def get_containers_name(
     """
     _ = request
 
-    filters_dict: dict[str, str] = json.loads(filters)
+    filters_dict: dict[str, str] = json_loads(filters)
     if not isinstance(filters_dict, dict):
         raise HTTPException(
             status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/cli.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/cli.py
@@ -1,10 +1,10 @@
 import asyncio
-import json
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import typer
+from common_library.json_serialization import json_dumps
 from fastapi import FastAPI
 from servicelib.fastapi.long_running_tasks.server import TaskProgress
 from settings_library.utils_cli import create_settings_command
@@ -31,7 +31,7 @@ main.command()(create_settings_command(settings_cls=ApplicationSettings, logger=
 def openapi():
     """Prints OpenAPI specifications in json format"""
     app = create_base_app()
-    typer.secho(json.dumps(app.openapi(), indent=2))
+    typer.secho(json_dumps(app.openapi(), indent=2))
 
 
 @asynccontextmanager

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/validation.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/validation.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import re
@@ -6,6 +5,7 @@ from collections.abc import Generator
 from typing import Any, NamedTuple
 
 import yaml
+from common_library.json_serialization import json_loads
 from servicelib.docker_constants import (
     DEFAULT_USER_SERVICES_NETWORK_NAME,
     SUFFIX_EGRESS_PROXY_NAME,
@@ -53,7 +53,7 @@ def _get_forwarded_env_vars(container_key: str) -> list[str]:
             new_entry_key = key.replace("FORWARD_ENV_", "")
 
             # parsing `VAR={"destination_containers": ["destination_container"], "env_var": "PAYLOAD"}`
-            new_entry_payload = json.loads(os.environ[key])
+            new_entry_payload = json_loads(os.environ[key])
             if container_key not in new_entry_payload["destination_containers"]:
                 continue
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/nodeports.py
@@ -14,6 +14,7 @@ from typing import cast
 import magic
 from aiofiles.os import remove
 from aiofiles.tempfile import TemporaryDirectory as AioTemporaryDirectory
+from common_library.json_serialization import json_loads
 from models_library.projects import ProjectIDStr
 from models_library.projects_nodes_io import NodeIDStr
 from models_library.services_types import ServicePortKey
@@ -208,7 +209,7 @@ async def upload_outputs(  # pylint:disable=too-many-statements  # noqa: PLR0915
             else:
                 data_file = outputs_path / _KEY_VALUE_FILE_NAME
                 if data_file.exists():
-                    data = json.loads(data_file.read_text())
+                    data = json_loads(data_file.read_text())
                     if port.key in data and data[port.key] is not None:
                         ports_values[port.key] = (data[port.key], None)
                     else:
@@ -390,7 +391,7 @@ async def download_target_ports(
     if data:
         data_file = target_dir / _KEY_VALUE_FILE_NAME
         if data_file.exists():
-            current_data = json.loads(data_file.read_text())
+            current_data = json_loads(data_file.read_text())
             # merge data
             data = {**current_data, **data}
         data_file.write_text(json.dumps(data))

--- a/services/storage/src/simcore_service_storage/utils/simcore_s3_dsm_utils.py
+++ b/services/storage/src/simcore_service_storage/utils/simcore_s3_dsm_utils.py
@@ -7,6 +7,7 @@ import orjson
 from aws_library.s3 import S3MetaData, SimcoreS3API
 from aws_library.s3._constants import STREAM_READER_CHUNK_SIZE
 from aws_library.s3._models import S3ObjectKey
+from common_library.json_serialization import json_loads
 from models_library.api_schemas_storage.storage_schemas import S3BucketName
 from models_library.projects import ProjectID, ProjectIDStr
 from models_library.projects_nodes_io import (
@@ -250,7 +251,7 @@ async def list_child_paths_from_s3(
     """
     objects_cursor = None
     if cursor is not None:
-        cursor_params = orjson.loads(cursor)
+        cursor_params = json_loads(cursor)
         assert cursor_params["file_filter"] == f"{file_filter}"  # nosec
         objects_cursor = cursor_params["objects_next_cursor"]
     list_s3_objects, objects_next_cursor = await s3_client.list_objects(

--- a/services/storage/src/simcore_service_storage/utils/simcore_s3_dsm_utils.py
+++ b/services/storage/src/simcore_service_storage/utils/simcore_s3_dsm_utils.py
@@ -3,11 +3,10 @@ from pathlib import Path
 from typing import TypeAlias
 from uuid import uuid4
 
-import orjson
 from aws_library.s3 import S3MetaData, SimcoreS3API
 from aws_library.s3._constants import STREAM_READER_CHUNK_SIZE
 from aws_library.s3._models import S3ObjectKey
-from common_library.json_serialization import json_loads
+from common_library.json_serialization import json_dumps, json_loads
 from models_library.api_schemas_storage.storage_schemas import S3BucketName
 from models_library.projects import ProjectID, ProjectIDStr
 from models_library.projects_nodes_io import (
@@ -278,7 +277,7 @@ async def list_child_paths_from_s3(
     ]
     next_cursor = None
     if objects_next_cursor:
-        next_cursor = orjson.dumps(
+        next_cursor = json_dumps(
             {
                 "file_filter": f"{file_filter}",
                 "objects_next_cursor": objects_next_cursor,

--- a/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
@@ -13,7 +13,7 @@ from typing import Final, NoReturn
 from aiohttp import web
 from aiopg.sa import Engine
 from aiopg.sa.connection import SAConnection
-from common_types.json_serialization import json_loads
+from common_library.json_serialization import json_loads
 from models_library.errors import ErrorDict
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID

--- a/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
@@ -4,7 +4,6 @@ of a record in comp_task table is changed.
 """
 
 import asyncio
-import json
 import logging
 from collections.abc import AsyncIterator
 from contextlib import suppress
@@ -14,6 +13,7 @@ from typing import Final, NoReturn
 from aiohttp import web
 from aiopg.sa import Engine
 from aiopg.sa.connection import SAConnection
+from commontypes.json_serialization import json_loads
 from models_library.errors import ErrorDict
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
@@ -152,7 +152,7 @@ async def _listen(app: web.Application, db_engine: Engine) -> NoReturn:
                 continue
             notification = conn.connection.notifies.get_nowait()
             # get the data and the info on what changed
-            payload = _CompTaskNotificationPayload(**json.loads(notification.payload))
+            payload = _CompTaskNotificationPayload(**json_loads(notification.payload))
             _logger.debug("received update from database: %s", f"{payload=}")
             await _handle_db_notification(app, payload, conn)
 

--- a/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
@@ -13,7 +13,7 @@ from typing import Final, NoReturn
 from aiohttp import web
 from aiopg.sa import Engine
 from aiopg.sa.connection import SAConnection
-from commontypes.json_serialization import json_loads
+from common_types.json_serialization import json_loads
 from models_library.errors import ErrorDict
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID

--- a/services/web/server/src/simcore_service_webserver/login/_preregistration_service.py
+++ b/services/web/server/src/simcore_service_webserver/login/_preregistration_service.py
@@ -54,7 +54,7 @@ async def send_close_account_email(
 
 
 def _json_encoder_and_dumps(obj: Any, **kwargs):
-    # NOTE: equivalent json.dumps(obj, default=jsonable_encode(pydantic_encoder(.))
+    # NOTE: equivalent json_dumps(obj, default=jsonable_encode(pydantic_encoder(.))
     return json_dumps(jsonable_encoder(obj), **kwargs)
 
 

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -10,7 +10,6 @@
 import asyncio
 import collections
 import datetime
-import json
 import logging
 from collections import defaultdict
 from collections.abc import Generator
@@ -21,7 +20,7 @@ from typing import Any, Final, cast
 from uuid import UUID, uuid4
 
 from aiohttp import web
-from common_library.json_serialization import json_dumps
+from common_library.json_serialization import json_dumps, json_loads
 from models_library.api_schemas_clusters_keeper.ec2_instances import EC2InstanceTypeGet
 from models_library.api_schemas_directorv2.dynamic_services import (
     GetProjectInactivityResponse,
@@ -1598,7 +1597,7 @@ async def add_project_states_for_user(
             prj_node = project["workbench"].get(str(node_id))
             if prj_node is None:
                 continue
-            node_state_dict = json.loads(
+            node_state_dict = json_loads(
                 node_state.model_dump_json(by_alias=True, exclude_unset=True)
             )
             prj_node.setdefault("state", {}).update(node_state_dict)

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_projects.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_projects.py
@@ -6,12 +6,12 @@ Keeps functionality that couples with the following app modules
 
 """
 
-import json
 import logging
 from pathlib import Path
 from typing import NamedTuple
 
 from aiohttp import web
+from common_library.json_serialization import json_loads
 from models_library.api_schemas_webserver.projects_ui import StudyUI
 from models_library.projects import DateTimeStr, Project, ProjectID
 from models_library.projects_access import AccessRights, GroupIDStr
@@ -194,7 +194,7 @@ async def _add_new_project(
     db: ProjectDBAPI = app[APP_PROJECT_DBAPI]
 
     # validated project is transform in dict via json to use only primitive types
-    project_in: dict = json.loads(
+    project_in: dict = json_loads(
         project.model_dump_json(exclude_none=True, by_alias=True)
     )
 

--- a/services/web/server/src/simcore_service_webserver/users/_notifications_rest.py
+++ b/services/web/server/src/simcore_service_webserver/users/_notifications_rest.py
@@ -1,8 +1,8 @@
-import json
 import logging
 
 import redis.asyncio as aioredis
 from aiohttp import web
+from common_library.json_serialization import json_loads
 from models_library.api_schemas_webserver.users import MyPermissionGet
 from models_library.users import UserPermission
 from pydantic import BaseModel
@@ -45,7 +45,7 @@ async def _get_user_notifications(
             get_notification_key(user_id), -1 * MAX_NOTIFICATIONS_FOR_USER_TO_SHOW, -1
         )
     )
-    notifications = [json.loads(x) for x in raw_notifications]
+    notifications = [json_loads(x) for x in raw_notifications]
     # Make it backwards compatible
     for n in notifications:
         if "product" not in n:

--- a/services/web/server/src/simcore_service_webserver/utils.py
+++ b/services/web/server/src/simcore_service_webserver/utils.py
@@ -1,5 +1,5 @@
 """
-    General utilities and helper functions
+General utilities and helper functions
 """
 
 import asyncio
@@ -11,11 +11,8 @@ import traceback
 import tracemalloc
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 
-import orjson
 from common_library.error_codes import ErrorCodeStr
-from models_library.basic_types import SHA1Str
 from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
     TypedDict,
 )
@@ -176,21 +173,3 @@ def compose_support_error_msg(
 
 def get_traceback_string(exception: BaseException) -> str:
     return "".join(traceback.format_exception(exception))
-
-
-# -----------------------------------------------
-#
-# SERIALIZATION, CHECKSUMS,
-#
-
-
-def compute_sha1_on_small_dataset(d: Any) -> SHA1Str:
-    """
-    This should be used for small datasets, otherwise it should be chuncked
-    and aggregated
-
-    More details in test_utils.py:test_compute_sha1_on_small_dataset
-    """
-    # SEE options in https://github.com/ijl/orjson#option
-    data_bytes = orjson.dumps(d, option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SORT_KEYS)
-    return SHA1Str(hashlib.sha1(data_bytes).hexdigest())  # nosec # NOSONAR


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?


Use the `json_loads` function from `common_library.json_serialization` instead of the built-in `json.dumps` and `json.loads` for serialization and deserialization. These functions are built on top of `orjson` and are significantly more reliable. Avoid using `json.dumps` and `json.loads`.

NOTE: json_dumps by default has no spaces compared to `json.dumps"
```
>>> from common_library.json_serialization import *
>>> import json

>>> data = {"x": 1, "y": "foo", "z":True }

>>> json_dumps(data)
'{"x":1,"y":"foo","z":true}'  # <-- NOTE that this string has no spaces
>>> json.dumps(data)
'{"x": 1, "y": "foo", "z": true}' # <-- NOTE that this string has spaces after `:` and ,
```


When working with Pydantic models, use their built-in methods for serialization/deserialization—for example, `model.model_dump_json()`—instead of external utilities.

This PR updates this practice across all the repo code-base (avoided scripts and tests)

## Related issue/s

Maintenance

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops 