### PR TITLE
⬆️ Maintenance: upgrade aiohttp, version 3.11.13 is yanked

### DIFF
--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c ../../requirements/constraints.txt
     #   -r requirements.in

--- a/ci/helpers/requirements/requirements.txt
+++ b/ci/helpers/requirements/requirements.txt
@@ -1,4 +1,6 @@
-aiohttp==3.9.5
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/requirements.in
@@ -33,6 +35,10 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
+propcache==0.3.1
+    # via
+    #   aiohttp
+    #   yarl
 pydantic==2.10.5
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -57,5 +63,5 @@ urllib3==2.3.0
     #   -c requirements/../../../requirements/constraints.txt
     #   docker
     #   requests
-yarl==1.9.4
+yarl==1.20.0
     # via aiohttp

--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -18,7 +18,7 @@ aiofiles==24.1.0
     #   aioboto3
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/packages/notifications-library/requirements/_test.txt
+++ b/packages/notifications-library/requirements/_test.txt
@@ -2,7 +2,7 @@ aiodocker==0.24.0
     # via -r requirements/_test.in
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   aiodocker

--- a/packages/service-library/requirements/_aiohttp.txt
+++ b/packages/service-library/requirements/_aiohttp.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -10,7 +10,7 @@ aiofiles==24.1.0
     # via -r requirements/_base.in
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -3,7 +3,7 @@ aiohappyeyeballs==2.4.6
     #   -c requirements/_aiohttp.txt
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_aiohttp.txt

--- a/packages/service-library/src/servicelib/aiohttp/rest_middlewares.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_middlewares.py
@@ -5,7 +5,7 @@ SEE  https://gist.github.com/amitripshtos/854da3f4217e3441e8fceea85b0cbd91
 
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any, Union
+from typing import Any
 
 from aiohttp import web
 from aiohttp.web_request import Request
@@ -37,7 +37,7 @@ def is_api_request(request: web.Request, api_version: str) -> bool:
     return bool(request.path.startswith(base_path))
 
 
-def error_middleware_factory(
+def error_middleware_factory(  # noqa: C901
     api_version: str,
 ) -> Middleware:
     _is_prod: bool = is_production_environ()
@@ -69,7 +69,7 @@ def error_middleware_factory(
         raise http_error
 
     @web.middleware
-    async def _middleware_handler(request: web.Request, handler: Handler):
+    async def _middleware_handler(request: web.Request, handler: Handler):  # noqa: C901
         """
         Ensure all error raised are properly enveloped and json responses
         """
@@ -147,12 +147,14 @@ def error_middleware_factory(
     return _middleware_handler
 
 
-_ResponseOrBodyData = Union[StreamResponse, Any]
+_ResponseOrBodyData = StreamResponse | Any
 HandlerFlexible = Callable[[Request], Awaitable[_ResponseOrBodyData]]
 MiddlewareFlexible = Callable[[Request, HandlerFlexible], Awaitable[StreamResponse]]
 
 
-def envelope_middleware_factory(api_version: str) -> MiddlewareFlexible:
+def envelope_middleware_factory(
+    api_version: str,
+) -> Callable[..., Awaitable[StreamResponse]]:
     # FIXME: This data conversion is very error-prone. Use decorators instead!
     _is_prod: bool = is_production_environ()
 

--- a/packages/service-library/src/servicelib/aiohttp/rest_middlewares.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_middlewares.py
@@ -199,4 +199,4 @@ def append_rest_middlewares(
 ):
     """Helper that appends rest-middlewares in the correct order"""
     app.middlewares.append(error_middleware_factory(api_version))
-    app.middlewares.append(envelope_middleware_factory(api_version))  # type: ignore[arg-type]
+    app.middlewares.append(envelope_middleware_factory(api_version))

--- a/packages/service-library/src/servicelib/docker_utils.py
+++ b/packages/service-library/src/servicelib/docker_utils.py
@@ -124,7 +124,7 @@ def get_image_complete_url(
         # NOTE: entries like nginx:latest or ngingx:1.3 will raise an exception here
         url = URL(f"https://{image}")
         assert url.host  # nosec
-        if not url.port or "." not in url.host:
+        if not url.port or ("." not in f"{url.host}"):
             # this is Dockerhub + official images are in /library
             url = _create_docker_hub_complete_url(image)
     except ValueError:

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -14,7 +14,7 @@ aiofiles==24.1.0
     #   -r requirements/_base.in
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -10,7 +10,7 @@ aiohappyeyeballs==2.4.6
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/_filemanager_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/_filemanager_utils.py
@@ -48,8 +48,8 @@ def _get_https_link_if_storage_secure(url: str) -> str:
     # DY-SIDECAR (simcore-sdk) -> STORAGE (httpS requests)
     # https://github.com/ITISFoundation/osparc-simcore/issues/5390
     parsed_url = URL(url)
-    if is_storage_secure() and parsed_url.scheme != "https":
-        return f'{parsed_url.with_scheme("https")}'
+    if bool(is_storage_secure()):
+        return f"{parsed_url.with_scheme('https')}"
 
     return url
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,7 +9,7 @@
 #
 # Vulnerabilities -----------------------------------------------------------------------------------------
 #
-aiohttp>=3.7.4                                # https://github.com/advisories/GHSA-v6wp-4m6f-gcjg
+aiohttp>=3.7.4, !=3.11.13                     # https://github.com/advisories/GHSA-v6wp-4m6f-gcjg, 3.11.13 was yanked https://github.com/aio-libs/aiohttp/issues/10617
 certifi>=2023.7.22                            # https://github.com/advisories/GHSA-xqr8-7jwr-rhp7
 cryptography>=41.0.6                          # https://github.com/advisories/GHSA-v8gr-m533-ghj9
 httpx>=0.23.0                                 # https://github.com/advisories/GHSA-h8pj-cxx2-jfg2 / CVE-2021-41945

--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -12,7 +12,7 @@ aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohappyeyeballs==2.5.0
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/agent/requirements/_test.txt
+++ b/services/agent/requirements/_test.txt
@@ -10,7 +10,7 @@ aiohappyeyeballs==2.5.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -23,7 +23,7 @@ aiofiles==24.1.0
     #   -r requirements/_base.in
 aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.10
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -2,7 +2,7 @@ aiohappyeyeballs==2.4.4
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.10
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -28,7 +28,7 @@ aiofiles==24.1.0
     #   aioboto3
 aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.10
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -12,7 +12,7 @@ aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -2,7 +2,7 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -26,7 +26,7 @@ aiofiles==24.1.0
     #   aioboto3
 aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.10
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/clusters-keeper/requirements/_test.txt
+++ b/services/clusters-keeper/requirements/_test.txt
@@ -6,7 +6,7 @@ aiohappyeyeballs==2.4.4
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.10
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -16,7 +16,7 @@ aiofiles==24.1.0
     #   -r requirements/_base.in
 aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.10
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -12,7 +12,9 @@ aiofiles==23.2.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiohttp==3.9.3
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -270,6 +272,10 @@ prometheus-client==0.20.0
     #   prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
+propcache==0.3.1
+    # via
+    #   aiohttp
+    #   yarl
 protobuf==4.25.4
     # via
     #   googleapis-common-protos
@@ -494,7 +500,7 @@ wrapt==1.16.0
     #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-redis
-yarl==1.9.4
+yarl==1.20.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aio-pika

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -25,7 +25,7 @@ aiofiles==24.1.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 aiohappyeyeballs==2.5.0
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -14,7 +14,7 @@ aiohappyeyeballs==2.5.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/director/requirements/_base.txt
+++ b/services/director/requirements/_base.txt
@@ -14,7 +14,7 @@ aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.11.1
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/director/requirements/_test.txt
+++ b/services/director/requirements/_test.txt
@@ -2,7 +2,7 @@ aiohappyeyeballs==2.4.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.1
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/docker-api-proxy/requirements/_test.txt
+++ b/services/docker-api-proxy/requirements/_test.txt
@@ -12,7 +12,7 @@ aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -12,7 +12,7 @@ aiofiles==24.1.0
     #   nicegui
 aiohappyeyeballs==2.5.0
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -25,7 +25,7 @@ aiofiles==24.1.0
     #   -r requirements/_base.in
 aiohappyeyeballs==2.5.0
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -10,7 +10,7 @@ aiohappyeyeballs==2.5.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/efs-guardian/requirements/_base.txt
+++ b/services/efs-guardian/requirements/_base.txt
@@ -26,7 +26,7 @@ aiofiles==24.1.0
     #   aioboto3
 aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.10
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -417,8 +417,10 @@ prometheus-client==0.21.0
     #   prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-propcache==0.2.0
-    # via yarl
+propcache==0.3.1
+    # via
+    #   aiohttp
+    #   yarl
 protobuf==4.25.5
     # via
     #   googleapis-common-protos
@@ -820,7 +822,7 @@ wrapt==1.16.0
     #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-redis
-yarl==1.15.4
+yarl==1.20.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in

--- a/services/efs-guardian/requirements/_test.txt
+++ b/services/efs-guardian/requirements/_test.txt
@@ -6,7 +6,7 @@ aiohappyeyeballs==2.4.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.10.10
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -198,9 +198,10 @@ pluggy==1.5.0
     # via pytest
 ply==3.11
     # via jsonpath-ng
-propcache==0.2.0
+propcache==0.3.1
     # via
     #   -c requirements/_base.txt
+    #   aiohttp
     #   yarl
 psutil==6.1.0
     # via
@@ -337,7 +338,7 @@ wrapt==1.16.0
     #   aws-xray-sdk
 xmltodict==0.14.2
     # via moto
-yarl==1.15.4
+yarl==1.20.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -10,7 +10,7 @@ aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/notifications/requirements/_base.txt
+++ b/services/notifications/requirements/_base.txt
@@ -10,7 +10,7 @@ aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.14
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -10,7 +10,7 @@ aiofiles==24.1.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.11.8
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/payments/requirements/_test.txt
+++ b/services/payments/requirements/_test.txt
@@ -2,7 +2,7 @@ aiohappyeyeballs==2.4.3
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.8
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/payments/tests/unit/test_services_payments_gateway.py
+++ b/services/payments/tests/unit/test_services_payments_gateway.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from faker import Faker
 from fastapi import FastAPI, status
+from httpx import URL as HttpxURL
 from httpx import ASGITransport
 from models_library.payments import UserInvoiceAddress
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
@@ -122,8 +123,11 @@ async def test_one_time_payment_workflow(
     )
 
     app_settings: ApplicationSettings = app.state.settings
-    assert isinstance(submission_link, URL)
-    assert submission_link.host == URL(f"{app_settings.PAYMENTS_GATEWAY_URL}").host
+    assert isinstance(submission_link, HttpxURL)
+    assert (
+        URL(f"{submission_link}").host
+        == URL(f"{app_settings.PAYMENTS_GATEWAY_URL}").host
+    )
 
     # cancel
     payment_canceled = await payment_gateway_api.cancel_payment(payment_initiated)
@@ -162,8 +166,8 @@ async def test_payment_methods_workflow(
     )
 
     app_settings: ApplicationSettings = app.state.settings
-    assert isinstance(form_link, URL)
-    assert form_link.host == URL(f"{app_settings.PAYMENTS_GATEWAY_URL}").host
+    assert isinstance(form_link, HttpxURL)
+    assert URL(f"{form_link}").host == URL(f"{app_settings.PAYMENTS_GATEWAY_URL}").host
 
     # CRUD
     payment_method_id = initiated.payment_method_id

--- a/services/payments/tests/unit/test_services_payments_gateway.py
+++ b/services/payments/tests/unit/test_services_payments_gateway.py
@@ -122,6 +122,7 @@ async def test_one_time_payment_workflow(
     )
 
     app_settings: ApplicationSettings = app.state.settings
+    assert isinstance(submission_link, URL)
     assert submission_link.host == URL(f"{app_settings.PAYMENTS_GATEWAY_URL}").host
 
     # cancel
@@ -161,6 +162,7 @@ async def test_payment_methods_workflow(
     )
 
     app_settings: ApplicationSettings = app.state.settings
+    assert isinstance(form_link, URL)
     assert form_link.host == URL(f"{app_settings.PAYMENTS_GATEWAY_URL}").host
 
     # CRUD

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -25,7 +25,9 @@ aiofiles==23.2.1
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   aioboto3
-aiohttp==3.9.3
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -447,6 +449,10 @@ prometheus-client==0.20.0
     #   prometheus-fastapi-instrumentator
 prometheus-fastapi-instrumentator==6.1.0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
+propcache==0.3.1
+    # via
+    #   aiohttp
+    #   yarl
 protobuf==4.25.4
     # via
     #   googleapis-common-protos
@@ -881,7 +887,7 @@ wrapt==1.16.0
     #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-redis
-yarl==1.9.4
+yarl==1.20.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -29,7 +29,7 @@ aiofiles==24.1.0
     #   aioboto3
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.12
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -2,7 +2,7 @@ aiohappyeyeballs==2.4.6
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.11.12
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -25,7 +25,9 @@ aiofiles==0.8.0
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-aiohttp==3.8.5
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -112,9 +114,7 @@ arrow==1.2.3
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 async-timeout==4.0.3
-    # via
-    #   aiohttp
-    #   aiopg
+    # via aiopg
 asyncpg==0.27.0
     # via
     #   -r requirements/_base.in
@@ -172,9 +172,7 @@ certifi==2023.7.22
 cffi==1.17.1
     # via cryptography
 charset-normalizer==2.0.12
-    # via
-    #   aiohttp
-    #   requests
+    # via requests
 click==8.1.3
     # via typer
 cryptography==41.0.7
@@ -592,6 +590,10 @@ pint==0.24.3
     #   -r requirements/_base.in
 prometheus-client==0.14.1
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
+propcache==0.3.1
+    # via
+    #   aiohttp
+    #   yarl
 protobuf==4.25.4
     # via
     #   googleapis-common-protos
@@ -1030,7 +1032,7 @@ wrapt==1.16.0
     #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-redis
-yarl==1.9.4
+yarl==1.20.0
     # via
     #   -c requirements/./constraints.txt
     #   -r requirements/../../../../packages/notifications-library/requirements/../../../packages/postgres-database/requirements/_base.in

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -1,4 +1,8 @@
-aiohttp==3.8.5
+aiohappyeyeballs==2.6.1
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -24,10 +28,6 @@ anyio==4.3.0
     #   httpx
     #   starlette
     #   watchfiles
-async-timeout==4.0.3
-    # via
-    #   -c requirements/_base.txt
-    #   aiohttp
 asyncpg==0.27.0
     # via
     #   -c requirements/_base.txt
@@ -52,7 +52,6 @@ certifi==2023.7.22
 charset-normalizer==2.0.12
     # via
     #   -c requirements/_base.txt
-    #   aiohttp
     #   requests
 click==8.1.3
     # via
@@ -182,6 +181,11 @@ pluggy==1.5.0
     # via pytest
 pprintpp==0.4.0
     # via pytest-icdiff
+propcache==0.3.1
+    # via
+    #   -c requirements/_base.txt
+    #   aiohttp
+    #   yarl
 py-cpuinfo==9.0.0
     # via pytest-benchmark
 pydantic==2.10.2
@@ -358,7 +362,7 @@ websockets==15.0
     # via
     #   -r requirements/_test.in
     #   uvicorn
-yarl==1.9.4
+yarl==1.20.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/services/web/server/src/simcore_service_webserver/session/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/session/plugin.py
@@ -1,6 +1,4 @@
-""" user's session plugin
-
-"""
+"""user's session plugin"""
 
 import logging
 
@@ -43,4 +41,4 @@ def setup_session(app: web.Application):
         samesite=settings.SESSION_COOKIE_SAMESITE,
     )
     aiohttp_session.setup(app=app, storage=encrypted_cookie_sessions)
-    app.middlewares[-1].__middleware_name__ = f"{__name__}.session"  # type: ignore[union-attr] # PC this attribute does not exist and mypy does not like it
+    app.middlewares[-1].__middleware_name__ = f"{__name__}.session"  # type: ignore[attr-defined] # PC this attribute does not exist and mypy does not like it

--- a/services/web/server/src/simcore_service_webserver/studies_dispatcher/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/studies_dispatcher/_constants.py
@@ -18,8 +18,8 @@ MSG_PUBLIC_PROJECT_NOT_PUBLISHED: Final[str] = (
 )
 
 MSG_GUESTS_NOT_ALLOWED: Final[str] = (
-    "Access restricted to registered users.\n"
-    "If you don't have an account, please email to support and request one\n"
+    "Access restricted to registered users.<br/><br/>"
+    "If you don't have an account, please email to support and request one<br/><br/>"
 )
 
 MSG_TOO_MANY_GUESTS: Final[str] = (

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -145,6 +145,7 @@ def test_disabled_plugins_settings_to_client_statics(
         assert settings.TEST_BAR is None
 
 
+@pytest.mark.filterwarnings("ignore::aiohttp.web_exceptions.NotAppKeyWarning")
 @pytest.mark.filterwarnings("error")
 def test_avoid_sensitive_info_in_public(app_settings: ApplicationSettings):
     # avoids display of sensitive info

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_change_email.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_change_email.py
@@ -80,6 +80,7 @@ async def test_change_and_confirm(
     login_url = client.app.router["auth_login"].url_for()
     logout_url = client.app.router["auth_logout"].url_for()
 
+    assert isinstance(index_url, URL)
     assert index_url.path == URL(login_options.LOGIN_REDIRECT).path
 
     async with LoggedUser(client) as user:

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_change_email.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_change_email.py
@@ -80,8 +80,7 @@ async def test_change_and_confirm(
     login_url = client.app.router["auth_login"].url_for()
     logout_url = client.app.router["auth_logout"].url_for()
 
-    assert isinstance(index_url, URL)
-    assert index_url.path == URL(login_options.LOGIN_REDIRECT).path
+    assert URL(f"{index_url}").path == URL(login_options.LOGIN_REDIRECT).path
 
     async with LoggedUser(client) as user:
         # request change email

--- a/tests/public-api/requirements/_test.txt
+++ b/tests/public-api/requirements/_test.txt
@@ -2,7 +2,7 @@ aiodocker==0.24.0
     # via -r requirements/_test.in
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -24,7 +24,7 @@ aiofiles==24.1.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
 aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.13
+aiohttp==3.11.18
     # via
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

##
Due to https://github.com/aio-libs/aiohttp/issues/10617 version 3.11.13 was _yanked_ and since we use it here is a repository-wide upgrade.

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 4
- #packages after ~ 4

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aiohttp                   | 3.9.3, 3.11.1, 3.11.14, 3.8.5, 3.11.13, 3.11.12, 3.11.10, 3.10.10, 3.11.8, 3.9.5 | 3.11.18    |            | 41 | agent⬆️🧪</br>api-server⬆️🧪</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️🧪</br>clusters-keeper⬆️🧪</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️🧪</br>director⬆️🧪</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️🧪</br>efs-guardian⬆️🧪</br>helpers🧪</br>invitations⬆️</br>notifications-library🧪</br>notifications⬆️</br>payments⬆️🧪</br>public-api🧪</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪🧪</br>storage⬆️🧪</br>swarm-deploy🧪</br>tests🧪</br>web⬆️🧪 |
|   2 | async-timeout             | 4.0.3           | 🗑️ removed |  | 1 | web🧪 |
|   3 | propcache                 | 0.2.0           | 0.3.1      | *minor*    | 2 | efs-guardian⬆️🧪 |
|   4 | yarl                      | 1.9.4, 1.15.4   | 1.20.0     | *minor*    | 7 | datcore-adapter⬆️</br>efs-guardian⬆️🧪</br>helpers🧪</br>resource-usage-tracker⬆️</br>web⬆️🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency