### PR TITLE
🎨Autoscaling in computations: send log/progress messages to rabbitMQ

### DIFF
--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/utils.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/utils.py
@@ -1,0 +1,44 @@
+from typing import Final
+from uuid import uuid4
+
+from models_library.projects import ProjectID
+from models_library.projects_nodes_io import NodeID
+from models_library.services_types import ServiceKey, ServiceVersion
+from models_library.users import UserID
+from pydantic import TypeAdapter
+
+from ..models import DaskJobID
+
+
+def generate_dask_job_id(
+    service_key: ServiceKey,
+    service_version: ServiceVersion,
+    user_id: UserID,
+    project_id: ProjectID,
+    node_id: NodeID,
+) -> DaskJobID:
+    """creates a dask job id:
+    The job ID shall contain the user_id, project_id, node_id
+    Also, it must be unique
+    and it is shown in the Dask scheduler dashboard website
+    """
+    return DaskJobID(
+        f"{service_key}:{service_version}:userid_{user_id}:projectid_{project_id}:nodeid_{node_id}:uuid_{uuid4()}"
+    )
+
+
+_JOB_ID_PARTS: Final[int] = 6
+
+
+def parse_dask_job_id(
+    job_id: str,
+) -> tuple[ServiceKey, ServiceVersion, UserID, ProjectID, NodeID]:
+    parts = job_id.split(":")
+    assert len(parts) == _JOB_ID_PARTS  # nosec
+    return (
+        parts[0],
+        parts[1],
+        TypeAdapter(UserID).validate_python(parts[2][len("userid_") :]),
+        ProjectID(parts[3][len("projectid_") :]),
+        NodeID(parts[4][len("nodeid_") :]),
+    )

--- a/packages/dask-task-models-library/src/dask_task_models_library/models.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/models.py
@@ -1,0 +1,4 @@
+from typing import TypeAlias
+
+DaskJobID: TypeAlias = str
+DaskResources: TypeAlias = dict[str, int | float]

--- a/packages/dask-task-models-library/tests/container_tasks/test_utils.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_utils.py
@@ -1,3 +1,9 @@
+# pylint: disable=too-many-positional-arguments
+# pylint:disable=redefined-outer-name
+# pylint:disable=too-many-arguments
+# pylint:disable=unused-argument
+# pylint:disable=unused-variable
+
 import pytest
 from dask_task_models_library.container_tasks.utils import (
     generate_dask_job_id,

--- a/packages/dask-task-models-library/tests/container_tasks/test_utils.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_utils.py
@@ -1,0 +1,62 @@
+import pytest
+from dask_task_models_library.container_tasks.utils import (
+    generate_dask_job_id,
+    parse_dask_job_id,
+)
+from faker import Faker
+from models_library.projects import ProjectID
+from models_library.projects_nodes_io import NodeID
+from models_library.services_types import ServiceKey, ServiceVersion
+from models_library.users import UserID
+from pydantic import TypeAdapter
+
+
+@pytest.fixture(
+    params=["simcore/service/comp/some/fake/service/key", "dockerhub-style/service_key"]
+)
+def service_key(request) -> ServiceKey:
+    return request.param
+
+
+@pytest.fixture()
+def service_version() -> str:
+    return "1234.32432.2344"
+
+
+@pytest.fixture
+def user_id(faker: Faker) -> UserID:
+    return TypeAdapter(UserID).validate_python(faker.pyint(min_value=1))
+
+
+@pytest.fixture
+def project_id(faker: Faker) -> ProjectID:
+    return ProjectID(faker.uuid4())
+
+
+@pytest.fixture
+def node_id(faker: Faker) -> NodeID:
+    return NodeID(faker.uuid4())
+
+
+def test_dask_job_id_serialization(
+    service_key: ServiceKey,
+    service_version: ServiceVersion,
+    user_id: UserID,
+    project_id: ProjectID,
+    node_id: NodeID,
+):
+    dask_job_id = generate_dask_job_id(
+        service_key, service_version, user_id, project_id, node_id
+    )
+    (
+        parsed_service_key,
+        parsed_service_version,
+        parsed_user_id,
+        parsed_project_id,
+        parsed_node_id,
+    ) = parse_dask_job_id(dask_job_id)
+    assert service_key == parsed_service_key
+    assert service_version == parsed_service_version
+    assert user_id == parsed_user_id
+    assert project_id == parsed_project_id
+    assert node_id == parsed_node_id

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -1091,7 +1091,7 @@ async def _notify_based_on_machine_type(
             await post_tasks_log_message(app, tasks, message=msg, level=logging.INFO)
             await post_tasks_progress_message(
                 app,
-                task=tasks,
+                tasks=tasks,
                 progress=time_since_launch.total_seconds()
                 / instance_max_time_to_start.total_seconds(),
                 progress_type=ProgressType.CLUSTER_UP_SCALING,

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_core.py
@@ -369,8 +369,8 @@ async def _activate_and_notify(
         ),
         post_tasks_log_message(
             app,
-            drained_node.assigned_tasks,
-            "cluster adjusted, service should start shortly...",
+            tasks=drained_node.assigned_tasks,
+            message="cluster adjusted, service should start shortly...",
             level=logging.INFO,
         ),
         post_tasks_progress_message(
@@ -792,8 +792,8 @@ async def _launch_instances(
     except EC2TooManyInstancesError:
         await post_tasks_log_message(
             app,
-            tasks,
-            "The maximum number of machines in the cluster was reached. Please wait for your running jobs "
+            tasks=tasks,
+            message="The maximum number of machines in the cluster was reached. Please wait for your running jobs "
             "to complete and try again later or contact osparc support if this issue does not resolve.",
             level=logging.ERROR,
         )
@@ -834,8 +834,8 @@ async def _launch_instances(
         if isinstance(r, EC2TooManyInstancesError):
             await post_tasks_log_message(
                 app,
-                tasks,
-                "Exceptionally high load on computational cluster, please try again later.",
+                tasks=tasks,
+                message="Exceptionally high load on computational cluster, please try again later.",
                 level=logging.ERROR,
             )
         elif isinstance(r, BaseException):
@@ -850,12 +850,14 @@ async def _launch_instances(
         f"{sum(n for n in capped_needed_machines.values())} new machines launched"
         ", it might take up to 3 minutes to start, Please wait..."
     )
-    await post_tasks_log_message(app, tasks, log_message, level=logging.INFO)
+    await post_tasks_log_message(
+        app, tasks=tasks, message=log_message, level=logging.INFO
+    )
     if last_issue:
         await post_tasks_log_message(
             app,
-            tasks,
-            "Unexpected issues detected, probably due to high load, please contact support",
+            tasks=tasks,
+            message="Unexpected issues detected, probably due to high load, please contact support",
             level=logging.ERROR,
         )
 
@@ -1088,7 +1090,9 @@ async def _notify_based_on_machine_type(
             f" est. remaining time: {timedelta_as_minute_second(estimated_time_to_completion)})...please wait..."
         )
         if tasks:
-            await post_tasks_log_message(app, tasks, message=msg, level=logging.INFO)
+            await post_tasks_log_message(
+                app, tasks=tasks, message=msg, level=logging.INFO
+            )
             await post_tasks_progress_message(
                 app,
                 tasks=tasks,
@@ -1189,8 +1193,8 @@ async def _scale_up_cluster(
     ):
         await post_tasks_log_message(
             app,
-            unassigned_tasks,
-            "service is pending due to missing resources, scaling up cluster now...",
+            tasks=unassigned_tasks,
+            message="service is pending due to missing resources, scaling up cluster now...",
             level=logging.INFO,
         )
         new_pending_instances = await _launch_instances(

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_base.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_base.py
@@ -33,12 +33,6 @@ class BaseAutoscaling(ABC):  # pragma: no cover
 
     @staticmethod
     @abstractmethod
-    async def progress_message_from_tasks(
-        app: FastAPI, tasks: list, progress: float
-    ) -> None: ...
-
-    @staticmethod
-    @abstractmethod
     def get_task_required_resources(task) -> Resources: ...
 
     @staticmethod

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_base.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_base.py
@@ -5,7 +5,6 @@ from aws_library.ec2 import EC2InstanceData, EC2Tags, Resources
 from fastapi import FastAPI
 from models_library.docker import DockerLabelKey
 from models_library.generated_models.docker_rest_api import Node as DockerNode
-from servicelib.logging_utils import LogLevelInt
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
 from ..models import AssociatedInstance
@@ -16,80 +15,67 @@ from ..utils import utils_docker
 class BaseAutoscaling(ABC):  # pragma: no cover
     @staticmethod
     @abstractmethod
-    async def get_monitored_nodes(app: FastAPI) -> list[DockerNode]:
-        ...
+    async def get_monitored_nodes(app: FastAPI) -> list[DockerNode]: ...
 
     @staticmethod
     @abstractmethod
-    def get_ec2_tags(app: FastAPI) -> EC2Tags:
-        ...
+    def get_ec2_tags(app: FastAPI) -> EC2Tags: ...
 
     @staticmethod
     @abstractmethod
     def get_new_node_docker_tags(
         app: FastAPI, ec2_instance_data: EC2InstanceData
-    ) -> dict[DockerLabelKey, str]:
-        ...
+    ) -> dict[DockerLabelKey, str]: ...
 
     @staticmethod
     @abstractmethod
-    async def list_unrunnable_tasks(app: FastAPI) -> list:
-        ...
-
-    @staticmethod
-    @abstractmethod
-    async def log_message_from_tasks(
-        app: FastAPI, tasks: list, message: str, *, level: LogLevelInt
-    ) -> None:
-        ...
+    async def list_unrunnable_tasks(app: FastAPI) -> list: ...
 
     @staticmethod
     @abstractmethod
     async def progress_message_from_tasks(
         app: FastAPI, tasks: list, progress: float
-    ) -> None:
-        ...
+    ) -> None: ...
 
     @staticmethod
     @abstractmethod
-    def get_task_required_resources(task) -> Resources:
-        ...
+    def get_task_required_resources(task) -> Resources: ...
 
     @staticmethod
     @abstractmethod
-    async def get_task_defined_instance(app: FastAPI, task) -> InstanceTypeType | None:
-        ...
+    async def get_task_defined_instance(
+        app: FastAPI, task
+    ) -> InstanceTypeType | None: ...
 
     @staticmethod
     @abstractmethod
     async def compute_node_used_resources(
         app: FastAPI, instance: AssociatedInstance
-    ) -> Resources:
-        ...
+    ) -> Resources: ...
 
     @staticmethod
     @abstractmethod
     async def compute_cluster_used_resources(
         app: FastAPI, instances: list[AssociatedInstance]
-    ) -> Resources:
-        ...
+    ) -> Resources: ...
 
     @staticmethod
     @abstractmethod
     async def compute_cluster_total_resources(
         app: FastAPI, instances: list[AssociatedInstance]
-    ) -> Resources:
-        ...
+    ) -> Resources: ...
 
     @staticmethod
     @abstractmethod
-    async def is_instance_active(app: FastAPI, instance: AssociatedInstance) -> bool:
-        ...
+    async def is_instance_active(
+        app: FastAPI, instance: AssociatedInstance
+    ) -> bool: ...
 
     @staticmethod
     @abstractmethod
-    async def is_instance_retired(app: FastAPI, instance: AssociatedInstance) -> bool:
-        ...
+    async def is_instance_retired(
+        app: FastAPI, instance: AssociatedInstance
+    ) -> bool: ...
 
     @staticmethod
     def is_instance_drained(instance: AssociatedInstance) -> bool:
@@ -97,5 +83,4 @@ class BaseAutoscaling(ABC):  # pragma: no cover
 
     @staticmethod
     @abstractmethod
-    async def try_retire_nodes(app: FastAPI) -> None:
-        ...
+    async def try_retire_nodes(app: FastAPI) -> None: ...

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
@@ -88,12 +88,6 @@ class ComputationalAutoscaling(BaseAutoscaling):
             return []
 
     @staticmethod
-    async def progress_message_from_tasks(app: FastAPI, tasks: list, progress: float):
-        assert app  # nosec
-        assert tasks is not None  # nosec
-        _logger.info("PROGRESS: %s", f"{progress:.2f}")
-
-    @staticmethod
     def get_task_required_resources(task) -> Resources:
         return utils.resources_from_dask_task(task)
 

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_computational.py
@@ -11,7 +11,6 @@ from models_library.docker import (
 )
 from models_library.generated_models.docker_rest_api import Node
 from pydantic import AnyUrl, ByteSize
-from servicelib.logging_utils import LogLevelInt
 from servicelib.utils import logged_gather
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
@@ -87,14 +86,6 @@ class ComputationalAutoscaling(BaseAutoscaling):
                 "No dask scheduler found. TIP: Normal during machine startup."
             )
             return []
-
-    @staticmethod
-    async def log_message_from_tasks(
-        app: FastAPI, tasks: list, message: str, *, level: LogLevelInt
-    ) -> None:
-        assert app  # nosec
-        assert tasks is not None  # nosec
-        _logger.log(level, "LOG: %s", message)
 
     @staticmethod
     async def progress_message_from_tasks(app: FastAPI, tasks: list, progress: float):

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_dynamic.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_dynamic.py
@@ -2,13 +2,12 @@ from aws_library.ec2 import EC2InstanceData, EC2Tags, Resources
 from fastapi import FastAPI
 from models_library.docker import DockerLabelKey
 from models_library.generated_models.docker_rest_api import Node, Task
-from servicelib.logging_utils import LogLevelInt
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
 from ..core.settings import get_application_settings
 from ..models import AssociatedInstance
 from ..utils import utils_docker, utils_ec2
-from ..utils.rabbitmq import log_tasks_message, progress_tasks_message
+from ..utils.rabbitmq import progress_tasks_message
 from .auto_scaling_mode_base import BaseAutoscaling
 from .docker import get_docker_client
 
@@ -43,12 +42,6 @@ class DynamicAutoscaling(BaseAutoscaling):
             get_docker_client(app),
             service_labels=app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_SERVICE_LABELS,
         )
-
-    @staticmethod
-    async def log_message_from_tasks(
-        app: FastAPI, tasks: list, message: str, *, level: LogLevelInt
-    ) -> None:
-        await log_tasks_message(app, tasks, message, level=level)
 
     @staticmethod
     async def progress_message_from_tasks(

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_dynamic.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/auto_scaling_mode_dynamic.py
@@ -7,7 +7,6 @@ from types_aiobotocore_ec2.literals import InstanceTypeType
 from ..core.settings import get_application_settings
 from ..models import AssociatedInstance
 from ..utils import utils_docker, utils_ec2
-from ..utils.rabbitmq import progress_tasks_message
 from .auto_scaling_mode_base import BaseAutoscaling
 from .docker import get_docker_client
 
@@ -42,12 +41,6 @@ class DynamicAutoscaling(BaseAutoscaling):
             get_docker_client(app),
             service_labels=app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_SERVICE_LABELS,
         )
-
-    @staticmethod
-    async def progress_message_from_tasks(
-        app: FastAPI, tasks: list, progress: float
-    ) -> None:
-        await progress_tasks_message(app, tasks, progress=progress)
 
     @staticmethod
     def get_task_required_resources(task) -> Resources:

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
@@ -26,7 +26,7 @@ from ..modules.rabbitmq import post_message
 _logger = logging.getLogger(__name__)
 
 
-async def log_tasks_message(
+async def post_tasks_log_message(
     app: FastAPI,
     tasks: list[DockerTask] | list[DaskTask],
     message: str,
@@ -57,7 +57,7 @@ async def log_tasks_message(
         )
 
 
-async def progress_tasks_message(
+async def post_tasks_progress_message(
     app: FastAPI,
     *,
     tasks: list[DockerTask] | list[DaskTask],
@@ -80,7 +80,7 @@ async def progress_tasks_message(
         await asyncio.gather(
             *(
                 _post_task_progress_message_from_dask_task(
-                    app, cast(DockerTask, task), progress, progress_type
+                    app, cast(DaskTask, task), progress, progress_type
                 )
                 for task in tasks
             ),

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
@@ -37,9 +37,9 @@ def _get_task_ids(task: DockerTask | DaskTask) -> tuple[UserID, ProjectID, NodeI
 
 async def post_tasks_log_message(
     app: FastAPI,
+    *,
     tasks: list[DockerTask] | list[DaskTask],
     message: str,
-    *,
     level: int = logging.INFO,
 ) -> None:
     if not tasks:

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
@@ -1,45 +1,86 @@
 import asyncio
 import logging
+from typing import cast, overload
 
 from aws_library.ec2 import Resources
+from dask_task_models_library.container_tasks.utils import parse_dask_job_id
 from fastapi import FastAPI
 from models_library.docker import StandardSimcoreDockerLabels
-from models_library.generated_models.docker_rest_api import Task
+from models_library.generated_models.docker_rest_api import Task as DockerTask
 from models_library.progress_bar import ProgressReport
+from models_library.projects import ProjectID
+from models_library.projects_nodes_io import NodeID
 from models_library.rabbitmq_messages import (
     LoggerRabbitMessage,
     ProgressRabbitMessageNode,
     ProgressType,
     RabbitAutoscalingStatusMessage,
 )
+from models_library.users import UserID
 from servicelib.logging_utils import log_catch
 
 from ..core.settings import ApplicationSettings, get_application_settings
-from ..models import Cluster
+from ..models import Cluster, DaskTask
 from ..modules.rabbitmq import post_message
 
 logger = logging.getLogger(__name__)
 
 
+@overload
 async def log_tasks_message(
-    app: FastAPI, tasks: list[Task], message: str, *, level: int = logging.INFO
+    app: FastAPI, tasks: list[DockerTask], message: str, *, level: int = logging.INFO
+) -> None: ...
+
+
+@overload
+async def log_tasks_message(
+    app: FastAPI, tasks: list[DaskTask], message: str, *, level: int = logging.INFO
+) -> None: ...
+
+
+async def log_tasks_message(
+    app: FastAPI,
+    tasks: list[DockerTask] | list[DaskTask],
+    message: str,
+    *,
+    level: int = logging.INFO,
 ) -> None:
-    await asyncio.gather(
-        *(post_task_log_message(app, task, message, level) for task in tasks),
-        return_exceptions=True,
-    )
+    if not tasks:
+        return
+    if isinstance(tasks[0], DockerTask):
+        await asyncio.gather(
+            *(
+                _post_task_log_message_from_docker_task(
+                    app, cast(DockerTask, task), message, level
+                )
+                for task in tasks
+            ),
+            return_exceptions=True,
+        )
+    else:
+        await asyncio.gather(
+            *(
+                _post_task_log_message_from_dask_task(
+                    app, cast(DaskTask, task), message, level
+                )
+                for task in tasks
+            ),
+            return_exceptions=True,
+        )
 
 
 async def progress_tasks_message(
-    app: FastAPI, tasks: list[Task], progress: float
+    app: FastAPI, tasks: list[DockerTask], progress: float
 ) -> None:
     await asyncio.gather(
-        *(post_task_progress_message(app, task, progress) for task in tasks),
+        *(_post_task_progress_message(app, task, progress) for task in tasks),
         return_exceptions=True,
     )
 
 
-async def post_task_progress_message(app: FastAPI, task: Task, progress: float) -> None:
+async def _post_task_progress_message(
+    app: FastAPI, task: DockerTask, progress: float
+) -> None:
     with log_catch(logger, reraise=False):
         simcore_label_keys = StandardSimcoreDockerLabels.from_docker_task(task)
         message = ProgressRabbitMessageNode.model_construct(
@@ -52,21 +93,63 @@ async def post_task_progress_message(app: FastAPI, task: Task, progress: float) 
         await post_message(app, message)
 
 
-async def post_task_log_message(app: FastAPI, task: Task, log: str, level: int) -> None:
+async def _post_task_log_message_from_docker_task(
+    app: FastAPI, task: DockerTask, log: str, level: int
+) -> None:
     with log_catch(logger, reraise=False):
         simcore_label_keys = StandardSimcoreDockerLabels.from_docker_task(task)
-        message = LoggerRabbitMessage.model_construct(
-            node_id=simcore_label_keys.node_id,
+        await _post_task_log_message(
+            app,
             user_id=simcore_label_keys.user_id,
             project_id=simcore_label_keys.project_id,
-            messages=[f"[cluster] {log}"],
-            log_level=level,
+            node_id=simcore_label_keys.node_id,
+            log=log,
+            level=level,
         )
-        logger.log(level, message)
-        await post_message(app, message)
 
 
-async def create_autoscaling_status_message(
+async def _post_task_log_message_from_dask_task(
+    app: FastAPI, task: DaskTask, log: str, level: int
+) -> None:
+    with log_catch(logger, reraise=False):
+        (
+            _service_key,
+            _service_version,
+            user_id,
+            project_id,
+            node_id,
+        ) = parse_dask_job_id(task.task_id)
+        await _post_task_log_message(
+            app,
+            user_id=user_id,
+            project_id=project_id,
+            node_id=node_id,
+            log=log,
+            level=level,
+        )
+
+
+async def _post_task_log_message(
+    app: FastAPI,
+    *,
+    user_id: UserID,
+    project_id: ProjectID,
+    node_id: NodeID,
+    log: str,
+    level: int,
+) -> None:
+    message = LoggerRabbitMessage.model_construct(
+        user_id=user_id,
+        project_id=project_id,
+        node_id=node_id,
+        messages=[f"[cluster] {log}"],
+        log_level=level,
+    )
+    logger.log(level, message)
+    await post_message(app, message)
+
+
+async def _create_autoscaling_status_message(
     app_settings: ApplicationSettings,
     cluster: Cluster,
     cluster_total_resources: Resources,
@@ -103,7 +186,7 @@ async def post_autoscaling_status_message(
 ) -> None:
     await post_message(
         app,
-        await create_autoscaling_status_message(
+        await _create_autoscaling_status_message(
             get_application_settings(app),
             cluster,
             cluster_total_resources,

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/rabbitmq.py
@@ -142,12 +142,11 @@ async def _create_autoscaling_status_message(
 ) -> RabbitAutoscalingStatusMessage:
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
 
+    origin = "unknown"
     if app_settings.AUTOSCALING_NODES_MONITORING:
         origin = f"dynamic:node_labels={app_settings.AUTOSCALING_NODES_MONITORING.NODES_MONITORING_NODE_LABELS!s}"
     elif app_settings.AUTOSCALING_DASK:
         origin = f"computational:scheduler_url={app_settings.AUTOSCALING_DASK.DASK_MONITORING_URL!s}"
-    else:
-        origin = "unknown"
 
     total_nodes = (
         len(cluster.active_nodes)

--- a/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/utils_docker.py
@@ -1,6 +1,4 @@
-""" Free helper functions for docker API
-
-"""
+"""Free helper functions for docker API"""
 
 import asyncio
 import collections
@@ -384,7 +382,7 @@ async def compute_cluster_used_resources(
     list_of_used_resources = await logged_gather(
         *(compute_node_used_resources(docker_client, node) for node in nodes)
     )
-    counter = collections.Counter({k: 0 for k in Resources.model_fields})
+    counter = collections.Counter({k: 0 for k in list(Resources.model_fields)})
     for result in list_of_used_resources:
         counter.update(result.model_dump())
 
@@ -413,7 +411,7 @@ async def get_docker_swarm_join_bash_command(*, join_as_drained: bool) -> str:
     decoded_stdout = stdout.decode()
     if match := re.search(_DOCKER_SWARM_JOIN_PATTERN, decoded_stdout):
         capture = match.groupdict()
-        return f"{capture['command']} --availability={'drain' if join_as_drained  else 'active'} {capture['token']} {capture['address']}"
+        return f"{capture['command']} --availability={'drain' if join_as_drained else 'active'} {capture['token']} {capture['address']}"
     msg = f"expected docker '{_DOCKER_SWARM_JOIN_RE}' command not found: received {decoded_stdout}!"
     raise RuntimeError(msg)
 
@@ -445,7 +443,7 @@ def write_compose_file_command(
 ) -> str:
     compose = {
         "services": {
-            f"{image_tag.split('/')[-1].replace(':','-')}": {"image": image_tag}
+            f"{image_tag.split('/')[-1].replace(':', '-')}": {"image": image_tag}
             for n, image_tag in enumerate(docker_tags)
         },
     }

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -322,7 +322,7 @@ def mocked_ec2_instances_envs(
 
 
 @pytest.fixture
-def disable_dynamic_service_background_task(mocker: MockerFixture) -> None:
+def disable_autoscaling_background_task(mocker: MockerFixture) -> None:
     mocker.patch(
         "simcore_service_autoscaling.modules.auto_scaling_task.create_periodic_task",
         autospec=True,

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -866,14 +866,21 @@ def cluster() -> Callable[..., Cluster]:
 @pytest.fixture
 async def create_dask_task(
     dask_spec_cluster_client: distributed.Client,
-) -> Callable[[DaskTaskResources], distributed.Future]:
+) -> Callable[..., distributed.Future]:
     def _remote_pytest_fct(x: int, y: int) -> int:
         return x + y
 
-    def _creator(required_resources: DaskTaskResources) -> distributed.Future:
+    def _creator(
+        required_resources: DaskTaskResources, **overrides
+    ) -> distributed.Future:
         # NOTE: pure will ensure dask does not re-use the task results if we run it several times
         future = dask_spec_cluster_client.submit(
-            _remote_pytest_fct, 23, 43, resources=required_resources, pure=False
+            _remote_pytest_fct,
+            23,
+            43,
+            resources=required_resources,
+            pure=False,
+            **overrides,
         )
         assert future
         return future

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_computational.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_computational.py
@@ -82,7 +82,7 @@ def minimal_configuration(
     local_dask_scheduler_server_envs: EnvVarsDict,
     mocked_ec2_instances_envs: EnvVarsDict,
     disabled_rabbitmq: None,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     disable_buffers_pool_background_task: None,
     mocked_redis_server: None,
 ) -> None: ...

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
@@ -1787,9 +1787,7 @@ async def test__activate_drained_nodes_with_no_tasks(
 ):
     # no tasks, does nothing and returns True
     empty_cluster = cluster()
-    updated_cluster = await _activate_drained_nodes(
-        initialized_app, empty_cluster, DynamicAutoscaling()
-    )
+    updated_cluster = await _activate_drained_nodes(initialized_app, empty_cluster)
     assert updated_cluster == empty_cluster
 
     active_cluster = cluster(
@@ -1801,9 +1799,7 @@ async def test__activate_drained_nodes_with_no_tasks(
             create_associated_instance(drained_host_node, True)  # noqa: FBT003
         ],
     )
-    updated_cluster = await _activate_drained_nodes(
-        initialized_app, active_cluster, DynamicAutoscaling()
-    )
+    updated_cluster = await _activate_drained_nodes(initialized_app, active_cluster)
     assert updated_cluster == active_cluster
     mock_docker_tag_node.assert_not_called()
 
@@ -1855,7 +1851,7 @@ async def test__activate_drained_nodes_with_no_drained_nodes(
         active_nodes=[create_associated_instance(host_node, True)]  # noqa: FBT003
     )
     updated_cluster = await _activate_drained_nodes(
-        initialized_app, cluster_without_drained_nodes, DynamicAutoscaling()
+        initialized_app, cluster_without_drained_nodes
     )
     assert updated_cluster == cluster_without_drained_nodes
     mock_docker_tag_node.assert_not_called()
@@ -1916,7 +1912,7 @@ async def test__activate_drained_nodes_with_drained_node(
     )
 
     updated_cluster = await _activate_drained_nodes(
-        initialized_app, cluster_with_drained_nodes, DynamicAutoscaling()
+        initialized_app, cluster_with_drained_nodes
     )
     # they are the same nodes, but the availability might have changed here
     assert updated_cluster.active_nodes != cluster_with_drained_nodes.drained_nodes

--- a/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
+++ b/services/autoscaling/tests/unit/test_modules_auto_scaling_dynamic.py
@@ -201,7 +201,7 @@ def minimal_configuration(
     enabled_dynamic_mode: EnvVarsDict,
     mocked_ec2_instances_envs: EnvVarsDict,
     disabled_rabbitmq: None,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     disable_buffers_pool_background_task: None,
     mocked_redis_server: None,
 ) -> None: ...
@@ -1075,7 +1075,7 @@ async def test_cluster_scaling_up_and_down_against_aws(
     app_with_docker_join_drained: EnvVarsDict,
     docker_swarm: None,
     disabled_rabbitmq: None,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     disable_buffers_pool_background_task: None,
     mocked_redis_server: None,
     external_envfile_dict: EnvVarsDict,

--- a/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
+++ b/services/autoscaling/tests/unit/test_modules_buffer_machine_core.py
@@ -59,7 +59,7 @@ def with_ec2_instance_allowed_types_env(
 @pytest.fixture
 def minimal_configuration(
     disabled_rabbitmq: None,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     disable_buffers_pool_background_task: None,
     enabled_dynamic_mode: EnvVarsDict,
     mocked_ec2_server_envs: EnvVarsDict,
@@ -509,7 +509,7 @@ async def test_monitor_buffer_machines_terminates_unneeded_pool(
 
 @pytest.fixture
 def pre_pull_images(
-    ec2_instances_allowed_types_with_only_1_buffered: dict[InstanceTypeType, Any]
+    ec2_instances_allowed_types_with_only_1_buffered: dict[InstanceTypeType, Any],
 ) -> list[DockerGenericTag]:
     allowed_ec2_types = ec2_instances_allowed_types_with_only_1_buffered
     allowed_ec2_types_with_pre_pull_images_defined = dict(
@@ -534,7 +534,7 @@ def pre_pull_images(
 async def test_monitor_buffer_machines_against_aws(
     skip_if_external_envfile_dict: None,
     disable_buffers_pool_background_task: None,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     disabled_rabbitmq: None,
     mocked_redis_server: None,
     external_envfile_dict: EnvVarsDict,

--- a/services/autoscaling/tests/unit/test_modules_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_modules_rabbitmq.py
@@ -106,7 +106,7 @@ def test_rabbitmq_initializes(
 
 
 async def test_post_message(
-    disable_dynamic_service_background_task,
+    disable_autoscaling_background_task,
     enabled_rabbitmq: RabbitSettings,
     disabled_ec2: None,
     disabled_ssm: None,

--- a/services/autoscaling/tests/unit/test_utils_auto_scaling_core.py
+++ b/services/autoscaling/tests/unit/test_utils_auto_scaling_core.py
@@ -89,7 +89,7 @@ async def test_associate_ec2_instances_with_nodes_with_no_correspondence(
     nodes = [node() for _ in range(10)]
     ec2_instances = [
         (
-            fake_ec2_instance_data(aws_private_dns=f"ip-10-12-32-{n+1}.internal-data")
+            fake_ec2_instance_data(aws_private_dns=f"ip-10-12-32-{n + 1}.internal-data")
             if valid_ec2_dns
             else fake_ec2_instance_data()
         )
@@ -113,7 +113,7 @@ async def test_associate_ec2_instances_with_corresponding_nodes(
     nodes = []
     ec2_instances = []
     for n in range(10):
-        host_name = f"ip-10-12-32-{n+1}"
+        host_name = f"ip-10-12-32-{n + 1}"
         nodes.append(node(Description={"Hostname": host_name}))
         ec2_instances.append(
             fake_ec2_instance_data(aws_private_dns=f"{host_name}.internal-data")
@@ -143,10 +143,9 @@ def minimal_configuration(
     disabled_rabbitmq: None,
     disabled_ec2: None,
     disabled_ssm: None,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     mocked_redis_server: None,
-) -> None:
-    ...
+) -> None: ...
 
 
 @pytest.fixture
@@ -367,9 +366,9 @@ def test_sort_drained_nodes(
         fake_node = create_fake_node()
         assert fake_node.spec
         assert fake_node.spec.labels
-        fake_node.spec.labels[
-            _OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY
-        ] = arrow.utcnow().datetime.isoformat()
+        fake_node.spec.labels[_OSPARC_NODE_TERMINATION_PROCESS_LABEL_KEY] = (
+            arrow.utcnow().datetime.isoformat()
+        )
         fake_associated_instance = create_associated_instance(
             fake_node,
             terminateable_time=False,

--- a/services/autoscaling/tests/unit/test_utils_docker.py
+++ b/services/autoscaling/tests/unit/test_utils_docker.py
@@ -921,7 +921,7 @@ async def test_find_node_with_name_with_common_prefixed_nodes(
     mocked_aiodocker = mocker.patch.object(autoscaling_docker, "nodes", autospec=True)
     mocked_aiodocker.list.return_value = [
         create_fake_node(
-            Description=NodeDescription(Hostname=f"{common_prefix}{'1'*(i+1)}")
+            Description=NodeDescription(Hostname=f"{common_prefix}{'1' * (i + 1)}")
         )
         for i in range(3)
     ]
@@ -941,7 +941,7 @@ async def test_find_node_with_smaller_name_with_common_prefixed_nodes_returns_no
     mocked_aiodocker = mocker.patch.object(autoscaling_docker, "nodes", autospec=True)
     mocked_aiodocker.list.return_value = [
         create_fake_node(
-            Description=NodeDescription(Hostname=f"{common_prefix}{'1'*(i+1)}")
+            Description=NodeDescription(Hostname=f"{common_prefix}{'1' * (i + 1)}")
         )
         for i in range(3)
     ]
@@ -1022,7 +1022,7 @@ def test_get_new_node_docker_tags(
     disabled_ssm: None,
     mocked_redis_server: None,
     enabled_dynamic_mode: EnvVarsDict,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     app_settings: ApplicationSettings,
     fake_ec2_instance_data: Callable[..., EC2InstanceData],
 ):
@@ -1167,7 +1167,7 @@ async def test_set_node_osparc_ready(
     disabled_ssm: None,
     mocked_redis_server: None,
     enabled_dynamic_mode: EnvVarsDict,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     app_settings: ApplicationSettings,
     autoscaling_docker: AutoscalingDocker,
     host_node: Node,
@@ -1210,7 +1210,7 @@ async def test_set_node_found_empty(
     disabled_ssm: None,
     mocked_redis_server: None,
     enabled_dynamic_mode: EnvVarsDict,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     host_node: Node,
     autoscaling_docker: AutoscalingDocker,
 ):
@@ -1254,7 +1254,7 @@ async def test_set_node_begin_termination_process(
     disabled_ssm: None,
     mocked_redis_server: None,
     enabled_dynamic_mode: EnvVarsDict,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     host_node: Node,
     autoscaling_docker: AutoscalingDocker,
 ):
@@ -1287,7 +1287,7 @@ async def test_attach_node(
     disabled_ssm: None,
     mocked_redis_server: None,
     enabled_dynamic_mode: EnvVarsDict,
-    disable_dynamic_service_background_task: None,
+    disable_autoscaling_background_task: None,
     app_settings: ApplicationSettings,
     autoscaling_docker: AutoscalingDocker,
     host_node: Node,

--- a/services/autoscaling/tests/unit/test_utils_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_utils_rabbitmq.py
@@ -11,24 +11,31 @@ from unittest.mock import AsyncMock
 
 import aiodocker
 import pytest
+from dask_task_models_library.container_tasks.utils import generate_dask_job_id
 from faker import Faker
 from fastapi import FastAPI
 from models_library.docker import DockerLabelKey, StandardSimcoreDockerLabels
 from models_library.generated_models.docker_rest_api import Service, Task
 from models_library.progress_bar import ProgressReport
+from models_library.projects import ProjectID
+from models_library.projects_nodes_io import NodeID
 from models_library.rabbitmq_messages import (
     LoggerRabbitMessage,
     ProgressRabbitMessageNode,
     ProgressType,
 )
+from models_library.services_types import ServiceKey, ServiceVersion
+from models_library.users import UserID
 from pydantic import TypeAdapter
 from pytest_mock.plugin import MockerFixture
 from servicelib.rabbitmq import BIND_TO_ALL_TOPICS, RabbitMQClient
 from settings_library.rabbit import RabbitSettings
+from simcore_service_autoscaling.models import DaskTask
 from simcore_service_autoscaling.utils.rabbitmq import (
     post_tasks_log_message,
     post_tasks_progress_message,
 )
+from tenacity import RetryError, retry_always
 from tenacity.asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
@@ -39,6 +46,13 @@ _TENACITY_RETRY_PARAMS = {
     "retry": retry_if_exception_type(AssertionError),
     "stop": stop_after_delay(30),
     "wait": wait_fixed(0.1),
+}
+
+_TENACITY_STABLE_RETRY_PARAMS = {
+    "reraise": True,
+    "retry": retry_always,
+    "stop": stop_after_delay(3),
+    "wait": wait_fixed(1),
 }
 
 
@@ -97,17 +111,95 @@ async def running_service_tasks(
         )
         assert service.spec
 
-        service_tasks = TypeAdapter(list[Task]).validate_python(
+        docker_tasks = TypeAdapter(list[Task]).validate_python(
             await async_docker_client.tasks.list(filters={"service": service.spec.name})
         )
-        assert service_tasks
-        assert len(service_tasks) == 1
-        return service_tasks
+        assert docker_tasks
+        assert len(docker_tasks) == 1
+        return docker_tasks
 
     return _
 
 
-async def test_post_task_log_message(
+@pytest.fixture
+def service_version() -> ServiceVersion:
+    return "1.0.0"
+
+
+@pytest.fixture
+def service_key() -> ServiceKey:
+    return "simcore/services/dynamic/test"
+
+
+@pytest.fixture
+def node_id(faker: Faker) -> NodeID:
+    return faker.uuid4(cast_to=None)
+
+
+@pytest.fixture
+def project_id(faker: Faker) -> ProjectID:
+    return faker.uuid4(cast_to=None)
+
+
+@pytest.fixture
+def user_id(faker: Faker) -> UserID:
+    return faker.pyint(min_value=1)
+
+
+@pytest.fixture
+def dask_task(
+    service_key: ServiceKey,
+    service_version: ServiceVersion,
+    user_id: UserID,
+    project_id: ProjectID,
+    node_id: NodeID,
+) -> DaskTask:
+    dask_key = generate_dask_job_id(
+        service_key, service_version, user_id, project_id, node_id
+    )
+    return DaskTask(task_id=dask_key, required_resources={})
+
+
+@pytest.fixture
+def dask_task_with_invalid_key(
+    faker: Faker,
+) -> DaskTask:
+    dask_key = faker.pystr()
+    return DaskTask(task_id=dask_key, required_resources={})
+
+
+async def test_post_task_empty_tasks(
+    disable_autoscaling_background_task,
+    disable_buffers_pool_background_task,
+    enabled_rabbitmq: RabbitSettings,
+    disabled_ec2: None,
+    disabled_ssm: None,
+    mocked_redis_server: None,
+    initialized_app: FastAPI,
+    logs_rabbitmq_consumer: AsyncMock,
+    progress_rabbitmq_consumer: AsyncMock,
+):
+    await post_tasks_log_message(initialized_app, tasks=[], message="no tasks")
+    await post_tasks_progress_message(
+        initialized_app,
+        tasks=[],
+        progress=0,
+        progress_type=ProgressType.CLUSTER_UP_SCALING,
+    )
+
+    with pytest.raises(RetryError):  # noqa: PT012
+        async for attempt in AsyncRetrying(**_TENACITY_STABLE_RETRY_PARAMS):
+            with attempt:
+                print(
+                    f"--> checking for message in rabbit exchange {LoggerRabbitMessage.get_channel_name()}, {attempt.retry_state.retry_object.statistics}"
+                )
+
+                logs_rabbitmq_consumer.assert_not_called()
+                progress_rabbitmq_consumer.assert_not_called()
+                print("... no message received")
+
+
+async def test_post_task_log_message_docker(
     disable_autoscaling_background_task,
     disable_buffers_pool_background_task,
     enabled_rabbitmq: RabbitSettings,
@@ -120,13 +212,13 @@ async def test_post_task_log_message(
     faker: Faker,
     logs_rabbitmq_consumer: AsyncMock,
 ):
-    service_tasks = await running_service_tasks(
+    docker_tasks = await running_service_tasks(
         osparc_docker_label_keys.to_simcore_runtime_docker_labels()
     )
-    assert len(service_tasks) == 1
+    assert len(docker_tasks) == 1
     log_message = faker.pystr()
     await post_tasks_log_message(
-        initialized_app, tasks=service_tasks, message=log_message, level=0
+        initialized_app, tasks=docker_tasks, message=log_message, level=0
     )
 
     async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
@@ -148,7 +240,46 @@ async def test_post_task_log_message(
             print("... message received")
 
 
-async def test_post_task_progress_message(
+async def test_post_task_log_message_dask(
+    disable_autoscaling_background_task,
+    disable_buffers_pool_background_task,
+    enabled_rabbitmq: RabbitSettings,
+    disabled_ec2: None,
+    disabled_ssm: None,
+    mocked_redis_server: None,
+    initialized_app: FastAPI,
+    dask_task: DaskTask,
+    user_id: UserID,
+    project_id: ProjectID,
+    node_id: NodeID,
+    faker: Faker,
+    logs_rabbitmq_consumer: AsyncMock,
+):
+    log_message = faker.pystr()
+    await post_tasks_log_message(
+        initialized_app, tasks=[dask_task], message=log_message, level=0
+    )
+
+    async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
+        with attempt:
+            print(
+                f"--> checking for message in rabbit exchange {LoggerRabbitMessage.get_channel_name()}, {attempt.retry_state.retry_object.statistics}"
+            )
+            logs_rabbitmq_consumer.assert_called_once_with(
+                LoggerRabbitMessage(
+                    node_id=node_id,
+                    project_id=project_id,
+                    user_id=user_id,
+                    messages=[f"[cluster] {log_message}"],
+                    log_level=0,
+                )
+                .model_dump_json()
+                .encode()
+            )
+            print("... message received")
+
+
+async def test_post_task_progress_message_docker(
     disable_autoscaling_background_task,
     disable_buffers_pool_background_task,
     enabled_rabbitmq: RabbitSettings,
@@ -161,15 +292,15 @@ async def test_post_task_progress_message(
     faker: Faker,
     progress_rabbitmq_consumer: AsyncMock,
 ):
-    service_tasks = await running_service_tasks(
+    docker_tasks = await running_service_tasks(
         osparc_docker_label_keys.to_simcore_runtime_docker_labels(),
     )
-    assert len(service_tasks) == 1
+    assert len(docker_tasks) == 1
 
     progress_value = faker.pyfloat(min_value=0)
     await post_tasks_progress_message(
         initialized_app,
-        tasks=service_tasks,
+        tasks=docker_tasks,
         progress=progress_value,
         progress_type=ProgressType.CLUSTER_UP_SCALING,
     )
@@ -193,6 +324,48 @@ async def test_post_task_progress_message(
             print("... message received")
 
 
+async def test_post_task_progress_message_dask(
+    disable_autoscaling_background_task,
+    disable_buffers_pool_background_task,
+    enabled_rabbitmq: RabbitSettings,
+    disabled_ec2: None,
+    disabled_ssm: None,
+    mocked_redis_server: None,
+    initialized_app: FastAPI,
+    dask_task: DaskTask,
+    user_id: UserID,
+    project_id: ProjectID,
+    node_id: NodeID,
+    faker: Faker,
+    progress_rabbitmq_consumer: AsyncMock,
+):
+    progress_value = faker.pyfloat(min_value=0)
+    await post_tasks_progress_message(
+        initialized_app,
+        tasks=[dask_task],
+        progress=progress_value,
+        progress_type=ProgressType.CLUSTER_UP_SCALING,
+    )
+
+    async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
+        with attempt:
+            print(
+                f"--> checking for message in rabbit exchange {ProgressRabbitMessageNode.get_channel_name()}, {attempt.retry_state.retry_object.statistics}"
+            )
+            progress_rabbitmq_consumer.assert_called_once_with(
+                ProgressRabbitMessageNode(
+                    node_id=node_id,
+                    project_id=project_id,
+                    user_id=user_id,
+                    progress_type=ProgressType.CLUSTER_UP_SCALING,
+                    report=ProgressReport(actual_value=progress_value, total=1),
+                )
+                .model_dump_json()
+                .encode()
+            )
+            print("... message received")
+
+
 async def test_post_task_messages_does_not_raise_if_service_has_no_labels(
     disable_autoscaling_background_task,
     disable_buffers_pool_background_task,
@@ -204,17 +377,44 @@ async def test_post_task_messages_does_not_raise_if_service_has_no_labels(
     running_service_tasks: Callable[[dict[DockerLabelKey, str]], Awaitable[list[Task]]],
     faker: Faker,
 ):
-    service_tasks = await running_service_tasks({})
-    assert len(service_tasks) == 1
+    docker_tasks = await running_service_tasks({})
+    assert len(docker_tasks) == 1
 
     # this shall not raise any exception even if the task does not contain
     # the necessary labels
     await post_tasks_log_message(
-        initialized_app, tasks=service_tasks, message=faker.pystr(), level=0
+        initialized_app, tasks=docker_tasks, message=faker.pystr(), level=0
     )
     await post_tasks_progress_message(
         initialized_app,
-        tasks=service_tasks,
+        tasks=docker_tasks,
+        progress=faker.pyfloat(min_value=0),
+        progress_type=ProgressType.CLUSTER_UP_SCALING,
+    )
+
+
+async def test_post_task_messages_does_not_raise_if_dask_task_key_is_invalid(
+    disable_autoscaling_background_task,
+    disable_buffers_pool_background_task,
+    enabled_rabbitmq: RabbitSettings,
+    disabled_ec2: None,
+    disabled_ssm: None,
+    mocked_redis_server: None,
+    initialized_app: FastAPI,
+    dask_task_with_invalid_key: DaskTask,
+    faker: Faker,
+):
+    # this shall not raise any exception even if the task does not contain
+    # the necessary labels
+    await post_tasks_log_message(
+        initialized_app,
+        tasks=[dask_task_with_invalid_key],
+        message=faker.pystr(),
+        level=0,
+    )
+    await post_tasks_progress_message(
+        initialized_app,
+        tasks=[dask_task_with_invalid_key],
         progress=faker.pyfloat(min_value=0),
         progress_type=ProgressType.CLUSTER_UP_SCALING,
     )

--- a/services/autoscaling/tests/unit/test_utils_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_utils_rabbitmq.py
@@ -49,7 +49,7 @@ pytest_simcore_ops_services_selection = []
 
 
 async def test_post_task_log_message(
-    disable_dynamic_service_background_task,
+    disable_autoscaling_background_task,
     enabled_rabbitmq: RabbitSettings,
     disabled_ec2: None,
     disabled_ssm: None,
@@ -112,7 +112,7 @@ async def test_post_task_log_message(
 
 
 async def test_post_task_log_message_does_not_raise_if_service_has_no_labels(
-    disable_dynamic_service_background_task,
+    disable_autoscaling_background_task,
     enabled_rabbitmq: RabbitSettings,
     disabled_ec2: None,
     disabled_ssm: None,
@@ -143,7 +143,7 @@ async def test_post_task_log_message_does_not_raise_if_service_has_no_labels(
 
 
 async def test_post_task_progress_message(
-    disable_dynamic_service_background_task,
+    disable_autoscaling_background_task,
     enabled_rabbitmq: RabbitSettings,
     disabled_ec2: None,
     disabled_ssm: None,
@@ -209,7 +209,7 @@ async def test_post_task_progress_message(
 
 
 async def test_post_task_progress_does_not_raise_if_service_has_no_labels(
-    disable_dynamic_service_background_task,
+    disable_autoscaling_background_task,
     enabled_rabbitmq: RabbitSettings,
     disabled_ec2: None,
     disabled_ssm: None,

--- a/services/autoscaling/tests/unit/test_utils_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_utils_rabbitmq.py
@@ -24,8 +24,8 @@ from pytest_mock.plugin import MockerFixture
 from servicelib.rabbitmq import BIND_TO_ALL_TOPICS, RabbitMQClient
 from settings_library.rabbit import RabbitSettings
 from simcore_service_autoscaling.utils.rabbitmq import (
-    post_task_log_message,
-    post_task_progress_message,
+    post_tasks_log_message,
+    post_tasks_progress_message,
 )
 from tenacity.asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
@@ -88,7 +88,9 @@ async def test_post_task_log_message(
     assert len(service_tasks) == 1
 
     log_message = faker.pystr()
-    await post_task_log_message(initialized_app, service_tasks[0], log_message, 0)
+    await post_tasks_log_message(
+        initialized_app, tasks=service_tasks, message=log_message, level=0
+    )
 
     async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
         with attempt:
@@ -135,7 +137,9 @@ async def test_post_task_log_message_does_not_raise_if_service_has_no_labels(
 
     # this shall not raise any exception even if the task does not contain
     # the necessary labels
-    await post_task_log_message(initialized_app, service_tasks[0], faker.pystr(), 0)
+    await post_tasks_log_message(
+        initialized_app, tasks=service_tasks, message=faker.pystr(), level=0
+    )
 
 
 async def test_post_task_progress_message(
@@ -178,7 +182,12 @@ async def test_post_task_progress_message(
     assert len(service_tasks) == 1
 
     progress_value = faker.pyfloat(min_value=0)
-    await post_task_progress_message(initialized_app, service_tasks[0], progress_value)
+    await post_tasks_progress_message(
+        initialized_app,
+        tasks=service_tasks,
+        progress=progress_value,
+        progress_type=ProgressType.CLUSTER_UP_SCALING,
+    )
 
     async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
         with attempt:
@@ -225,6 +234,9 @@ async def test_post_task_progress_does_not_raise_if_service_has_no_labels(
 
     # this shall not raise any exception even if the task does not contain
     # the necessary labels
-    await post_task_progress_message(
-        initialized_app, service_tasks[0], faker.pyfloat(min_value=0)
+    await post_tasks_progress_message(
+        initialized_app,
+        tasks=service_tasks,
+        progress=faker.pyfloat(min_value=0),
+        progress_type=ProgressType.CLUSTER_UP_SCALING,
     )

--- a/services/director-v2/src/simcore_service_director_v2/models/dask_subsystem.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/dask_subsystem.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import TypeAlias
 
 
 # NOTE: mypy fails with src/simcore_service_director_v2/modules/dask_client.py:101:5: error: Dict entry 0 has incompatible type "str": "auto"; expected "Any": "DaskClientTaskState"  [dict-item]
@@ -12,7 +11,3 @@ class DaskClientTaskState(str, Enum):
     ERRED = "ERRED"
     ABORTED = "ABORTED"
     SUCCESS = "SUCCESS"
-
-
-DaskJobID: TypeAlias = str
-DaskResources: TypeAlias = dict[str, int | float]

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -12,6 +12,7 @@ from dask_task_models_library.container_tasks.events import (
     TaskProgressEvent,
 )
 from dask_task_models_library.container_tasks.io import TaskOutputData
+from dask_task_models_library.container_tasks.utils import parse_dask_job_id
 from models_library.clusters import BaseCluster
 from models_library.errors import ErrorDict
 from models_library.projects import ProjectID
@@ -33,7 +34,6 @@ from ...models.comp_tasks import CompTaskAtDB
 from ...models.dask_subsystem import DaskClientTaskState
 from ...utils.dask import (
     clean_task_output_and_log_files_if_invalid,
-    parse_dask_job_id,
     parse_output_data,
 )
 from ...utils.dask_client_utils import TaskHandlers

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -37,6 +37,7 @@ from dask_task_models_library.container_tasks.protocol import (
     LogFileUploadURL,
     TaskOwner,
 )
+from dask_task_models_library.container_tasks.utils import generate_dask_job_id
 from dask_task_models_library.resource_constraints import (
     create_ec2_resource_constraint_key,
 )
@@ -310,7 +311,7 @@ class DaskClient:
 
         list_of_node_id_to_job_id: list[PublishedComputationTask] = []
         for node_id, node_image in tasks.items():
-            job_id = dask_utils.generate_dask_job_id(
+            job_id = generate_dask_job_id(
                 service_key=node_image.name,
                 service_version=node_image.tag,
                 user_id=user_id,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -38,6 +38,7 @@ from dask_task_models_library.container_tasks.protocol import (
     TaskOwner,
 )
 from dask_task_models_library.container_tasks.utils import generate_dask_job_id
+from dask_task_models_library.models import DaskJobID, DaskResources
 from dask_task_models_library.resource_constraints import (
     create_ec2_resource_constraint_key,
 )
@@ -70,7 +71,7 @@ from ..core.errors import (
 from ..core.settings import AppSettings, ComputationalBackendSettings
 from ..models.comp_runs import RunMetadataDict
 from ..models.comp_tasks import Image
-from ..models.dask_subsystem import DaskClientTaskState, DaskJobID, DaskResources
+from ..models.dask_subsystem import DaskClientTaskState
 from ..modules.storage import StorageClient
 from ..utils import dask as dask_utils
 from ..utils.dask_client_utils import (

--- a/services/director-v2/tests/unit/with_dbs/conftest.py
+++ b/services/director-v2/tests/unit/with_dbs/conftest.py
@@ -14,6 +14,7 @@ import arrow
 import pytest
 import sqlalchemy as sa
 from _helpers import PublishedProject, RunningProject
+from dask_task_models_library.container_tasks.utils import generate_dask_job_id
 from faker import Faker
 from fastapi.encoders import jsonable_encoder
 from models_library.projects import ProjectAtDB, ProjectID
@@ -30,7 +31,6 @@ from simcore_service_director_v2.models.comp_runs import (
 )
 from simcore_service_director_v2.models.comp_tasks import CompTaskAtDB, Image
 from simcore_service_director_v2.utils.computations import to_node_class
-from simcore_service_director_v2.utils.dask import generate_dask_job_id
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR improves logging of the autoscaling micro-service w.r.t computational tasks:
- now parse the dask tasks to discover `user_id`, `project_id` and `node_id` so that logs can be published accordingly

The effect is that the autoscaling service in computational mode now also sends minimal log messages into RabbitMQ that can be displayed in the frontend.


This is a pre-requisite to sending events that can be shown for job submission feature.

### Details
- code for generating/parsing dask job id moved from DV-2 to dask-task-models-library
- code now also used in autoscaling
- refactored autoscaling rabbitMQ message publications
- driving tests: `test_utils_rabbitmq.py`

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/6667
<!-- Link pull request to an issue
  SEE https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

- resolves ITISFoundation/osparc-issues#428
- fixes #26
-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops checklist

- [x] No ENV changes or I properly updated ENV ([read the instruction](https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables))

<!-- Some checks that might help your code run stable on production, and help devops assess criticality.
Modified from https://oschvr.com/posts/what-id-like-as-sre/

- How can DevOps check the health of the service ?
- How can DevOps safely and gracefully restart the service ?
- How and why would this code fail ?
- What kind of metrics are you exposing ?
- Is there any documentation/design specification for the service ?
- How (e.g. through which loglines) can DevOps detect unexpected situations that require escalation to human ?
- What are the resource limitations (CPU, RAM) expected for this service ?
- Are all relevant variables documented and adjustable via environment variables (i.e. no hardcoded magic numbers) ?
-->
