### PR TITLE
🎨 `api-server`: Add GET /solvers/page Public API Route with Pagination and Filter Support

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_catalog/services.py
+++ b/packages/models-library/src/models_library/api_schemas_catalog/services.py
@@ -210,6 +210,7 @@ class ServiceSummary(CatalogOutputSchema):
     model_config = ConfigDict(
         extra="ignore",
         populate_by_name=True,
+        alias_generator=snake_to_camel,
         json_schema_extra=_update_json_schema_extra,
     )
 

--- a/packages/models-library/src/models_library/api_schemas_catalog/services.py
+++ b/packages/models-library/src/models_library/api_schemas_catalog/services.py
@@ -216,8 +216,6 @@ class ServiceSummary(CatalogOutputSchema):
 
 
 class _BaseServiceGetV2(ServiceSummary):
-    # Model used in catalog's rpc and rest interfaces
-
     service_type: Annotated[ServiceType, Field(alias="type")]
 
     thumbnail: HttpUrl | None = None
@@ -286,7 +284,6 @@ class LatestServiceGet(_BaseServiceGetV2):
 
 
 class ServiceGetV2(_BaseServiceGetV2):
-    # Model used in catalog's rpc and rest interfaces
     history: Annotated[
         list[ServiceRelease],
         Field(

--- a/packages/models-library/src/models_library/api_schemas_catalog/services.py
+++ b/packages/models-library/src/models_library/api_schemas_catalog/services.py
@@ -341,6 +341,9 @@ PageRpcServiceRelease: TypeAlias = PageRpc[
     ServiceRelease
 ]
 
+# Create PageRpc types
+PageRpcServiceSummary = PageRpc[ServiceSummary]
+
 ServiceResourcesGet: TypeAlias = ServiceResourcesDict
 
 

--- a/packages/models-library/src/models_library/api_schemas_catalog/services.py
+++ b/packages/models-library/src/models_library/api_schemas_catalog/services.py
@@ -252,6 +252,7 @@ class _BaseServiceGetV2(ServiceSummary):
         extra="forbid",
         populate_by_name=True,
         alias_generator=snake_to_camel,
+        json_schema_extra={"example": _EXAMPLE_SLEEPER},
     )
 
 

--- a/packages/models-library/src/models_library/api_schemas_catalog/services.py
+++ b/packages/models-library/src/models_library/api_schemas_catalog/services.py
@@ -182,6 +182,41 @@ class ServiceSummary(CatalogOutputSchema):
 
     contact: LowerCaseEmailStr | None
 
+    service_type: Annotated[ServiceType, Field(alias="type")]
+
+    @staticmethod
+    def _update_json_schema_extra(schema: JsonDict) -> None:
+        schema.update(
+            {
+                "examples": [
+                    {
+                        "key": _EXAMPLE_SLEEPER["key"],
+                        "version": _EXAMPLE_SLEEPER["version"],
+                        "name": _EXAMPLE_SLEEPER["name"],
+                        "description": _EXAMPLE_SLEEPER["description"],
+                        "version_display": _EXAMPLE_SLEEPER["version_display"],
+                        "contact": _EXAMPLE_SLEEPER["contact"],
+                        "type": _EXAMPLE_SLEEPER["type"],
+                    },
+                    {
+                        "key": _EXAMPLE_FILEPICKER["key"],
+                        "version": _EXAMPLE_FILEPICKER["version"],
+                        "name": _EXAMPLE_FILEPICKER["name"],
+                        "description": _EXAMPLE_FILEPICKER["description"],
+                        "version_display": None,
+                        "contact": _EXAMPLE_FILEPICKER["contact"],
+                        "type": _EXAMPLE_FILEPICKER["type"],
+                    },
+                ]
+            }
+        )
+
+    model_config = ConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        json_schema_extra=_update_json_schema_extra,
+    )
+
 
 class _BaseServiceGetV2(ServiceSummary):
     # Model used in catalog's rpc and rest interfaces
@@ -189,8 +224,6 @@ class _BaseServiceGetV2(ServiceSummary):
     icon: HttpUrl | None = None
 
     description_ui: bool = False
-
-    service_type: Annotated[ServiceType, Field(alias="type")]
 
     authors: Annotated[list[Author], Field(min_length=1)]
     owner: Annotated[

--- a/packages/models-library/src/models_library/api_schemas_catalog/services.py
+++ b/packages/models-library/src/models_library/api_schemas_catalog/services.py
@@ -172,23 +172,26 @@ class ServiceGet(
     )
 
 
-class _BaseServiceGetV2(CatalogOutputSchema):
-    # Model used in catalog's rpc and rest interfaces
+class ServiceSummary(CatalogOutputSchema):
     key: ServiceKey
     version: ServiceVersion
-
     name: str
-    thumbnail: HttpUrl | None = None
-    icon: HttpUrl | None = None
     description: str
-
-    description_ui: bool = False
 
     version_display: str | None = None
 
+    contact: LowerCaseEmailStr | None
+
+
+class _BaseServiceGetV2(ServiceSummary):
+    # Model used in catalog's rpc and rest interfaces
+    thumbnail: HttpUrl | None = None
+    icon: HttpUrl | None = None
+
+    description_ui: bool = False
+
     service_type: Annotated[ServiceType, Field(alias="type")]
 
-    contact: LowerCaseEmailStr | None
     authors: Annotated[list[Author], Field(min_length=1)]
     owner: Annotated[
         LowerCaseEmailStr | None,

--- a/packages/models-library/src/models_library/api_schemas_catalog/services.py
+++ b/packages/models-library/src/models_library/api_schemas_catalog/services.py
@@ -182,8 +182,6 @@ class ServiceSummary(CatalogOutputSchema):
 
     contact: LowerCaseEmailStr | None
 
-    service_type: Annotated[ServiceType, Field(alias="type")]
-
     @staticmethod
     def _update_json_schema_extra(schema: JsonDict) -> None:
         schema.update(
@@ -196,7 +194,6 @@ class ServiceSummary(CatalogOutputSchema):
                         "description": _EXAMPLE_SLEEPER["description"],
                         "version_display": _EXAMPLE_SLEEPER["version_display"],
                         "contact": _EXAMPLE_SLEEPER["contact"],
-                        "type": _EXAMPLE_SLEEPER["type"],
                     },
                     {
                         "key": _EXAMPLE_FILEPICKER["key"],
@@ -205,7 +202,6 @@ class ServiceSummary(CatalogOutputSchema):
                         "description": _EXAMPLE_FILEPICKER["description"],
                         "version_display": None,
                         "contact": _EXAMPLE_FILEPICKER["contact"],
-                        "type": _EXAMPLE_FILEPICKER["type"],
                     },
                 ]
             }
@@ -220,6 +216,9 @@ class ServiceSummary(CatalogOutputSchema):
 
 class _BaseServiceGetV2(ServiceSummary):
     # Model used in catalog's rpc and rest interfaces
+
+    service_type: Annotated[ServiceType, Field(alias="type")]
+
     thumbnail: HttpUrl | None = None
     icon: HttpUrl | None = None
 

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/catalog_rpc_server.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/catalog_rpc_server.py
@@ -225,7 +225,11 @@ class CatalogRpcSideEffects:
                 # Match service type if specified
                 if (
                     filters.service_type
-                    and summary.service_type != filters.service_type
+                    and {
+                        ServiceType.COMPUTATIONAL: "/comp/",
+                        ServiceType.DYNAMIC: "/dynamic/",
+                    }[filters.service_type]
+                    in summary.key
                 ):
                     continue
 

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/catalog_rpc_server.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/catalog_rpc_server.py
@@ -229,7 +229,7 @@ class CatalogRpcSideEffects:
                         ServiceType.COMPUTATIONAL: "/comp/",
                         ServiceType.DYNAMIC: "/dynamic/",
                     }[filters.service_type]
-                    in summary.key
+                    not in summary.key
                 ):
                     continue
 

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/catalog_rpc_server.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/catalog_rpc_server.py
@@ -13,6 +13,7 @@ from models_library.api_schemas_catalog.services import (
     LatestServiceGet,
     ServiceGetV2,
     ServiceListFilters,
+    ServiceSummary,
     ServiceUpdateV2,
 )
 from models_library.api_schemas_catalog.services_ports import ServicePortGet
@@ -200,6 +201,62 @@ class CatalogRpcSideEffects:
             ServicePortGet.model_json_schema()["examples"],
         )
 
+    @validate_call(config={"arbitrary_types_allowed": True})
+    async def list_all_services_summaries_paginated(
+        self,
+        rpc_client: RabbitMQRPCClient | MockType,
+        *,
+        product_name: ProductName,
+        user_id: UserID,
+        limit: PageLimitInt,
+        offset: NonNegativeInt,
+        filters: ServiceListFilters | None = None,
+    ):
+        assert rpc_client
+        assert product_name
+        assert user_id
+
+        service_summaries = TypeAdapter(list[ServiceSummary]).validate_python(
+            ServiceSummary.model_json_schema()["examples"],
+        )
+        if filters:
+            filtered_summaries = []
+            for summary in service_summaries:
+                # Match service type if specified
+                if (
+                    filters.service_type
+                    and summary.service_type != filters.service_type
+                ):
+                    continue
+
+                # Match service key pattern if specified
+                if filters.service_key_pattern and not fnmatch.fnmatch(
+                    summary.key, filters.service_key_pattern
+                ):
+                    continue
+
+                # Match version display pattern if specified
+                if filters.version_display_pattern and (
+                    summary.version_display is None
+                    or not fnmatch.fnmatch(
+                        summary.version_display, filters.version_display_pattern
+                    )
+                ):
+                    continue
+
+                filtered_summaries.append(summary)
+
+            service_summaries = filtered_summaries
+
+        total_count = len(service_summaries)
+
+        return PageRpc[ServiceSummary].create(
+            service_summaries[offset : offset + limit],
+            total=total_count,
+            limit=limit,
+            offset=offset,
+        )
+
 
 @dataclass
 class ZeroListingCatalogRpcSideEffects:
@@ -211,6 +268,14 @@ class ZeroListingCatalogRpcSideEffects:
     async def get_service_ports(self, *args, **kwargs): ...
     async def list_my_service_history_latest_first(self, *args, **kwargs):
         return PageRpc[ServiceRelease].create(
+            [],
+            total=0,
+            limit=10,
+            offset=0,
+        )
+
+    async def list_all_services_summaries_paginated(self, *args, **kwargs):
+        return PageRpc[ServiceSummary].create(
             [],
             total=0,
             limit=10,

--- a/services/api-server/docs/api-server.drawio.svg
+++ b/services/api-server/docs/api-server.drawio.svg
@@ -1,6 +1,6 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="799px" height="816px" viewBox="-0.5 -0.5 799 816" content="&lt;mxfile&gt;&lt;diagram id=&quot;LaSDd4dBGiKKec7Fc6nT&quot; name=&quot;Page-1&quot;&gt;3VxRd6O2Ev41fqwPQoDgMXHi3r1Nu2m8be8+5WCQbW6xoaAk9v76SkZyQJITsGXjZHM2MYPA0jefZkajgQEcLdc/F2G++DWLcTqwrXg9gDcD2waua9E/TLKpJL6DKsG8SOJKZL0KJskPzK8U0qckxiWXVSKSZSlJ8qYwylYrHJGGLCyK7KXZbJalcUOQh3OsCCZRmKrSv5KYLLgUeMHrif/gZL7gX+3bfHzLUDTmIykXYZy91ETwdgBHRZaR6tNyPcIpA6+Jy3jP2V3HCrwibS6wqwuew/SJj21ge+EyH8Dr1bRkfwbsDk3R6Otv3x6+3t3dPvBBkI1ApsieVjFmN7dow5dFQvAkDyN29oVygcoWZJnSI0A/zpI0HWVpVmyvhbPZzI4iKi9Jkf2NxZlVtqKXX4dpMl/RwxTPyLZb8kD52J9xQfC6JuID/xlnS0yKDW3Cz9rAqS7hLHS96vDlVaWeYNyipk2XaznkLJrv7vwKNP3AsdbjDg/BfXL78OeX0a1R0GMX+7HTH+gAuO1QBx44HnanDewPt/dfJ1++fX34bhRpDCjWqD+kbQQ1SAMVaWgAaLcN0KO7L7e/fZuYNSJ+hPs0ItByWvIZ2sfDLG7cwFlCc07hzNuPdOc1w6m4g/U2AlAyo9BSENj5uzoCNjRgSL1P5MCsPSrZC701dJAHAuv1t+rCbBAMrUaz03g09Fk8mjktbJroSkpxbehbgfitKsWzjleK/4H9nXE9AKBXxHuzw4Qigo/qD9trQaCM+qO7o3o/HNOVGz/kg66BhdcJ+R/Ddejyo++1MzdrDvn2YMMP9oNUZk9FhIVzq2QkLOaYt3N4O9anN6EscBqS5Lm52jwGGM16o8AleYNp4H2mmZizwLIac5TyRGGPq4kdHBNsAV3ZsqLfUKMLO/wuKMIOXgmzPerIGOeiGKMulYo8ugDCeP0RJjifeZEU/j57xPjq7An2BO7GyeKoy5C8yP5PFxHlBTBGMjGe6p/QqQgDL5cwgY4w57IuwWkJo1nUqnC0JgyAauLkZIwBKjBZSebUW9OAMWVB2rSgn+bsU1huVlE+7x+xQALMV5ehwYkAAypgCh6nzoC4IofZSwYE2BoEPmoKpHP+7ZJSIODTZPXNqaH/HAj4yEl/44roMwkCPuyuQHs1XEAWRLP5cpLFfmdu9rnY12wUnGI92x2THtezTqCM3/zyxGDSZKAsYgDfdagvYgBPep8/Z+K6XfE8Nzae3Rc2QN0fmmQpnScTXDwntM+mZ2LXieggqTBBpAdrExHogngTM9FXFy0fbSb6Ktv83rKXQN34GoUkTLP5pdDNhc24bJeiPwfdYOe81CmpY2sMlUDj/NRx1EXcgpB8rUXsLpzitAmVCCYjOmRMg8xrxokkCtMrfmKZxDG7xzUNypIfPMfAwMqzZEW2PXevB+6NFj6hueOTFj9ZQ2CJZVlrFPnt7llXa02y2azERIF5963tQjTVRVw9kcUEl2WSrXqfsXbgN2YsFP09Q5ZL1AqdfMLiVXzFCmTpYZbjVSUZJ6xj2/MlnaREtOBfu5XV2rSa9J7GX4g9J3OTfnsp7W64qTXg80xls4gEgmYk4ASWpKvqjofy3HcOdPbi8/eG4+/B2dsX5ew1VS5/Ta/y5CGPRmnCxtG36XDkIkFbXeSdynT4nRclu9DSgUGDccE7lKMH97hIaBeZ4+tAp0ClEzIeABxkC5Do284WeHXwlfb+2+2Pth2aQqKz7A8dRX/P32U1xATwzzcBoJr/LZNllBX4sawWA49RtTZQgKLjI/uShvUMozqJZtmK8OdW6FqEH/Mbg7eCQiV8NIC/6zfRR74auexyc8bhVxNvMvwveMo+0uF+UgXIoSPS0P90ClDDalkBYZ48fm4NOAg0NCAStedQgMjzt/bArZymSAo3Up/ItNNsPUbdgwjjcpvhU0s6OKkOWjXr3FVza8iExbSaARuyNGl5T8MXaIIvndcHp4z1XU0ha48pdjU7c19k8yJclpeS2fM8ydRAtSJBn9lzDeCDLoo7nsodt7fMnqt7Vmicc/p8PCPlBT0aKa/rsrIdYTSJhf72rFw1sTAhT/HmUiwNlOrO2m9ZGbA0wspdiKXRpBDc/ryU7nGfcUm5k+APaGig0/Ro6Ixm5qJ2qoQpaiSte4u5va5x4uFj7G0mid7UZtJ/s+nFGGDxREjnTVwD0KCuy8qDthE0Od1Dp9hp94683iiqe8hWUkz5NybRYqDb572m9BhV/13adMQkQ7Y/oAh1MqQKgdqM/gG6b5CFOhlShUBtxo5Er5tCnQy5ao/lq4HmaiBdvd0kz55ImqzwaPeuH4snm2r1n/RnzLQn14XeIuCiayW/VRWy03/0TByWi50zFX54u+9/n5UJYTvT8GaaEZItNY6aZLnOn+9Jk9lSmszaJvHzalizZM36cV0uwpydXK7n7O1Kw/CldIYFribIl4j1h5UWVJ+arcp/SlP5EdQwfI6jZpRdXZW9Y8Du6arspfmWLLdvcFLBqwGvllsoapJ1w297kyzntJdpMqW/wx9PBWa9j0MSTsOSBXjjKyZ8vOGSx/tqi2by+93jZJtmHZbPczOa8C0pNtNsLYp4rfH6EctAdIa8A13Qkc9bqy4BaR6eFXtl53cJSN1yusqTX/CmfMA5sxoZv9/BwUtYRJyYrqEgH1lSQZqvSycAoJnVwBsiAytK1Dl3dWlFkAKF07Jwz061tEiDvjTBq07xqyStdNuEFsOs0fuPEhcnILdjKp8fNP3VHnJbcKgzlWhogN3+OZ4F3gUrgB/ch4S6MubUaJRq+W2J7Gs2l7zeFoG+urn0EE6nCfn1d7Xo4eF+dClVP36zFgSi8xUM+m0WJTyQnKV4zZdl9fq/KA3LMomkaLXLc1VinDavLBShFBpCSCU0MI2Zomr3G48h3J7bC/+77HvnuRkhO9LaBkJJ0rsjxR2qyaQYW819pMoAYajMW23BxholbnBO1YJX0TYtac0z1nz1EhaxmqXspdx5R2MT5c4+ksrwfgJmuNC8qbzGMVIbHRxaM3pgbGR5sBEdDV24y67uLR2mR/r6v7dfTqG6H/EWBLUg0HjY5NvNiYyQNJP3TMCuhYRQKkBBPpAo0akwkB6+viS4av76qmV4+y8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="799px" height="816px" viewBox="-0.5 -0.5 799 816" content="&lt;mxfile&gt;&lt;diagram id=&quot;LaSDd4dBGiKKec7Fc6nT&quot; name=&quot;Page-1&quot;&gt;3V1Rd6O2Ev41fqwPQoDgMXHi3r1Nu2m8be8+5WCQbW6xoUASe399JSM5IMkJ2MKQ7J5NzCAw+uaTZjQzYkdwst7+nPnp6tckxPHINMLtCN6MTBNAyyK/qGRXSjzbKwXLLApLkfEqmEU/MLuSS5+iEOdMVoqKJImLKK0Lg2SzwUFRk/lZlrzUmy2SOKwJUn+JJcEs8GNZ+lcUFismBY73euI/OFqu2Fe7JipPrH3emPUkX/lh8lIRwdsRnGRJUpSf1tsJjil4dVymR84eHizDm6LJBWZ5wbMfP7G+jUzHX6cjeL2Z5/TXiN6hLpp8/e3bw9e7u9sH1olix5HJkqdNiOnNDdLwZRUVeJb6AT37QrhAZKtiHZMjQD4uojieJHGS7a+Fi8XCDAIiz4ss+RvzM5tkQy6/9uNouSGHMV4U+8cSO8r6/oyzAm8rItbxn3GyxkW2I03YWRMwGjIW2k55+PKqUoczblXRJierz1i0PNz5FWjygWGtxh2egvvs9uHPL5NbraCHNnZDqz/QAbCboQ4ccD7sVhPYH27vv86+fPv68F0r0hgQrFF/SJsIKpAGMtJQA9B2E6And19uf/s20zuJuAHucxKBhtWQz9A8H2Z+4xrOAppLAmfavKcHq+nP+R2MtxGAwjQKDQmBg72rImBCDROp84kMmHFEJUehN8YWcoBnvP6UTZgJvLFRa9aNRUOfxaLp08Kujq6gFNuEruHxn7JSHON8pbgf2N5p1wMAakW8Nzp0KML7qPawuRY4yqg/uluy9cMhWbmxQ9bpClh4GxX/o7iObXb0vXLmZssg3x/s2MFxkPLkKQswN26lrPCzJWbtLNaOPtObUGY49ovoub7aPAcYxXojw3nxBtPA+0zTMWaBYdTGKOGJxB5b4TtYOtgC2rJlQ76hQhd6+J1ThB68EmZ/1JIx1qAYIy+VsjQYAGGc/gjjDWd64d2pksXrjSyWvAxJs+T/ZBGRD4AxwhTjyPYJdUUYOBjCeCrCgL4I430kwgAoB046YwyQgMn9kX3t57vNMl2O7Jv+8fEEeFx50el1BA+Q4ZHw6DreYQOz1v/Lxjv4l3+KgEfraNuQAh7g08Tw9amh/4gH+Mghfu2K6DPkAT5sDqC5GgYQ81CkWjpZ2rfmZpOlPVSAosWNcqT+63e8zwsHCE63Gu1afID1qebB22oV6A8HyHmWLsIB7UnGfSpGMiRRrKtgADC8z8cxz5Y5Bgz3QiTz5Kksx9lzFGAtq0KF6y/jcZxppsA02fPsalEIDqrqPo7QmjKMHgJnwJE1lHbOHL6+QprAL/w4WT7m2fPweAOgbAa7I44cZzmEEwJt4YQzAQICQK7sTHUVT7CGP4crYhi14YcUo89VjuULjEbbbovnpbFxzL6wAXKFxCyJydiZlTZOx0g8q5TJQkJpHk+QVQYiUAW2dIxE1/zwI1FhB93eUjJANouT0iwOhW42rMcqDknqS9ANts7MdEkdUzFRcTR6yObJgc1VUaRbJWJ3/hzHdah4gCUgXcYZEVBORIEfX7ET6ygM6T2uM5xHP1jcnYKVJtGm2D+5fU19ExV8XHPnB/J/MsbA4KHKxiiy293TR600SRaLHBcSzIdvbbbKlk3E1VOxmuE8j5JN7yPW9NzaiIWK5XZXnhqPFHU+YPEmvKJbRMhhkuJNKZlG9MH253MySAvegn3tXlZp02jQOwp7wasu9A36/aXkcf1dpQEbZzKbuSfg1T0ByzMEXZV3PJXnrnWiseefv9cMfw/G3hyUsVfUef41v0qjhzSYxBHtR99ThyWWyZvyKrirqcNtvSg5uJYW9GqM896hHDm4x1lEHpEavhZ08mQ6Ie0OwElzARLiFxaLrU+PtHffbn/23KEopX0NaXRSINGW6457SHVwtruXYzuUE6B5tA6SDD+yYOoji49JQJH+FceyZtUUmzxiFsmmYNs0ycKDHbMbg7c8QMlX1IC/7dbRR67sphySU9rhlxMlIvwveE4/ku5+UgWIfiJS0L87Bcg+tKgAP40eP7cGLARqGuCB+0sogCe6G5vbRhaSp/FqcU6k20I27qNq390034fz5FwVI9VJS2SVuarXRuiYMY26d4YMRa7eUfAF6uBL68VAl469rdi30WM8XQ7F3GfJMvPX+VDCeI4jTDVQToyqw3i2BnzQoLijqNCwewvj2aqtsdOU0efjTVKO1+Mk5bRdQzYjjCKK0F+CypajCLPiKdwNZaaBoO7XN89PaZhp+Cw3kJlGES+w+7NSqt2t05xwJ1JU7gx+ooFW3aKhC04zg0pL8amoFqHuzed22vqJp/ext5HEn6Yykv6bzAczAfMNkK0zthqgQW2XlSflDBQB3FOHWLeJIqc3iqreKSEoJv8bF8FqpErqXhN6TMp/NFQ7oZIxTQZIQpUMyUIgNyO/gOobRKFKhmQhkJvRI/7UdaFKhmz5icWrgeJqIFy9z4gnT0UcbfDk8Go7gwWbKhsgyN8p1Z64MeIWARtdS/GtcicX+UPOhH6+OhhTbof3Sf77JI8KmoaGN/OkKJK1wlAXSaqy50fCZKYQJqNf6edp2a1FtKXPcZ2v/JSeXG+X9GWCY/8lt8YZLgfIl4A+D60jKD/VW+X/5LriI6g28VmWos5ctc3M0jDvqbaZCeMtWu9fWCiDVwFerq2Q1CTqht32JlovyVPG0Zz89H88ZZg+fegX/tzPqYM3vaLCxxsmeSRMKZYZnv1+9zjbh1nH+fNSjyZcQ/DNFHlE7q/V3rZlaPDO0CV2lTQyCUjxrgieGLu8SUByyukqjX7Bu/wBp3TWSNj9TnZe/CxgxLQ1OfnIEKrPXFU4AQDFqAbOGGlYUaLWsauhVTxyFLpl4ZG0tLBIg64wwMuHYlcJWmmXcebdrND7jxxnHZDb0hXP9+r26gi5DThWTZVorIHd7iVefXFwVgA7uPcLYsqoUSNequE2JbKrSC45vS0CXTm59ODP51Hx6+8j04lp8GSekU9L+unhfjKUEh++b4OPSHS56kC3yaKEOZKLGG/Zsqxa7BfEfp5HgeCtttlYzPtpsjJC7kqhMYREQhzTkCqqcr/pFML9uaPwv8u+d3Y6ctmZs63HlSS8KpnfoRxM0mSruI9QGcAnKv2zNmdjhRI3OCVqwZtgH5Y0lgltvnnxs1COUvZS23ygsY7aZhcJNXc/AT1cqN9UXONoKYT2Ti0QPdE3MhxY847GNjxEV4/WCZOjk4r9+Dt+LlDsp6jOqw9khISRfGQAtq0ahEIBCnKBQInzqgABfw9OxwwJhQBevRZcqbP3NwqdvTlWjbmDHAHzZi7xcd02H8Hk8PU/LSibv/7XD/D2Xw==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs>
-        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="drawio-svg-hQIOx4ciC2akPxezZKwc-gradient-light-dark_f8cecc_512d2b_-1-light-dark_ff3333_ff7777_-1-s-0">
+        <linearGradient x1="0%" y1="0%" x2="0%" y2="100%" id="drawio-svg-oHT77SGrpPskH5ZcJOoe-gradient-light-dark_f8cecc_512d2b_-1-light-dark_ff3333_ff7777_-1-s-0">
             <stop offset="0%" stop-color="#f8cecc" stop-opacity="1" style="stop-color: light-dark(rgb(248, 206, 204), rgb(81, 45, 43)); stop-opacity: 1;"/>
             <stop offset="100%" stop-color="#FF3333" stop-opacity="1" style="stop-color: light-dark(rgb(255, 51, 51), rgb(255, 119, 119)); stop-opacity: 1;"/>
         </linearGradient>
@@ -285,28 +285,26 @@
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 725px; margin-left: 111px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    postgres
-                                    <br/>
-                                    asyncpg
+                                    sa[asyngpg]
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
                     <text x="155" y="729" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        postgres...
+                        sa[asyngpg]
                     </text>
                 </switch>
             </g>
         </g>
         <g/>
         <g>
-            <rect x="301.48" y="519" width="219.05" height="59" fill="#fff2cc" stroke="none" pointer-events="all" style="fill: light-dark(rgb(255, 242, 204), rgb(40, 29, 0));"/>
+            <rect x="298.48" y="519" width="219.05" height="59" fill="#fff2cc" stroke="none" pointer-events="all" style="fill: light-dark(rgb(255, 242, 204), rgb(40, 29, 0));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 217px; height: 1px; padding-top: 549px; margin-left: 303px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 217px; height: 1px; padding-top: 549px; margin-left: 300px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     CONTROLLER
@@ -314,20 +312,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="303" y="552" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
+                    <text x="300" y="552" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
                         CONTROLLER
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="301.48" y="578" width="219.52" height="60" fill="#d5e8d4" stroke="none" pointer-events="all" style="fill: light-dark(rgb(213, 232, 212), rgb(31, 47, 30));"/>
+            <rect x="298.48" y="578" width="219.52" height="60" fill="#d5e8d4" stroke="none" pointer-events="all" style="fill: light-dark(rgb(213, 232, 212), rgb(31, 47, 30));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 218px; height: 1px; padding-top: 608px; margin-left: 303px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 218px; height: 1px; padding-top: 608px; margin-left: 300px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     SERVICE
@@ -335,20 +333,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="303" y="612" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
+                    <text x="300" y="612" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
                         SERVICE
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="301.48" y="638" width="219.05" height="60" fill="#e1d5e7" stroke="none" pointer-events="all" style="fill: light-dark(rgb(225, 213, 231), rgb(57, 47, 63));"/>
+            <rect x="298.48" y="638" width="219.05" height="60" fill="#e1d5e7" stroke="none" pointer-events="all" style="fill: light-dark(rgb(225, 213, 231), rgb(57, 47, 63));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 217px; height: 1px; padding-top: 668px; margin-left: 303px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 217px; height: 1px; padding-top: 668px; margin-left: 300px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     REPOSITORY
@@ -356,20 +354,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="303" y="672" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
+                    <text x="300" y="672" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
                         REPOSITORY
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="301" y="698" width="219.52" height="60" fill="#f8cecc" stroke="none" pointer-events="all" style="fill: light-dark(rgb(248, 206, 204), rgb(81, 45, 43));"/>
+            <rect x="298" y="698" width="219.52" height="60" fill="#f8cecc" stroke="none" pointer-events="all" style="fill: light-dark(rgb(248, 206, 204), rgb(81, 45, 43));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 218px; height: 1px; padding-top: 728px; margin-left: 303px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 218px; height: 1px; padding-top: 728px; margin-left: 300px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     CLIENTS
@@ -377,20 +375,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="303" y="732" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
+                    <text x="300" y="732" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px">
                         CLIENTS
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="401" y="528.5" width="50" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <rect x="398" y="528.5" width="32" height="40" rx="4.8" ry="4.8" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 549px; margin-left: 402px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 30px; height: 1px; padding-top: 549px; margin-left: 399px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     rest
@@ -398,20 +396,24 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="426" y="552" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="414" y="552" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         rest
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="461" y="528.5" width="50" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 462 566 L 462 588.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 462 593.88 L 458.5 586.88 L 462 588.63 L 465.5 586.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="437" y="526" width="50" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 549px; margin-left: 462px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 48px; height: 1px; padding-top: 546px; margin-left: 438px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
                                     rpc
@@ -419,8 +421,79 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="486" y="552" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                    <text x="462" y="550" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
                         rpc
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 462 635 L 462 647.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 462 652.88 L 458.5 645.88 L 462 647.63 L 465.5 645.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="427" y="595" width="70" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 68px; height: 1px; padding-top: 615px; margin-left: 428px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    services
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="462" y="619" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        services
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 462 694 L 462 701.63" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 462 706.88 L 458.5 699.88 L 462 701.63 L 465.5 699.88 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <rect x="427" y="654" width="70" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 68px; height: 1px; padding-top: 674px; margin-left: 428px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    catalog_srv
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="462" y="678" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        catalog_srv
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="417" y="708" width="90" height="40" rx="6" ry="6" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 728px; margin-left: 418px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
+                                <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    sa[asyncpg]
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="462" y="732" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
+                        sa[asyncpg]
                     </text>
                 </switch>
             </g>
@@ -565,15 +638,13 @@
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 394px; margin-left: 477px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; ">
                                 <div style="display: inline-block; font-size: 12px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-                                    postgres
-                                    <br/>
-                                    asyncpg
+                                    sa[asyncg]
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
                     <text x="521" y="398" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12px" text-anchor="middle">
-                        postgres...
+                        sa[asyncg]
                     </text>
                 </switch>
             </g>
@@ -796,8 +867,8 @@
             </g>
         </g>
         <g>
-            <path d="M 347 463 L 480.24 525.79" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 484.99 528.02 L 477.16 528.21 L 480.24 525.79 L 480.15 521.87 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 347 463 L 456.42 522.94" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 461.02 525.46 L 453.2 525.17 L 456.42 522.94 L 456.56 519.03 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <path d="M 293 436 L 347 436 L 347 490 L 293 490 Z" fill="#e7157b" stroke="none" pointer-events="all" style="fill: light-dark(rgb(231, 21, 123), rgb(255, 129, 217));"/>
@@ -884,7 +955,7 @@
             </g>
         </g>
         <g>
-            <path d="M 716.01 45.61 L 736 45.39 L 743.42 732.41 L 753.92 732.29 L 733.99 785.5 L 712.92 732.73 L 723.42 732.62 Z" fill="url(#drawio-svg-hQIOx4ciC2akPxezZKwc-gradient-light-dark_f8cecc_512d2b_-1-light-dark_ff3333_ff7777_-1-s-0)" stroke="none" pointer-events="all" style="fill: url(&quot;#drawio-svg-hQIOx4ciC2akPxezZKwc-gradient-light-dark_f8cecc_512d2b_-1-light-dark_ff3333_ff7777_-1-s-0&quot;);"/>
+            <path d="M 716.01 45.61 L 736 45.39 L 743.42 732.41 L 753.92 732.29 L 733.99 785.5 L 712.92 732.73 L 723.42 732.62 Z" fill="url(#drawio-svg-oHT77SGrpPskH5ZcJOoe-gradient-light-dark_f8cecc_512d2b_-1-light-dark_ff3333_ff7777_-1-s-0)" stroke="none" pointer-events="all" style="fill: url(&quot;#drawio-svg-oHT77SGrpPskH5ZcJOoe-gradient-light-dark_f8cecc_512d2b_-1-light-dark_ff3333_ff7777_-1-s-0&quot;);"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
@@ -907,6 +978,9 @@
         <g>
             <path d="M 155 745 L 156.2 760.03 Q 157 770 167 769.93 L 585.36 767.14" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
             <path d="M 590.61 767.11 L 583.63 770.65 L 585.36 767.14 L 583.58 763.65 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+        </g>
+        <g>
+            <path d="M 462 748 L 462 769" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
     </g>
     <switch>

--- a/services/api-server/src/simcore_service_api_server/_service_solvers.py
+++ b/services/api-server/src/simcore_service_api_server/_service_solvers.py
@@ -125,15 +125,15 @@ class SolverService:
         self,
         *,
         solver_key: SolverKeyId,
-        offset: NonNegativeInt,
-        limit: PositiveInt,
+        pagination_offset: NonNegativeInt,
+        pagination_limit: PositiveInt,
     ) -> tuple[list[Solver], PageMetaInfoLimitOffset]:
 
         releases, page_meta = (
             await self.catalog_service.list_release_history_latest_first(
                 filter_by_service_key=solver_key,
-                pagination_offset=offset,
-                pagination_limit=limit,
+                pagination_offset=pagination_offset,
+                pagination_limit=pagination_limit,
             )
         )
 
@@ -158,16 +158,16 @@ class SolverService:
         *,
         pagination_offset: NonNegativeInt,
         pagination_limit: PositiveInt,
-        filter_by_solver_id: str | None = None,
-        filter_by_version_display: str | None = None,
+        filter_by_solver_key_pattern: str | None = None,
+        filter_by_version_display_pattern: str | None = None,
     ) -> tuple[list[Solver], PageMetaInfoLimitOffset]:
         """Lists the latest solvers with pagination and filtering.
 
         Args:
-            offset: Pagination offset
-            limit: Pagination limit
-            solver_id_pattern: Optional pattern to filter solvers by ID
-            version_display_pattern: Optional pattern to filter by version display
+            pagination_offset: Pagination offset
+            pagination_limit: Pagination limit
+            filter_by_solver_key_pattern: Optional pattern to filter solvers by key e.g. "simcore/service/my_solver*"
+            filter_by_version_display_pattern: Optional pattern to filter by version display e.g. "1.0.*-beta"
 
         Returns:
             A tuple with the list of filtered solvers and pagination metadata
@@ -175,12 +175,12 @@ class SolverService:
         filters = ServiceListFilters(service_type=ServiceType.COMPUTATIONAL)
 
         # Add key_pattern filter for solver ID if provided
-        if filter_by_solver_id:
-            filters.service_key_pattern = filter_by_solver_id
+        if filter_by_solver_key_pattern:
+            filters.service_key_pattern = filter_by_solver_key_pattern
 
         # Add version_display_pattern filter if provided
-        if filter_by_version_display:
-            filters.version_display_pattern = filter_by_version_display
+        if filter_by_version_display_pattern:
+            filters.version_display_pattern = filter_by_version_display_pattern
 
         services, page_meta = await self.catalog_service.list_latest_releases(
             pagination_offset=pagination_offset,

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers.py
@@ -84,20 +84,20 @@ async def list_solvers(
     "/page",
     response_model=Page[Solver],
     description=create_route_description(
-        base="Lists the latest version of all available solvers (paginated)",
+        base="Lists all available solvers (paginated)",
         changelog=[
             FMSG_CHANGELOG_NEW_IN_VERSION.format("0.9-rc1"),
         ],
     ),
     include_in_schema=False,  # TO BE RELEASED in 0.9
 )
-async def list_solvers_paginated(
+async def list_all_solvers_paginated(
     page_params: Annotated[PaginationParams, Depends()],
     solver_service: Annotated[SolverService, Depends(get_solver_service)],
     filters: Annotated[SolversListFilters, Depends(get_solvers_filters)],
     url_for: Annotated[Callable, Depends(get_reverse_url_mapper)],
 ):
-    solvers, page_meta = await solver_service.latest_solvers(
+    solvers, page_meta = await solver_service.list_all_solvers(
         pagination_offset=page_params.offset,
         pagination_limit=page_params.limit,
         filter_by_solver_key_pattern=filters.solver_id,

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers.py
@@ -45,7 +45,9 @@ _SOLVER_STATUS_CODES: dict[int | str, dict[str, Any]] = {
     **DEFAULT_BACKEND_SERVICE_STATUS_CODES,
 }
 
-router = APIRouter()
+router = APIRouter(
+    # /v0/solvers/
+)
 
 
 @router.get(
@@ -98,8 +100,8 @@ async def list_solvers_paginated(
     solvers, page_meta = await solver_service.latest_solvers(
         pagination_offset=page_params.offset,
         pagination_limit=page_params.limit,
-        filter_by_solver_id=filters.solver_id,
-        filter_by_version_display=filters.version_display,
+        filter_by_solver_key_pattern=filters.solver_id,
+        filter_by_version_display_pattern=filters.version_display,
     )
 
     for solver in solvers:
@@ -145,8 +147,8 @@ async def list_solvers_releases(
         for page_params in iter_pagination_params(limit=DEFAULT_PAGINATION_LIMIT):
             solvers, page_meta = await solver_service.solver_release_history(
                 solver_key=solver.id,
-                offset=page_params.offset,
-                limit=page_params.limit,
+                pagination_offset=page_params.offset,
+                pagination_limit=page_params.limit,
             )
             page_params.total_number_of_items = page_meta.total
             all_solvers.extend(solvers)
@@ -216,8 +218,8 @@ async def list_solver_releases(
     for page_params in iter_pagination_params(limit=DEFAULT_PAGINATION_LIMIT):
         solvers, page_meta = await solver_service.solver_release_history(
             solver_key=solver_key,
-            offset=page_params.offset,
-            limit=page_params.limit,
+            pagination_offset=page_params.offset,
+            pagination_limit=page_params.limit,
         )
         page_params.total_number_of_items = page_meta.total
         all_releases.extend(solvers)
@@ -249,8 +251,8 @@ async def list_solver_releases_paginated(
 ):
     solvers, page_meta = await solver_service.solver_release_history(
         solver_key=solver_key,
-        offset=page_params.offset,
-        limit=page_params.limit,
+        pagination_offset=page_params.offset,
+        pagination_limit=page_params.limit,
     )
 
     for solver in solvers:

--- a/services/api-server/src/simcore_service_api_server/models/schemas/solvers.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/solvers.py
@@ -1,6 +1,10 @@
 from typing import Annotated, Any, Literal, Self, TypeAlias
 
-from models_library.api_schemas_catalog.services import LatestServiceGet, ServiceGetV2
+from models_library.api_schemas_catalog.services import (
+    LatestServiceGet,
+    ServiceGetV2,
+    ServiceSummary,
+)
 from models_library.basic_regex import PUBLIC_VARIABLE_NAME_RE
 from models_library.emails import LowerCaseEmailStr
 from models_library.services import ServiceMetaDataPublished
@@ -72,14 +76,23 @@ class Solver(BaseService):
         )
 
     @classmethod
-    def create_from_service(cls, service: ServiceGetV2 | LatestServiceGet) -> Self:
+    def create_from_service(
+        cls, service: ServiceGetV2 | LatestServiceGet | ServiceSummary
+    ) -> Self:
+        # Common fields in all service types
+        maintainer = ""
+        if hasattr(service, "contact") and service.contact:
+            maintainer = service.contact
+
         return cls(
             id=service.key,
             version=service.version,
             title=service.name,
             description=service.description,
-            maintainer=service.contact or "UNDEFINED",
-            version_display=service.version_display,
+            maintainer=maintainer or "UNDEFINED",
+            version_display=(
+                service.version_display if hasattr(service, "version_display") else None
+            ),
             url=None,
         )
 

--- a/services/api-server/src/simcore_service_api_server/services_rpc/catalog.py
+++ b/services/api-server/src/simcore_service_api_server/services_rpc/catalog.py
@@ -5,6 +5,7 @@ from models_library.api_schemas_catalog.services import (
     LatestServiceGet,
     ServiceGetV2,
     ServiceListFilters,
+    ServiceSummary,
 )
 from models_library.api_schemas_catalog.services_ports import ServicePortGet
 from models_library.products import ProductName
@@ -80,6 +81,41 @@ class CatalogService:
             service_key=filter_by_service_key,
             offset=pagination_offset,
             limit=pagination_limit,
+        )
+        meta = PageMetaInfoLimitOffset(
+            limit=page.meta.limit,
+            offset=page.meta.offset,
+            total=page.meta.total,
+            count=page.meta.count,
+        )
+        return page.data, meta
+
+    async def list_all_services_summaries(
+        self,
+        *,
+        pagination_offset: PageOffsetInt = 0,
+        pagination_limit: PageLimitInt = DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
+        filters: ServiceListFilters | None = None,
+    ) -> tuple[list[ServiceSummary], PageMetaInfoLimitOffset]:
+        """Lists all services with pagination, including all versions of each service.
+
+        Returns a lightweight summary view of services for better performance.
+
+        Args:
+            pagination_offset: Number of items to skip
+            pagination_limit: Maximum number of items to return
+            filters: Optional filters to apply
+
+        Returns:
+            Tuple containing list of service summaries and pagination metadata
+        """
+        page = await catalog_rpc.list_all_services_summaries_paginated(
+            self._rpc_client,
+            product_name=self.product_name,
+            user_id=self.user_id,
+            offset=pagination_offset,
+            limit=pagination_limit,
+            filters=filters,
         )
         meta = PageMetaInfoLimitOffset(
             limit=page.meta.limit,

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers.py
@@ -6,12 +6,12 @@
 
 
 import httpx
+from fastapi import status
 from pydantic import TypeAdapter
 from pytest_mock import MockType
 from simcore_service_api_server._meta import API_VTAG
 from simcore_service_api_server.models.pagination import OnePage
 from simcore_service_api_server.models.schemas.solvers import Solver, SolverPort
-from starlette import status
 
 
 async def test_list_all_solvers(

--- a/services/api-server/tests/unit/conftest.py
+++ b/services/api-server/tests/unit/conftest.py
@@ -509,38 +509,27 @@ def mocked_catalog_rpc_api(
         services as catalog_rpc,  # keep import here
     )
 
-    return {
-        "list_services_paginated": mocker.patch.object(
-            catalog_rpc,
-            "list_services_paginated",
-            autospec=True,
-            side_effect=catalog_rpc_side_effects.list_services_paginated,
-        ),
-        "get_service": mocker.patch.object(
-            catalog_rpc,
-            "get_service",
-            autospec=True,
-            side_effect=catalog_rpc_side_effects.get_service,
-        ),
-        "update_service": mocker.patch.object(
-            catalog_rpc,
-            "update_service",
-            autospec=True,
-            side_effect=catalog_rpc_side_effects.update_service,
-        ),
-        "list_my_service_history_latest_first": mocker.patch.object(
-            catalog_rpc,
-            "list_my_service_history_latest_first",
-            autospec=True,
-            side_effect=catalog_rpc_side_effects.list_my_service_history_latest_first,
-        ),
-        "get_service_ports": mocker.patch.object(
-            catalog_rpc,
-            "get_service_ports",
-            autospec=True,
-            side_effect=catalog_rpc_side_effects.get_service_ports,
-        ),
-    }
+    mocks = {}
+
+    # Get all callable methods from the side effects class that are not built-ins
+    side_effect_methods = [
+        method_name
+        for method_name in dir(catalog_rpc_side_effects)
+        if not method_name.startswith("_")
+        and callable(getattr(catalog_rpc_side_effects, method_name))
+    ]
+
+    # Create mocks for each method in catalog_rpc that has a corresponding side effect
+    for method_name in side_effect_methods:
+        if hasattr(catalog_rpc, method_name):
+            mocks[method_name] = mocker.patch.object(
+                catalog_rpc,
+                method_name,
+                autospec=True,
+                side_effect=getattr(catalog_rpc_side_effects, method_name),
+            )
+
+    return mocks
 
 
 #

--- a/services/catalog/src/simcore_service_catalog/api/rpc/_services.py
+++ b/services/catalog/src/simcore_service_catalog/api/rpc/_services.py
@@ -7,6 +7,7 @@ from models_library.api_schemas_catalog.services import (
     MyServiceGet,
     PageRpcLatestServiceGet,
     PageRpcServiceRelease,
+    PageRpcServiceSummary,
     ServiceGetV2,
     ServiceListFilters,
     ServiceUpdateV2,
@@ -310,3 +311,59 @@ async def get_service_ports(
         )
         for port in service_ports
     ]
+
+
+@router.expose(reraise_if_error_type=(CatalogForbiddenError, ValidationError))
+@_profile_rpc_call
+@validate_call(config={"arbitrary_types_allowed": True})
+async def list_all_services_summaries_paginated(
+    app: FastAPI,
+    *,
+    product_name: ProductName,
+    user_id: UserID,
+    limit: PageLimitInt = DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
+    offset: PageOffsetInt = 0,
+    filters: ServiceListFilters | None = None,
+) -> PageRpcServiceSummary:
+    """Lists all services with pagination, including all versions of each service.
+
+    Returns a lightweight summary view of services for better performance compared to
+    full service details. This is useful for listings where complete details aren't needed.
+
+    Args:
+        app: FastAPI application
+        product_name: Product name
+        user_id: User ID
+        limit: Maximum number of items to return
+        offset: Number of items to skip
+        filters: Optional filters to apply
+
+    Returns:
+        Paginated list of all services as summaries
+    """
+    assert app.state.engine  # nosec
+
+    total_count, items = await catalog_services.list_all_service_summaries(
+        repo=ServicesRepository(app.state.engine),
+        director_api=get_director_client(app),
+        product_name=product_name,
+        user_id=user_id,
+        limit=limit,
+        offset=offset,
+        filters=TypeAdapter(ServiceDBFilters | None).validate_python(
+            filters, from_attributes=True
+        ),
+    )
+
+    assert len(items) <= total_count  # nosec
+    assert len(items) <= limit if limit is not None else True  # nosec
+
+    return cast(
+        PageRpcServiceSummary,
+        PageRpcServiceSummary.create(
+            items,
+            total=total_count,
+            limit=limit,
+            offset=offset,
+        ),
+    )

--- a/services/catalog/src/simcore_service_catalog/api/rpc/_services.py
+++ b/services/catalog/src/simcore_service_catalog/api/rpc/_services.py
@@ -252,8 +252,8 @@ async def list_my_service_history_latest_first(
         product_name=product_name,
         user_id=user_id,
         service_key=service_key,
-        limit=limit,
-        offset=offset,
+        pagination_limit=limit,
+        pagination_offset=offset,
         filters=TypeAdapter(ServiceDBFilters | None).validate_python(
             filters, from_attributes=True
         ),

--- a/services/catalog/src/simcore_service_catalog/repository/services.py
+++ b/services/catalog/src/simcore_service_catalog/repository/services.py
@@ -383,8 +383,8 @@ class ServicesRepository(BaseRepository):
         product_name: ProductName,
         user_id: UserID,
         # list args: pagination
-        limit: int | None = None,
-        offset: int | None = None,
+        pagination_limit: int | None = None,
+        pagination_offset: int | None = None,
         filters: ServiceDBFilters | None = None,
     ) -> tuple[PositiveInt, list[ServiceWithHistoryDBGet]]:
 
@@ -399,8 +399,8 @@ class ServicesRepository(BaseRepository):
             product_name=product_name,
             user_id=user_id,
             access_rights=AccessRightsClauses.can_read,
-            limit=limit,
-            offset=offset,
+            limit=pagination_limit,
+            offset=pagination_offset,
             filters=filters,
         )
 
@@ -475,8 +475,8 @@ class ServicesRepository(BaseRepository):
         # get args
         key: ServiceKey,
         # list args: pagination
-        limit: int | None = None,
-        offset: int | None = None,
+        pagination_limit: int | None = None,
+        pagination_offset: int | None = None,
         filters: ServiceDBFilters | None = None,
     ) -> tuple[PositiveInt, list[ReleaseDBGet]]:
 
@@ -540,8 +540,8 @@ class ServicesRepository(BaseRepository):
                 )
             )
             .order_by(sql.desc(_services_sql.by_version(services_meta_data.c.version)))
-            .offset(offset)
-            .limit(limit)
+            .offset(pagination_offset)
+            .limit(pagination_limit)
         )
 
         async with pass_or_acquire_connection(self.db_engine) as conn:

--- a/services/catalog/src/simcore_service_catalog/service/catalog_services.py
+++ b/services/catalog/src/simcore_service_catalog/service/catalog_services.py
@@ -144,8 +144,8 @@ async def list_latest_catalog_services(
     total_count, services = await repo.list_latest_services(
         product_name=product_name,
         user_id=user_id,
-        limit=limit,
-        offset=offset,
+        pagination_limit=limit,
+        pagination_offset=offset,
         filters=filters,
     )
 
@@ -519,11 +519,11 @@ async def list_user_service_release_history(
     # target service
     service_key: ServiceKey,
     # pagination
-    limit: PageLimitInt | None = None,
-    offset: NonNegativeInt | None = None,
+    pagination_limit: PageLimitInt | None = None,
+    pagination_offset: NonNegativeInt | None = None,
     # filters
     filters: ServiceDBFilters | None = None,
-    # options
+    # result options
     include_compatibility: bool = False,
 ) -> tuple[PageTotalCount, list[ServiceRelease]]:
 
@@ -533,8 +533,8 @@ async def list_user_service_release_history(
         product_name=product_name,
         user_id=user_id,
         key=service_key,
-        limit=limit,
-        offset=offset,
+        pagination_limit=pagination_limit,
+        pagination_offset=pagination_offset,
         filters=filters,
     )
 

--- a/services/catalog/src/simcore_service_catalog/service/catalog_services.py
+++ b/services/catalog/src/simcore_service_catalog/service/catalog_services.py
@@ -70,9 +70,7 @@ def _aggregate(
         "contact": service_manifest.contact,
         "authors": service_manifest.authors,
         # Check if owner attribute is available in the service_db object
-        "owner": (
-            service_db.owner_email if hasattr(service_db, "owner_email") else None
-        ),
+        "owner": getattr(service_db, "owner_email", None),
         "inputs": service_manifest.inputs or {},
         "outputs": service_manifest.outputs or {},
         "boot_options": service_manifest.boot_options,

--- a/services/catalog/tests/unit/with_dbs/test_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_repositories.py
@@ -390,7 +390,7 @@ async def test_list_latest_services_with_pagination(
         assert service.version == expected_latest_version
 
     _, services_items = await services_repo.list_latest_services(
-        product_name=target_product, user_id=user_id, limit=2
+        product_name=target_product, user_id=user_id, pagination_limit=2
     )
     assert len(services_items) == 2
 
@@ -711,8 +711,8 @@ async def test_get_service_history_page(
         product_name=target_product,
         user_id=user_id,
         key=service_key,
-        limit=limit,
-        offset=offset,
+        pagination_limit=limit,
+        pagination_offset=offset,
     )
     assert total_count == num_versions
     assert len(paginated_history) == limit

--- a/services/catalog/tests/unit/with_dbs/test_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_repositories.py
@@ -1052,6 +1052,7 @@ async def test_compare_list_all_and_latest_services(
 
     # Verify pagination
     assert total_all_page1 == 6  # Total count should still be total
+    assert total_all_page2 == 6
     assert len(all_services_page1) == 2  # But only 2 items on first page
     assert len(all_services_page2) == 2  # And 2 items on second page
 

--- a/services/catalog/tests/unit/with_dbs/test_repositories.py
+++ b/services/catalog/tests/unit/with_dbs/test_repositories.py
@@ -900,3 +900,262 @@ async def test_list_services_from_published_templates_with_invalid_service(
             "service {'key': 'simcore/services/dynamic/invalid-service', 'version': 'invalid'} could not be validated"
             in caplog.text
         )
+
+
+async def test_compare_list_all_and_latest_services(
+    target_product: ProductName,
+    create_fake_service_data: CreateFakeServiceDataCallable,
+    services_db_tables_injector: Callable,
+    services_repo: ServicesRepository,
+    user_id: UserID,
+):
+    # Setup: Create multiple versions of the same service and a few distinct services
+    service_data: list[tuple] = []
+
+    # Service 1 with multiple versions
+    service_key_1 = "simcore/services/dynamic/multi-version"
+    service_versions_1 = ["1.0.0", "1.1.0", "2.0.0"]
+    service_data.extend(
+        [
+            create_fake_service_data(
+                service_key_1,
+                version_,
+                team_access=None,
+                everyone_access=None,
+                product=target_product,
+            )
+            for version_ in service_versions_1
+        ]
+    )
+
+    # Service 2 with single version
+    service_key_2 = "simcore/services/dynamic/single-version"
+    service_data.append(
+        create_fake_service_data(
+            service_key_2,
+            "1.0.0",
+            team_access=None,
+            everyone_access=None,
+            product=target_product,
+        )
+    )
+
+    # Service 3 with computational type
+    service_key_3 = "simcore/services/comp/computational-service"
+    service_versions_3 = ["0.5.0", "1.0.0"]
+    service_data.extend(
+        [
+            create_fake_service_data(
+                service_key_3,
+                version_,
+                team_access=None,
+                everyone_access=None,
+                product=target_product,
+            )
+            for version_ in service_versions_3
+        ]
+    )
+
+    await services_db_tables_injector(service_data)
+
+    # Test 1: Compare all services vs latest without filters
+    total_all, all_services = await services_repo.list_all_services(
+        product_name=target_product, user_id=user_id
+    )
+    total_latest, latest_services = await services_repo.list_latest_services(
+        product_name=target_product, user_id=user_id
+    )
+
+    # Verify counts
+    # All services should be 6 (3 versions of service 1, 1 of service 2, 2 of service 3)
+    assert total_all == 6
+    # Latest services should be 3 (one latest for each distinct service key)
+    assert total_latest == 3
+
+    # Verify latest services are contained in all services
+    latest_key_versions = {(s.key, s.version) for s in latest_services}
+    all_key_versions = {(s.key, s.version) for s in all_services}
+    assert latest_key_versions.issubset(all_key_versions)
+
+    # Verify latest versions are correct
+    latest_versions_by_key = {s.key: s.version for s in latest_services}
+    assert latest_versions_by_key[service_key_1] == "2.0.0"
+    assert latest_versions_by_key[service_key_2] == "1.0.0"
+    assert latest_versions_by_key[service_key_3] == "1.0.0"
+
+    # Test 2: Using service_type filter to get only dynamic services
+    filters = ServiceDBFilters(service_type=ServiceType.DYNAMIC)
+
+    total_all_filtered, all_services_filtered = await services_repo.list_all_services(
+        product_name=target_product, user_id=user_id, filters=filters
+    )
+    total_latest_filtered, latest_services_filtered = (
+        await services_repo.list_latest_services(
+            product_name=target_product, user_id=user_id, filters=filters
+        )
+    )
+
+    # Verify counts with filter
+    assert total_all_filtered == 4  # 3 versions of service 1, 1 of service 2
+    assert total_latest_filtered == 2  # 1 latest each for service 1 and 2
+
+    # Verify service types are correct after filtering
+    assert all(
+        s.key.startswith(DYNAMIC_SERVICE_KEY_PREFIX) for s in all_services_filtered
+    )
+    assert all(
+        s.key.startswith(DYNAMIC_SERVICE_KEY_PREFIX) for s in latest_services_filtered
+    )
+
+    # Verify latest versions are correct
+    latest_versions_by_key = {s.key: s.version for s in latest_services_filtered}
+    assert latest_versions_by_key[service_key_1] == "2.0.0"
+    assert latest_versions_by_key[service_key_2] == "1.0.0"
+    assert service_key_3 not in latest_versions_by_key  # Filtered out
+
+    # Test 3: Using service_key_pattern to find specific service
+    filters = ServiceDBFilters(service_key_pattern="*/multi-*")
+
+    total_all_filtered, all_services_filtered = await services_repo.list_all_services(
+        product_name=target_product, user_id=user_id, filters=filters
+    )
+    total_latest_filtered, latest_services_filtered = (
+        await services_repo.list_latest_services(
+            product_name=target_product, user_id=user_id, filters=filters
+        )
+    )
+
+    # Verify counts with key pattern filter
+    assert total_all_filtered == 3  # All 3 versions of service 1
+    assert total_latest_filtered == 1  # Only latest version of service 1
+
+    # Verify service key pattern is matched
+    assert all(s.key == service_key_1 for s in all_services_filtered)
+    assert all(s.key == service_key_1 for s in latest_services_filtered)
+
+    # Test 4: Pagination
+    # Get first page (limit=2)
+    total_all_page1, all_services_page1 = await services_repo.list_all_services(
+        product_name=target_product,
+        user_id=user_id,
+        pagination_limit=2,
+        pagination_offset=0,
+    )
+
+    # Get second page (limit=2, offset=2)
+    total_all_page2, all_services_page2 = await services_repo.list_all_services(
+        product_name=target_product,
+        user_id=user_id,
+        pagination_limit=2,
+        pagination_offset=2,
+    )
+
+    # Verify pagination
+    assert total_all_page1 == 6  # Total count should still be total
+    assert len(all_services_page1) == 2  # But only 2 items on first page
+    assert len(all_services_page2) == 2  # And 2 items on second page
+
+    # Ensure pages have different items
+    page1_key_versions = {(s.key, s.version) for s in all_services_page1}
+    page2_key_versions = {(s.key, s.version) for s in all_services_page2}
+    assert not page1_key_versions.intersection(page2_key_versions)
+
+
+async def test_list_all_services_empty_database(
+    target_product: ProductName,
+    services_repo: ServicesRepository,
+    user_id: UserID,
+):
+    """Test list_all_services and list_latest_services with an empty database."""
+    # Test with empty database
+    total_all, all_services = await services_repo.list_all_services(
+        product_name=target_product, user_id=user_id
+    )
+    total_latest, latest_services = await services_repo.list_latest_services(
+        product_name=target_product, user_id=user_id
+    )
+
+    assert total_all == 0
+    assert len(all_services) == 0
+    assert total_latest == 0
+    assert len(latest_services) == 0
+
+
+async def test_list_all_services_deprecated_versions(
+    target_product: ProductName,
+    create_fake_service_data: CreateFakeServiceDataCallable,
+    services_db_tables_injector: Callable,
+    services_repo: ServicesRepository,
+    user_id: UserID,
+):
+    """Test that list_all_services includes deprecated versions while list_latest_services ignores them."""
+    from datetime import datetime, timedelta
+
+    # Create a service with regular and deprecated versions
+    service_key = "simcore/services/dynamic/with-deprecated"
+    service_data = []
+
+    # Add regular version
+    service_data.append(
+        create_fake_service_data(
+            service_key,
+            "1.0.0",
+            team_access=None,
+            everyone_access=None,
+            product=target_product,
+        )
+    )
+
+    # Add deprecated version (with higher version number)
+    deprecated_service = create_fake_service_data(
+        service_key,
+        "2.0.0",
+        team_access=None,
+        everyone_access=None,
+        product=target_product,
+    )
+    # Set deprecated timestamp to yesterday
+    deprecated_service[0]["deprecated"] = datetime.now() - timedelta(days=1)
+    service_data.append(deprecated_service)
+
+    # Add newer non-deprecated version
+    service_data.append(
+        create_fake_service_data(
+            service_key,
+            "3.0.0",
+            team_access=None,
+            everyone_access=None,
+            product=target_product,
+        )
+    )
+
+    await services_db_tables_injector(service_data)
+
+    # Get all services - should include both deprecated and non-deprecated
+    total_all, all_services = await services_repo.list_all_services(
+        product_name=target_product, user_id=user_id
+    )
+
+    # Get latest services - should only show latest non-deprecated
+    total_latest, latest_services = await services_repo.list_latest_services(
+        product_name=target_product, user_id=user_id
+    )
+
+    # Verify counts
+    assert total_all == 3  # All 3 versions
+
+    # Verify latest is the newest non-deprecated version
+    assert len(latest_services) == 1
+    assert latest_services[0].key == service_key
+    assert latest_services[0].version == "3.0.0"
+
+    # Get versions from all services
+    versions = [s.version for s in all_services if s.key == service_key]
+    assert sorted(versions) == ["1.0.0", "2.0.0", "3.0.0"]
+
+    # Verify the deprecated status is correctly set
+    for service in all_services:
+        if service.key == service_key and service.version == "2.0.0":
+            assert service.deprecated is not None
+        else:
+            assert service.deprecated is None

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.yaml
@@ -8616,6 +8616,22 @@ components:
         name:
           type: string
           title: Name
+        description:
+          type: string
+          title: Description
+        versionDisplay:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Versiondisplay
+        contact:
+          anyOf:
+          - type: string
+            format: email
+          - type: 'null'
+          title: Contact
+        type:
+          $ref: '#/components/schemas/ServiceType'
         thumbnail:
           anyOf:
           - type: string
@@ -8626,26 +8642,10 @@ components:
           - type: string
           - type: 'null'
           title: Icon
-        description:
-          type: string
-          title: Description
         descriptionUi:
           type: boolean
           title: Descriptionui
           default: false
-        versionDisplay:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Versiondisplay
-        type:
-          $ref: '#/components/schemas/ServiceType'
-        contact:
-          anyOf:
-          - type: string
-            format: email
-          - type: 'null'
-          title: Contact
         authors:
           items:
             $ref: '#/components/schemas/Author'
@@ -8702,8 +8702,8 @@ components:
       - version
       - name
       - description
-      - type
       - contact
+      - type
       - authors
       - owner
       - inputs
@@ -8835,6 +8835,22 @@ components:
         name:
           type: string
           title: Name
+        description:
+          type: string
+          title: Description
+        versionDisplay:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Versiondisplay
+        contact:
+          anyOf:
+          - type: string
+            format: email
+          - type: 'null'
+          title: Contact
+        type:
+          $ref: '#/components/schemas/ServiceType'
         thumbnail:
           anyOf:
           - type: string
@@ -8845,26 +8861,10 @@ components:
           - type: string
           - type: 'null'
           title: Icon
-        description:
-          type: string
-          title: Description
         descriptionUi:
           type: boolean
           title: Descriptionui
           default: false
-        versionDisplay:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Versiondisplay
-        type:
-          $ref: '#/components/schemas/ServiceType'
-        contact:
-          anyOf:
-          - type: string
-            format: email
-          - type: 'null'
-          title: Contact
         authors:
           items:
             $ref: '#/components/schemas/Author'
@@ -8928,8 +8928,8 @@ components:
       - version
       - name
       - description
-      - type
       - contact
+      - type
       - authors
       - owner
       - inputs


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

This PR implements the public-api `GET /solvers/page` route to `List` **all** items of the `Solver`s collection (paginated) with query filters by attribute `solver_id` and `version_display` patterns

Examples
```
GET /solvers/page # gives you first page of solvers
GET /solvers/page?solver_id=*isolve*  # gives you all isolve flavours and versions
GET /solvers/page?solver_id=*isolve*&version_display=1.0.*  # gives you all isolve flavours on version 1.0.*
```
### Details on the implementation

- 
![image](https://github.com/user-attachments/assets/46ed728a-4b74-427c-b990-b04ee2b3ae31)

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- resolves #7692

## How to test

- `api-server` 
    - tests from rest-api to rpc-mocked backend
- `catalog`:
     - `test_api_rpc.py`: tests catalog's rpc_client end-to-end
     - `test_repositories.py`: tests repo-layer to end
     - `tests_service_catalog_service.py`: tests service-layer to end

- Manual exploratory test using api-server swagger site
![image](https://github.com/user-attachments/assets/a06bfbc3-20e2-4dc8-93d2-a091b7085537)



## Dev-ops
None
<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
