### PR TITLE
🎨 [Frontend] Enable/disable Create Functions

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -839,6 +839,10 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
     },
 
     __getCreateFunctionsPage: function() {
+      if (!osparc.utils.DisabledPlugins.isFunctionsDisabled()) {
+        return null;
+      }
+
       if (!osparc.utils.Resources.isStudy(this.__resourceData)) {
         return null;
       }

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -839,7 +839,7 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
     },
 
     __getCreateFunctionsPage: function() {
-      if (!osparc.utils.DisabledPlugins.isFunctionsDisabled()) {
+      if (osparc.utils.DisabledPlugins.isFunctionsDisabled()) {
         return null;
       }
 

--- a/services/static-webserver/client/source/class/osparc/utils/DisabledPlugins.js
+++ b/services/static-webserver/client/source/class/osparc/utils/DisabledPlugins.js
@@ -28,6 +28,7 @@ qx.Class.define("osparc.utils.DisabledPlugins", {
     SCICRUNCH: "WEBSERVER_SCICRUNCH",
     VERSION_CONTROL: "WEBSERVER_VERSION_CONTROL",
     META_MODELING: "WEBSERVER_META_MODELING",
+    FUNCTIONS: "WEBSERVER_FUNCTIONS",
     LICENSES: "WEBSERVER_LICENSES",
 
     isExportDisabled: function() {
@@ -46,6 +47,10 @@ qx.Class.define("osparc.utils.DisabledPlugins", {
 
     isMetaModelingDisabled: function() {
       return this.__isPluginDisabled(this.META_MODELING);
+    },
+
+    isFunctionsDisabled: function() {
+      return this.__isPluginDisabled(this.FUNCTIONS);
     },
 
     isLicensesDisabled: function() {


### PR DESCRIPTION
## What do these changes do?

This PR allows the backend disable the "Create Functions" section in the frontend by making the pluginsDisabled ``WEBSERVER_FUNCTIONS`` flag truthy.


## Related issue/s

- related to https://github.com/ITISFoundation/private-issues/issues/14


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
