### PR TITLE
Let frontend return 'number' instead of 'float' for the func schema   🐛

### DIFF
--- a/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
+++ b/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
@@ -36,7 +36,7 @@ qx.Class.define("osparc.study.CreateFunction", {
     typeToFunctionType: function(type) {
       switch (type) {
         case "number":
-          return "float"
+          return "number"
         case "data:*/*":
           return "FileID"
       }


### PR DESCRIPTION
## What do these changes do?

Json schemas don't support 'float', but need 'number'. 
The Create functions window of the frontend now returns 'number' in the function schemas




## How to test

Create function on frontend, run function.
