### PR TITLE
🐛Computational services with large amount of inputs/outputs fail to start (🗃️)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,8 @@ This document provides guidelines and best practices for using GitHub Copilot in
 - ensure we use `fastapi` >0.100 compatible code
 - use f-string formatting
 - Only add comments in function if strictly necessary
+- use relative imports
+- imports should be at top of the file
 
 
 ### Json serialization

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/278daef7e99d_remove_whole_row_in_payload.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/278daef7e99d_remove_whole_row_in_payload.py
@@ -1,0 +1,134 @@
+"""remove whole row in payload
+
+Revision ID: 278daef7e99d
+Revises: 4e7d8719855b
+Create Date: 2025-05-22 21:22:11.084001+00:00
+
+"""
+
+from typing import Final
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "278daef7e99d"
+down_revision = "4e7d8719855b"
+branch_labels = None
+depends_on = None
+
+DB_PROCEDURE_NAME: Final[str] = "notify_comp_tasks_changed"
+DB_TRIGGER_NAME: Final[str] = f"{DB_PROCEDURE_NAME}_event"
+DB_CHANNEL_NAME: Final[str] = "comp_tasks_output_events"
+
+
+def upgrade():
+    drop_trigger = sa.DDL(
+        f"""
+DROP TRIGGER IF EXISTS {DB_TRIGGER_NAME} on comp_tasks;
+"""
+    )
+
+    task_output_changed_procedure = sa.DDL(
+        f"""
+CREATE OR REPLACE FUNCTION {DB_PROCEDURE_NAME}() RETURNS TRIGGER AS $$
+    DECLARE
+        record RECORD;
+        payload JSON;
+        changes JSONB;
+    BEGIN
+        IF (TG_OP = 'DELETE') THEN
+            record = OLD;
+        ELSE
+            record = NEW;
+        END IF;
+
+        SELECT jsonb_agg(pre.key ORDER BY pre.key) INTO changes
+        FROM jsonb_each(to_jsonb(OLD)) AS pre, jsonb_each(to_jsonb(NEW)) AS post
+        WHERE pre.key = post.key AND pre.value IS DISTINCT FROM post.value;
+
+        payload = json_build_object(
+            'table', TG_TABLE_NAME,
+            'changes', changes,
+            'action', TG_OP,
+            'task_id', record.task_id,
+            'project_id', record.project_id,
+            'node_id', record.node_id
+        );
+
+        PERFORM pg_notify('{DB_CHANNEL_NAME}', payload::text);
+
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+"""
+    )
+
+    task_output_changed_trigger = sa.DDL(
+        f"""
+DROP TRIGGER IF EXISTS {DB_TRIGGER_NAME} on comp_tasks;
+CREATE TRIGGER {DB_TRIGGER_NAME}
+AFTER UPDATE OF outputs,state ON comp_tasks
+    FOR EACH ROW
+    WHEN ((OLD.outputs::jsonb IS DISTINCT FROM NEW.outputs::jsonb OR OLD.state IS DISTINCT FROM NEW.state))
+    EXECUTE PROCEDURE {DB_PROCEDURE_NAME}();
+"""
+    )
+
+    op.execute(drop_trigger)
+    op.execute(task_output_changed_procedure)
+    op.execute(task_output_changed_trigger)
+
+
+def downgrade():
+    drop_trigger = sa.DDL(
+        f"""
+DROP TRIGGER IF EXISTS {DB_TRIGGER_NAME} on comp_tasks;
+"""
+    )
+
+    task_output_changed_procedure = sa.DDL(
+        f"""
+CREATE OR REPLACE FUNCTION {DB_PROCEDURE_NAME}() RETURNS TRIGGER AS $$
+    DECLARE
+        record RECORD;
+        payload JSON;
+        changes JSONB;
+    BEGIN
+        IF (TG_OP = 'DELETE') THEN
+            record = OLD;
+        ELSE
+            record = NEW;
+        END IF;
+
+        SELECT jsonb_agg(pre.key ORDER BY pre.key) INTO changes
+        FROM jsonb_each(to_jsonb(OLD)) AS pre, jsonb_each(to_jsonb(NEW)) AS post
+        WHERE pre.key = post.key AND pre.value IS DISTINCT FROM post.value;
+
+        payload = json_build_object('table', TG_TABLE_NAME,
+                                    'changes', changes,
+                                    'action', TG_OP,
+                                    'data', row_to_json(record));
+
+        PERFORM pg_notify('{DB_CHANNEL_NAME}', payload::text);
+
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+"""
+    )
+
+    task_output_changed_trigger = sa.DDL(
+        f"""
+DROP TRIGGER IF EXISTS {DB_TRIGGER_NAME} on comp_tasks;
+CREATE TRIGGER {DB_TRIGGER_NAME}
+AFTER UPDATE OF outputs,state ON comp_tasks
+    FOR EACH ROW
+    WHEN ((OLD.outputs::jsonb IS DISTINCT FROM NEW.outputs::jsonb OR OLD.state IS DISTINCT FROM NEW.state))
+    EXECUTE PROCEDURE {DB_PROCEDURE_NAME}();
+"""
+    )
+
+    op.execute(drop_trigger)
+    op.execute(task_output_changed_procedure)
+    op.execute(task_output_changed_trigger)

--- a/packages/postgres-database/src/simcore_postgres_database/models/comp_tasks.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/comp_tasks.py
@@ -152,10 +152,14 @@ CREATE OR REPLACE FUNCTION {DB_PROCEDURE_NAME}() RETURNS TRIGGER AS $$
         FROM jsonb_each(to_jsonb(OLD)) AS pre, jsonb_each(to_jsonb(NEW)) AS post
         WHERE pre.key = post.key AND pre.value IS DISTINCT FROM post.value;
 
-        payload = json_build_object('table', TG_TABLE_NAME,
-                                    'changes', changes,
-                                    'action', TG_OP,
-                                    'data', row_to_json(record));
+        payload = json_build_object(
+            'table', TG_TABLE_NAME,
+            'changes', changes,
+            'action', TG_OP,
+            'task_id', record.task_id,
+            'project_id', record.project_id,
+            'node_id', record.node_id
+        );
 
         PERFORM pg_notify('{DB_CHANNEL_NAME}', payload::text);
 

--- a/packages/postgres-database/tests/test_comp_tasks.py
+++ b/packages/postgres-database/tests/test_comp_tasks.py
@@ -152,8 +152,8 @@ async def test_listen_query(
     for n, output in enumerate(update_outputs):
         assert output
         assert tasks[n]["changes"] == ["modified", "outputs"]
-        assert tasks[0]["action"] == "UPDATE"
-        assert tasks[0]["table"] == "comp_tasks"
-        assert tasks[0]["task_id"] == task["task_id"]
-        assert tasks[0]["project_id"] == task["project_id"]
-        assert tasks[0]["node_id"] == task["node_id"]
+        assert tasks[n]["action"] == "UPDATE"
+        assert tasks[n]["table"] == "comp_tasks"
+        assert tasks[n]["task_id"] == task["task_id"]
+        assert tasks[n]["project_id"] == task["project_id"]
+        assert tasks[n]["node_id"] == task["node_id"]

--- a/packages/pytest-simcore/src/pytest_simcore/db_entries_mocks.py
+++ b/packages/pytest-simcore/src/pytest_simcore/db_entries_mocks.py
@@ -171,9 +171,8 @@ def comp_task(postgres_db: sa.engine.Engine) -> Iterator[Callable[..., dict[str,
                 .values(**task_config)
                 .returning(sa.literal_column("*"))
             )
-            new_task = result.first()
-            assert new_task
-            new_task = dict(new_task)
+            row = result.one()
+            new_task = row._asdict()
             created_task_ids.append(new_task["task_id"])
         return new_task
 

--- a/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
@@ -7,7 +7,7 @@ import asyncio
 import datetime
 import logging
 from collections.abc import AsyncIterator
-from typing import Final, NoReturn
+from typing import Final, NoReturn, cast
 
 from aiohttp import web
 from aiopg.sa.connection import SAConnection

--- a/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
@@ -19,6 +19,7 @@ from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.projects_state import RunningState
 from pydantic.types import PositiveInt
+from simcore_postgres_database.models.comp_tasks import comp_tasks
 from simcore_postgres_database.webserver_models import DB_CHANNEL_NAME, projects
 from sqlalchemy.sql import select
 
@@ -61,23 +62,24 @@ async def _update_project_state(
 @dataclass(frozen=True)
 class _CompTaskNotificationPayload:
     action: str
-    data: dict
     changes: dict
     table: str
+    task_id: str | None = None
+    project_id: str | None = None
+    node_id: str | None = None
 
 
 async def _handle_db_notification(
     app: web.Application, payload: _CompTaskNotificationPayload, conn: SAConnection
 ) -> None:
-    task_data = payload.data
+    project_uuid = payload.project_id
+    node_uuid = payload.node_id
     task_changes = payload.changes
 
-    project_uuid = task_data.get("project_id", None)
-    node_uuid = task_data.get("node_id", None)
     if any(x is None for x in [project_uuid, node_uuid]):
         _logger.warning(
             "comp_tasks row is corrupted. TIP: please check DB entry containing '%s'",
-            f"{task_data=}",
+            f"{payload=}",
         )
         return
 
@@ -85,14 +87,28 @@ async def _handle_db_notification(
     assert node_uuid  # nosec
 
     try:
-        # NOTE: we need someone with the rights to modify that project. the owner is one.
-        # find the user(s) linked to that project
         the_project_owner = await _get_project_owner(conn, project_uuid)
 
-        if any(f in task_changes for f in ["outputs", "run_hash"]):
-            new_outputs = task_data.get("outputs", {})
-            new_run_hash = task_data.get("run_hash", None)
+        # Fetch the latest comp_tasks row for this node/project
+        result = await conn.execute(
+            select(comp_tasks).where(
+                (comp_tasks.c.project_id == project_uuid)
+                & (comp_tasks.c.node_id == node_uuid)
+            )
+        )
+        row = await result.first()
+        if not row:
+            _logger.warning(
+                "No comp_tasks row found for project_id=%s node_id=%s",
+                project_uuid,
+                node_uuid,
+            )
+            return
 
+        if any(f in task_changes for f in ["outputs", "run_hash"]):
+            new_outputs = row.outputs if hasattr(row, "outputs") else {}
+            new_run_hash = row.run_hash if hasattr(row, "run_hash") else None
+            node_errors = row.errors if hasattr(row, "errors") else None
             await update_node_outputs(
                 app,
                 the_project_owner,
@@ -100,20 +116,21 @@ async def _handle_db_notification(
                 NodeID(node_uuid),
                 new_outputs,
                 new_run_hash,
-                node_errors=task_data.get("errors", None),
+                node_errors=node_errors,
                 ui_changed_keys=None,
             )
 
         if "state" in task_changes:
-            new_state = convert_state_from_db(task_data["state"])
-            await _update_project_state(
-                app,
-                the_project_owner,
-                ProjectID(project_uuid),
-                NodeID(node_uuid),
-                new_state,
-                node_errors=task_data.get("errors", None),
-            )
+            new_state = row.state if hasattr(row, "state") else None
+            if new_state is not None:
+                await _update_project_state(
+                    app,
+                    the_project_owner,
+                    ProjectID(project_uuid),
+                    NodeID(node_uuid),
+                    convert_state_from_db(new_state),
+                    node_errors=row.errors if hasattr(row, "errors") else None,
+                )
 
     except exceptions.ProjectNotFoundError as exc:
         _logger.warning(
@@ -151,7 +168,6 @@ async def _listen(app: web.Application, db_engine: Engine) -> NoReturn:
                 await asyncio.sleep(_LISTENING_TASK_BASE_SLEEPING_TIME_S)
                 continue
             notification = conn.connection.notifies.get_nowait()
-            # get the data and the info on what changed
             payload = _CompTaskNotificationPayload(**json_loads(notification.payload))
             _logger.debug("received update from database: %s", f"{payload=}")
             await _handle_db_notification(app, payload, conn)
@@ -161,12 +177,10 @@ async def _comp_tasks_listening_task(app: web.Application) -> None:
     _logger.info("starting comp_task db listening task...")
     while True:
         try:
-            # create a special connection here
             db_engine = get_database_engine(app)
             _logger.info("listening to comp_task events...")
             await _listen(app, db_engine)
-        except asyncio.CancelledError:  # noqa: PERF203
-            # we are closing the app..
+        except asyncio.CancelledError:
             _logger.info("cancelled comp_tasks events")
             raise
         except Exception:  # pylint: disable=broad-except

--- a/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
+++ b/services/web/server/src/simcore_service_webserver/db_listener/_db_comp_tasks_listening_task.py
@@ -67,7 +67,7 @@ async def _get_changed_comp_task_row(
     result = await conn.execute(
         select(comp_tasks).where(comp_tasks.c.task_id == task_id)
     )
-    return await result.fetchone()
+    return cast(RowProxy | None, await result.fetchone())
 
 
 async def _handle_db_notification(

--- a/services/web/server/src/simcore_service_webserver/db_listener/_models.py
+++ b/services/web/server/src/simcore_service_webserver/db_listener/_models.py
@@ -1,0 +1,16 @@
+from typing import TypeAlias
+
+from models_library.projects import ProjectID
+from models_library.projects_nodes_io import NodeID
+from pydantic import BaseModel
+
+_DB_KEY: TypeAlias = str
+
+
+class CompTaskNotificationPayload(BaseModel):
+    action: str
+    changes: list[_DB_KEY]
+    table: str
+    task_id: int
+    project_id: ProjectID
+    node_id: NodeID

--- a/services/web/server/src/simcore_service_webserver/db_listener/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/db_listener/plugin.py
@@ -10,7 +10,6 @@ from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setu
 
 from ..db.plugin import setup_db
 from ..projects._projects_repository_legacy import setup_projects_db
-from ..rabbitmq import setup_rabbitmq
 from ..socketio.plugin import setup_socketio
 from ._db_comp_tasks_listening_task import create_comp_tasks_listening_task
 
@@ -24,7 +23,6 @@ _logger = logging.getLogger(__name__)
     logger=_logger,
 )
 def setup_db_listener(app: web.Application):
-    setup_rabbitmq(app)
     setup_socketio(app)
     setup_projects_db(app)
     # Creates a task to listen to comp_task pg-db's table events

--- a/services/web/server/tests/unit/with_dbs/04/notifications/test_notifications__db_comp_tasks_listening_task.py
+++ b/services/web/server/tests/unit/with_dbs/04/notifications/test_notifications__db_comp_tasks_listening_task.py
@@ -3,6 +3,7 @@
 # pylint:disable=redefined-outer-name
 # pylint:disable=no-value-for-parameter
 # pylint:disable=too-many-arguments
+# pylint:disable=protected-access
 
 import json
 import logging
@@ -204,6 +205,6 @@ async def test_db_listener_triggers_on_event_with_multiple_tasks(
         assert any(
             call.args[1] == updated_task_id
             for call in spied_get_changed_comp_task_row.call_args_list
-        ), f"_get_changed_comp_task_row was not called with task_id={updated_task_id}. Calls: {spy_get_changed.call_args_list}"
+        ), f"_get_changed_comp_task_row was not called with task_id={updated_task_id}. Calls: {spied_get_changed_comp_task_row.call_args_list}"
     else:
         spied_get_changed_comp_task_row.assert_not_called()


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR fixes the issue described in https://github.com/ITISFoundation/osparc-simcore/issues/7722. 
The _comp_tasks_ table uses an event trigger and the webservers _listens_ to that event to transmit changes in _comp_tasks_ _outputs_, _state_. This includes payload generation for table updates and ensures proper handling of `outputs` and `state` fields changes. The procedure used to transmit the whole row as payload through _pg_notify_. This is limited to 8000 bytes.

This PR changes the procedure to **not** pass the row in the payload anymore due to that limitation.

Therefore changes are now in the listener code of the webserver, such that an additional query to _comp_tasks_ is necessary in order to transmit the notifications to the next nodes/frontend.


## What is still not good?
- see the following up case: https://github.com/ITISFoundation/osparc-simcore/issues/7748

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/7722

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
