### PR TITLE
🐛Dask-Sidecar: explicitely set expand flag to remove confusing error message

### DIFF
--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/file_utils.py
@@ -106,8 +106,12 @@ async def _copy_file(
     src_storage_kwargs = src_storage_cfg or {}
     dst_storage_kwargs = dst_storage_cfg or {}
     with (
-        fsspec.open(f"{src_url}", mode="rb", **src_storage_kwargs) as src_fp,
-        fsspec.open(f"{dst_url}", mode="wb", **dst_storage_kwargs) as dst_fp,
+        fsspec.open(
+            f"{src_url}", mode="rb", expand=False, **src_storage_kwargs
+        ) as src_fp,
+        fsspec.open(
+            f"{dst_url}", mode="wb", expand=False, **dst_storage_kwargs
+        ) as dst_fp,
     ):
         assert isinstance(src_fp, IOBase)  # nosec
         assert isinstance(dst_fp, IOBase)  # nosec


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

This flag should silence the wrongly shown error message: 
```
ERROR: [2024-09-05 08:04:11,514/Dask Worker process (from Nanny)] [simcore_service_dask_sidecar.dask_utils:publish_logs(98)]  -  [sidecar] Task error:
[Errno %s not found. The URL contains glob characters: you maybe needed
to pass expand=True in fsspec.open() or the storage_options of 
your library. You can also set the config value 'open_expand'
before import, or fsspec.core.DEFAULT_EXPAND at runtime, to True.] https://s3.amazonaws.com/production-simcore/0cb0a922-6adf-11ef-a2bb-0242ac174682/69c7a296-f83f-4b61-abf1-a569b04f653a/input0.json?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIATHZO54NSLAMDH4NW/20240904/us-east-1/s3/aws4_request&X-Amz-Date=20240904T171209Z&X-Amz-Expires=43200&X-Amz-SignedHeaders=host&X-Amz-Signature=97d134030154638cedc3adf7e560af2ba75ef71c4ce42a52d562dd24f7c9b076
```
which is confusing

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/6308

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
