### PR TITLE
♻️E2e: definite fix to ensure idle timeout is always smaller than waiting timeout

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -13,7 +13,6 @@ from collections.abc import Generator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import Enum, unique
-from pathlib import Path
 from typing import Any, Final
 
 import arrow
@@ -590,7 +589,6 @@ def expected_service_running(
     press_start_button: bool,
     product_url: AnyUrl,
     is_service_legacy: bool,
-    assertion_output_folder: Path,
 ) -> Generator[ServiceRunning, None, None]:
     started = arrow.utcnow()
     with contextlib.ExitStack() as stack:
@@ -647,7 +645,6 @@ def wait_for_service_running(
     press_start_button: bool,
     product_url: AnyUrl,
     is_service_legacy: bool,
-    assertion_output_folder: Path,
 ) -> FrameLocator:
     """NOTE: if the service was already started this will not work as some of the required websocket events will not be emitted again
     In which case this will need further adjutment"""

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -608,6 +608,10 @@ def expected_service_running(
             waiter = SocketIONodeProgressCompleteWaiter(
                 node_id=node_id,
                 logger=ctx.logger,
+                max_idle_timeout=min(
+                    _SOCKET_IO_NODE_PROGRESS_WAITER_MAX_IDLE_TIMEOUT,
+                    timedelta(seconds=timeout / 1000 - 10),
+                ),
             )
             stack.enter_context(
                 websocket.expect_event("framereceived", waiter, timeout=timeout)
@@ -666,6 +670,10 @@ def wait_for_service_running(
             waiter = SocketIONodeProgressCompleteWaiter(
                 node_id=node_id,
                 logger=ctx.logger,
+                max_idle_timeout=min(
+                    _SOCKET_IO_NODE_PROGRESS_WAITER_MAX_IDLE_TIMEOUT,
+                    timedelta(seconds=timeout / 1000 - 10),
+                ),
             )
             stack.enter_context(
                 websocket.expect_event("framereceived", waiter, timeout=timeout)

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright_sim4life.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright_sim4life.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import re
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Final, TypedDict
 
 import arrow
@@ -108,7 +107,6 @@ def wait_for_launched_s4l(
     copy_workspace: bool,
     product_url: AnyUrl,
     is_service_legacy: bool,
-    assertion_output_folder: Path,
 ) -> WaitForS4LDict:
     with log_context(logging.INFO, "launch S4L") as ctx:
         predicate = S4LWaitForWebsocket(logger=ctx.logger)
@@ -136,7 +134,6 @@ def wait_for_launched_s4l(
                 press_start_button=False,
                 product_url=product_url,
                 is_service_legacy=is_service_legacy,
-                assertion_output_folder=assertion_output_folder,
             )
         s4l_websocket = ws_info.value
         ctx.logger.info("acquired S4L websocket!")

--- a/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
@@ -11,7 +11,6 @@ import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Final, Literal
 
 from playwright.sync_api import Page, WebSocket
@@ -73,7 +72,6 @@ def test_jupyterlab(
     large_file_block_size: ByteSize,
     product_url: AnyUrl,
     is_service_legacy: bool,
-    playwright_test_results_dir: Path,
 ):
     # NOTE: this waits for the jupyter to send message, but is not quite enough
     with (
@@ -106,7 +104,6 @@ def test_jupyterlab(
             press_start_button=False,
             product_url=product_url,
             is_service_legacy=is_service_legacy,
-            assertion_output_folder=playwright_test_results_dir,
         )
 
     iframe = page.frame_locator("iframe")

--- a/tests/e2e-playwright/tests/sim4life/test_sim4life.py
+++ b/tests/e2e-playwright/tests/sim4life/test_sim4life.py
@@ -8,7 +8,6 @@
 
 
 from collections.abc import Callable
-from pathlib import Path
 from typing import Any
 
 from playwright.sync_api import Page
@@ -35,7 +34,6 @@ def test_sim4life(
     check_videostreaming: bool,
     product_url: AnyUrl,
     is_service_legacy: bool,
-    playwright_test_results_dir: Path,
 ):
     if use_plus_button:
         project_data = create_project_from_new_button(service_key)
@@ -59,7 +57,6 @@ def test_sim4life(
         copy_workspace=False,
         product_url=product_url,
         is_service_legacy=is_service_legacy,
-        assertion_output_folder=playwright_test_results_dir,
     )
     s4l_websocket = resp["websocket"]
     s4l_iframe = resp["iframe"]

--- a/tests/e2e-playwright/tests/sim4life/test_template.py
+++ b/tests/e2e-playwright/tests/sim4life/test_template.py
@@ -8,7 +8,6 @@
 
 
 from collections.abc import Callable
-from pathlib import Path
 from typing import Any
 
 from playwright.sync_api import Page
@@ -30,7 +29,6 @@ def test_template(
     check_videostreaming: bool,
     product_url: AnyUrl,
     is_service_legacy: bool,
-    playwright_test_results_dir: Path,
 ):
     project_data = create_project_from_template_dashboard(template_id)
 
@@ -49,7 +47,6 @@ def test_template(
         copy_workspace=True,
         product_url=product_url,
         is_service_legacy=is_service_legacy,
-        assertion_output_folder=playwright_test_results_dir,
     )
     s4l_websocket = resp["websocket"]
     s4l_iframe = resp["iframe"]

--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -161,7 +161,6 @@ def test_classic_ti_plan(  # noqa: PLR0915
             press_start_button=False,
             product_url=product_url,
             is_service_legacy=is_service_legacy,
-            assertion_output_folder=playwright_test_results_dir,
         )
         # NOTE: Sometimes this iframe flicks and shows a white page. This wait will avoid it
         page.wait_for_timeout(_ELECTRODE_SELECTOR_FLICKERING_WAIT_TIME)
@@ -227,7 +226,6 @@ def test_classic_ti_plan(  # noqa: PLR0915
                 press_start_button=False,
                 product_url=product_url,
                 is_service_legacy=is_service_legacy,
-                assertion_output_folder=playwright_test_results_dir,
             ) as service_running:
                 app_mode_trigger_next_app(page)
             ti_iframe = service_running.iframe_locator
@@ -345,7 +343,6 @@ def test_classic_ti_plan(  # noqa: PLR0915
                 press_start_button=False,
                 product_url=product_url,
                 is_service_legacy=is_service_legacy,
-                assertion_output_folder=playwright_test_results_dir,
             ) as service_running:
                 app_mode_trigger_next_app(page)
             s4l_postpro_iframe = service_running.iframe_locator


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
