### PR TITLE
⬆️Maintenance: unblock boto3 🚨🚨🚨🚨

### DIFF
--- a/ci/helpers/requirements/requirements.txt
+++ b/ci/helpers/requirements/requirements.txt
@@ -1,4 +1,7 @@
 aiohttp==3.9.5
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -r requirements/requirements.in
 aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.7.0
@@ -8,11 +11,15 @@ anyio==4.3.0
 attrs==23.2.0
     # via aiohttp
 certifi==2024.12.14
-    # via requests
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   requests
 charset-normalizer==3.4.1
     # via requests
 docker==7.1.0
+    # via -r requirements/requirements.in
 fastapi==0.115.0
+    # via -r requirements/requirements.in
 frozenlist==1.4.1
     # via
     #   aiohttp
@@ -27,7 +34,9 @@ multidict==6.0.5
     #   aiohttp
     #   yarl
 pydantic==2.10.5
-    # via fastapi
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 pydantic-core==2.27.2
     # via pydantic
 requests==2.32.3
@@ -35,7 +44,9 @@ requests==2.32.3
 sniffio==1.3.1
     # via anyio
 starlette==0.38.6
-    # via fastapi
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 typing-extensions==4.12.2
     # via
     #   fastapi
@@ -43,6 +54,7 @@ typing-extensions==4.12.2
     #   pydantic-core
 urllib3==2.3.0
     # via
+    #   -c requirements/../../../requirements/constraints.txt
     #   docker
     #   requests
 yarl==1.9.4

--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -1,8 +1,8 @@
 aio-pika==9.5.5
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==13.3.0
+aioboto3==14.1.0
     # via -r requirements/_base.in
-aiobotocore==2.16.0
+aiobotocore==2.21.1
     # via aioboto3
 aiocache==0.12.3
     # via
@@ -57,22 +57,9 @@ attrs==25.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.35.81
-    # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   aiobotocore
-botocore==1.35.81
+boto3==1.37.1
+    # via aiobotocore
+botocore==1.37.1
     # via
     #   aiobotocore
     #   boto3
@@ -134,6 +121,7 @@ importlib-metadata==8.5.0
     # via opentelemetry-api
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 jsonschema==4.23.0
@@ -148,6 +136,7 @@ mdurl==0.1.2
     # via markdown-it-py
 multidict==6.1.0
     # via
+    #   aiobotocore
     #   aiohttp
     #   yarl
 opentelemetry-api==1.30.0
@@ -311,6 +300,7 @@ pyinstrument==5.0.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
+    #   aiobotocore
     #   arrow
     #   botocore
 python-dotenv==1.0.1
@@ -372,7 +362,7 @@ rpds-py==0.23.1
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via boto3
 sh==2.2.2
     # via -r requirements/_base.in

--- a/packages/aws-library/requirements/_test.txt
+++ b/packages/aws-library/requirements/_test.txt
@@ -20,13 +20,12 @@ aws-xray-sdk==2.14.0
     # via moto
 blinker==1.9.0
     # via flask
-boto3==1.35.81
+boto3==1.37.1
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.35.81
+botocore==1.37.1
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -142,7 +141,7 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto==5.1.1
+moto==5.1.4
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -258,7 +257,7 @@ rpds-py==0.23.1
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via
     #   -c requirements/_base.txt
     #   boto3

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -29,7 +29,7 @@ attrs==25.1.0
     #   jsonschema
     #   pytest-docker
     #   referencing
-botocore==1.37.4
+botocore==1.38.1
     # via -r requirements/_test.in
 certifi==2025.1.31
     # via

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -1,6 +1,6 @@
-aioboto3==13.3.0
+aioboto3==14.1.0
     # via -r requirements/_test.in
-aiobotocore==2.16.0
+aiobotocore==2.21.1
     # via aioboto3
 aiofiles==24.1.0
     # via
@@ -46,13 +46,12 @@ aws-xray-sdk==2.14.0
     # via moto
 blinker==1.9.0
     # via flask
-boto3==1.35.81
+boto3==1.37.1
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   aiobotocore
     #   aws-sam-translator
     #   moto
-botocore==1.35.81
+botocore==1.37.1
     # via
     #   aiobotocore
     #   aws-xray-sdk
@@ -133,6 +132,7 @@ jinja2==3.1.5
     #   moto
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 joserfc==1.0.4
@@ -169,13 +169,14 @@ markupsafe==3.0.2
     #   jinja2
     #   mako
     #   werkzeug
-moto==5.1.1
+moto==5.1.4
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
 multidict==6.1.0
     # via
     #   -c requirements/_base.txt
+    #   aiobotocore
     #   aiohttp
     #   yarl
 mypy==1.15.0
@@ -253,6 +254,7 @@ pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
     # via
     #   -c requirements/_base.txt
+    #   aiobotocore
     #   botocore
     #   moto
 python-dotenv==1.0.1
@@ -293,7 +295,7 @@ rpds-py==0.23.1
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via boto3
 setuptools==75.8.2
     # via moto

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -72,10 +72,5 @@ pytest-lazy-fixture>=999999999
 # avoid downgrades of openapi-spec-validator related libraries
 referencing<=0.35.1
 
-# Pin boto3<1.36.0 till the following is addressed https://github.com/boto/botocore/issues/2308
-# when removing this pin, also update the aws cli inside ci/github/helpers/install_aws_cli_v2.bash
-# SEE https://github.com/ITISFoundation/osparc-simcore/issues/7127
-boto3<1.36.0
-
 # See issue https://github.com/ITISFoundation/osparc-simcore/issues/7300
 pydantic-settings<2.7.1

--- a/services/agent/requirements/_test.txt
+++ b/services/agent/requirements/_test.txt
@@ -1,6 +1,6 @@
-aioboto3==13.3.0
+aioboto3==14.1.0
     # via -r requirements/_test.in
-aiobotocore==2.16.0
+aiobotocore==2.21.1
     # via aioboto3
 aiofiles==24.1.0
     # via
@@ -45,13 +45,12 @@ aws-xray-sdk==2.14.0
     # via moto
 blinker==1.9.0
     # via flask
-boto3==1.35.81
+boto3==1.37.1
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   aiobotocore
     #   aws-sam-translator
     #   moto
-botocore==1.35.81
+botocore==1.37.1
     # via
     #   aiobotocore
     #   aws-xray-sdk
@@ -134,6 +133,7 @@ jinja2==3.1.6
     #   moto
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 joserfc==1.0.4
@@ -163,13 +163,14 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-moto==5.1.1
+moto==5.1.4
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
 multidict==6.1.0
     # via
     #   -c requirements/_base.txt
+    #   aiobotocore
     #   aiohttp
     #   yarl
 networkx==3.4.2
@@ -227,6 +228,7 @@ pytest-runner==6.0.1
 python-dateutil==2.9.0.post0
     # via
     #   -c requirements/_base.txt
+    #   aiobotocore
     #   botocore
     #   moto
 python-dotenv==1.0.1
@@ -266,7 +268,7 @@ rpds-py==0.23.1
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via boto3
 setuptools==75.8.2
     # via moto

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -56,9 +56,7 @@ aiohttp==3.11.10
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiodocker
 aiopg==1.4.0
-    # via
-    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-    #   -r requirements/_base.in
+    # via -r requirements/_base.in
 aiormq==6.8.1
     # via aio-pika
 aiosignal==1.3.1
@@ -354,10 +352,8 @@ opentelemetry-api==1.28.2
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
@@ -379,25 +375,19 @@ opentelemetry-exporter-otlp-proto-http==1.28.2
     # via opentelemetry-exporter-otlp
 opentelemetry-instrumentation==0.49b2
     # via
-    #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aiopg==0.49b2
-    # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.49b2
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.49b2
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-opentelemetry-instrumentation-dbapi==0.49b2
-    # via opentelemetry-instrumentation-aiopg
 opentelemetry-instrumentation-fastapi==0.49b2
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.49b2
@@ -430,7 +420,6 @@ opentelemetry-semantic-conventions==0.49b2
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
@@ -795,6 +784,7 @@ sqlalchemy==1.4.54
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiopg
     #   alembic
 starlette==0.41.3
@@ -952,8 +942,6 @@ wrapt==1.17.0
     # via
     #   deprecated
     #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-aiopg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 yarl==1.18.3

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -42,12 +42,11 @@ aws-sam-translator==1.55.0
     #   cfn-lint
 aws-xray-sdk==2.14.0
     # via moto
-boto3==1.35.99
+boto3==1.38.1
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   aws-sam-translator
     #   moto
-botocore==1.35.99
+botocore==1.38.1
     # via
     #   aws-xray-sdk
     #   boto3
@@ -314,7 +313,7 @@ rsa==4.9
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   python-jose
-s3transfer==0.10.4
+s3transfer==0.12.0
     # via boto3
 sarif-om==1.0.4
     # via cfn-lint

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -2,9 +2,9 @@ aio-pika==9.5.3
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==13.2.0
+aioboto3==14.1.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-aiobotocore==2.15.2
+aiobotocore==2.21.1
     # via aioboto3
 aiocache==0.12.3
     # via
@@ -86,34 +86,9 @@ attrs==24.2.0
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.35.36
-    # via
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   aiobotocore
-botocore==1.35.36
+boto3==1.37.1
+    # via aiobotocore
+botocore==1.37.1
     # via
     #   aiobotocore
     #   boto3
@@ -286,6 +261,7 @@ jinja2==3.1.4
     #   distributed
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 jsonschema==4.23.0
@@ -315,6 +291,7 @@ msgpack==1.1.0
     #   distributed
 multidict==6.1.0
     # via
+    #   aiobotocore
     #   aiohttp
     #   yarl
 opentelemetry-api==1.28.2
@@ -596,6 +573,7 @@ pyinstrument==5.0.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
+    #   aiobotocore
     #   arrow
     #   botocore
 python-dotenv==1.0.1
@@ -700,7 +678,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via boto3
 sh==2.1.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in

--- a/services/autoscaling/requirements/_test.txt
+++ b/services/autoscaling/requirements/_test.txt
@@ -21,13 +21,12 @@ aws-xray-sdk==2.14.0
     # via moto
 blinker==1.9.0
     # via flask
-boto3==1.35.36
+boto3==1.37.1
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.35.36
+botocore==1.37.1
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -153,7 +152,7 @@ markupsafe==3.0.2
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.1.1
+moto==5.1.4
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -268,7 +267,7 @@ rpds-py==0.22.3
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via
     #   -c requirements/_base.txt
     #   boto3

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -2,9 +2,9 @@ aio-pika==9.5.3
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==13.2.0
+aioboto3==14.1.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-aiobotocore==2.15.2
+aiobotocore==2.21.1
     # via aioboto3
 aiocache==0.12.3
     # via
@@ -84,34 +84,9 @@ attrs==24.2.0
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.35.36
-    # via
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   aiobotocore
-botocore==1.35.36
+boto3==1.37.1
+    # via aiobotocore
+botocore==1.37.1
     # via
     #   aiobotocore
     #   boto3
@@ -284,6 +259,7 @@ jinja2==3.1.4
     #   distributed
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 jsonschema==4.23.0
@@ -313,6 +289,7 @@ msgpack==1.1.0
     #   distributed
 multidict==6.1.0
     # via
+    #   aiobotocore
     #   aiohttp
     #   yarl
 opentelemetry-api==1.28.2
@@ -594,6 +571,7 @@ pyinstrument==5.0.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
+    #   aiobotocore
     #   arrow
     #   botocore
 python-dotenv==1.0.1
@@ -698,7 +676,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via boto3
 sh==2.1.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -39,13 +39,12 @@ aws-xray-sdk==2.14.0
     # via moto
 blinker==1.9.0
     # via flask
-boto3==1.35.36
+boto3==1.37.1
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.35.36
+botocore==1.37.1
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -171,7 +170,7 @@ markupsafe==3.0.2
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.1.1
+moto==5.1.4
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -289,7 +288,7 @@ rpds-py==0.22.3
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via
     #   -c requirements/_base.txt
     #   boto3

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -1,6 +1,6 @@
 aio-pika==9.5.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiobotocore==2.15.2
+aiobotocore==2.21.1
     # via s3fs
 aiocache==0.12.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
@@ -67,7 +67,7 @@ blosc==1.11.2
     # via -r requirements/_base.in
 bokeh==3.6.2
     # via dask
-botocore==1.35.36
+botocore==1.37.1
     # via aiobotocore
 certifi==2024.8.30
     # via
@@ -176,7 +176,9 @@ jinja2==3.1.4
     #   dask
     #   distributed
 jmespath==1.0.1
-    # via botocore
+    # via
+    #   aiobotocore
+    #   botocore
 jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -200,6 +202,7 @@ msgpack==1.1.0
     # via distributed
 multidict==6.1.0
     # via
+    #   aiobotocore
     #   aiohttp
     #   yarl
 numpy==2.1.3
@@ -408,6 +411,7 @@ pyinstrument==5.0.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
+    #   aiobotocore
     #   arrow
     #   botocore
     #   pandas

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -15,12 +15,11 @@ aws-xray-sdk==2.14.0
     # via moto
 blinker==1.9.0
     # via flask
-boto3==1.35.36
+boto3==1.37.1
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   aws-sam-translator
     #   moto
-botocore==1.35.36
+botocore==1.37.1
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -117,7 +116,7 @@ markupsafe==3.0.2
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.1.1
+moto==5.1.4
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -227,7 +226,7 @@ rpds-py==0.22.3
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via boto3
 setuptools==75.8.2
     # via moto

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -52,22 +52,9 @@ attrs==23.2.0
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.34.75
-    # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   -r requirements/_base.in
-botocore==1.34.75
+boto3==1.38.1
+    # via -r requirements/_base.in
+botocore==1.38.1
     # via
     #   boto3
     #   s3transfer
@@ -424,7 +411,7 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.1
+s3transfer==0.12.0
     # via boto3
 setuptools==74.0.0
     # via opentelemetry-instrumentation

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -64,9 +64,7 @@ aiohttp==3.11.13
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiodocker
 aiopg==1.4.0
-    # via
-    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
-    #   -r requirements/_base.in
+    # via -r requirements/_base.in
 aiormq==6.8.1
     # via aio-pika
 aiosignal==1.3.2
@@ -403,10 +401,8 @@ opentelemetry-api==1.30.0
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
@@ -428,25 +424,19 @@ opentelemetry-exporter-otlp-proto-http==1.30.0
     # via opentelemetry-exporter-otlp
 opentelemetry-instrumentation==0.51b0
     # via
-    #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aiopg==0.51b0
-    # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.51b0
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.51b0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-opentelemetry-instrumentation-dbapi==0.51b0
-    # via opentelemetry-instrumentation-aiopg
 opentelemetry-instrumentation-fastapi==0.51b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.51b0
@@ -479,7 +469,6 @@ opentelemetry-semantic-conventions==0.51b0
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
@@ -951,6 +940,7 @@ sqlalchemy==1.4.54
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiopg
     #   alembic
 starlette==0.41.3
@@ -1139,8 +1129,6 @@ wrapt==1.17.2
     # via
     #   deprecated
     #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-aiopg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 wsproto==1.2.0

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -2,9 +2,9 @@ aio-pika==9.5.5
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-aioboto3==13.3.0
+aioboto3==14.1.0
     # via -r requirements/_test.in
-aiobotocore==2.16.0
+aiobotocore==2.21.1
     # via aioboto3
 aiofiles==24.1.0
     # via
@@ -48,11 +48,9 @@ attrs==25.1.0
     #   pytest-docker
 bokeh==3.6.3
     # via dask
-boto3==1.35.81
-    # via
-    #   -c requirements/../../../requirements/constraints.txt
-    #   aiobotocore
-botocore==1.35.81
+boto3==1.37.1
+    # via aiobotocore
+botocore==1.37.1
     # via
     #   aiobotocore
     #   boto3
@@ -153,6 +151,7 @@ jinja2==3.1.4
     #   distributed
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 locket==1.0.0
@@ -177,6 +176,7 @@ msgpack==1.1.0
 multidict==6.1.0
     # via
     #   -c requirements/_base.txt
+    #   aiobotocore
     #   aiohttp
     #   async-asgi-testclient
     #   yarl
@@ -251,6 +251,7 @@ pytest-xdist==3.6.1
 python-dateutil==2.9.0.post0
     # via
     #   -c requirements/_base.txt
+    #   aiobotocore
     #   botocore
     #   pandas
 pytz==2025.1
@@ -269,7 +270,7 @@ requests==2.32.3
     #   docker
 respx==0.22.0
     # via -r requirements/_test.in
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via boto3
 six==1.17.0
     # via

--- a/services/docker-compose-ops-ci.yml
+++ b/services/docker-compose-ops-ci.yml
@@ -20,7 +20,7 @@
 
 services:
   minio:
-    image: minio/minio:RELEASE.2020-05-16T01-33-21Z
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     init: true
     environment:
       MINIO_ACCESS_KEY : ${S3_ACCESS_KEY:?access_key_required}

--- a/services/docker-compose-ops.yml
+++ b/services/docker-compose-ops.yml
@@ -53,7 +53,7 @@ services:
       - portainer_data:/data
 
   minio:
-    image: minio/minio:RELEASE.2023-12-02T10-51-33Z
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     init: true
     environment:
       MINIO_ROOT_USER : ${S3_ACCESS_KEY:?access_key_required}

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -1,6 +1,6 @@
-aioboto3==13.3.0
+aioboto3==14.1.0
     # via -r requirements/_test.in
-aiobotocore==2.16.0
+aiobotocore==2.21.1
     # via aioboto3
 aiofiles==24.1.0
     # via
@@ -29,11 +29,9 @@ attrs==25.1.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-boto3==1.35.81
-    # via
-    #   -c requirements/../../../requirements/constraints.txt
-    #   aiobotocore
-botocore==1.35.81
+boto3==1.37.1
+    # via aiobotocore
+botocore==1.37.1
     # via
     #   aiobotocore
     #   boto3
@@ -73,11 +71,13 @@ iniconfig==2.0.0
     # via pytest
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 multidict==6.1.0
     # via
     #   -c requirements/_base.txt
+    #   aiobotocore
     #   aiohttp
     #   async-asgi-testclient
     #   yarl
@@ -113,6 +113,7 @@ pytest-mock==3.14.0
 python-dateutil==2.9.0.post0
     # via
     #   -c requirements/_base.txt
+    #   aiobotocore
     #   botocore
 python-dotenv==1.0.1
     # via
@@ -123,7 +124,7 @@ requests==2.32.3
     #   -c requirements/_base.txt
     #   async-asgi-testclient
     #   docker
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via boto3
 six==1.17.0
     # via

--- a/services/efs-guardian/requirements/_base.txt
+++ b/services/efs-guardian/requirements/_base.txt
@@ -2,9 +2,9 @@ aio-pika==9.4.3
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==13.2.0
+aioboto3==14.1.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-aiobotocore==2.15.2
+aiobotocore==2.21.1
     # via aioboto3
 aiocache==0.12.3
     # via
@@ -92,36 +92,9 @@ attrs==24.2.0
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.35.36
-    # via
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   aiobotocore
-botocore==1.35.36
+boto3==1.37.1
+    # via aiobotocore
+botocore==1.37.1
     # via
     #   aiobotocore
     #   boto3
@@ -247,6 +220,7 @@ importlib-metadata==8.4.0
     # via opentelemetry-api
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 jsonschema==4.23.0
@@ -294,6 +268,7 @@ mdurl==0.1.2
     # via markdown-it-py
 multidict==6.1.0
     # via
+    #   aiobotocore
     #   aiohttp
     #   yarl
 opentelemetry-api==1.27.0
@@ -578,6 +553,7 @@ pyinstrument==5.0.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
+    #   aiobotocore
     #   arrow
     #   botocore
 python-dotenv==1.0.1
@@ -685,7 +661,7 @@ rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.3
+s3transfer==0.11.3
     # via boto3
 setuptools==75.2.0
     # via opentelemetry-instrumentation

--- a/services/efs-guardian/requirements/_test.txt
+++ b/services/efs-guardian/requirements/_test.txt
@@ -39,13 +39,12 @@ aws-xray-sdk==2.14.0
     # via moto
 blinker==1.9.0
     # via flask
-boto3==1.35.36
+boto3==1.37.1
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.35.36
+botocore==1.37.1
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -170,7 +169,7 @@ markupsafe==3.0.1
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.1.1
+moto==5.1.4
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -287,7 +286,7 @@ rpds-py==0.20.0
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.3
+s3transfer==0.11.3
     # via
     #   -c requirements/_base.txt
     #   boto3

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -2,9 +2,9 @@ aio-pika==9.4.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==13.1.0
+aioboto3==14.1.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-aiobotocore==2.13.1
+aiobotocore==2.21.1
     # via aioboto3
 aiocache==0.12.2
     # via
@@ -92,36 +92,9 @@ attrs==23.2.0
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.34.131
-    # via
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   aiobotocore
-botocore==1.34.131
+boto3==1.37.1
+    # via aiobotocore
+botocore==1.37.1
     # via
     #   aiobotocore
     #   boto3
@@ -259,6 +232,7 @@ importlib-metadata==8.0.0
     # via opentelemetry-api
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 jsonschema==4.21.1
@@ -310,6 +284,7 @@ mdurl==0.1.2
     # via markdown-it-py
 multidict==6.0.5
     # via
+    #   aiobotocore
     #   aiohttp
     #   yarl
 numpy==1.26.4
@@ -608,6 +583,7 @@ pyparsing==3.1.2
     # via matplotlib
 python-dateutil==2.9.0.post0
     # via
+    #   aiobotocore
     #   arrow
     #   botocore
     #   dateparser
@@ -730,7 +706,7 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.1
+s3transfer==0.11.3
     # via boto3
 setuptools==74.0.0
     # via opentelemetry-instrumentation

--- a/services/resource-usage-tracker/requirements/_test.txt
+++ b/services/resource-usage-tracker/requirements/_test.txt
@@ -25,13 +25,12 @@ aws-xray-sdk==2.14.0
     # via moto
 blinker==1.9.0
     # via flask
-boto3==1.34.131
+boto3==1.37.1
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.34.131
+botocore==1.37.1
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -156,7 +155,7 @@ markupsafe==2.1.5
     #   jinja2
     #   mako
     #   werkzeug
-moto==5.1.1
+moto==5.1.4
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -271,7 +270,7 @@ rpds-py==0.18.0
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.1
+s3transfer==0.11.3
     # via
     #   -c requirements/_base.txt
     #   boto3

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -2,11 +2,11 @@ aio-pika==9.5.4
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==13.3.0
+aioboto3==14.1.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/_base.in
     #   -r requirements/_base.in
-aiobotocore==2.16.0
+aiobotocore==2.21.1
     # via aioboto3
 aiocache==0.12.3
     # via
@@ -102,36 +102,9 @@ attrs==25.1.0
     #   referencing
 billiard==4.2.1
     # via celery
-boto3==1.35.81
-    # via
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   aiobotocore
-botocore==1.35.81
+boto3==1.37.1
+    # via aiobotocore
+botocore==1.37.1
     # via
     #   aiobotocore
     #   boto3
@@ -312,6 +285,7 @@ jinja2==3.1.5
     #   fastapi
 jmespath==1.0.1
     # via
+    #   aiobotocore
     #   boto3
     #   botocore
 jsonschema==4.23.0
@@ -363,6 +337,7 @@ mdurl==0.1.2
     # via markdown-it-py
 multidict==6.1.0
     # via
+    #   aiobotocore
     #   aiohttp
     #   yarl
 opentelemetry-api==1.30.0
@@ -662,6 +637,7 @@ pyinstrument==5.0.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
+    #   aiobotocore
     #   arrow
     #   botocore
     #   celery
@@ -780,7 +756,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via boto3
 sh==2.2.1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -47,13 +47,12 @@ billiard==4.2.1
     #   celery
 blinker==1.9.0
     # via flask
-boto3==1.35.81
+boto3==1.37.1
     # via
-    #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.35.81
+botocore==1.37.1
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -215,7 +214,7 @@ markupsafe==3.0.2
     #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
-moto==5.1.1
+moto==5.1.4
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
@@ -363,7 +362,7 @@ rpds-py==0.22.3
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.10.4
+s3transfer==0.11.3
     # via
     #   -c requirements/_base.txt
     #   boto3

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -79,7 +79,6 @@ aiohttp-session==2.11.0
 aiopg==1.4.0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-    #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
 aiormq==6.7.6
     # via aio-pika
@@ -465,7 +464,6 @@ opentelemetry-instrumentation-aiohttp-server==0.48b0
 opentelemetry-instrumentation-aiopg==0.48b0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-    #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.48b0
     # via
@@ -937,6 +935,7 @@ sqlalchemy==1.4.47
     #   -r requirements/../../../../packages/notifications-library/requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   aiopg
     #   alembic
 stream-zip==0.0.83

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -53,8 +53,6 @@ aiohttp==3.11.13
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiodocker
-aiopg==1.4.0
-    # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 aiormq==6.8.1
     # via aio-pika
 aiosignal==1.3.2
@@ -78,8 +76,6 @@ arrow==1.3.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-async-timeout==4.0.3
-    # via aiopg
 asyncpg==0.30.0
     # via sqlalchemy
 attrs==25.1.0
@@ -235,9 +231,7 @@ opentelemetry-api==1.30.0
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
@@ -257,18 +251,12 @@ opentelemetry-exporter-otlp-proto-http==1.30.0
     # via opentelemetry-exporter-otlp
 opentelemetry-instrumentation==0.51b0
     # via
-    #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aiopg==0.51b0
-    # via -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.51b0
     # via -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-opentelemetry-instrumentation-dbapi==0.51b0
-    # via opentelemetry-instrumentation-aiopg
 opentelemetry-instrumentation-logging==0.51b0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -296,7 +284,6 @@ opentelemetry-semantic-conventions==0.51b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
@@ -372,9 +359,7 @@ psutil==7.0.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 psycopg2-binary==2.9.10
-    # via
-    #   aiopg
-    #   sqlalchemy
+    # via sqlalchemy
 pycryptodome==3.21.0
     # via stream-zip
 pydantic==2.10.6
@@ -680,7 +665,7 @@ sqlalchemy==1.4.54
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_migration.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-    #   aiopg
+    #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   alembic
 stream-zip==0.0.83
     # via
@@ -763,8 +748,6 @@ wrapt==1.17.2
     # via
     #   deprecated
     #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-aiopg
-    #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-redis
 yarl==1.18.3
     # via


### PR DESCRIPTION
🚨🚨🚨: Check CEPH S3 compatibility when deleting a file

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/7127

The issue arising in tests was coming from Minio: https://github.com/minio/minio/issues/20845, updating the minio to the latest version `RELEASE.2025-04-22T22-12-26Z` solves the problem


###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 10
- #packages after ~ 6

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aioboto3                  | 13.3.0, 13.1.0, 13.2.0 | 14.1.0     | **MAJOR**  | 10 | agent🧪</br>autoscaling⬆️</br>aws-library🧪</br>clusters-keeper⬆️</br>director-v2🧪</br>dynamic-sidecar🧪</br>efs-guardian⬆️</br>resource-usage-tracker⬆️</br>simcore-sdk🧪</br>storage⬆️ |
|   2 | aiobotocore               | 2.16.0, 2.15.2, 2.13.1 | 2.21.1     | *minor*    | 11 | agent🧪</br>autoscaling⬆️</br>aws-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>director-v2🧪</br>dynamic-sidecar🧪</br>efs-guardian⬆️</br>resource-usage-tracker⬆️</br>simcore-sdk🧪</br>storage⬆️ |
|   3 | aiopg                     | 1.4.0           | 🗑️ removed |  | 1 | swarm-deploy🧪 |
|   4 | async-timeout             | 4.0.3           | 🗑️ removed |  | 1 | swarm-deploy🧪 |
|   5 | boto3                     | 1.34.131, 1.34.75, 1.35.81, 1.35.99, 1.35.36 | 1.37.1,1.38.1 | *minor*    | 19 | agent🧪</br>api-server🧪</br>autoscaling⬆️🧪</br>aws-library🧪🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar🧪</br>datcore-adapter⬆️</br>director-v2🧪</br>dynamic-sidecar🧪</br>efs-guardian⬆️🧪</br>resource-usage-tracker⬆️🧪</br>simcore-sdk🧪</br>storage⬆️🧪 |
|   6 | botocore                  | 1.37.4, 1.34.131, 1.34.75, 1.35.81, 1.35.99, 1.35.36 | 1.37.1,1.38.1 | *minor*    | 21 | agent🧪</br>api-server🧪</br>autoscaling⬆️🧪</br>aws-library🧪🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️🧪</br>datcore-adapter⬆️</br>director-v2🧪</br>dynamic-sidecar🧪</br>efs-guardian⬆️🧪</br>resource-usage-tracker⬆️🧪</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️🧪 |
|   7 | moto                      | 5.1.1           | 5.1.4      |            | 9 | agent🧪</br>autoscaling🧪</br>aws-library🧪</br>clusters-keeper🧪</br>dask-sidecar🧪</br>efs-guardian🧪</br>resource-usage-tracker🧪</br>simcore-sdk🧪</br>storage🧪 |
|   8 | opentelemetry-instrumentation-aiopg | 0.49, 0.51      | 🗑️ removed |  | 3 | api-server⬆️</br>director-v2⬆️</br>swarm-deploy🧪 |
|   9 | opentelemetry-instrumentation-dbapi | 0.49, 0.51      | 🗑️ removed |  | 3 | api-server⬆️</br>director-v2⬆️</br>swarm-deploy🧪 |
|  10 | s3transfer                | 0.10.4, 0.10.1, 0.10.3 | 0.12.0,0.11.3 | *minor*    | 19 | agent🧪</br>api-server🧪</br>autoscaling⬆️🧪</br>aws-library🧪🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar🧪</br>datcore-adapter⬆️</br>director-v2🧪</br>dynamic-sidecar🧪</br>efs-guardian⬆️🧪</br>resource-usage-tracker⬆️🧪</br>simcore-sdk🧪</br>storage⬆️🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency