### PR TITLE
✨ [Frontend] Multiple ``conversations`` per project

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -333,7 +333,7 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
         this.__getBillingPage,
         this.__getServicesUpdatePage,
         this.__getServicesBootOptionsPage,
-        this.__getCommentsPage,
+        this.__getConversationsPage,
         this.__getPermissionsPage,
         this.__getSaveAsTemplatePage,
         this.__getTagsPage,
@@ -509,20 +509,20 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
       return page;
     },
 
-    __getCommentsPage: function() {
+    __getConversationsPage: function() {
       const resourceData = this.__resourceData;
       if (osparc.utils.Resources.isService(resourceData)) {
         return null;
       }
 
-      const id = "Comments";
-      const title = this.tr("Comments");
+      const id = "Conversations";
+      const title = this.tr("Conversations");
       const iconSrc = "@FontAwesome5Solid/comments/22";
       const page = new osparc.dashboard.resources.pages.BasePage(title, iconSrc, id);
       this.__addOpenButton(page);
 
       const lazyLoadContent = () => {
-        const conversations = new osparc.info.Conversations(resourceData);
+        const conversations = new osparc.study.Conversations(resourceData);
         page.addToContent(conversations);
       }
       page.addListenerOnce("appear", lazyLoadContent, this);

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -322,9 +322,17 @@ qx.Class.define("osparc.data.Resources", {
       "conversations": {
         useCache: false,
         endpoints: {
-          get: {
+          addConversation: {
+            method: "POST",
+            url: statics.API + "/projects/{studyId}/conversations"
+          },
+          getPage: {
             method: "GET",
             url: statics.API + "/projects/{studyId}/conversations?offset={offset}&limit={limit}"
+          },
+          addMessage: {
+            method: "POST",
+            url: statics.API + "/projects/{studyId}/conversations/{conversationId}/messages"
           },
         }
       },

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -330,6 +330,10 @@ qx.Class.define("osparc.data.Resources", {
             method: "GET",
             url: statics.API + "/projects/{studyId}/conversations?offset={offset}&limit={limit}"
           },
+          renameConversation: {
+            method: "PUT",
+            url: statics.API + "/projects/{studyId}/conversations/{conversationId}"
+          },
           addMessage: {
             method: "POST",
             url: statics.API + "/projects/{studyId}/conversations/{conversationId}/messages"

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -305,20 +305,6 @@ qx.Class.define("osparc.data.Resources", {
           },
         }
       },
-      "studyComments": {
-        useCache: true,
-        idField: "uuid",
-        endpoints: {
-          getPage: {
-            method: "GET",
-            url: statics.API + "/projects/{studyId}/comments?offset={offset}&limit={limit}"
-          },
-          addComment: {
-            method: "POST",
-            url: statics.API + "/projects/{studyId}/comments"
-          }
-        }
-      },
       "conversations": {
         useCache: false,
         endpoints: {

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -321,7 +321,7 @@ qx.Class.define("osparc.data.Resources", {
             url: statics.API + "/projects/{studyId}/conversations/{conversationId}"
           },
           deleteConversation: {
-            method: "PUT",
+            method: "DELETE",
             url: statics.API + "/projects/{studyId}/conversations/{conversationId}"
           },
           addMessage: {

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -320,6 +320,10 @@ qx.Class.define("osparc.data.Resources", {
             method: "PUT",
             url: statics.API + "/projects/{studyId}/conversations/{conversationId}"
           },
+          deleteConversation: {
+            method: "PUT",
+            url: statics.API + "/projects/{studyId}/conversations/{conversationId}"
+          },
           addMessage: {
             method: "POST",
             url: statics.API + "/projects/{studyId}/conversations/{conversationId}/messages"

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -326,13 +326,17 @@ qx.Class.define("osparc.data.Resources", {
             method: "POST",
             url: statics.API + "/projects/{studyId}/conversations"
           },
-          getPage: {
+          getConversationsPage: {
             method: "GET",
             url: statics.API + "/projects/{studyId}/conversations?offset={offset}&limit={limit}"
           },
           addMessage: {
             method: "POST",
             url: statics.API + "/projects/{studyId}/conversations/{conversationId}/messages"
+          },
+          getMessagesPage: {
+            method: "GET",
+            url: statics.API + "/projects/{studyId}/conversations/{conversationId}/messages?offset={offset}&limit={limit}"
           },
         }
       },

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -319,6 +319,15 @@ qx.Class.define("osparc.data.Resources", {
           }
         }
       },
+      "conversations": {
+        useCache: false,
+        endpoints: {
+          get: {
+            method: "GET",
+            url: statics.API + "/projects/{studyId}/conversations?offset={offset}&limit={limit}"
+          },
+        }
+      },
       "jobs": {
         useCache: false, // handled in osparc.store.Jobs
         endpoints: {

--- a/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
@@ -869,7 +869,7 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
         this.__editSlidesButton.setEnabled(canIWrite);
         const canStart = study.hasSlideshow() || study.getWorkbench().isPipelineLinear();
         this.__startAppButton.setEnabled(canStart);
-        this.__startAppButtonTB.setVisibility(canStart ? "visible" : "hidden");
+        this.__startAppButtonTB.setVisibility(canStart ? "visible" : "excluded");
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
@@ -447,7 +447,7 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
           marginTop: 7,
           ...osparc.navigation.NavigationBar.BUTTON_OPTIONS
         });
-        commentsButton.addListener("execute", () => osparc.info.Conversations.popUpInWindow(study.serialize()));
+        commentsButton.addListener("execute", () => osparc.study.Conversations.popUpInWindow(study.serialize()));
         topBar.add(commentsButton);
       }
 

--- a/services/static-webserver/client/source/class/osparc/info/CommentAdd.js
+++ b/services/static-webserver/client/source/class/osparc/info/CommentAdd.js
@@ -21,7 +21,7 @@ qx.Class.define("osparc.info.CommentAdd", {
 
   /**
     * @param studyId {String} Study Id
-    * @param conversationId {int} Conversation Id
+    * @param conversationId {String} Conversation Id
     */
   construct: function(studyId, conversationId = null) {
     this.base(arguments);
@@ -120,7 +120,10 @@ qx.Class.define("osparc.info.CommentAdd", {
         } else {
           // create new conversation first
           this.__addConversation()
-            .then(() => this.__addComment())
+            .then(data => {
+              this.__conversationId = data["conversationId"];
+              this.__addComment();
+            })
         }
       });
     },
@@ -135,12 +138,13 @@ qx.Class.define("osparc.info.CommentAdd", {
             conversationId: this.__conversationId,
           },
           data: {
-            "contents": comment
+            "content": comment,
+            "type": "MESSAGE",
           }
         };
         osparc.data.Resources.fetch("conversations", "addMessage", params)
-          .then(() => {
-            this.fireEvent("commentAdded");
+          .then(data => {
+            this.fireDataEvent("commentAdded", data);
             commentField.getChildControl("text-area").setValue("");
           })
           .catch(err => osparc.FlashMessenger.logError(err));

--- a/services/static-webserver/client/source/class/osparc/info/CommentAdd.js
+++ b/services/static-webserver/client/source/class/osparc/info/CommentAdd.js
@@ -138,22 +138,11 @@ qx.Class.define("osparc.info.CommentAdd", {
       const commentField = this.getChildControl("comment-field");
       const comment = commentField.getChildControl("text-area").getValue();
       if (comment) {
-        const params = {
-          url: {
-            studyId: this.__studyId,
-            conversationId: this.__conversationId,
-          },
-          data: {
-            "content": comment,
-            "type": "MESSAGE",
-          }
-        };
-        osparc.data.Resources.fetch("conversations", "addMessage", params)
+        osparc.study.Conversations.addMessage(this.__studyId, this.__conversationId, comment)
           .then(data => {
             this.fireDataEvent("commentAdded", data);
             commentField.getChildControl("text-area").setValue("");
-          })
-          .catch(err => osparc.FlashMessenger.logError(err));
+          });
       }
     },
   }

--- a/services/static-webserver/client/source/class/osparc/info/CommentAdd.js
+++ b/services/static-webserver/client/source/class/osparc/info/CommentAdd.js
@@ -119,7 +119,7 @@ qx.Class.define("osparc.info.CommentAdd", {
           this.__addComment();
         } else {
           // create new conversation first
-          this.__addConversation()
+          osparc.study.Conversations.addConversation(this.__studyId)
             .then(data => {
               this.__conversationId = data["conversationId"];
               this.__addComment();
@@ -150,19 +150,5 @@ qx.Class.define("osparc.info.CommentAdd", {
           .catch(err => osparc.FlashMessenger.logError(err));
       }
     },
-
-    __addConversation: function() {
-      const params = {
-        url: {
-          studyId: this.__studyId,
-        },
-        data: {
-          "name": "hello 1",
-          "type": "PROJECT_STATIC",
-        }
-      };
-      return osparc.data.Resources.fetch("conversations", "addConversation", params)
-        .catch(err => osparc.FlashMessenger.logError(err));
-    }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/info/CommentAdd.js
+++ b/services/static-webserver/client/source/class/osparc/info/CommentAdd.js
@@ -96,13 +96,19 @@ qx.Class.define("osparc.info.CommentAdd", {
           });
           break;
         }
+        case "buttons-layout": {
+          control = new qx.ui.container.Composite(new qx.ui.layout.HBox(5).set({
+            alignX: "right"
+          }));
+          this._add(control);
+          break;
+        }
         case "add-comment-button": {
-          control = new qx.ui.form.Button(this.tr("Add")).set({
+          control = new qx.ui.form.Button(this.tr("Add message")).set({
             appearance: "form-button",
             allowGrowX: false,
-            alignX: "right"
           });
-          this._add(control);
+          this.getChildControl("buttons-layout").add(control);
           break;
         }
       }

--- a/services/static-webserver/client/source/class/osparc/info/CommentUI.js
+++ b/services/static-webserver/client/source/class/osparc/info/CommentUI.js
@@ -41,7 +41,7 @@ qx.Class.define("osparc.info.CommentUI", {
     __comment: null,
 
     __isMyComment: function() {
-      return this.__comment && osparc.auth.Data.getInstance().getUserId() === this.__comment["user_id"];
+      return this.__comment && osparc.auth.Data.getInstance().getGroupId() === this.__comment["userGroupId"];
     },
 
     _createChildControlImpl: function(id) {
@@ -85,7 +85,6 @@ qx.Class.define("osparc.info.CommentUI", {
           break;
         case "comment-content":
           control = new osparc.ui.markdown.Markdown().set({
-            // backgroundColor: "background-main-2",
             decorator: "rounded",
             noMargin: true,
             paddingLeft: 8,
@@ -125,9 +124,9 @@ qx.Class.define("osparc.info.CommentUI", {
       lastUpdate.setValue(date2);
 
       const commentContent = this.getChildControl("comment-content");
-      commentContent.setValue(this.__comment["contents"]);
+      commentContent.setValue(this.__comment["content"]);
 
-      const user = osparc.store.Groups.getInstance().getUserByUserId(this.__comment["user_id"])
+      const user = osparc.store.Groups.getInstance().getUserByGroupId(this.__comment["userGroupId"])
       if (user) {
         thumbnail.setSource(user.getThumbnail());
         userName.setValue(user.getLabel());

--- a/services/static-webserver/client/source/class/osparc/info/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/info/Conversation.js
@@ -36,6 +36,27 @@ qx.Class.define("osparc.info.Conversation", {
       showCloseButton: false,
     });
 
+    const tabButton = this.getChildControl("button").set({
+      cursor: "text",
+    });
+    tabButton.addListener("execute", () => {
+      const titleEditor = new osparc.widget.Renamer(tabButton.getLabel());
+      titleEditor.addListener("labelChanged", e => {
+        titleEditor.close();
+        const newLabel = e.getData()["newLabel"];
+        if (this.__conversationId) {
+          this.__renameConversation(newLabel);
+        } else {
+          // create new conversation first
+          osparc.study.Conversations.addConversation(this.__studyId)
+            .then(data => {
+              this.__conversationId = data["conversationId"];
+              this.__renameConversation(newLabel);
+            })
+        }
+      }, this);
+    });
+
     this.__buildLayout();
 
     this.fetchMessages();
@@ -135,6 +156,13 @@ qx.Class.define("osparc.info.Conversation", {
         const messageUi = new osparc.info.CommentUI(message);
         this.__messagesList.add(messageUi);
       });
+    },
+
+    __renameConversation: function(newLabel) {
+      osparc.study.Conversations.renameConversation(this.__studyId, this.__conversationId, newLabel)
+        .then(() => {
+          this.getChildControl("button").setLabel(newLabel);
+        });
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/info/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/info/Conversation.js
@@ -147,7 +147,7 @@ qx.Class.define("osparc.info.Conversation", {
         addMessages.setPaddingLeft(10);
         addMessages.addListener("commentAdded", e => {
           const data = e.getData();
-          if (this.getConversationId()) {
+          if (data["conversationId"]) {
             this.setConversationId(data["conversationId"]);
           }
           this.fetchMessages();
@@ -158,11 +158,13 @@ qx.Class.define("osparc.info.Conversation", {
 
     fetchMessages: function(removeMessages = true) {
       if (this.getConversationId() === null) {
+        this.__messagesTitle.setValue(this.tr("No messages yet"));
         this.__messagesList.hide();
         this.__loadMoreMessages.hide();
         return;
       }
 
+      this.__messagesList.show();
       this.__loadMoreMessages.show();
       this.__loadMoreMessages.setFetching(true);
 

--- a/services/static-webserver/client/source/class/osparc/info/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/info/Conversation.js
@@ -65,7 +65,7 @@ qx.Class.define("osparc.info.Conversation", {
       this._add(this.__loadMoreComments);
 
       if (osparc.data.model.Study.canIWrite(this.__studyData["accessRights"])) {
-        const addComments = new osparc.info.CommentAdd(this.__studyData["uuid"]);
+        const addComments = new osparc.info.CommentAdd(this.__studyData["uuid"], this.__conversationId);
         addComments.setPaddingLeft(10);
         addComments.addListener("commentAdded", () => this.fetchComments());
         this._add(addComments);

--- a/services/static-webserver/client/source/class/osparc/info/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/info/Conversation.js
@@ -45,16 +45,21 @@ qx.Class.define("osparc.info.Conversation", {
         titleEditor.close();
         const newLabel = e.getData()["newLabel"];
         if (this.__conversationId) {
-          this.__renameConversation(newLabel);
+          osparc.study.Conversations.renameConversation(this.__studyData["uuid"], this.__conversationId, newLabel)
+            .then(() => {
+              this.getChildControl("button").setLabel(newLabel);
+            });
         } else {
           // create new conversation first
-          osparc.study.Conversations.addConversation(this.__studyId)
+          osparc.study.Conversations.addConversation(this.__studyData["uuid"], newLabel)
             .then(data => {
               this.__conversationId = data["conversationId"];
-              this.__renameConversation(newLabel);
-            })
+              this.getChildControl("button").setLabel(newLabel);
+            });
         }
       }, this);
+      titleEditor.center();
+      titleEditor.open();
     });
 
     this.__buildLayout();
@@ -157,12 +162,5 @@ qx.Class.define("osparc.info.Conversation", {
         this.__messagesList.add(messageUi);
       });
     },
-
-    __renameConversation: function(newLabel) {
-      osparc.study.Conversations.renameConversation(this.__studyId, this.__conversationId, newLabel)
-        .then(() => {
-          this.getChildControl("button").setLabel(newLabel);
-        });
-    }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/info/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/info/Conversation.js
@@ -107,7 +107,7 @@ qx.Class.define("osparc.info.Conversation", {
 
       const trashButton = new qx.ui.form.Button(null, "@FontAwesome5Solid/times/12").set({
         ...buttonsAesthetics,
-        paddingLeft: 4,
+        paddingLeft: 4, // adds spacing between buttons
       });
       trashButton.addListener("execute", () => {
         osparc.study.Conversations.deleteConversation(this.__studyData["uuid"], this.getConversationId())

--- a/services/static-webserver/client/source/class/osparc/info/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/info/Conversation.js
@@ -1,0 +1,133 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2023 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+
+qx.Class.define("osparc.info.Conversation", {
+  extend: qx.ui.tabview.Page,
+
+  /**
+    * @param studyData {String} Study Data
+    * @param conversationId {int} Conversation Id
+    */
+  construct: function(studyData, conversationId = null) {
+    this.base(arguments);
+
+    this.__studyData = studyData;
+    this.__conversationId = conversationId;
+
+    this._setLayout(new qx.ui.layout.VBox(10));
+
+    this.set({
+      padding: 10,
+      showCloseButton: false,
+    });
+
+    this.__buildLayout();
+
+    this.fetchComments();
+  },
+
+  members: {
+    __studyData: null,
+    __conversationId: null,
+    __nextRequestParams: null,
+    __commentsTitle: null,
+    __commentsList: null,
+    __loadMoreComments: null,
+
+    __buildLayout: function() {
+      this.__commentsTitle = new qx.ui.basic.Label();
+      this._add(this.__commentsTitle);
+
+      this.__commentsList = new qx.ui.container.Composite(new qx.ui.layout.VBox(5)).set({
+        alignY: "middle"
+      });
+      this._add(this.__commentsList, {
+        flex: 1
+      });
+
+      this.__loadMoreComments = new osparc.ui.form.FetchButton(this.tr("Load more comments..."));
+      this.__loadMoreComments.addListener("execute", () => this.fetchComments(false));
+      this._add(this.__loadMoreComments);
+
+      if (osparc.data.model.Study.canIWrite(this.__studyData["accessRights"])) {
+        const addComments = new osparc.info.CommentAdd(this.__studyData["uuid"]);
+        addComments.setPaddingLeft(10);
+        addComments.addListener("commentAdded", () => this.fetchComments());
+        this._add(addComments);
+      }
+    },
+
+    fetchComments: function(removeComments = true) {
+      if (this.__conversationId === null) {
+        this.__commentsList.hide();
+        this.__loadMoreComments.hide();
+        return;
+      }
+
+      this.__loadMoreComments.show();
+      this.__loadMoreComments.setFetching(true);
+
+      if (removeComments) {
+        this.__commentsList.removeAll();
+      }
+
+      this.__getNextRequest()
+        .then(resp => {
+          const comments = resp["data"];
+          this.__addComments(comments);
+          this.__nextRequestParams = resp["_links"]["next"];
+          if (this.__nextRequestParams === null) {
+            this.__loadMoreComments.exclude();
+          }
+        })
+        .finally(() => this.__loadMoreComments.setFetching(false));
+    },
+
+    __getNextRequest: function() {
+      const params = {
+        url: {
+          studyId: this.__studyData["uuid"],
+          offset: 0,
+          limit: 20
+        }
+      };
+      const nextRequestParams = this.__nextRequestParams;
+      if (nextRequestParams) {
+        params.url.offset = nextRequestParams.offset;
+        params.url.limit = nextRequestParams.limit;
+      }
+      const options = {
+        resolveWResponse: true
+      };
+      return osparc.data.Resources.fetch("studyComments", "getPage", params, options);
+    },
+
+    __addComments: function(comments) {
+      if (comments.length === 1) {
+        this.__commentsTitle.setValue(this.tr("1 Comment"));
+      } else if (comments.length > 1) {
+        this.__commentsTitle.setValue(comments.length + this.tr(" Comments"));
+      }
+
+      comments.forEach(comment => {
+        const commentUi = new osparc.info.CommentUI(comment);
+        this.__commentsList.add(commentUi);
+      });
+    }
+  }
+});

--- a/services/static-webserver/client/source/class/osparc/info/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/info/Conversation.js
@@ -114,8 +114,26 @@ qx.Class.define("osparc.info.Conversation", {
         paddingLeft: 4, // adds spacing between buttons
       });
       trashButton.addListener("execute", () => {
-        osparc.study.Conversations.deleteConversation(this.__studyData["uuid"], this.getConversationId())
-          .then(() => this.fireEvent("conversationDeleted"));
+        const deleteConversation = () => {
+          osparc.study.Conversations.deleteConversation(this.__studyData["uuid"], this.getConversationId())
+            .then(() => this.fireEvent("conversationDeleted"));
+        }
+        if (this.__messagesList.getChildren().length === 0) {
+          deleteConversation();
+        } else {
+          const msg = this.tr("Are you sure you want to delete the conversation?");
+          const confirmationWin = new osparc.ui.window.Confirmation(msg).set({
+            caption: this.tr("Delete Conversation"),
+            confirmText: this.tr("Delete"),
+            confirmAction: "delete"
+          });
+          confirmationWin.open();
+          confirmationWin.addListener("close", () => {
+            if (confirmationWin.getConfirmed()) {
+              deleteConversation();
+            }
+          }, this);
+        }
       });
       // eslint-disable-next-line no-underscore-dangle
       tabButton._add(trashButton, {

--- a/services/static-webserver/client/source/class/osparc/info/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/info/Conversation.js
@@ -58,6 +58,10 @@ qx.Class.define("osparc.info.Conversation", {
     },
   },
 
+  events: {
+    "conversationDeleted": "qx.event.type.Event",
+  },
+
   members: {
     __studyData: null,
     __nextRequestParams: null,
@@ -74,7 +78,7 @@ qx.Class.define("osparc.info.Conversation", {
         padding: 0,
         backgroundColor: "transparent",
       };
-      const renameButton = new qx.ui.form.Button(null, "@FontAwesome5Solid/pencil-alt/12").set({
+      const renameButton = new qx.ui.form.Button(null, "@FontAwesome5Solid/pencil-alt/10").set({
         ...buttonsAesthetics,
       });
       renameButton.addListener("execute", () => {
@@ -111,6 +115,7 @@ qx.Class.define("osparc.info.Conversation", {
       });
       trashButton.addListener("execute", () => {
         osparc.study.Conversations.deleteConversation(this.__studyData["uuid"], this.getConversationId())
+          .then(() => this.fireEvent("conversationDeleted"));
       });
       // eslint-disable-next-line no-underscore-dangle
       tabButton._add(trashButton, {

--- a/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/StudyTitleWOptions.js
@@ -80,7 +80,7 @@ qx.Class.define("osparc.navigation.StudyTitleWOptions", {
             label: this.tr("Conversations"),
             icon: "@FontAwesome5Solid/comments/12",
           });
-          control.addListener("execute", () => osparc.info.Conversations.popUpInWindow(this.getStudy().serialize()), this);
+          control.addListener("execute", () => osparc.study.Conversations.popUpInWindow(this.getStudy().serialize()), this);
           break;
         case "study-menu-convert-to-pipeline":
           control = new qx.ui.menu.Button().set({

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -93,7 +93,7 @@ qx.Class.define("osparc.store.Store", {
       check: "Array",
       init: []
     },
-    studyComments: {
+    conversations: {
       check: "Array",
       init: []
     },

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -52,7 +52,7 @@ qx.Class.define("osparc.study.Conversations", {
           conversationId,
         },
       };
-      return osparc.data.Resources.fetch("conversations", "addConversation", params)
+      return osparc.data.Resources.fetch("conversations", "deleteConversation", params)
         .catch(err => osparc.FlashMessenger.logError(err));
     },
 
@@ -94,6 +94,7 @@ qx.Class.define("osparc.study.Conversations", {
       const loadMoreButton = this.getChildControl("loading-button");
       loadMoreButton.setFetching(true);
 
+      const conversationsLayout = this.getChildControl("conversations-layout");
       const params = {
         url: {
           studyId: studyData["uuid"],
@@ -103,16 +104,23 @@ qx.Class.define("osparc.study.Conversations", {
       };
       osparc.data.Resources.fetch("conversations", "getConversationsPage", params)
         .then(conversations => {
-          const conversationsLayout = this.getChildControl("conversations-layout");
           if (conversations.length === 0) {
             const noConversationTab = new osparc.info.Conversation(studyData);
             noConversationTab.setLabel(this.tr("new 1"));
+            noConversationTab.addListener("conversationDeleted", () => {
+              this._removeAll();
+              this.fetchConversations(studyData);
+            });
             conversationsLayout.add(noConversationTab);
           } else {
             conversations.forEach(conversation => {
               const conversationId = conversation["conversationId"];
               const conversationTab = new osparc.info.Conversation(studyData, conversationId);
               conversationTab.setLabel(conversation["name"]);
+              conversationTab.addListener("conversationDeleted", () => {
+                this._removeAll();
+                this.fetchConversations(studyData);
+              });
               conversationsLayout.add(conversationTab);
             });
           }

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -94,7 +94,6 @@ qx.Class.define("osparc.study.Conversations", {
       const loadMoreButton = this.getChildControl("loading-button");
       loadMoreButton.setFetching(true);
 
-      const conversationsLayout = this.getChildControl("conversations-layout");
       const params = {
         url: {
           studyId: studyData["uuid"],
@@ -103,32 +102,37 @@ qx.Class.define("osparc.study.Conversations", {
         }
       };
       osparc.data.Resources.fetch("conversations", "getConversationsPage", params)
-        .then(conversations => {
-          if (conversations.length === 0) {
-            const noConversationTab = new osparc.info.Conversation(studyData);
-            noConversationTab.setLabel(this.tr("new 1"));
-            noConversationTab.addListener("conversationDeleted", () => {
-              this._removeAll();
-              this.fetchConversations(studyData);
-            });
-            conversationsLayout.add(noConversationTab);
-          } else {
-            conversations.forEach(conversation => {
-              const conversationId = conversation["conversationId"];
-              const conversationTab = new osparc.info.Conversation(studyData, conversationId);
-              conversationTab.setLabel(conversation["name"]);
-              conversationTab.addListener("conversationDeleted", () => {
-                this._removeAll();
-                this.fetchConversations(studyData);
-              });
-              conversationsLayout.add(conversationTab);
-            });
-          }
-        })
+        .then(conversations => this.__addConversations(conversations, studyData))
         .finally(() => {
           loadMoreButton.setFetching(false);
           loadMoreButton.exclude();
         });
     },
+
+    __addConversations: function(conversations, studyData) {
+      const conversationsLayout = this.getChildControl("conversations-layout");
+      if (conversations.length === 0) {
+        const noConversationTab = new osparc.info.Conversation(studyData);
+        noConversationTab.setLabel(this.tr("new 1"));
+        noConversationTab.addListener("conversationDeleted", () => {
+          this._removeAll();
+          this.fetchConversations(studyData);
+        });
+        conversationsLayout.add(noConversationTab);
+      } else {
+        conversations.forEach(conversation => {
+          const conversationId = conversation["conversationId"];
+          const conversationTab = new osparc.info.Conversation(studyData, conversationId);
+          conversationTab.setLabel(conversation["name"]);
+          conversationTab.addListener("conversationDeleted", () => {
+            this._removeAll();
+            this.fetchConversations(studyData);
+          });
+          conversationsLayout.add(conversationTab);
+        });
+      }
+      const newConversation = new qx.ui.tabview.Page(null, "@FontAwesome5Solid/plus/12");
+      conversationsLayout.add(newConversation);
+    }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -78,6 +78,21 @@ qx.Class.define("osparc.study.Conversations", {
       return osparc.data.Resources.fetch("conversations", "renameConversation", params)
         .catch(err => osparc.FlashMessenger.logError(err));
     },
+
+    addMessage: function(studyId, conversationId, message) {
+      const params = {
+        url: {
+          studyId,
+          conversationId,
+        },
+        data: {
+          "content": message,
+          "type": "MESSAGE",
+        }
+      };
+      osparc.data.Resources.fetch("conversations", "addMessage", params)
+        .catch(err => osparc.FlashMessenger.logError(err));
+    },
   },
 
   members: {

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -131,8 +131,17 @@ qx.Class.define("osparc.study.Conversations", {
           conversationsLayout.add(conversationTab);
         });
       }
-      const newConversation = new qx.ui.tabview.Page(null, "@FontAwesome5Solid/plus/12");
-      conversationsLayout.add(newConversation);
-    }
+
+      const newConversationButton = new qx.ui.form.Button().set({
+        icon: "@FontAwesome5Solid/plus/12",
+        toolTipText: this.tr("Add new conversation"),
+        allowGrowX: false,
+        backgroundColor: "transparent",
+      });
+      newConversationButton.addListener("execute", () => {
+        osparc.study.Conversations.addConversation(studyData["uuid"], "new " + (conversations.length + 1))
+      });
+      conversationsLayout.getChildControl("bar").add(newConversationButton);
+    },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -31,6 +31,15 @@ qx.Class.define("osparc.study.Conversations", {
   },
 
   statics: {
+    popUpInWindow: function(studyData) {
+      const conversations = new osparc.study.Conversations(studyData);
+      const title = qx.locale.Manager.tr("Conversations");
+      const viewWidth = 600;
+      const viewHeight = 700;
+      const win = osparc.ui.window.Window.popUpInWindow(conversations, title, viewWidth, viewHeight);
+      return win;
+    },
+
     addConversation: function(studyId, name = "new 1") {
       const params = {
         url: {

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -60,7 +60,7 @@ qx.Class.define("osparc.study.Conversations", {
           limit: 42,
         }
       };
-      osparc.data.Resources.fetch("conversations", "get", params)
+      osparc.data.Resources.fetch("conversations", "getPage", params)
         .then(conversations => {
           const conversationsLayout = this.getChildControl("conversations-layout");
           console.log("Conversations fetched", conversations);

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -45,6 +45,17 @@ qx.Class.define("osparc.study.Conversations", {
         .catch(err => osparc.FlashMessenger.logError(err));
     },
 
+    deleteConversation: function(studyId, conversationId) {
+      const params = {
+        url: {
+          studyId,
+          conversationId,
+        },
+      };
+      return osparc.data.Resources.fetch("conversations", "addConversation", params)
+        .catch(err => osparc.FlashMessenger.logError(err));
+    },
+
     renameConversation: function(studyId, conversationId, name) {
       const params = {
         url: {

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -16,7 +16,7 @@
 ************************************************************************ */
 
 
-qx.Class.define("osparc.info.Conversations", {
+qx.Class.define("osparc.study.Conversations", {
   extend: qx.ui.core.Widget,
 
   /**
@@ -31,12 +31,13 @@ qx.Class.define("osparc.info.Conversations", {
 
     this.__buildLayout();
 
+    // this.fetchConversations();
     this.fetchComments();
   },
 
   statics: {
     popUpInWindow: function(studyData) {
-      const conversations = new osparc.info.Conversations(studyData);
+      const conversations = new osparc.study.Conversations(studyData);
       const title = qx.locale.Manager.tr("Conversations");
       const viewWidth = 600;
       const viewHeight = 700;
@@ -91,6 +92,9 @@ qx.Class.define("osparc.info.Conversations", {
       this.getChildControl("add-comment");
     },
 
+    fetchConversations: function() {
+    },
+
     fetchComments: function(removeComments = true) {
       const loadMoreButton = this.getChildControl("load-more-button");
       loadMoreButton.show();
@@ -116,8 +120,9 @@ qx.Class.define("osparc.info.Conversations", {
       const params = {
         url: {
           studyId: this.__studyData["uuid"],
+          conversationId: this.__studyData["uuid"],
           offset: 0,
-          limit: 20
+          limit: 40
         }
       };
       const nextRequestParams = this.__nextRequestParams;

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -93,7 +93,6 @@ qx.Class.define("osparc.study.Conversations", {
       osparc.data.Resources.fetch("conversations", "getConversationsPage", params)
         .then(conversations => {
           const conversationsLayout = this.getChildControl("conversations-layout");
-          console.log("Conversations fetched", conversations);
           if (conversations.length === 0) {
             const noConversationTab = new osparc.info.Conversation(studyData);
             noConversationTab.setLabel(this.tr("new 1"));

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -30,6 +30,36 @@ qx.Class.define("osparc.study.Conversations", {
     this.fetchConversations(studyData);
   },
 
+  statics: {
+    addConversation: function(studyId, name = "new 1") {
+      const params = {
+        url: {
+          studyId,
+        },
+        data: {
+          name,
+          "type": "PROJECT_STATIC",
+        }
+      };
+      return osparc.data.Resources.fetch("conversations", "addConversation", params)
+        .catch(err => osparc.FlashMessenger.logError(err));
+    },
+
+    renameConversation: function(studyId, conversationId, name) {
+      const params = {
+        url: {
+          studyId,
+          conversationId,
+        },
+        data: {
+          name,
+        }
+      };
+      return osparc.data.Resources.fetch("conversations", "renameConversation", params)
+        .catch(err => osparc.FlashMessenger.logError(err));
+    },
+  },
+
   members: {
     _createChildControlImpl: function(id) {
       let control;

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -60,7 +60,7 @@ qx.Class.define("osparc.study.Conversations", {
           limit: 42,
         }
       };
-      osparc.data.Resources.fetch("conversations", "getPage", params)
+      osparc.data.Resources.fetch("conversations", "getConversationsPage", params)
         .then(conversations => {
           const conversationsLayout = this.getChildControl("conversations-layout");
           console.log("Conversations fetched", conversations);
@@ -70,7 +70,7 @@ qx.Class.define("osparc.study.Conversations", {
             conversationsLayout.add(noConversationTab);
           } else {
             conversations.forEach(conversation => {
-              const conversationId = conversation["id"];
+              const conversationId = conversation["conversationId"];
               const conversationTab = new osparc.info.Conversation(studyData, conversationId);
               conversationTab.setLabel(conversation["name"]);
               conversationsLayout.add(conversationTab);

--- a/services/static-webserver/client/source/class/osparc/task/ExportData.js
+++ b/services/static-webserver/client/source/class/osparc/task/ExportData.js
@@ -100,7 +100,7 @@ qx.Class.define("osparc.task.ExportData", {
         }
       });
       task.addListener("taskAborted", () => {
-        osparc.FlashMessenger.logAs(qx.locale.Manager.tr("Download aborted"), "WARNING");
+        osparc.FlashMessenger.logAs(qx.locale.Manager.tr("Download cancelled"), "WARNING");
       });
       task.addListener("pollingError", e => {
         const err = e.getData();


### PR DESCRIPTION
## What do these changes do?

This PR replaces ``/comments`` with ``/conversations`` and, in order to support multiple conversations per project, it brings a UX similar to Notepad++'s tab, with an always present conversation-placeholder.

- [x] Stop using ``/comments`` endpoints, replaced with ``/conversations``. @matusdrobuliak66 you can retire them on your side.
- [x] List conversations
- [x] Create conversation:
  - [x] Renaming the placeholder-conversation
  - [x] Adding a message to the placeholder-conversation
  - [x] Pressing the plus button
- [x] Read conversation: selecting a conversation lists all messages
- [x] Update conversation: rename title by using the button
- [x] Delete conversation: by using the button

![CRUD_conversations](https://github.com/user-attachments/assets/ca3110b7-97cf-43f8-9ef3-a4ab36ee9a48)


## Related issue/s

- follows https://github.com/ITISFoundation/osparc-simcore/pull/7591
- related to https://github.com/ITISFoundation/private-issues/issues/51


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
