### PR TITLE
🐛 Process canonical endpoint in fastapi case when collecting prometheus metrics

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/monitoring.py
+++ b/packages/service-library/src/servicelib/aiohttp/monitoring.py
@@ -2,8 +2,8 @@
 
 import asyncio
 import logging
-import time
 from collections.abc import Awaitable, Callable
+from time import perf_counter
 from typing import Final
 
 from aiohttp import web
@@ -67,7 +67,7 @@ def middleware_factory(
         canonical_endpoint = request.path
         if request.match_info.route.resource:
             canonical_endpoint = request.match_info.route.resource.canonical
-        start_time = time.time()
+        start_time = perf_counter()
         try:
             if enter_middleware_cb:
                 with log_catch(logger=log, reraise=False):
@@ -111,7 +111,7 @@ def middleware_factory(
             raise resp from exc
 
         finally:
-            resp_time_secs: float = time.time() - start_time
+            response_latency_seconds = perf_counter() - start_time
 
             record_response_metrics(
                 metrics=metrics,
@@ -119,6 +119,7 @@ def middleware_factory(
                 endpoint=canonical_endpoint,
                 user_agent=user_agent,
                 http_status=resp.status,
+                response_latency_seconds=response_latency_seconds,
             )
 
             if exit_middleware_cb:
@@ -133,7 +134,7 @@ def middleware_factory(
                     request.remote,
                     request.method,
                     request.path,
-                    resp_time_secs,
+                    response_latency_seconds,
                     resp.status,
                     exc_info=log_exception,
                     stack_info=True,

--- a/packages/service-library/src/servicelib/fastapi/monitoring.py
+++ b/packages/service-library/src/servicelib/fastapi/monitoring.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from collections.abc import AsyncIterator
+from time import perf_counter
 from typing import Final
 
 from fastapi import FastAPI, Request, Response, status
@@ -39,10 +40,12 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         canonical_endpoint = request.url.path
+
         user_agent = request.headers.get(
             X_SIMCORE_USER_AGENT, UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
         )
 
+        start_time = perf_counter()
         try:
             with record_request_metrics(
                 metrics=self.metrics,
@@ -52,18 +55,26 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
             ):
                 response = await call_next(request)
                 status_code = response.status_code
+
+                # manually cleanup path because routing is not yet available
+                # https://github.com/encode/starlette/issues/685#issuecomment-550240999
+                for k, v in request.path_params.items():
+                    key = "{" + k + "}"
+                    canonical_endpoint = canonical_endpoint.replace(f"/{v}", f"/{key}")
         except Exception:  # pylint: disable=broad-except
             # NOTE: The prometheus metrics middleware should be "outside" exception handling
             # middleware. See https://fastapi.tiangolo.com/advanced/middleware/#adding-asgi-middlewares
             status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
             raise
         finally:
+            reponse_latency_seconds = perf_counter() - start_time
             record_response_metrics(
                 metrics=self.metrics,
                 method=request.method,
                 endpoint=canonical_endpoint,
                 user_agent=user_agent,
                 http_status=status_code,
+                response_latency_seconds=reponse_latency_seconds,
             )
 
         return response


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
- "Resolve" endpoint when recording Prometheus metrics to avoid excessive number of labels.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
