### PR TITLE
🐛 Avoid 401 when listing in process tasks in webserver

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/server.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/server.py
@@ -5,6 +5,7 @@ in a AIOHTTP application.
 The server only has to return a `TaskId` in the handler creating the long
 running task.
 """
+
 from ...long_running_tasks._errors import TaskAlreadyRunningError, TaskCancelledError
 from ...long_running_tasks._models import ProgressMessage, ProgressPercent
 from ...long_running_tasks._task import (
@@ -14,12 +15,17 @@ from ...long_running_tasks._task import (
     TasksManager,
     TaskStatus,
 )
-from ._dependencies import create_task_name_from_request, get_tasks_manager
+from ._dependencies import (
+    create_task_name_from_request,
+    get_task_context,
+    get_tasks_manager,
+)
 from ._routes import TaskGet
 from ._server import setup, start_long_running_task
 
 __all__: tuple[str, ...] = (
     "create_task_name_from_request",
+    "get_task_context",
     "get_tasks_manager",
     "ProgressMessage",
     "ProgressPercent",

--- a/services/web/server/src/simcore_service_webserver/long_running_tasks.py
+++ b/services/web/server/src/simcore_service_webserver/long_running_tasks.py
@@ -13,7 +13,7 @@ from .login.decorators import login_required
 from .models import RequestContext
 
 
-def _webserver_request_context_decorator(handler: Handler):
+def webserver_request_context_decorator(handler: Handler):
     @wraps(handler)
     async def _test_task_context_decorator(
         request: web.Request,
@@ -31,5 +31,5 @@ def setup_long_running_tasks(app: web.Application) -> None:
         app,
         router_prefix=f"/{API_VTAG}/tasks-legacy",
         handler_check_decorator=login_required,
-        task_request_context_decorator=_webserver_request_context_decorator,
+        task_request_context_decorator=webserver_request_context_decorator,
     )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- Call long running tasks module in `service_lib` directly when listing legacy tasks instead of calling the REST interface.

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes #7654 

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
