### PR TITLE
🐛 Fixes `WEBSERVER_FUNCTIONS` to run in development deploys

### DIFF
--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -56,7 +56,7 @@ _logger = logging.getLogger(__name__)
 # NOTE: to mark a plugin as a DEV-FEATURE annotated it with
 #    `Field(json_schema_extra={_X_DEV_FEATURE_FLAG: True})`
 # This will force it to be disabled when WEBSERVER_DEV_FEATURES_ENABLED=False
-_X_DEV_FEATURE_FLAG: Final[str] = "x-dev-feature"
+_X_FEATURE_UNDER_DEVELOPMENT: Final[str] = "x-dev-feature"
 
 
 class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
@@ -108,10 +108,9 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
     WEBSERVER_FUNCTIONS: Annotated[
         bool,
         Field(
-            validation_alias=AliasChoices("WEBSERVER_FUNCTIONS"),
-            json_schema_extra={_X_DEV_FEATURE_FLAG: True},
+            json_schema_extra={_X_FEATURE_UNDER_DEVELOPMENT: True},
         ),
-    ] = False
+    ] = True
 
     WEBSERVER_LOGLEVEL: Annotated[
         LogLevel,
@@ -406,8 +405,8 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
 
     @model_validator(mode="before")
     @classmethod
-    def _enable_only_if_dev_features_allowed(cls, data: Any) -> Any:
-        """Force disables plugins marked 'under development' when WEBSERVER_DEV_FEATURES_ENABLED=False"""
+    def _disable_development_features_in_production(cls, data: Any) -> Any:
+        """Force disables plugins marked '_X_FEATURE_UNDER_DEVELOPMENT' when WEBSERVER_DEV_FEATURES_ENABLED=False"""
 
         dev_features_allowed = TypeAdapter(bool).validate_python(
             data.get("WEBSERVER_DEV_FEATURES_ENABLED", False)
@@ -423,7 +422,8 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
                 field.json_schema_extra(json_schema)
 
             assert isinstance(json_schema, dict)  # nosec
-            if json_schema.get(_X_DEV_FEATURE_FLAG):
+            if json_schema.get(_X_FEATURE_UNDER_DEVELOPMENT):
+                assert not dev_features_allowed  # nosec
                 _logger.warning(
                     "'%s' is still under development and will be forcibly disabled [WEBSERVER_DEV_FEATURES_ENABLED=%s].",
                     field_name,

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -405,7 +405,7 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
 
     @model_validator(mode="before")
     @classmethod
-    def _disable_development_features_in_production(cls, data: Any) -> Any:
+    def _disable_features_under_development_in_production(cls, data: Any) -> Any:
         """Force disables plugins marked '_X_FEATURE_UNDER_DEVELOPMENT' when WEBSERVER_DEV_FEATURES_ENABLED=False"""
 
         dev_features_allowed = TypeAdapter(bool).validate_python(

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -12,7 +12,7 @@ from pydantic import Field, HttpUrl, TypeAdapter
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from simcore_service_webserver.application_settings import (
-    _X_DEV_FEATURE_FLAG,
+    _X_FEATURE_UNDER_DEVELOPMENT,
     APP_SETTINGS_KEY,
     ApplicationSettings,
     setup_settings,
@@ -130,17 +130,25 @@ def test_disabled_plugins_settings_to_client_statics(
     )
 
     class DevSettings(ApplicationSettings):
-        TEST_FOO: Annotated[bool, Field(json_schema_extra={_X_DEV_FEATURE_FLAG: True})]
+        TEST_FOO: Annotated[
+            bool, Field(json_schema_extra={_X_FEATURE_UNDER_DEVELOPMENT: True})
+        ]
         TEST_BAR: Annotated[
-            int | None, Field(json_schema_extra={_X_DEV_FEATURE_FLAG: True})
+            int | None, Field(json_schema_extra={_X_FEATURE_UNDER_DEVELOPMENT: True})
         ]
 
     settings = DevSettings.create_from_envs()
 
     if is_dev_feature_enabled:
+        assert settings.WEBSERVER_DEV_FEATURES_ENABLED is True
+        assert settings.WEBSERVER_FUNCTIONS is True
+
         assert settings.TEST_FOO is True
         assert settings.TEST_BAR == 42
     else:
+        assert settings.WEBSERVER_DEV_FEATURES_ENABLED is False
+        assert settings.WEBSERVER_FUNCTIONS is False
+
         assert settings.TEST_FOO is False
         assert settings.TEST_BAR is None
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Fixes  configuration of `WEBSERVER_FUNCTIONS` 

`WEBSERVER_FUNCTIONS` was incorrectly configured: it was marked as `_X_FEATURE_UNDER_DEVELOPMENT`, which is correct, but it was also explicitly set to `False`. 

The `_X_FEATURE_UNDER_DEVELOPMENT` flag is meant to **disable features in production** while keeping the actuall setting in development. Explicitly setting `WEBSERVER_FUNCTIONS=False`  will always (either development or production) keep this feature disabled.

- Fixes `WEBSERVER_FUNCTIONS` such that it only runs if `WEBSERVER_DEV_FEATURES_ENABLED=True` and otherwise it is disabled.
- ♻️ Cleanup tests and flag names

**Side note:** 
- The mechanism depending on the `WEBSERVER_DEV_FEATURES_ENABLED` environment variable is INDEED misleading—likely the result of incremental changes without a full review of the underlying logic. 
- I will follow up in https://github.com/ITISFoundation/osparc-simcore/issues/7688 and improve this mechanism. 
- For now, this PR hsould solve the ongoing issue and unblock  @wvangeit and @JavierGOrdonnez .


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
