### PR TITLE
🎨 add `WAITING_FOR_RESOURCES` to `get_pipeline_state_from_task_states`

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations_tasks.py
@@ -154,7 +154,7 @@ async def get_task_log_file(
     comp_tasks_repo: Annotated[
         CompTasksRepository, Depends(get_repository(CompTasksRepository))
     ],
-) -> TaskLogFileGet:  # MATUS CHECK
+) -> TaskLogFileGet:
     """Returns a link to download logs file of a give task.
     The log is only available when the task is done
     """

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations_tasks.py
@@ -154,7 +154,7 @@ async def get_task_log_file(
     comp_tasks_repo: Annotated[
         CompTasksRepository, Depends(get_repository(CompTasksRepository))
     ],
-) -> TaskLogFileGet:
+) -> TaskLogFileGet:  # MATUS CHECK
     """Returns a link to download logs file of a give task.
     The log is only available when the task is done
     """

--- a/services/director-v2/src/simcore_service_director_v2/utils/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/computations.py
@@ -26,7 +26,7 @@ _TASK_TO_PIPELINE_CONVERSIONS = {
         RunningState.NOT_STARTED,
         RunningState.WAITING_FOR_CLUSTER,
     ): RunningState.WAITING_FOR_CLUSTER,
-    # if there are tasks waiting for resources, then the pipeline is also waiting for resources
+    # if there are tasks waiting for resources and nothing is running/pending, then the pipeline is also waiting for resources
     (
         RunningState.PUBLISHED,
         RunningState.NOT_STARTED,

--- a/services/director-v2/src/simcore_service_director_v2/utils/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/computations.py
@@ -26,6 +26,12 @@ _TASK_TO_PIPELINE_CONVERSIONS = {
         RunningState.NOT_STARTED,
         RunningState.WAITING_FOR_CLUSTER,
     ): RunningState.WAITING_FOR_CLUSTER,
+    # if there are tasks waiting for resources, then the pipeline is also waiting for resources
+    (
+        RunningState.PUBLISHED,
+        RunningState.NOT_STARTED,
+        RunningState.WAITING_FOR_RESOURCES,
+    ): RunningState.WAITING_FOR_RESOURCES,
     # if there are PENDING states that means the pipeline was published and is awaiting sidecars
     (
         RunningState.PENDING,

--- a/services/director-v2/tests/unit/test_utils_computation.py
+++ b/services/director-v2/tests/unit/test_utils_computation.py
@@ -257,6 +257,15 @@ def fake_task(fake_task_file: Path) -> CompTaskAtDB:
             RunningState.WAITING_FOR_CLUSTER,
             id="published and waiting for cluster = waiting for cluster",
         ),
+        pytest.param(
+            [
+                (RunningState.WAITING_FOR_RESOURCES),
+                (RunningState.PUBLISHED),
+                (RunningState.PUBLISHED),
+            ],
+            RunningState.WAITING_FOR_RESOURCES,
+            id="published and waiting for resources = waiting for resources",
+        ),
     ],
 )
 def test_get_pipeline_state_from_task_states(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- 🎨 add `WAITING_FOR_RESOURCES` to `get_pipeline_state_from_task_states` --> fixing: if task was in state WAITING_FOR_RESOURCES it was reported as ERROR in the Comp runs

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
- relates https://github.com/ITISFoundation/osparc-issues/issues/1645
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
