### PR TITLE
✨Maintenance: autoscaled clusters allows to write outputs to a file

### DIFF
--- a/scripts/maintenance/computational-clusters/autoscaled_monitor/cli.py
+++ b/scripts/maintenance/computational-clusters/autoscaled_monitor/cli.py
@@ -209,19 +209,5 @@ def check_database_connection() -> None:
     asyncio.run(api.check_database_connection(state))
 
 
-@app.command()
-def terminate_instances(
-    user_id: Annotated[int, typer.Option(help="the user ID")],
-    wallet_id: Annotated[
-        Optional[int | None],  # noqa: UP007 # typer does not understand | syntax
-        typer.Option(help="the wallet ID"),
-    ] = None,
-    *,
-    force: Annotated[bool, typer.Option(help="will not ask for confirmation")] = False,
-) -> None:
-    """this will terminate the instance(s) used for the given user/wallet"""
-    asyncio.run(api.terminate_instances(state, user_id, wallet_id, force=force))
-
-
 if __name__ == "__main__":
     app()

--- a/scripts/maintenance/computational-clusters/autoscaled_monitor/cli.py
+++ b/scripts/maintenance/computational-clusters/autoscaled_monitor/cli.py
@@ -127,9 +127,11 @@ def main(
 
 @app.command()
 def summary(
+    *,
     user_id: Annotated[int, typer.Option(help="filters by the user ID")] = 0,
     wallet_id: Annotated[int, typer.Option(help="filters by the wallet ID")] = 0,
     as_json: Annotated[bool, typer.Option(help="outputs as json")] = False,
+    output: Annotated[Path | None, typer.Option(help="outputs to a file")] = None,
 ) -> None:
     """Show a summary of the current situation of autoscaled EC2 instances.
 
@@ -142,7 +144,13 @@ def summary(
     """
 
     if not asyncio.run(
-        api.summary(state, user_id or None, wallet_id or None, output_json=as_json)
+        api.summary(
+            state,
+            user_id or None,
+            wallet_id or None,
+            output_json=as_json,
+            output=output,
+        )
     ):
         raise typer.Exit(1)
 

--- a/scripts/maintenance/computational-clusters/autoscaled_monitor/cli.py
+++ b/scripts/maintenance/computational-clusters/autoscaled_monitor/cli.py
@@ -209,5 +209,19 @@ def check_database_connection() -> None:
     asyncio.run(api.check_database_connection(state))
 
 
+@app.command()
+def terminate_instances(
+    user_id: Annotated[int, typer.Option(help="the user ID")],
+    wallet_id: Annotated[
+        Optional[int | None],  # noqa: UP007 # typer does not understand | syntax
+        typer.Option(help="the wallet ID"),
+    ] = None,
+    *,
+    force: Annotated[bool, typer.Option(help="will not ask for confirmation")] = False,
+) -> None:
+    """this will terminate the instance(s) used for the given user/wallet"""
+    asyncio.run(api.terminate_instances(state, user_id, wallet_id, force=force))
+
+
 if __name__ == "__main__":
     app()

--- a/scripts/maintenance/computational-clusters/autoscaled_monitor/core.py
+++ b/scripts/maintenance/computational-clusters/autoscaled_monitor/core.py
@@ -786,18 +786,22 @@ async def terminate_instances(
         state, user_id, wallet_id
     )
 
-    if not dynamic_instances:
+    dynamic_autoscaled_instances = await _parse_dynamic_instances(
+        state, dynamic_instances, state.ssh_key_path, user_id, wallet_id
+    )
+
+    if not dynamic_autoscaled_instances:
         rich.print("no instances found")
         raise typer.Exit(0)
 
-    for instance in dynamic_instances:
+    for instance in dynamic_autoscaled_instances:
         rich.print(
-            f"terminating instance {instance.instance_id} with name {utils.get_instance_name(instance)}"
+            f"terminating instance {instance.ec2_instance.instance_id} with name {utils.get_instance_name(instance.ec2_instance)}"
         )
         if force is True or typer.confirm(
-            f"Are you sure you want to terminate instance {instance.instance_id}?"
+            f"Are you sure you want to terminate instance {instance.ec2_instance.instance_id}?"
         ):
-            instance.terminate()
-            rich.print(f"terminated instance {instance.instance_id}")
+            instance.ec2_instance.terminate()
+            rich.print(f"terminated instance {instance.ec2_instance.instance_id}")
         else:
             rich.print("not terminating anything")

--- a/scripts/maintenance/computational-clusters/autoscaled_monitor/core.py
+++ b/scripts/maintenance/computational-clusters/autoscaled_monitor/core.py
@@ -776,32 +776,3 @@ async def trigger_cluster_termination(
 
 async def check_database_connection(state: AppState) -> None:
     await db.check_db_connection(state)
-
-
-async def terminate_instances(
-    state: AppState, user_id: int | None, wallet_id: int | None, *, force: bool
-) -> None:
-    assert state.ec2_resource_autoscaling
-    dynamic_instances = await ec2.list_dynamic_instances_from_ec2(
-        state, user_id, wallet_id
-    )
-
-    dynamic_autoscaled_instances = await _parse_dynamic_instances(
-        state, dynamic_instances, state.ssh_key_path, user_id, wallet_id
-    )
-
-    if not dynamic_autoscaled_instances:
-        rich.print("no instances found")
-        raise typer.Exit(0)
-
-    for instance in dynamic_autoscaled_instances:
-        rich.print(
-            f"terminating instance {instance.ec2_instance.instance_id} with name {utils.get_instance_name(instance.ec2_instance)}"
-        )
-        if force is True or typer.confirm(
-            f"Are you sure you want to terminate instance {instance.ec2_instance.instance_id}?"
-        ):
-            instance.ec2_instance.terminate()
-            rich.print(f"terminated instance {instance.ec2_instance.instance_id}")
-        else:
-            rich.print("not terminating anything")

--- a/scripts/maintenance/computational-clusters/autoscaled_monitor/core.py
+++ b/scripts/maintenance/computational-clusters/autoscaled_monitor/core.py
@@ -728,7 +728,7 @@ async def cancel_jobs(  # noqa: C901, PLR0912
 
 
 async def trigger_cluster_termination(
-    state: AppState, user_id: int, wallet_id: int, *, force: bool
+    state: AppState, user_id: int, wallet_id: int | None, *, force: bool
 ) -> None:
     assert state.ec2_resource_clusters_keeper
     computational_instances = await ec2.list_computational_instances_from_ec2(
@@ -746,6 +746,7 @@ async def trigger_cluster_termination(
         computational_clusters,
         state.environment,
         state.ec2_resource_clusters_keeper.meta.client.meta.region_name,
+        output=None,
     )
     if (force is True) or typer.confirm(
         "Are you sure you want to trigger termination of that cluster?"
@@ -775,3 +776,31 @@ async def trigger_cluster_termination(
 
 async def check_database_connection(state: AppState) -> None:
     await db.check_db_connection(state)
+
+
+async def terminate_instances(
+    state: AppState, user_id: int | None, wallet_id: int | None, *, force: bool
+) -> None:
+    assert state.ec2_resource_autoscaling
+    dynamic_instances = await ec2.list_dynamic_instances_from_ec2(
+        state, user_id, wallet_id
+    )
+    dynamic_autoscaled_instances = await _parse_dynamic_instances(
+        state, dynamic_instances, state.ssh_key_path, user_id, wallet_id
+    )
+
+    if not dynamic_autoscaled_instances:
+        rich.print("no instances found")
+        raise typer.Exit(0)
+
+    for instance in dynamic_autoscaled_instances:
+        rich.print(
+            f"terminating instance {instance.ec2_instance.instance_id} with name {utils.get_instance_name(instance)}"
+        )
+        if force is True or typer.confirm(
+            f"Are you sure you want to terminate instance {instance.ec2_instance.instance_id}?"
+        ):
+            instance.ec2_instance.terminate()
+            rich.print(f"terminated instance {instance.ec2_instance.instance_id}")
+        else:
+            rich.print("not terminating anything")

--- a/scripts/maintenance/computational-clusters/autoscaled_monitor/core.py
+++ b/scripts/maintenance/computational-clusters/autoscaled_monitor/core.py
@@ -785,22 +785,19 @@ async def terminate_instances(
     dynamic_instances = await ec2.list_dynamic_instances_from_ec2(
         state, user_id, wallet_id
     )
-    dynamic_autoscaled_instances = await _parse_dynamic_instances(
-        state, dynamic_instances, state.ssh_key_path, user_id, wallet_id
-    )
 
-    if not dynamic_autoscaled_instances:
+    if not dynamic_instances:
         rich.print("no instances found")
         raise typer.Exit(0)
 
-    for instance in dynamic_autoscaled_instances:
+    for instance in dynamic_instances:
         rich.print(
-            f"terminating instance {instance.ec2_instance.instance_id} with name {utils.get_instance_name(instance)}"
+            f"terminating instance {instance.instance_id} with name {utils.get_instance_name(instance)}"
         )
         if force is True or typer.confirm(
-            f"Are you sure you want to terminate instance {instance.ec2_instance.instance_id}?"
+            f"Are you sure you want to terminate instance {instance.instance_id}?"
         ):
-            instance.ec2_instance.terminate()
-            rich.print(f"terminated instance {instance.ec2_instance.instance_id}")
+            instance.terminate()
+            rich.print(f"terminated instance {instance.instance_id}")
         else:
             rich.print("not terminating anything")


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request introduces enhancements to the `autoscaled_monitor` CLI tool, primarily focusing on adding support for outputting results to a file and improving the flexibility of certain functions. The changes include updates to the `summary` command, modifications to the output handling logic, and adjustments to function parameters for better usability.


### Usage example
```bash
autoscaled-monitor --deploy-config my_osparc summary --as-json --output test.json
```

### Enhancements to output handling:

* Added an optional `output` parameter of type `Path` to the `summary` command in `cli.py`, allowing users to specify a file for saving the command's output. [[1]](diffhunk://#diff-cd78fe84a38b754ca7765cebc4a0d2f8f7e7f474443e133f72ea24a973413d31R130-R134) [[2]](diffhunk://#diff-cd78fe84a38b754ca7765cebc4a0d2f8f7e7f474443e133f72ea24a973413d31L145-R153)
* Updated `_print_dynamic_instances` and `_print_computational_clusters` to write output to a file if the `output` parameter is provided, appending data as needed. Otherwise, the output is printed to the console. [[1]](diffhunk://#diff-d699445e6d7cdedb268604fb980e44797f0ee864ce417b7a1a714a1e9dd711c8R93) [[2]](diffhunk://#diff-d699445e6d7cdedb268604fb980e44797f0ee864ce417b7a1a714a1e9dd711c8R156-R167) [[3]](diffhunk://#diff-d699445e6d7cdedb268604fb980e44797f0ee864ce417b7a1a714a1e9dd711c8R254-R257)
* Enhanced `_print_summary_as_json` to write JSON output to a file if `output` is specified; otherwise, it prints JSON to the console. [[1]](diffhunk://#diff-d699445e6d7cdedb268604fb980e44797f0ee864ce417b7a1a714a1e9dd711c8R429) [[2]](diffhunk://#diff-d699445e6d7cdedb268604fb980e44797f0ee864ce417b7a1a714a1e9dd711c8R476-R489)

### Improvements to parameter flexibility:

* Updated the `trigger_cluster_termination` function to accept `wallet_id` as an optional parameter (`int | None`), providing more flexibility when triggering cluster termination.
* Ensured all relevant functions propagate the new `output` parameter where applicable, maintaining consistency across the codebase. [[1]](diffhunk://#diff-d699445e6d7cdedb268604fb980e44797f0ee864ce417b7a1a714a1e9dd711c8L489-R524) [[2]](diffhunk://#diff-d699445e6d7cdedb268604fb980e44797f0ee864ce417b7a1a714a1e9dd711c8R749)
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
