### PR TITLE
🎨Webserver: use uvloop and aiohttp UV loop worker to increase performances

### DIFF
--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -57,7 +57,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
   exec python -m debugpy --listen 0.0.0.0:"${WEBSERVER_REMOTE_DEBUGGING_PORT}" -m gunicorn simcore_service_webserver.cli:app_factory \
     --log-level="${SERVER_LOG_LEVEL}" \
     --bind 0.0.0.0:8080 \
-    --worker-class aiohttp.GunicornWebWorker \
+    --worker-class aiohttp.GunicornUVLoopWebWorker \
     --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
     --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
     --access-logfile='-' \
@@ -70,7 +70,7 @@ else
   exec gunicorn simcore_service_webserver.cli:app_factory \
     --log-level="${SERVER_LOG_LEVEL}" \
     --bind 0.0.0.0:8080 \
-    --worker-class aiohttp.GunicornWebWorker \
+    --worker-class aiohttp.GunicornUVLoopWebWorker \
     --workers="${WEBSERVER_GUNICORN_WORKERS:-1}" \
     --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
     --access-logfile='-' \

--- a/services/web/server/requirements/_base.in
+++ b/services/web/server/requirements/_base.in
@@ -54,3 +54,4 @@ redis
 swagger-ui-py
 tenacity
 twilio
+uvloop

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -1021,6 +1021,8 @@ urllib3==2.2.3
     #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../requirements/constraints.txt
     #   requests
+uvloop==0.21.0
+    # via -r requirements/_base.in
 werkzeug==2.1.2
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
 wrapt==1.16.0

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -355,7 +355,9 @@ uvicorn==0.34.0
     #   fastapi
     #   fastapi-cli
 uvloop==0.21.0
-    # via uvicorn
+    # via
+    #   -c requirements/_base.txt
+    #   uvicorn
 watchfiles==1.0.4
     # via uvicorn
 websockets==15.0


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
After testing it looks like the `uvloop`-powered aiohttp gunicorn worker performs much better than the standard one.
note that the response time on this example project is notably improved.
![image](https://github.com/user-attachments/assets/8de096bf-7cdc-401a-b442-e01236f27c2a)


uvloop is a drop-in replacement for the standard asyncio event loop (note that fastapi already uses it by default)

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/private-issues/issues/79

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
