### PR TITLE
♻️Dask-sidecar: remove dask Pub/Sub

### DIFF
--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/dask.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/dask.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from typing import Final
 
 import distributed
-from common_library.async_tools import maybe_await
 from dask_task_models_library.container_tasks.errors import TaskCancelledError
 from dask_task_models_library.container_tasks.events import (
     BaseTaskEvent,
@@ -75,7 +74,6 @@ class TaskPublisher:
         if rounded_value > self._last_published_progress_value:
             with log_catch(logger=_logger, reraise=False):
                 publish_event(
-                    self.progress,
                     TaskProgressEvent.from_dask_worker(
                         progress=rounded_value, task_owner=self.task_owner
                     ),
@@ -170,7 +168,7 @@ async def monitor_task_abortion(
                 await periodically_checking_task
 
 
-async def publish_event(
+def publish_event(
     event: BaseTaskEvent,
 ) -> None:
     """never reraises, only CancellationError"""
@@ -180,6 +178,4 @@ async def publish_event(
         log_catch(_logger, reraise=False),
         log_context(_logger, logging.DEBUG, msg=f"publishing {event=}"),
     ):
-        await maybe_await(
-            worker.log_event(TaskProgressEvent.topic_name(), event.model_dump_json())
-        )
+        worker.log_event(TaskProgressEvent.topic_name(), event.model_dump_json())

--- a/services/dask-sidecar/tests/unit/conftest.py
+++ b/services/dask-sidecar/tests/unit/conftest.py
@@ -99,7 +99,7 @@ def app_environment(
                 model_dump_with_secrets(rabbit_service, show_secrets=True)
             ),
             "SC_BOOT_MODE": "debug",
-            "SIDECAR_LOGLEVEL": "DEBUG",
+            "DASK_SIDECAR_LOGLEVEL": "DEBUG",
             "SIDECAR_COMP_SERVICES_SHARED_VOLUME_NAME": "simcore_computational_shared_data",
             "SIDECAR_COMP_SERVICES_SHARED_FOLDER": f"{shared_data_folder}",
         },

--- a/services/dask-sidecar/tests/unit/test_utils_dask.py
+++ b/services/dask-sidecar/tests/unit/test_utils_dask.py
@@ -75,7 +75,7 @@ async def test_publish_event(
 
             async def _() -> int:
                 with log_context(logging.INFO, "_worker_task_async"):
-                    await publish_event(event_to_publish)
+                    publish_event(event_to_publish)
                     return 2
 
             return asyncio.run(_())

--- a/services/dask-sidecar/tests/unit/test_utils_dask.py
+++ b/services/dask-sidecar/tests/unit/test_utils_dask.py
@@ -24,6 +24,7 @@ from simcore_service_dask_sidecar.utils.dask import (
     monitor_task_abortion,
     publish_event,
 )
+from tenacity import Retrying
 from tenacity.asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
@@ -47,54 +48,60 @@ def test_publish_event(
         task_owner=task_owner,
     )
 
-    def handler_some_topic_event(event: tuple) -> None:
+    def handler(event: tuple) -> None:
         print("received event", event)
         assert isinstance(event, tuple)
         received_task_log_event = TaskProgressEvent.model_validate_json(event[1])
         assert received_task_log_event == event_to_publish
 
-    dask_client.subscribe_topic("some_topic", handler_some_topic_event)
-    time.sleep(1)
-    dask_client.log_event("some_topic", event_to_publish.model_dump_json())
-    time.sleep(1)
-    # publish_event(dask_pub=dask_pub, event=event_to_publish)
+    dask_client.subscribe_topic(TaskProgressEvent.topic_name(), handler)
 
-    # NOTE: this tests runs a sync dask client,
-    # and the CI seems to have sometimes difficulties having this run in a reasonable time
-    # hence the long time out
-    events = dask_client.get_events("some_topic")
-    assert events is not None
+    publish_event(dask_client, event=event_to_publish)
+    for attempt in Retrying(
+        wait=wait_fixed(0.2), stop=stop_after_delay(15), reraise=True
+    ):
+        with attempt:
+            events = dask_client.get_events(TaskProgressEvent.topic_name())
+            assert events is not None
+
     assert isinstance(events, tuple)
     assert len(events) == 1
     assert isinstance(events[0], tuple)
     received_task_log_event = TaskProgressEvent.model_validate_json(events[0][1])
     assert received_task_log_event == event_to_publish
 
-    # message = dask_sub.get(timeout=DASK_TESTING_TIMEOUT_S)
-    # assert message is not None
-    # assert isinstance(message, str)
-    # received_task_log_event = TaskProgressEvent.model_validate_json(message)
-    # assert received_task_log_event == event_to_publish
-
 
 async def test_publish_event_async(
     async_dask_client: distributed.Client, job_id: str, task_owner: TaskOwner
 ):
-    dask_pub = distributed.Pub("some_topic", client=async_dask_client)
-    dask_sub = distributed.Sub("some_topic", client=async_dask_client)
     event_to_publish = TaskProgressEvent(
-        job_id=job_id, msg="the log", progress=2, task_owner=task_owner
+        job_id=job_id,
+        msg="the log",
+        progress=2,
+        task_owner=task_owner,
     )
-    publish_event(dask_pub=dask_pub, event=event_to_publish)
 
-    # NOTE: this tests runs a sync dask client,
-    # and the CI seems to have sometimes difficulties having this run in a reasonable time
-    # hence the long time out
-    message = dask_sub.get(timeout=DASK_TESTING_TIMEOUT_S)
-    assert isinstance(message, Coroutine)
-    message = await message
-    assert message is not None
-    received_task_log_event = TaskProgressEvent.model_validate_json(message)
+    async def handler(event: tuple) -> None:
+        print("received event", event)
+        assert isinstance(event, tuple)
+        received_task_log_event = TaskProgressEvent.model_validate_json(event[1])
+        assert received_task_log_event == event_to_publish
+
+    async_dask_client.subscribe_topic(TaskProgressEvent.topic_name(), handler)
+
+    await publish_event(async_dask_client, event=event_to_publish)
+
+    async for attempt in AsyncRetrying(
+        wait=wait_fixed(0.2), stop=stop_after_delay(15), reraise=True
+    ):
+        with attempt:
+            events = await async_dask_client.get_events(TaskProgressEvent.topic_name())
+            assert events is not None
+
+    assert isinstance(events, tuple)
+    assert len(events) == 1
+    assert isinstance(events[0], tuple)
+    received_task_log_event = TaskProgressEvent.model_validate_json(events[0][1])
     assert received_task_log_event == event_to_publish
 
 

--- a/services/dask-sidecar/tests/unit/test_utils_dask.py
+++ b/services/dask-sidecar/tests/unit/test_utils_dask.py
@@ -46,7 +46,17 @@ def test_publish_event(
         progress=1,
         task_owner=task_owner,
     )
+
+    def handler_some_topic_event(event: tuple) -> None:
+        print("received event", event)
+        assert isinstance(event, tuple)
+        received_task_log_event = TaskProgressEvent.model_validate_json(event[1])
+        assert received_task_log_event == event_to_publish
+
+    dask_client.subscribe_topic("some_topic", handler_some_topic_event)
+    time.sleep(1)
     dask_client.log_event("some_topic", event_to_publish.model_dump_json())
+    time.sleep(1)
     # publish_event(dask_pub=dask_pub, event=event_to_publish)
 
     # NOTE: this tests runs a sync dask client,

--- a/services/dask-sidecar/tests/unit/test_utils_dask.py
+++ b/services/dask-sidecar/tests/unit/test_utils_dask.py
@@ -8,12 +8,12 @@ import asyncio
 import concurrent.futures
 import logging
 import time
-from collections.abc import AsyncIterator, Callable, Coroutine
 from typing import Any
 from unittest import mock
 
 import distributed
 import pytest
+from common_library.async_tools import maybe_await
 from dask_task_models_library.container_tasks.errors import TaskCancelledError
 from dask_task_models_library.container_tasks.events import TaskProgressEvent
 from dask_task_models_library.container_tasks.io import TaskCancelEventName
@@ -28,7 +28,6 @@ from simcore_service_dask_sidecar.utils.dask import (
     publish_event,
 )
 from tenacity import Retrying
-from tenacity.asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
@@ -41,12 +40,24 @@ pytest_simcore_core_services_selection = [
 ]
 
 
-@pytest.mark.parametrize("handler", [mock.Mock(), mock.AsyncMock()])
-async def test_publish_event(
+@pytest.fixture(params=["sync-dask-client", "async-dask-client"])
+def dask_client_multi(
+    request: pytest.FixtureRequest,
     dask_client: distributed.Client,
+    async_dask_client: distributed.Client,
+) -> distributed.Client:
+    if request.param == "sync-dask-client":
+        return dask_client
+    return async_dask_client
+
+
+@pytest.mark.parametrize(
+    "handler", [mock.Mock(), mock.AsyncMock()], ids=["sync-handler", "async-handler"]
+)
+async def test_publish_event(
+    dask_client_multi: distributed.Client,
     job_id: str,
     task_owner: TaskOwner,
-    monkeypatch: pytest.MonkeyPatch,
     handler: mock.Mock | mock.AsyncMock,
 ):
     event_to_publish = TaskProgressEvent(
@@ -56,8 +67,8 @@ async def test_publish_event(
         task_owner=task_owner,
     )
 
-    # NOTE: only 1 handler per topic is allowed
-    dask_client.subscribe_topic(TaskProgressEvent.topic_name(), handler)
+    # NOTE: only 1 handler per topic is allowed at a time
+    dask_client_multi.subscribe_topic(TaskProgressEvent.topic_name(), handler)
 
     def _worker_task() -> int:
         with log_context(logging.INFO, "_worker_task"):
@@ -69,8 +80,8 @@ async def test_publish_event(
 
             return asyncio.run(_())
 
-    future = dask_client.submit(_worker_task)
-    assert future.result(timeout=DASK_TESTING_TIMEOUT_S) == 2
+    future = dask_client_multi.submit(_worker_task)
+    assert await maybe_await(future.result(timeout=DASK_TESTING_TIMEOUT_S)) == 2
 
     for attempt in Retrying(
         wait=wait_fixed(0.2),
@@ -79,7 +90,9 @@ async def test_publish_event(
         retry=retry_if_exception_type(AssertionError),
     ):
         with attempt:
-            events = dask_client.get_events(TaskProgressEvent.topic_name())
+            events = await maybe_await(
+                dask_client_multi.get_events(TaskProgressEvent.topic_name())
+            )
             assert events is not None, "No events received"
             assert isinstance(events, tuple)
 
@@ -92,114 +105,20 @@ async def test_publish_event(
     assert received_task_log_event == event_to_publish
 
 
-async def test_publish_event_async(
-    async_dask_client: distributed.Client, job_id: str, task_owner: TaskOwner
-):
-    event_to_publish = TaskProgressEvent(
-        job_id=job_id,
-        msg="the log",
-        progress=2,
-        task_owner=task_owner,
-    )
-
-    async def handler(event: tuple) -> None:
-        print("received event", event)
-        assert isinstance(event, tuple)
-        received_task_log_event = TaskProgressEvent.model_validate_json(event[1])
-        assert received_task_log_event == event_to_publish
-
-    async_dask_client.subscribe_topic(TaskProgressEvent.topic_name(), handler)
-
-    await publish_event(async_dask_client, event=event_to_publish)
-
-    async for attempt in AsyncRetrying(
-        wait=wait_fixed(0.2), stop=stop_after_delay(15), reraise=True
-    ):
-        with attempt:
-            events = await async_dask_client.get_events(TaskProgressEvent.topic_name())
-            assert events is not None
-
-    assert isinstance(events, tuple)
-    assert len(events) == 1
-    assert isinstance(events[0], tuple)
-    received_task_log_event = TaskProgressEvent.model_validate_json(events[0][1])
-    assert received_task_log_event == event_to_publish
-
-
-@pytest.fixture
-async def asyncio_task() -> AsyncIterator[Callable[[Coroutine], asyncio.Task]]:
-    created_tasks = []
-
-    def _creator(coro: Coroutine) -> asyncio.Task:
-        task = asyncio.create_task(coro, name="pytest_asyncio_task")
-        created_tasks.append(task)
-        return task
-
-    yield _creator
-    for task in created_tasks:
-        task.cancel()
-
-    await asyncio.gather(*created_tasks, return_exceptions=True)
-
-
-async def test_publish_event_async_using_task(
-    async_dask_client: distributed.Client,
-    asyncio_task: Callable[[Coroutine], asyncio.Task],
-    job_id: str,
-    task_owner: TaskOwner,
-):
-    NUMBER_OF_MESSAGES = 1000
-    received_messages = []
-
-    async def _consumer(event: tuple) -> None:
-        print("received event", event)
-        assert isinstance(event, tuple)
-        received_messages.append(event)
-
-    async_dask_client.subscribe_topic(TaskProgressEvent.topic_name(), _consumer)
-    await asyncio.sleep(0)
-
-    async def _dask_publisher_task(async_dask_client: distributed.Client) -> None:
-        print("--> starting publisher task")
-        for _ in range(NUMBER_OF_MESSAGES):
-            event_to_publish = TaskProgressEvent(
-                job_id=job_id,
-                progress=0.5,
-                task_owner=task_owner,
-            )
-            await publish_event(async_dask_client, event=event_to_publish)
-        print("<-- finished publisher task")
-
-    publisher_task = asyncio_task(_dask_publisher_task(async_dask_client))
-    assert publisher_task
-
-    async for attempt in AsyncRetrying(
-        retry=retry_if_exception_type(AssertionError),
-        stop=stop_after_delay(DASK_TESTING_TIMEOUT_S),
-        wait=wait_fixed(0.01),
-        reraise=True,
-    ):
-        with attempt:
-            print(
-                f"checking number of received messages...currently {len(received_messages)}"
-            )
-            assert len(received_messages) == NUMBER_OF_MESSAGES
-            print("all expected messages received")
-
-
-def _wait_for_task_to_start() -> None:
-    start_event = distributed.Event(DASK_TASK_STARTED_EVENT)
+def _wait_for_task_to_start(dask_client: distributed.Client) -> None:
+    start_event = distributed.Event(DASK_TASK_STARTED_EVENT, dask_client)
     start_event.wait(timeout=DASK_TESTING_TIMEOUT_S)
 
 
-def _notify_task_is_started_and_ready() -> None:
-    start_event = distributed.Event(DASK_TASK_STARTED_EVENT)
+def _notify_task_is_started_and_ready(dask_client: distributed.Client) -> None:
+    start_event = distributed.Event(DASK_TASK_STARTED_EVENT, dask_client)
     start_event.set()
 
 
 def _some_long_running_task() -> int:
     assert is_current_task_aborted() is False
-    _notify_task_is_started_and_ready()
+    dask_client = distributed.get_worker().client
+    _notify_task_is_started_and_ready(dask_client)
 
     for i in range(300):
         print("running iteration", i)
@@ -217,7 +136,7 @@ def test_task_is_aborted(dask_client: distributed.Client):
     not work in distributed mode where an Event is necessary."""
     # NOTE: this works because the cluster is in the same machine
     future = dask_client.submit(_some_long_running_task)
-    _wait_for_task_to_start()
+    _wait_for_task_to_start(dask_client)
     future.cancel()
     assert future.cancelled()
     with pytest.raises(concurrent.futures.CancelledError):
@@ -227,7 +146,7 @@ def test_task_is_aborted(dask_client: distributed.Client):
 def test_task_is_aborted_using_event(dask_client: distributed.Client):
     job_id = "myfake_job_id"
     future = dask_client.submit(_some_long_running_task, key=job_id)
-    _wait_for_task_to_start()
+    _wait_for_task_to_start(dask_client)
 
     dask_event = distributed.Event(TaskCancelEventName.format(job_id))
     dask_event.set()
@@ -244,7 +163,8 @@ def _some_long_running_task_with_monitoring(task_owner: TaskOwner) -> int:
 
     async def _long_running_task_async() -> int:
         task_publishers = TaskPublisher(task_owner=task_owner)
-        _notify_task_is_started_and_ready()
+        worker = distributed.get_worker()
+        _notify_task_is_started_and_ready(worker.client)
         current_task = asyncio.current_task()
         assert current_task
         async with monitor_task_abortion(
@@ -270,7 +190,7 @@ def test_monitor_task_abortion(
     future = dask_client.submit(
         _some_long_running_task_with_monitoring, task_owner=task_owner, key=job_id
     )
-    _wait_for_task_to_start()
+    _wait_for_task_to_start(dask_client)
     # trigger cancellation
     dask_event = distributed.Event(TaskCancelEventName.format(job_id))
     dask_event.set()

--- a/services/dask-sidecar/tests/unit/test_utils_dask.py
+++ b/services/dask-sidecar/tests/unit/test_utils_dask.py
@@ -49,7 +49,6 @@ async def test_publish_event(
     monkeypatch: pytest.MonkeyPatch,
     handler: mock.Mock | mock.AsyncMock,
 ):
-    monkeypatch.setenv("DASK_SIDECAR_LOGLEVEL", "DEBUG")
     event_to_publish = TaskProgressEvent(
         job_id=job_id,
         msg="the log",

--- a/services/dask-sidecar/tests/unit/test_utils_dask.py
+++ b/services/dask-sidecar/tests/unit/test_utils_dask.py
@@ -136,6 +136,7 @@ async def test_publish_event_async_using_task(
         received_messages.append(event)
 
     async_dask_client.subscribe_topic(TaskProgressEvent.topic_name(), _consumer)
+    await asyncio.sleep(0)
 
     async def _dask_publisher_task(async_dask_client: distributed.Client) -> None:
         print("--> starting publisher task")

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask_client_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask_client_utils.py
@@ -3,6 +3,7 @@ import os
 import socket
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Any, TypeAlias
 
 import distributed
 from models_library.clusters import ClusterAuthentication, TLSAuthentication
@@ -11,10 +12,12 @@ from pydantic import AnyUrl
 from ..core.errors import ConfigurationError
 from .dask import wrap_client_async_routine
 
+UnixTimestamp: TypeAlias = float
+
 
 @dataclass
 class TaskHandlers:
-    task_progress_handler: Callable[[str], Awaitable[None]]
+    task_progress_handler: Callable[[tuple[UnixTimestamp, Any]], Awaitable[None]]
 
 
 logger = logging.getLogger(__name__)

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask_client_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask_client_utils.py
@@ -2,12 +2,9 @@ import logging
 import os
 import socket
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import distributed
-from dask_task_models_library.container_tasks.events import (
-    TaskProgressEvent,
-)
 from models_library.clusters import ClusterAuthentication, TLSAuthentication
 from pydantic import AnyUrl
 
@@ -27,12 +24,6 @@ logger = logging.getLogger(__name__)
 class DaskSubSystem:
     client: distributed.Client
     scheduler_id: str
-    progress_sub: distributed.Sub = field(init=False)
-
-    def __post_init__(self) -> None:
-        self.progress_sub = distributed.Sub(
-            TaskProgressEvent.topic_name(), client=self.client
-        )
 
     async def close(self) -> None:
         # NOTE: if the Sub are deleted before closing the connection,

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import Any, cast
 from unittest import mock
 
+import arrow
 import pytest
 from _helpers import (
     PublishedProject,
@@ -401,11 +402,10 @@ async def _trigger_progress_event(
         ),
     )
     await cast(DaskScheduler, scheduler)._task_progress_change_handler(  # noqa: SLF001
-        event.model_dump_json()
+        (arrow.utcnow().timestamp(), event.model_dump_json())
     )
 
 
-@pytest.mark.acceptance_test()
 async def test_proper_pipeline_is_scheduled(  # noqa: PLR0915
     with_disabled_auto_scheduling: mock.Mock,
     with_disabled_scheduler_publisher: mock.Mock,
@@ -1191,7 +1191,9 @@ async def test_task_progress_triggers(
         )
         await cast(  # noqa: SLF001
             DaskScheduler, scheduler_api
-        )._task_progress_change_handler(progress_event.model_dump_json())
+        )._task_progress_change_handler(
+            (arrow.utcnow().timestamp(), progress_event.model_dump_json())
+        )
         # NOTE: not sure whether it should switch to STARTED.. it would make sense
         await assert_comp_tasks(
             sqlalchemy_async_engine,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR introduces several updates to the Dask-sidecar and Director-v2 and their associated tests. 
The changes focus on transitioning from Dask's deprecated `Pub/Sub` mechanism to their recommended event-based communication. Additionally, minor refactoring and cleanup have been performed to streamline the codebase.

### Key Changes:

#### Transition from `Pub/Sub` to Event-Based (using `log_event`) Communication:
* Replaced Dask's `Pub/Sub` mechanism with event-based communication using `worker.log_event` for publishing task progress and logs. (`[services/dask-sidecar/src/simcore_service_dask_sidecar/utils/dask.pyL172-R181](diffhunk://#diff-27830c4191d3861064437bb2474d4cbd8e1d90a2d3b0e8217c028e14fb674a2bL172-R181)`)
* Removed all references to `distributed.Pub` and `distributed.Sub` throughout the codebase and tests. (`[[1]](diffhunk://#diff-27830c4191d3861064437bb2474d4cbd8e1d90a2d3b0e8217c028e14fb674a2bL66-L83)`, `[[2]](diffhunk://#diff-c66b25f1d5f48cb131389bf7b17fbe391d0bd704a54c10715d617d8684851a14L109-L116)`, `[[3]](diffhunk://#diff-c66b25f1d5f48cb131389bf7b17fbe391d0bd704a54c10715d617d8684851a14L141)`)

#### Test Suite Updates:
* Refactored tests to use event handlers instead of `Sub` for verifying task progress and event publishing. Added helper functions like `_assert_parse_progresses_from_progress_event_handler` to validate progress ordering and completeness. (`[[1]](diffhunk://#diff-29344dd3643e46b1bd55fb9f0d6cda0bec4a8131a71154f17ab0cb833ac41880L40-R121)`, `[[2]](diffhunk://#diff-c66b25f1d5f48cb131389bf7b17fbe391d0bd704a54c10715d617d8684851a14L644-R650)`, `[[3]](diffhunk://#diff-c66b25f1d5f48cb131389bf7b17fbe391d0bd704a54c10715d617d8684851a14L760-R757)`)
* Consolidated sync and async Dask client tests into a single parameterized test fixture (`dask_client_multi`) to reduce redundancy. (`[services/dask-sidecar/tests/unit/test_utils_dask.pyL40-R121](diffhunk://#diff-29344dd3643e46b1bd55fb9f0d6cda0bec4a8131a71154f17ab0cb833ac41880L40-R121)`)
* Updated test utilities like `_wait_for_task_to_start` and `_notify_task_is_started_and_ready` to use the Dask client explicitly. (`[[1]](diffhunk://#diff-29344dd3643e46b1bd55fb9f0d6cda0bec4a8131a71154f17ab0cb833ac41880L179-R139)`, `[[2]](diffhunk://#diff-29344dd3643e46b1bd55fb9f0d6cda0bec4a8131a71154f17ab0cb833ac41880L189-R149)`)


### Next PR:
- re-organize task lifetime using the log_event facilities and worker/scheduler plugins to finallyt fix the issue https://github.com/ITISFoundation/osparc-simcore/issues/7629

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/7629

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
