### PR TITLE
🐛lock botocore<1.36.0 until CEPH S3 is updated to be compatible with AWS S3

### DIFF
--- a/packages/aws-library/src/aws_library/s3/__init__.py
+++ b/packages/aws-library/src/aws_library/s3/__init__.py
@@ -22,10 +22,10 @@ from ._models import (
 )
 
 __all__: tuple[str, ...] = (
-    "CopiedBytesTransferredCallback",
-    "MultiPartUploadLinks",
     "PRESIGNED_LINK_MAX_SIZE",
     "S3_MAX_FILE_SIZE",
+    "CopiedBytesTransferredCallback",
+    "MultiPartUploadLinks",
     "S3AccessError",
     "S3BucketInvalidError",
     "S3DestinationNotEmptyError",
@@ -37,8 +37,8 @@ __all__: tuple[str, ...] = (
     "S3RuntimeError",
     "S3UploadNotFoundError",
     "SimcoreS3API",
-    "UploadedBytesTransferredCallback",
     "UploadID",
+    "UploadedBytesTransferredCallback",
 )
 
 # nopycln: file

--- a/packages/aws-library/src/aws_library/s3/_client.py
+++ b/packages/aws-library/src/aws_library/s3/_client.py
@@ -3,6 +3,7 @@ import contextlib
 import functools
 import logging
 import urllib.parse
+import warnings
 from collections.abc import AsyncGenerator, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -11,6 +12,7 @@ from typing import Any, Final, Literal, Protocol, cast
 import aioboto3
 from aiobotocore.session import ClientCreatorContext
 from boto3.s3.transfer import TransferConfig
+from botocore import __version__ as botocore_version
 from botocore import exceptions as botocore_exc
 from botocore.client import Config
 from models_library.api_schemas_storage.storage_schemas import (
@@ -20,6 +22,7 @@ from models_library.api_schemas_storage.storage_schemas import (
 )
 from models_library.basic_types import SHA256Str
 from models_library.bytes_iters import BytesIter, DataSize
+from packaging import version
 from pydantic import AnyUrl, ByteSize, TypeAdapter
 from servicelib.bytes_iters import DEFAULT_READ_CHUNK_SIZE, BytesStreamer
 from servicelib.logging_utils import log_catch, log_context
@@ -50,6 +53,22 @@ from ._models import (
     UploadID,
 )
 from ._utils import compute_num_file_chunks, create_final_prefix
+
+_BOTOCORE_VERSION: Final[version.Version] = version.parse(botocore_version)
+_MAX_BOTOCORE_VERSION_COMPATIBLE_WITH_CEPH_S3: Final[version.Version] = version.parse(
+    "1.36.0"
+)
+
+
+def _check_botocore_version() -> None:
+    if _BOTOCORE_VERSION >= _MAX_BOTOCORE_VERSION_COMPATIBLE_WITH_CEPH_S3:
+        warnings.warn(
+            f"Botocore version {botocore_version} is not supported for file uploads with CEPH S3 until CEPH is updated. "
+            "Please use a version < 1.36.0. The upload operation will likely fail.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
 
 _logger = logging.getLogger(__name__)
 
@@ -504,6 +523,9 @@ class SimcoreS3API:  # pylint: disable=too-many-public-methods
         bytes_transfered_cb: UploadedBytesTransferredCallback | None,
     ) -> None:
         """upload a file using aioboto3 transfer manager (e.g. works >5Gb and creates multiple threads)"""
+
+        _check_botocore_version()
+
         upload_options: dict[str, Any] = {
             "Bucket": bucket,
             "Key": object_key,
@@ -528,6 +550,9 @@ class SimcoreS3API:  # pylint: disable=too-many-public-methods
         object_metadata: S3MetaData | None = None,
     ) -> None:
         """copy a file in S3 using aioboto3 transfer manager (e.g. works >5Gb and creates multiple threads)"""
+
+        _check_botocore_version()
+
         copy_options: dict[str, Any] = {
             "CopySource": {"Bucket": bucket, "Key": src_object_key},
             "Bucket": bucket,
@@ -634,6 +659,7 @@ class SimcoreS3API:  # pylint: disable=too-many-public-methods
         file_like_reader: FileLikeReader,
     ) -> None:
         """streams write an object in S3 from an AsyncIterable[bytes]"""
+        _check_botocore_version()
         await self._client.upload_fileobj(file_like_reader, bucket_name, object_key)  # type: ignore[arg-type]
 
     @staticmethod

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -1,6 +1,6 @@
 aio-pika==9.5.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-aiobotocore==2.21.1
+aiobotocore==2.17.0
     # via s3fs
 aiocache==0.12.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
@@ -67,8 +67,10 @@ blosc==1.11.2
     # via -r requirements/_base.in
 bokeh==3.6.2
     # via dask
-botocore==1.37.1
-    # via aiobotocore
+botocore==1.35.93
+    # via
+    #   -c requirements/constraints.txt
+    #   aiobotocore
 certifi==2024.8.30
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -567,6 +569,7 @@ urllib3==2.2.3
     #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
+    #   aiobotocore
     #   botocore
     #   distributed
     #   requests

--- a/services/dask-sidecar/requirements/_test.txt
+++ b/services/dask-sidecar/requirements/_test.txt
@@ -15,11 +15,11 @@ aws-xray-sdk==2.14.0
     # via moto
 blinker==1.9.0
     # via flask
-boto3==1.37.1
+boto3==1.35.93
     # via
     #   aws-sam-translator
     #   moto
-botocore==1.37.1
+botocore==1.35.93
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -226,7 +226,7 @@ rpds-py==0.22.3
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.11.3
+s3transfer==0.10.4
     # via boto3
 setuptools==75.8.2
     # via moto

--- a/services/dask-sidecar/requirements/constraints.txt
+++ b/services/dask-sidecar/requirements/constraints.txt
@@ -13,3 +13,6 @@ dask[distributed]>=2024.4.2 # issue with publish_dataset: https://github.com/das
 #
 # Compatibility/coordination
 #
+# botocore does not always add the checksums to the s3 object metadata leading to issues with CEPH S3
+# see https://github.com/ITISFoundation/osparc-simcore/issues/7585
+botocore<1.36.0

--- a/services/storage/requirements/_base.in
+++ b/services/storage/requirements/_base.in
@@ -3,6 +3,7 @@
 #
 
 --constraint ../../../requirements/constraints.txt
+--constraint ./constraints.txt
 
 
 --requirement ../../../packages/aws-library/requirements/_base.in

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -2,11 +2,11 @@ aio-pika==9.5.4
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==14.1.0
+aioboto3==13.3.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/_base.in
     #   -r requirements/_base.in
-aiobotocore==2.21.1
+aiobotocore==2.16.0
     # via aioboto3
 aiocache==0.12.3
     # via
@@ -102,10 +102,11 @@ attrs==25.1.0
     #   referencing
 billiard==4.2.1
     # via celery
-boto3==1.37.1
+boto3==1.35.81
     # via aiobotocore
-botocore==1.37.1
+botocore==1.35.81
     # via
+    #   -c requirements/./constraints.txt
     #   aiobotocore
     #   boto3
     #   s3transfer
@@ -285,7 +286,6 @@ jinja2==3.1.5
     #   fastapi
 jmespath==1.0.1
     # via
-    #   aiobotocore
     #   boto3
     #   botocore
 jsonschema==4.23.0
@@ -337,7 +337,6 @@ mdurl==0.1.2
     # via markdown-it-py
 multidict==6.1.0
     # via
-    #   aiobotocore
     #   aiohttp
     #   yarl
 opentelemetry-api==1.30.0
@@ -637,7 +636,6 @@ pyinstrument==5.0.1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 python-dateutil==2.9.0.post0
     # via
-    #   aiobotocore
     #   arrow
     #   botocore
     #   celery
@@ -756,7 +754,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.11.3
+s3transfer==0.10.4
     # via boto3
 sh==2.2.1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -47,12 +47,12 @@ billiard==4.2.1
     #   celery
 blinker==1.9.0
     # via flask
-boto3==1.37.1
+boto3==1.35.81
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.37.1
+botocore==1.35.81
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
@@ -362,7 +362,7 @@ rpds-py==0.22.3
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.11.3
+s3transfer==0.10.4
     # via
     #   -c requirements/_base.txt
     #   boto3

--- a/services/storage/requirements/constraints.txt
+++ b/services/storage/requirements/constraints.txt
@@ -1,0 +1,3 @@
+# botocore does not always add the checksums to the s3 object metadata leading to issues with CEPH S3
+# see https://github.com/ITISFoundation/osparc-simcore/issues/7585
+botocore<1.36.0


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->



## What do these changes do?
our CEPH S3 is not 100% compatible anymore (or at least for our use) anymore with AWS S3 since [botocore 1.36.0](https://github.com/boto/botocore/tree/1.36.0) was released this year.

Until CEPH is updated botocore version is locked which has implications on many other libraries.
this is now constrained on storage and dask-sidecar services which are the only one uploading data to S3 at this time.

The current CEPH S3 is incompatible with botocore, the AWS CLI, and any other tools based on botocore (which is almost everything)

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 5
- #packages after ~ 5

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aioboto3                  | 14.1.0          | 13.3.0     | 🔥 downgrade     | 1 | storage⬆️ |
|   2 | aiobotocore               | 2.21.1          | 2.17.0,2.16.0 | 🔥 downgrade | 2 | dask-sidecar⬆️</br>storage⬆️ |
|   3 | boto3                     | 1.37.1          | 1.35.93,1.35.81 | 🔥 downgrade | 3 | dask-sidecar🧪</br>storage⬆️🧪 |
|   4 | botocore                  | 1.37.1          | 1.35.93,1.35.81 | 🔥 downgrade | 4 | dask-sidecar⬆️🧪</br>storage⬆️🧪 |
|   5 | s3transfer                | 0.11.3          | 0.10.4     | 🔥 downgrade | 3 | dask-sidecar🧪</br>storage⬆️🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/7585
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [ ] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
