### PR TITLE
🐛On-demand computational backend failing

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/rest_responses.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_responses.py
@@ -8,10 +8,10 @@ from aiohttp.web_exceptions import HTTPError, HTTPException
 from common_library.error_codes import ErrorCodeStr
 from common_library.json_serialization import json_dumps
 from models_library.rest_error import ErrorGet, ErrorItemType
-from servicelib.rest_constants import RESPONSE_MODEL_POLICY
 
 from ..aiohttp.status import HTTP_200_OK
 from ..mimetype_constants import MIMETYPE_APPLICATION_JSON
+from ..rest_constants import RESPONSE_MODEL_POLICY
 from ..rest_responses import is_enveloped
 from ..status_codes_utils import get_code_description
 
@@ -54,7 +54,7 @@ def create_http_error(
     http_error_cls: type[HTTPError] = web.HTTPInternalServerError,
     *,
     skip_internal_error_details: bool = False,
-    error_code: ErrorCodeStr | None = None
+    error_code: ErrorCodeStr | None = None,
 ) -> HTTPError:
     """
     - Response body conforms OAS schema model
@@ -90,9 +90,8 @@ def create_http_error(
     payload = wrap_as_envelope(
         error=error.model_dump(mode="json", **RESPONSE_MODEL_POLICY)
     )
-
     return http_error_cls(
-        # Multiline not allowed in HTTP reason
+        # NOTE: reason cannot contain new lines
         reason=reason.replace("\n", " ") if reason else None,
         text=json_dumps(
             payload,

--- a/services/agent/docker/boot.sh
+++ b/services/agent/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -48,7 +52,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/agent/src/simcore_service_agent && \
-    python -m debugpy --listen 0.0.0.0:${AGENT_SERVER_REMOTE_DEBUG_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${AGENT_SERVER_REMOTE_DEBUG_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --port 8000 \
       --reload \

--- a/services/api-server/docker/boot.sh
+++ b/services/api-server/docker/boot.sh
@@ -27,7 +27,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 # RUNNING application ----------------------------------------
@@ -40,7 +44,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/api-server/src/simcore_service_api_server && \
-    python -m debugpy --listen 0.0.0.0:${API_SERVER_REMOTE_DEBUG_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${API_SERVER_REMOTE_DEBUG_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/autoscaling/docker/boot.sh
+++ b/services/autoscaling/docker/boot.sh
@@ -31,7 +31,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -47,7 +51,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/autoscaling/src/simcore_service_autoscaling && \
-    python -m debugpy --listen 0.0.0.0:${AUTOSCALING_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${AUTOSCALING_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/catalog/docker/boot.sh
+++ b/services/catalog/docker/boot.sh
@@ -27,7 +27,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 # RUNNING application ----------------------------------------
@@ -40,7 +44,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/catalog/src/simcore_service_catalog && \
-    python -m debugpy --listen 0.0.0.0:${CATALOG_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${CATALOG_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/clusters-keeper/docker/boot.sh
+++ b/services/clusters-keeper/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -48,7 +52,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/clusters-keeper/src/simcore_service_clusters_keeper && \
-    python -m debugpy --listen 0.0.0.0:${CLUSTERS_KEEPER_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${CLUSTERS_KEEPER_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: ${DOCKER_REGISTRY:-itisfoundation}/dask-sidecar:${DOCKER_IMAGE_TAG}
     init: true
     hostname: "{{.Node.Hostname}}-{{.Task.Slot}}"
+    volumes:
+      - computational_shared_data:${SIDECAR_COMP_SERVICES_SHARED_FOLDER:-/home/scu/computational_shared_data}
     networks:
       - cluster
     environment:
@@ -14,6 +16,9 @@ services:
       DASK_START_AS_SCHEDULER: 1
       DASK_WORKER_SATURATION: ${DASK_WORKER_SATURATION}
       LOG_LEVEL: ${LOG_LEVEL}
+
+      SIDECAR_COMP_SERVICES_SHARED_FOLDER: /home/scu/computational_shared_data
+      SIDECAR_COMP_SERVICES_SHARED_VOLUME_NAME: computational_shared_data
 
     ports:
       - 8786:8786 # dask-scheduler access
@@ -110,7 +115,7 @@ services:
       EC2_INSTANCES_TIME_BEFORE_DRAINING: ${WORKERS_EC2_INSTANCES_TIME_BEFORE_DRAINING}
       EC2_INSTANCES_TIME_BEFORE_TERMINATION: ${WORKERS_EC2_INSTANCES_TIME_BEFORE_TERMINATION}
       LOG_FORMAT_LOCAL_DEV_ENABLED: 1
-      LOG_LEVEL: ${LOG_LEVEL:-WARNING}
+      LOG_LEVEL: ${LOG_LEVEL}
       REDIS_HOST: redis
       REDIS_PORT: 6379
     volumes:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/dask.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/utils/dask.py
@@ -7,10 +7,9 @@ from ..core.settings import get_application_settings
 
 
 def get_scheduler_url(ec2_instance: EC2InstanceData) -> AnyUrl:
-    url: AnyUrl = TypeAdapter(AnyUrl).validate_python(
+    return TypeAdapter(AnyUrl).validate_python(
         f"tls://{ec2_instance.aws_private_dns}:8786"
     )
-    return url
 
 
 def get_scheduler_auth(app: FastAPI) -> ClusterAuthentication:

--- a/services/dask-sidecar/docker/boot.sh
+++ b/services/dask-sidecar/docker/boot.sh
@@ -33,7 +33,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 # RUNNING application ----------------------------------------

--- a/services/datcore-adapter/docker/boot.sh
+++ b/services/datcore-adapter/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 # RUNNING application ----------------------------------------
@@ -45,7 +49,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/datcore-adapter/src/simcore_service_datcore_adapter && \
-    python -m debugpy --listen 0.0.0.0:${DATCORE_ADAPTER_REMOTE_DEBUG_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${DATCORE_ADAPTER_REMOTE_DEBUG_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/director-v2/docker/boot.sh
+++ b/services/director-v2/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -47,7 +51,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/director-v2/src/simcore_service_director_v2 && \
-    python -m debugpy --listen 0.0.0.0:${DIRECTOR_V2_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${DIRECTOR_V2_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/director/docker/boot.sh
+++ b/services/director/docker/boot.sh
@@ -31,7 +31,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -47,7 +51,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/director/src/simcore_service_director && \
-    python -m debugpy --listen 0.0.0.0:${DIRECTOR_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${DIRECTOR_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/dynamic-scheduler/docker/boot.sh
+++ b/services/dynamic-scheduler/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -48,7 +52,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/dynamic-scheduler/src/simcore_service_dynamic_scheduler && \
-    python -m debugpy --listen 0.0.0.0:${DYNAMIC_SCHEDULER_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${DYNAMIC_SCHEDULER_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/dynamic-sidecar/docker/boot.sh
+++ b/services/dynamic-sidecar/docker/boot.sh
@@ -33,7 +33,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -49,7 +53,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/dynamic-sidecar/src/simcore_service_dynamic_sidecar && \
-    python -m debugpy --listen 0.0.0.0:${DYNAMIC_SIDECAR_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${DYNAMIC_SIDECAR_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/efs-guardian/docker/boot.sh
+++ b/services/efs-guardian/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -48,7 +52,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/efs-guardian/src/simcore_service_efs_guardian && \
-    python -m debugpy --listen 0.0.0.0:${EFS_GUARDIAN_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${EFS_GUARDIAN_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/invitations/docker/boot.sh
+++ b/services/invitations/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -48,7 +52,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/invitations/src/simcore_service_invitations && \
-    python -m debugpy --listen 0.0.0.0:${INVITATIONS_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${INVITATIONS_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/notifications/docker/boot.sh
+++ b/services/notifications/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -48,7 +52,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/notifications/src/simcore_service_notifications && \
-    python -m debugpy --listen 0.0.0.0:${NOTIFICATIONS_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${NOTIFICATIONS_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --port 8000 \
       --reload \

--- a/services/payments/docker/boot.sh
+++ b/services/payments/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -48,7 +52,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/payments/src/simcore_service_payments && \
-    python -m debugpy --listen 0.0.0.0:${PAYMENTS_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${PAYMENTS_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/resource-usage-tracker/docker/boot.sh
+++ b/services/resource-usage-tracker/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -48,7 +52,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
   exec sh -c "
     cd services/resource-usage-tracker/src/simcore_service_resource_usage_tracker && \
-    python -m debugpy --listen 0.0.0.0:${RESOURCE_USAGE_TRACKER_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${RESOURCE_USAGE_TRACKER_REMOTE_DEBUGGING_PORT} -m uvicorn main:the_app \
       --host 0.0.0.0 \
       --reload \
       $reload_dir_packages

--- a/services/storage/docker/boot.sh
+++ b/services/storage/docker/boot.sh
@@ -32,7 +32,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 #
@@ -70,7 +74,7 @@ else
 
     exec sh -c "
     cd services/storage/src/simcore_service_storage && \
-    python -m debugpy --listen 0.0.0.0:${STORAGE_REMOTE_DEBUGGING_PORT} -m uvicorn main:app \
+    python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:${STORAGE_REMOTE_DEBUGGING_PORT} -m uvicorn main:app \
       --host 0.0.0.0 \
       --port ${STORAGE_PORT} \
       --reload \

--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -31,7 +31,11 @@ fi
 
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: production does NOT pre-installs debugpy
-  uv pip install debugpy
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install debugpy
+  else
+    pip install debugpy
+  fi
 fi
 
 APP_LOG_LEVEL=${WEBSERVER_LOGLEVEL:-${LOG_LEVEL:-${LOGLEVEL:-INFO}}}
@@ -54,7 +58,7 @@ echo "$INFO" "GUNICORN_CMD_ARGS: $GUNICORN_CMD_ARGS"
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: ptvsd is programmatically enabled inside of the service
   # this way we can have reload in place as well
-  exec python -m debugpy --listen 0.0.0.0:"${WEBSERVER_REMOTE_DEBUGGING_PORT}" -m gunicorn simcore_service_webserver.cli:app_factory \
+  exec python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:"${WEBSERVER_REMOTE_DEBUGGING_PORT}" -m gunicorn simcore_service_webserver.cli:app_factory \
     --log-level="${SERVER_LOG_LEVEL}" \
     --bind 0.0.0.0:8080 \
     --worker-class aiohttp.GunicornUVLoopWebWorker \


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request introduces several updates across multiple services to improve debugging workflows, enhance logging, and refine service configurations. The most significant changes include adding conditional logic for installing `debugpy`, updating Python debug options, reducing noisy loggers, and modifying service-specific configurations and **the potential bugfix for on-demand clusters that were missing some ENV variables for the dask-scheduler due to the changes in .**

### Debugging Enhancements:
* Added conditional logic to check for the `uv` command before installing `debugpy` in debug mode across multiple services. This ensures compatibility with environments where `uv` is available. (`services/agent/docker/boot.sh` [[1]](diffhunk://#diff-a7ea21dff8c7308ccc4fdc350c447c24a73fa6147865f4a9a3bb86865a563b39R35-R39) `services/api-server/docker/boot.sh` [[2]](diffhunk://#diff-5c2bd1360bc1fb1329fab10d4c52e3c2e95780fe6696643fa8e0f0d6baa55aa1R30-R34) and others)
* Updated the Python debug command to include the `-Xfrozen_modules=off` option for better debugging support in services. (`services/agent/docker/boot.sh` [[1]](diffhunk://#diff-a7ea21dff8c7308ccc4fdc350c447c24a73fa6147865f4a9a3bb86865a563b39L51-R55) `services/api-server/docker/boot.sh` [[2]](diffhunk://#diff-5c2bd1360bc1fb1329fab10d4c52e3c2e95780fe6696643fa8e0f0d6baa55aa1L43-R47) and others)

### Logging Improvements:
* Reduced verbosity of specific third-party loggers (e.g., `aiobotocore`, `aio_pika`) by dynamically adjusting their log levels based on the root logger's configuration. (`services/clusters-keeper/src/simcore_service_clusters_keeper/core/application.py` [services/clusters-keeper/src/simcore_service_clusters_keeper/core/application.pyL26-R46](diffhunk://#diff-91761c55f2b3479b7d16be76ec405da76b6b656aff650a04ffe8c9b235de4a98L26-R46))

### Configuration Updates:
* Added shared volume and environment variable configurations for `dask-sidecar` in the `docker-compose.yml` file to support computational shared data. (`services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml` [[1]](diffhunk://#diff-9d7939fa4aaab3cbba1ff9c8cf2d6ecadc12483981fad9468efc30a1a0cab555R6-R7) [[2]](diffhunk://#diff-9d7939fa4aaab3cbba1ff9c8cf2d6ecadc12483981fad9468efc30a1a0cab555R20-R22), a.k.a. the fix.


<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
