### PR TITLE
🐛 Fix: Add default headers for authenticated HTTP methods

### DIFF
--- a/tests/performance/common/base_user.py
+++ b/tests/performance/common/base_user.py
@@ -36,26 +36,31 @@ class OsparcUserBase(FastHttpUser):
     def authenticated_get(self, url, **kwargs):
         """Make GET request with deployment auth"""
         kwargs.setdefault("auth", self.deploy_auth.to_auth())
+        kwargs.setdefault("headers", {"Accept-Encoding": "gzip, deflate"})
         return self.client.get(url, **kwargs)
 
     def authenticated_post(self, url, **kwargs):
         """Make POST request with deployment auth"""
         kwargs.setdefault("auth", self.deploy_auth.to_auth())
+        kwargs.setdefault("headers", {"Accept-Encoding": "gzip, deflate"})
         return self.client.post(url, **kwargs)
 
     def authenticated_put(self, url, **kwargs):
         """Make PUT request with deployment auth"""
         kwargs.setdefault("auth", self.deploy_auth.to_auth())
+        kwargs.setdefault("headers", {"Accept-Encoding": "gzip, deflate"})
         return self.client.put(url, **kwargs)
 
     def authenticated_delete(self, url, **kwargs):
         """Make DELETE request with deployment auth"""
         kwargs.setdefault("auth", self.deploy_auth.to_auth())
+        kwargs.setdefault("headers", {"Accept-Encoding": "gzip, deflate"})
         return self.client.delete(url, **kwargs)
 
     def authenticated_patch(self, url, **kwargs):
         """Make PATCH request with deployment auth"""
         kwargs.setdefault("auth", self.deploy_auth.to_auth())
+        kwargs.setdefault("headers", {"Accept-Encoding": "gzip, deflate"})
         return self.client.patch(url, **kwargs)
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
locust FastHttpUser does not like zstd compression that our production deployment are returning.

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
