### PR TITLE
⬆️♻️Uniformize uvicorn/fastapi dependencies repository-wide

### DIFF
--- a/ci/helpers/requirements/requirements.txt
+++ b/ci/helpers/requirements/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.4.1
     # via requests
 docker==7.1.0
     # via -r requirements/requirements.in
-fastapi==0.115.0
+fastapi==0.115.12
     # via -r requirements/requirements.in
 frozenlist==1.4.1
     # via
@@ -49,7 +49,7 @@ requests==2.32.3
     # via docker
 sniffio==1.3.1
     # via anyio
-starlette==0.38.6
+starlette==0.46.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   fastapi

--- a/packages/aws-library/requirements/_test.txt
+++ b/packages/aws-library/requirements/_test.txt
@@ -70,7 +70,7 @@ docker==7.1.0
     # via moto
 faker==36.1.1
     # via -r requirements/_test.in
-fastapi==0.115.11
+fastapi==0.115.12
     # via -r requirements/_test.in
 flask==3.1.0
     # via

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -220,7 +220,7 @@ pyinstrument==5.0.1
     # via -r requirements/_base.in
 python-dateutil==2.9.0.post0
     # via arrow
-python-dotenv==1.0.1
+python-dotenv==1.1.0
     # via pydantic-settings
 pyyaml==6.0.2
     # via
@@ -252,7 +252,7 @@ referencing==0.35.1
     #   jsonschema-specifications
 requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
-rich==13.9.4
+rich==14.0.0
     # via
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
@@ -274,7 +274,7 @@ toolz==1.0.0
     # via -r requirements/_base.in
 tqdm==4.67.1
     # via -r requirements/_base.in
-typer==0.15.2
+typer==0.16.0
     # via -r requirements/../../../packages/settings-library/requirements/_base.in
 types-python-dateutil==2.9.0.20241206
     # via arrow

--- a/packages/service-library/requirements/_fastapi.in
+++ b/packages/service-library/requirements/_fastapi.in
@@ -4,10 +4,9 @@
 #
 
 
-fastapi
+fastapi[standard]
 fastapi-lifespan-manager
-httpx
+httpx[http2]
 opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-httpx
 prometheus-client
-uvicorn

--- a/packages/service-library/requirements/_fastapi.txt
+++ b/packages/service-library/requirements/_fastapi.txt
@@ -132,7 +132,7 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   rich-toolkit
     #   typer
-uvicorn==0.34.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/packages/service-library/requirements/_fastapi.txt
+++ b/packages/service-library/requirements/_fastapi.txt
@@ -4,6 +4,7 @@ anyio==4.8.0
     # via
     #   httpx
     #   starlette
+    #   watchfiles
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
 certifi==2025.1.31
@@ -11,31 +12,59 @@ certifi==2025.1.31
     #   httpcore
     #   httpx
 click==8.1.8
-    # via uvicorn
+    # via
+    #   rich-toolkit
+    #   typer
+    #   uvicorn
 deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-semantic-conventions
-fastapi==0.115.11
+dnspython==2.7.0
+    # via email-validator
+email-validator==2.2.0
+    # via fastapi
+fastapi==0.115.12
     # via
     #   -r requirements/_fastapi.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/_fastapi.in
 h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.7
     # via httpx
+httptools==0.6.4
+    # via uvicorn
 httpx==0.28.1
-    # via -r requirements/_fastapi.in
+    # via
+    #   -r requirements/_fastapi.in
+    #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
+    #   email-validator
     #   httpx
 importlib-metadata==8.5.0
     # via opentelemetry-api
+jinja2==3.1.6
+    # via fastapi
+markdown-it-py==3.0.0
+    # via rich
+markupsafe==3.0.2
+    # via jinja2
+mdurl==0.1.2
+    # via markdown-it-py
 opentelemetry-api==1.30.0
     # via
     #   opentelemetry-instrumentation
@@ -73,18 +102,46 @@ pydantic==2.10.6
     # via fastapi
 pydantic-core==2.27.2
     # via pydantic
+pygments==2.19.1
+    # via rich
+python-dotenv==1.1.0
+    # via uvicorn
+python-multipart==0.0.20
+    # via fastapi
+pyyaml==6.0.2
+    # via uvicorn
+rich==14.0.0
+    # via
+    #   rich-toolkit
+    #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
+shellingham==1.5.4
+    # via typer
 sniffio==1.3.1
     # via anyio
 starlette==0.46.0
     # via fastapi
+typer==0.16.0
+    # via fastapi-cli
 typing-extensions==4.12.2
     # via
     #   anyio
     #   fastapi
     #   pydantic
     #   pydantic-core
+    #   rich-toolkit
+    #   typer
 uvicorn==0.34.0
-    # via -r requirements/_fastapi.in
+    # via
+    #   fastapi
+    #   fastapi-cli
+uvloop==0.21.0
+    # via uvicorn
+watchfiles==1.0.5
+    # via uvicorn
+websockets==15.0.1
+    # via uvicorn
 wrapt==1.17.2
     # via
     #   deprecated

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -191,14 +191,16 @@ python-dateutil==2.9.0.post0
     # via
     #   -c requirements/_base.txt
     #   botocore
-python-dotenv==1.0.1
+python-dotenv==1.1.0
     # via
     #   -c requirements/_base.txt
+    #   -c requirements/_fastapi.txt
     #   -r requirements/_test.in
 pyyaml==6.0.2
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
+    #   -c requirements/_fastapi.txt
     #   jsonschema-path
 referencing==0.35.1
     # via

--- a/services/agent/requirements/_base.in
+++ b/services/agent/requirements/_base.in
@@ -14,7 +14,5 @@
 --requirement ../../../packages/service-library/requirements/_fastapi.in
 
 aiodocker
-fastapi
 packaging
 pydantic
-uvicorn

--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -493,7 +493,7 @@ urllib3==2.3.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.34.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -39,6 +39,7 @@ anyio==4.8.0
     #   faststream
     #   httpx
     #   starlette
+    #   watchfiles
 arrow==1.3.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -72,6 +73,7 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
+    #   rich-toolkit
     #   typer
     #   uvicorn
 deprecated==1.2.18
@@ -83,16 +85,19 @@ deprecated==1.2.18
 dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.11
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 faststream==0.5.35
@@ -111,8 +116,14 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.7
     # via httpx
+httptools==0.6.4
+    # via uvicorn
 httpx==0.28.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -128,6 +139,9 @@ httpx==0.28.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -137,6 +151,21 @@ idna==3.10
     #   yarl
 importlib-metadata==8.5.0
     # via opentelemetry-api
+jinja2==3.1.6
+    # via
+    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -145,6 +174,8 @@ jsonschema-specifications==2024.10.1
     # via jsonschema
 markdown-it-py==3.0.0
     # via rich
+markupsafe==3.0.2
+    # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.1.0
@@ -333,7 +364,11 @@ pyinstrument==5.0.1
 python-dateutil==2.9.0.post0
     # via arrow
 python-dotenv==1.0.1
-    # via pydantic-settings
+    # via
+    #   pydantic-settings
+    #   uvicorn
+python-multipart==0.0.20
+    # via fastapi
 pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -349,6 +384,7 @@ pyyaml==6.0.2
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   uvicorn
 redis==5.2.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -386,7 +422,10 @@ rich==13.9.4
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.23.1
     # via
     #   jsonschema
@@ -424,6 +463,7 @@ typer==0.15.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   fastapi-cli
 types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
@@ -436,6 +476,7 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   rich-toolkit
     #   typer
 urllib3==2.3.0
     # via
@@ -454,8 +495,14 @@ urllib3==2.3.0
     #   requests
 uvicorn==0.34.0
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
+    #   fastapi-cli
+uvloop==0.21.0
+    # via uvicorn
+watchfiles==1.0.5
+    # via uvicorn
+websockets==15.0.1
+    # via uvicorn
 wrapt==1.17.2
     # via
     #   deprecated

--- a/services/agent/requirements/_test.txt
+++ b/services/agent/requirements/_test.txt
@@ -129,6 +129,7 @@ itsdangerous==2.2.0
 jinja2==3.1.6
     # via
     #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   flask
     #   moto
 jmespath==1.0.1
@@ -161,6 +162,7 @@ lazy-object-proxy==1.10.0
     # via openapi-spec-validator
 markupsafe==3.0.2
     # via
+    #   -c requirements/_base.txt
     #   jinja2
     #   werkzeug
 moto==5.1.4

--- a/services/api-server/requirements/_base.in
+++ b/services/api-server/requirements/_base.in
@@ -19,8 +19,6 @@
 aiofiles
 cryptography
 fastapi-pagination
-fastapi[all]
-httpx
 orjson
 packaging
 parse

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -888,7 +888,7 @@ urllib3==2.2.3
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.32.1
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -177,10 +177,9 @@ exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.6
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
 fastapi-cli==0.0.6
     # via fastapi
@@ -212,6 +211,10 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.7
     # via httpx
 httptools==0.6.4
@@ -247,8 +250,9 @@ httpx==0.27.2
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -258,9 +262,7 @@ idna==3.10
     #   yarl
 importlib-metadata==8.5.0
     # via opentelemetry-api
-itsdangerous==2.2.0
-    # via fastapi
-jinja2==3.1.4
+jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -482,7 +484,6 @@ orjson==3.10.12
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/_base.in
-    #   fastapi
 packaging==24.2
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
@@ -601,7 +602,6 @@ pydantic-extra-types==2.10.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   fastapi
 pydantic-settings==2.6.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -640,7 +640,6 @@ pydantic-settings==2.6.1
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
-    #   fastapi
 pygments==2.18.0
     # via rich
 pyinstrument==5.0.0
@@ -690,7 +689,6 @@ pyyaml==6.0.2
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-    #   fastapi
     #   uvicorn
 redis==5.2.1
     # via
@@ -859,37 +857,6 @@ typing-extensions==4.12.2
     #   pydantic-extra-types
     #   rich-toolkit
     #   typer
-ujson==5.10.0
-    # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   fastapi
 urllib3==2.2.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -923,7 +890,6 @@ urllib3==2.2.3
     #   requests
 uvicorn==0.32.1
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   fastapi
     #   fastapi-cli
 uvloop==0.21.0

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -102,7 +102,7 @@ ecdsa==0.19.0
     #   sshpubkeys
 faker==36.1.1
     # via -r requirements/_test.in
-fastapi==0.115.6
+fastapi==0.115.12
     # via
     #   -c requirements/_base.txt
     #   pact-python
@@ -148,10 +148,8 @@ idna==3.10
 iniconfig==2.0.0
     # via pytest
 itsdangerous==2.2.0
-    # via
-    #   -c requirements/_base.txt
-    #   flask
-jinja2==3.1.4
+    # via flask
+jinja2==3.1.6
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -387,7 +387,7 @@ urllib3==2.2.3
     #   docker
     #   requests
     #   responses
-uvicorn==0.32.1
+uvicorn==0.34.2
     # via
     #   -c requirements/_base.txt
     #   pact-python

--- a/services/api-server/requirements/_tools.txt
+++ b/services/api-server/requirements/_tools.txt
@@ -28,7 +28,7 @@ isort==6.0.1
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
-jinja2==3.1.4
+jinja2==3.1.6
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/autoscaling/requirements/_base.in
+++ b/services/autoscaling/requirements/_base.in
@@ -18,5 +18,4 @@
 aiocache
 aiodocker
 dask[distributed]
-fastapi
 packaging

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -70,6 +70,7 @@ anyio==4.9.0
     #   faststream
     #   httpx
     #   starlette
+    #   watchfiles
 arrow==1.3.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -131,6 +132,7 @@ click==8.1.8
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
+    #   rich-toolkit
     #   typer
     #   uvicorn
 cloudpickle==3.1.1
@@ -156,7 +158,9 @@ distributed==2025.5.0
 dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 exceptiongroup==1.3.0
     # via aio-pika
 fast-depends==2.4.12
@@ -164,8 +168,9 @@ fast-depends==2.4.12
 fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 faststream==0.5.41
@@ -190,8 +195,14 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.9
     # via httpx
+httptools==0.6.4
+    # via uvicorn
 httpx==0.28.1
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -219,6 +230,9 @@ httpx==0.28.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -259,6 +273,7 @@ jinja2==3.1.6
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
+    #   fastapi
 jmespath==1.0.1
     # via
     #   aiobotocore
@@ -579,7 +594,11 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   botocore
 python-dotenv==1.1.0
-    # via pydantic-settings
+    # via
+    #   pydantic-settings
+    #   uvicorn
+python-multipart==0.0.20
+    # via fastapi
 pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -611,6 +630,7 @@ pyyaml==6.0.2
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
+    #   uvicorn
 redis==6.1.0
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -675,7 +695,10 @@ rich==14.0.0
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.25.0
     # via
     #   jsonschema
@@ -755,6 +778,7 @@ typer==0.15.4
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   fastapi-cli
 types-aiobotocore==2.22.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 types-aiobotocore-ec2==2.22.0
@@ -778,6 +802,7 @@ typing-extensions==4.13.2
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   rich-toolkit
     #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
@@ -817,7 +842,15 @@ urllib3==2.4.0
     #   distributed
     #   requests
 uvicorn==0.34.2
-    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    # via
+    #   fastapi
+    #   fastapi-cli
+uvloop==0.21.0
+    # via uvicorn
+watchfiles==1.0.5
+    # via uvicorn
+websockets==15.0.1
+    # via uvicorn
 wrapt==1.17.2
     # via
     #   aiobotocore

--- a/services/catalog/requirements/_base.in
+++ b/services/catalog/requirements/_base.in
@@ -18,8 +18,6 @@
 
 aiocache[redis,msgpack]
 asyncpg # database
-fastapi[all] # fastapi and extensions
-httpx # web client
 packaging
 pydantic[dotenv] # data models
 pyyaml

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -102,10 +102,9 @@ exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.11
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
 fastapi-cli==0.0.7
     # via fastapi
@@ -129,6 +128,10 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.7
     # via httpx
 httptools==0.6.4
@@ -150,8 +153,9 @@ httpx==0.28.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -161,8 +165,6 @@ idna==3.10
     #   yarl
 importlib-metadata==8.6.1
     # via opentelemetry-api
-itsdangerous==2.2.0
-    # via fastapi
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -320,7 +322,6 @@ orjson==3.10.15
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   fastapi
 packaging==24.2
     # via
     #   -r requirements/_base.in
@@ -390,7 +391,6 @@ pydantic-extra-types==2.10.3
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   fastapi
 pydantic-settings==2.7.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -411,7 +411,6 @@ pydantic-settings==2.7.0
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-    #   fastapi
 pygments==2.19.1
     # via rich
 pyinstrument==5.0.1
@@ -442,7 +441,6 @@ pyyaml==6.0.2
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-    #   fastapi
     #   uvicorn
 redis==5.2.1
     # via
@@ -565,23 +563,6 @@ typing-extensions==4.12.2
     #   pydantic-extra-types
     #   rich-toolkit
     #   typer
-ujson==5.10.0
-    # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   fastapi
 urllib3==2.3.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -601,7 +582,6 @@ urllib3==2.3.0
     #   requests
 uvicorn==0.34.0
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   fastapi
     #   fastapi-cli
 uvloop==0.21.0

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -580,7 +580,7 @@ urllib3==2.3.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.34.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/clusters-keeper/requirements/_base.in
+++ b/services/clusters-keeper/requirements/_base.in
@@ -18,5 +18,4 @@
 
 
 dask[distributed]
-fastapi
 packaging

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -68,6 +68,7 @@ anyio==4.9.0
     #   faststream
     #   httpx
     #   starlette
+    #   watchfiles
 arrow==1.3.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -129,6 +130,7 @@ click==8.1.8
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
+    #   rich-toolkit
     #   typer
     #   uvicorn
 cloudpickle==3.1.1
@@ -154,7 +156,9 @@ distributed==2025.5.0
 dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 exceptiongroup==1.3.0
     # via aio-pika
 fast-depends==2.4.12
@@ -162,8 +166,9 @@ fast-depends==2.4.12
 fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 faststream==0.5.41
@@ -188,8 +193,14 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.9
     # via httpx
+httptools==0.6.4
+    # via uvicorn
 httpx==0.28.1
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -217,6 +228,9 @@ httpx==0.28.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -257,6 +271,7 @@ jinja2==3.1.6
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
+    #   fastapi
 jmespath==1.0.1
     # via
     #   aiobotocore
@@ -577,7 +592,11 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   botocore
 python-dotenv==1.1.0
-    # via pydantic-settings
+    # via
+    #   pydantic-settings
+    #   uvicorn
+python-multipart==0.0.20
+    # via fastapi
 pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -609,6 +628,7 @@ pyyaml==6.0.2
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   dask
     #   distributed
+    #   uvicorn
 redis==6.1.0
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -673,7 +693,10 @@ rich==14.0.0
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.25.0
     # via
     #   jsonschema
@@ -753,6 +776,7 @@ typer==0.15.4
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   fastapi-cli
 types-aiobotocore==2.22.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 types-aiobotocore-ec2==2.22.0
@@ -776,6 +800,7 @@ typing-extensions==4.13.2
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   rich-toolkit
     #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
@@ -815,7 +840,15 @@ urllib3==2.4.0
     #   distributed
     #   requests
 uvicorn==0.34.2
-    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    # via
+    #   fastapi
+    #   fastapi-cli
+uvloop==0.21.0
+    # via uvicorn
+watchfiles==1.0.5
+    # via uvicorn
+websockets==15.0.1
+    # via uvicorn
 wrapt==1.17.2
     # via
     #   aiobotocore

--- a/services/datcore-adapter/requirements/_base.in
+++ b/services/datcore-adapter/requirements/_base.in
@@ -15,9 +15,6 @@
 aiocache
 boto3
 aiofiles
-fastapi
 fastapi-pagination
-httpx[http2]
 pydantic
 python-multipart # for fastapi multipart uploads
-uvicorn[standard]

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -81,6 +81,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
+    #   rich-toolkit
     #   typer
     #   uvicorn
 deprecated==1.2.14
@@ -92,14 +93,17 @@ deprecated==1.2.14
 dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.5
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 fastapi-pagination==0.12.31
@@ -143,7 +147,7 @@ httpx==0.27.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
 hyperframe==6.0.1
     # via h2
 idna==3.6
@@ -155,6 +159,21 @@ idna==3.6
     #   yarl
 importlib-metadata==8.0.0
     # via opentelemetry-api
+jinja2==3.1.6
+    # via
+    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 jmespath==1.0.1
     # via
     #   boto3
@@ -167,6 +186,8 @@ jsonschema-specifications==2023.7.1
     # via jsonschema
 markdown-it-py==3.0.0
     # via rich
+markupsafe==3.0.2
+    # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.0.5
@@ -356,8 +377,10 @@ python-dotenv==1.0.1
     # via
     #   pydantic-settings
     #   uvicorn
-python-multipart==0.0.9
-    # via -r requirements/_base.in
+python-multipart==0.0.20
+    # via
+    #   -r requirements/_base.in
+    #   fastapi
 pyyaml==6.0.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -411,7 +434,10 @@ rich==13.7.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -455,6 +481,7 @@ typer==0.12.3
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   fastapi-cli
 types-python-dateutil==2.9.0.20240316
     # via arrow
 typing-extensions==4.12.2
@@ -467,6 +494,7 @@ typing-extensions==4.12.2
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
+    #   rich-toolkit
     #   typer
 urllib3==2.2.3
     # via
@@ -486,8 +514,8 @@ urllib3==2.2.3
     #   requests
 uvicorn==0.29.0
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
+    #   fastapi-cli
 uvloop==0.19.0
     # via uvicorn
 watchfiles==0.21.0

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -130,7 +130,7 @@ hpack==4.0.0
     # via h2
 httpcore==1.0.5
     # via httpx
-httptools==0.6.1
+httptools==0.6.4
     # via uvicorn
 httpx==0.27.0
     # via
@@ -512,11 +512,11 @@ urllib3==2.2.3
     #   -c requirements/../../../requirements/constraints.txt
     #   botocore
     #   requests
-uvicorn==0.29.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli
-uvloop==0.19.0
+uvloop==0.21.0
     # via uvicorn
 watchfiles==0.21.0
     # via uvicorn

--- a/services/director-v2/requirements/_base.in
+++ b/services/director-v2/requirements/_base.in
@@ -22,8 +22,6 @@
 aio-pika
 aiocache[redis,msgpack]
 aiodocker
-fastapi[all]
-httpx
 networkx
 ordered-set
 orjson

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -184,7 +184,6 @@ fast-depends==2.4.12
 fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
 fastapi-cli==0.0.7
     # via fastapi
@@ -219,6 +218,10 @@ h11==0.16.0
     #   httpcore
     #   uvicorn
     #   wsproto
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.9
     # via httpx
 httptools==0.6.4
@@ -260,8 +263,9 @@ httpx==0.28.1
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -274,8 +278,6 @@ importlib-metadata==8.6.1
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   opentelemetry-api
-itsdangerous==2.2.0
-    # via fastapi
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -543,7 +545,6 @@ orjson==3.10.18
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/_base.in
-    #   fastapi
 packaging==25.0
     # via
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
@@ -681,7 +682,6 @@ pydantic-extra-types==2.10.4
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   fastapi
 pydantic-settings==2.7.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -728,7 +728,6 @@ pydantic-settings==2.7.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
-    #   fastapi
 pygments==2.19.1
     # via rich
 pyinstrument==5.0.1
@@ -788,7 +787,6 @@ pyyaml==6.0.2
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   dask
     #   distributed
-    #   fastapi
     #   uvicorn
 redis==6.1.0
     # via
@@ -1036,43 +1034,6 @@ typing-extensions==4.13.2
     #   typing-inspection
 typing-inspection==0.4.0
     # via pydantic
-ujson==5.10.0
-    # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/dask-task-models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   fastapi
 urllib3==2.4.0
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -1114,7 +1075,6 @@ urllib3==2.4.0
     #   requests
 uvicorn==0.34.2
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   fastapi
     #   fastapi-cli
 uvloop==0.21.0

--- a/services/director/requirements/_base.in
+++ b/services/director/requirements/_base.in
@@ -14,7 +14,6 @@
 
 aiocache
 aiodocker
-fastapi[all]
 httpx[http2]
 prometheus-client
 pydantic

--- a/services/director/requirements/_base.txt
+++ b/services/director/requirements/_base.txt
@@ -492,7 +492,7 @@ urllib3==2.2.3
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.32.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/director/requirements/_base.txt
+++ b/services/director/requirements/_base.txt
@@ -91,10 +91,9 @@ email-validator==2.2.0
     #   pydantic
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.5
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
 fastapi-cli==0.0.5
     # via fastapi
@@ -152,9 +151,7 @@ idna==3.10
     #   yarl
 importlib-metadata==8.5.0
     # via opentelemetry-api
-itsdangerous==2.2.0
-    # via fastapi
-jinja2==3.1.4
+jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -280,7 +277,6 @@ orjson==3.10.11
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   fastapi
 packaging==24.2
     # via opentelemetry-instrumentation
 pamqp==3.3.0
@@ -343,7 +339,6 @@ pydantic-extra-types==2.10.0
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   fastapi
 pydantic-settings==2.6.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -362,7 +357,6 @@ pydantic-settings==2.6.1
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-    #   fastapi
 pygments==2.18.0
     # via rich
 pyinstrument==5.0.0
@@ -373,7 +367,7 @@ python-dotenv==1.0.1
     # via
     #   pydantic-settings
     #   uvicorn
-python-multipart==0.0.17
+python-multipart==0.0.20
     # via fastapi
 pyyaml==6.0.2
     # via
@@ -390,7 +384,6 @@ pyyaml==6.0.2
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   fastapi
     #   uvicorn
 redis==5.2.1
     # via
@@ -484,21 +477,6 @@ typing-extensions==4.12.2
     #   pydantic-core
     #   pydantic-extra-types
     #   typer
-ujson==5.10.0
-    # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   fastapi
 urllib3==2.2.3
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -516,7 +494,6 @@ urllib3==2.2.3
     #   requests
 uvicorn==0.32.0
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   fastapi
     #   fastapi-cli
 uvloop==0.21.0

--- a/services/docker-api-proxy/requirements/_test.txt
+++ b/services/docker-api-proxy/requirements/_test.txt
@@ -90,7 +90,7 @@ faker==36.1.1
     # via -r requirements/_test.in
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.11
+fastapi==0.115.12
     # via
     #   -r requirements/_test.in
     #   fastapi-lifespan-manager

--- a/services/dynamic-scheduler/requirements/_base.in
+++ b/services/dynamic-scheduler/requirements/_base.in
@@ -16,11 +16,8 @@
 
 
 arrow
-fastapi
-httpx
 nicegui
 packaging
 python-socketio
 typer[all]
 u-msgpack-python
-uvicorn[standard]

--- a/services/dynamic-scheduler/requirements/_base.in
+++ b/services/dynamic-scheduler/requirements/_base.in
@@ -15,7 +15,6 @@
 --requirement ../../../packages/service-library/requirements/_fastapi.in
 
 
-arrow
 nicegui
 packaging
 python-socketio

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -51,7 +51,6 @@ arrow==1.3.0
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/_base.in
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
 asyncpg==0.30.0

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -87,6 +87,7 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
+    #   rich-toolkit
     #   typer
     #   uvicorn
 deprecated==1.2.18
@@ -100,17 +101,20 @@ dnspython==2.7.0
 docutils==0.21.2
     # via nicegui
 email-validator==2.2.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.11
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
     #   nicegui
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 faststream==0.5.35
@@ -132,6 +136,10 @@ h11==0.14.0
     #   httpcore
     #   uvicorn
     #   wsproto
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.7
     # via httpx
 httptools==0.6.4
@@ -153,8 +161,10 @@ httpx==0.28.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
     #   nicegui
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -184,6 +194,7 @@ jinja2==3.1.6
     #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
     #   nicegui
 jsonschema==4.23.0
     # via
@@ -433,7 +444,9 @@ python-dotenv==1.0.1
 python-engineio==4.11.2
     # via python-socketio
 python-multipart==0.0.20
-    # via nicegui
+    # via
+    #   fastapi
+    #   nicegui
 python-socketio==5.12.1
     # via
     #   -r requirements/_base.in
@@ -499,7 +512,10 @@ rich==13.9.4
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.23.1
     # via
     #   jsonschema
@@ -560,6 +576,7 @@ typer==0.15.2
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
+    #   fastapi-cli
 types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
@@ -574,6 +591,7 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   rich-toolkit
     #   typer
 u-msgpack-python==2.8.0
     # via -r requirements/_base.in
@@ -597,8 +615,8 @@ urllib3==2.3.0
     #   requests
 uvicorn==0.34.0
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
+    #   fastapi-cli
     #   nicegui
 uvloop==0.21.0
     # via uvicorn

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -612,7 +612,7 @@ urllib3==2.3.0
     #   -c requirements/../../../requirements/constraints.txt
     #   nicegui
     #   requests
-uvicorn==0.34.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/dynamic-scheduler/requirements/_test.txt
+++ b/services/dynamic-scheduler/requirements/_test.txt
@@ -35,9 +35,13 @@ h11==0.14.0
     #   hypercorn
     #   wsproto
 h2==4.2.0
-    # via hypercorn
+    # via
+    #   -c requirements/_base.txt
+    #   hypercorn
 hpack==4.1.0
-    # via h2
+    # via
+    #   -c requirements/_base.txt
+    #   h2
 httpcore==1.0.7
     # via
     #   -c requirements/_base.txt
@@ -50,7 +54,9 @@ httpx==0.28.1
 hypercorn==0.17.3
     # via -r requirements/_test.in
 hyperframe==6.1.0
-    # via h2
+    # via
+    #   -c requirements/_base.txt
+    #   h2
 icdiff==2.0.7
     # via pytest-icdiff
 idna==3.10

--- a/services/dynamic-sidecar/requirements/_base.in
+++ b/services/dynamic-sidecar/requirements/_base.in
@@ -30,13 +30,10 @@ aiodocker
 aiofiles
 aioprocessing
 arrow
-fastapi
-httpx
 psutil
 pydantic
 python-magic # file type identification library. See 'magic.from_file(...)' NOTE: requires `libmagic`` installed
 python-socketio
 PyYAML
 u-msgpack-python
-uvicorn
 watchdog

--- a/services/dynamic-sidecar/requirements/_base.in
+++ b/services/dynamic-sidecar/requirements/_base.in
@@ -29,7 +29,6 @@ aio-pika
 aiodocker
 aiofiles
 aioprocessing
-arrow
 psutil
 pydantic
 python-magic # file type identification library. See 'magic.from_file(...)' NOTE: requires `libmagic`` installed

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -84,7 +84,6 @@ arrow==1.3.0
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/_base.in
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
 asyncpg==0.30.0

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -75,6 +75,7 @@ anyio==4.8.0
     #   faststream
     #   httpx
     #   starlette
+    #   watchfiles
 arrow==1.3.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -132,6 +133,7 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
+    #   rich-toolkit
     #   typer
     #   uvicorn
 deprecated==1.2.18
@@ -143,16 +145,19 @@ deprecated==1.2.18
 dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.11
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 faststream==0.5.35
@@ -180,8 +185,14 @@ h11==0.14.0
     #   httpcore
     #   uvicorn
     #   wsproto
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.7
     # via httpx
+httptools==0.6.4
+    # via uvicorn
 httpx==0.28.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -213,7 +224,9 @@ httpx==0.28.1
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -223,6 +236,37 @@ idna==3.10
     #   yarl
 importlib-metadata==8.5.0
     # via opentelemetry-api
+jinja2==3.1.6
+    # via
+    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -265,7 +309,9 @@ mako==1.3.9
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.2
-    # via mako
+    # via
+    #   jinja2
+    #   mako
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.1.0
@@ -572,11 +618,15 @@ pyinstrument==5.0.1
 python-dateutil==2.9.0.post0
     # via arrow
 python-dotenv==1.0.1
-    # via pydantic-settings
+    # via
+    #   pydantic-settings
+    #   uvicorn
 python-engineio==4.11.2
     # via python-socketio
 python-magic==0.4.27
     # via -r requirements/_base.in
+python-multipart==0.0.20
+    # via fastapi
 python-socketio==5.12.1
     # via -r requirements/_base.in
 pyyaml==6.0.2
@@ -612,6 +662,7 @@ pyyaml==6.0.2
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
+    #   uvicorn
 redis==5.2.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -684,7 +735,10 @@ rich==13.9.4
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.23.1
     # via
     #   jsonschema
@@ -786,6 +840,7 @@ typer==0.15.2
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
+    #   fastapi-cli
 types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
@@ -802,6 +857,7 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   rich-toolkit
     #   typer
 u-msgpack-python==2.8.0
     # via -r requirements/_base.in
@@ -838,10 +894,16 @@ urllib3==2.3.0
     #   requests
 uvicorn==0.34.0
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
+    #   fastapi-cli
+uvloop==0.21.0
+    # via uvicorn
 watchdog==6.0.0
     # via -r requirements/_base.in
+watchfiles==1.0.5
+    # via uvicorn
+websockets==15.0.1
+    # via uvicorn
 wrapt==1.17.2
     # via
     #   deprecated

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -891,7 +891,7 @@ urllib3==2.3.0
     #   -c requirements/../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.34.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/efs-guardian/requirements/_base.in
+++ b/services/efs-guardian/requirements/_base.in
@@ -16,5 +16,4 @@
 --requirement ../../../packages/service-library/requirements/_fastapi.in
 
 
-fastapi
 packaging

--- a/services/efs-guardian/requirements/_base.txt
+++ b/services/efs-guardian/requirements/_base.txt
@@ -72,6 +72,7 @@ anyio==4.6.2.post1
     #   faststream
     #   httpx
     #   starlette
+    #   watchfiles
 arrow==1.3.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -136,6 +137,7 @@ charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via
+    #   rich-toolkit
     #   typer
     #   uvicorn
 deprecated==1.2.14
@@ -147,14 +149,17 @@ deprecated==1.2.14
 dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.5
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 faststream==0.5.31
@@ -177,8 +182,14 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.6
     # via httpx
+httptools==0.6.4
+    # via uvicorn
 httpx==0.27.2
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -208,6 +219,9 @@ httpx==0.27.2
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -217,6 +231,35 @@ idna==3.10
     #   yarl
 importlib-metadata==8.4.0
     # via opentelemetry-api
+jinja2==3.1.6
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 jmespath==1.0.1
     # via
     #   aiobotocore
@@ -262,7 +305,9 @@ mako==1.3.5
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.2
-    # via mako
+    # via
+    #   jinja2
+    #   mako
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.1.0
@@ -560,7 +605,11 @@ python-dateutil==2.9.0.post0
     #   arrow
     #   botocore
 python-dotenv==1.0.1
-    # via pydantic-settings
+    # via
+    #   pydantic-settings
+    #   uvicorn
+python-multipart==0.0.20
+    # via fastapi
 pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -591,6 +640,7 @@ pyyaml==6.0.2
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   uvicorn
 redis==5.2.1
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -659,7 +709,10 @@ rich==13.9.2
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.20.0
     # via
     #   jsonschema
@@ -759,6 +812,7 @@ typer==0.12.5
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   fastapi-cli
 types-aiobotocore==2.19.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 types-aiobotocore-ec2==2.19.0
@@ -780,6 +834,7 @@ typing-extensions==4.12.2
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
+    #   rich-toolkit
     #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
@@ -816,7 +871,15 @@ urllib3==2.2.3
     #   botocore
     #   requests
 uvicorn==0.32.0
-    # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    # via
+    #   fastapi
+    #   fastapi-cli
+uvloop==0.21.0
+    # via uvicorn
+watchfiles==1.0.5
+    # via uvicorn
+websockets==15.0.1
+    # via uvicorn
 wrapt==1.16.0
     # via
     #   aiobotocore

--- a/services/efs-guardian/requirements/_base.txt
+++ b/services/efs-guardian/requirements/_base.txt
@@ -870,7 +870,7 @@ urllib3==2.2.3
     #   -c requirements/../../../requirements/constraints.txt
     #   botocore
     #   requests
-uvicorn==0.32.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/efs-guardian/requirements/_test.txt
+++ b/services/efs-guardian/requirements/_test.txt
@@ -129,9 +129,10 @@ iniconfig==2.0.0
     # via pytest
 itsdangerous==2.2.0
     # via flask
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   flask
     #   moto
 jmespath==1.0.1

--- a/services/invitations/requirements/_base.in
+++ b/services/invitations/requirements/_base.in
@@ -15,7 +15,5 @@
 
 
 cryptography
-fastapi
 packaging
 typer[all]
-uvicorn[standard]

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -510,7 +510,7 @@ urllib3==2.3.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.34.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -73,6 +73,7 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
+    #   rich-toolkit
     #   typer
     #   uvicorn
 cryptography==44.0.2
@@ -99,16 +100,19 @@ deprecated==1.2.18
 dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.11
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 faststream==0.5.35
@@ -127,6 +131,10 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.7
     # via httpx
 httptools==0.6.4
@@ -146,6 +154,9 @@ httpx==0.28.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -155,6 +166,21 @@ idna==3.10
     #   yarl
 importlib-metadata==8.6.1
     # via opentelemetry-api
+jinja2==3.1.6
+    # via
+    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -163,6 +189,8 @@ jsonschema-specifications==2024.10.1
     # via jsonschema
 markdown-it-py==3.0.0
     # via rich
+markupsafe==3.0.2
+    # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.1.0
@@ -355,6 +383,8 @@ python-dotenv==1.0.1
     # via
     #   pydantic-settings
     #   uvicorn
+python-multipart==0.0.20
+    # via fastapi
 pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -408,7 +438,10 @@ rich==13.9.4
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.23.1
     # via
     #   jsonschema
@@ -447,6 +480,7 @@ typer==0.15.2
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
+    #   fastapi-cli
 types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
@@ -459,6 +493,7 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   rich-toolkit
     #   typer
 urllib3==2.3.0
     # via
@@ -477,8 +512,8 @@ urllib3==2.3.0
     #   requests
 uvicorn==0.34.0
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
+    #   fastapi-cli
 uvloop==0.21.0
     # via uvicorn
 watchfiles==1.0.4

--- a/services/notifications/requirements/_base.in
+++ b/services/notifications/requirements/_base.in
@@ -15,7 +15,5 @@
 --requirement ../../../packages/service-library/requirements/_fastapi.in
 
 
-fastapi
 packaging
 pydantic
-uvicorn

--- a/services/notifications/requirements/_base.txt
+++ b/services/notifications/requirements/_base.txt
@@ -573,7 +573,7 @@ urllib3==2.3.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.34.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/notifications/requirements/_base.txt
+++ b/services/notifications/requirements/_base.txt
@@ -41,6 +41,7 @@ anyio==4.9.0
     #   faststream
     #   httpx
     #   starlette
+    #   watchfiles
 arrow==1.3.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -78,6 +79,7 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
+    #   rich-toolkit
     #   typer
     #   uvicorn
 deprecated==1.2.18
@@ -89,7 +91,9 @@ deprecated==1.2.18
 dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
@@ -97,8 +101,9 @@ fast-depends==2.4.12
 fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 faststream==0.5.37
@@ -119,8 +124,14 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.7
     # via httpx
+httptools==0.6.4
+    # via uvicorn
 httpx==0.28.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -138,6 +149,9 @@ httpx==0.28.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -147,6 +161,23 @@ idna==3.10
     #   yarl
 importlib-metadata==8.6.1
     # via opentelemetry-api
+jinja2==3.1.6
+    # via
+    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -173,7 +204,9 @@ mako==1.3.9
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.2
-    # via mako
+    # via
+    #   jinja2
+    #   mako
 mdurl==0.1.2
     # via markdown-it-py
 multidict==6.2.0
@@ -379,7 +412,11 @@ pyinstrument==5.0.1
 python-dateutil==2.9.0.post0
     # via arrow
 python-dotenv==1.1.0
-    # via pydantic-settings
+    # via
+    #   pydantic-settings
+    #   uvicorn
+python-multipart==0.0.20
+    # via fastapi
 pyyaml==6.0.2
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -397,6 +434,7 @@ pyyaml==6.0.2
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   uvicorn
 redis==5.2.1
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -438,7 +476,10 @@ rich==13.9.4
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.24.0
     # via
     #   jsonschema
@@ -496,6 +537,7 @@ typer==0.15.2
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   fastapi-cli
 types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.13.0
@@ -509,6 +551,7 @@ typing-extensions==4.13.0
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   rich-toolkit
     #   typer
     #   typing-inspection
 typing-inspection==0.4.0
@@ -532,8 +575,14 @@ urllib3==2.3.0
     #   requests
 uvicorn==0.34.0
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
+    #   fastapi-cli
+uvloop==0.21.0
+    # via uvicorn
+watchfiles==1.0.5
+    # via uvicorn
+websockets==15.0.1
+    # via uvicorn
 wrapt==1.17.2
     # via
     #   deprecated

--- a/services/payments/openapi.json
+++ b/services/payments/openapi.json
@@ -356,7 +356,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "pattern": "password"
+                "pattern": "^password$"
               },
               {
                 "type": "null"

--- a/services/payments/requirements/_base.in
+++ b/services/payments/requirements/_base.in
@@ -17,12 +17,9 @@
 
 aiosmtplib # notifier
 cryptography
-fastapi
-httpx
 Jinja2 # notifier
 packaging
 python-jose
 python-multipart
 python-socketio # notifier
 typer[all]
-uvicorn[standard]

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -633,7 +633,7 @@ urllib3==2.2.3
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   requests
-uvicorn==0.32.1
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -85,6 +85,7 @@ charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via
+    #   rich-toolkit
     #   typer
     #   uvicorn
 cryptography==44.0.0
@@ -115,16 +116,19 @@ dnspython==2.7.0
 ecdsa==0.19.0
     # via python-jose
 email-validator==2.2.0
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.5
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 faststream==0.5.31
@@ -146,6 +150,10 @@ h11==0.14.0
     #   httpcore
     #   uvicorn
     #   wsproto
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.7
     # via httpx
 httptools==0.6.4
@@ -167,7 +175,9 @@ httpx==0.27.2
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -177,7 +187,7 @@ idna==3.10
     #   yarl
 importlib-metadata==8.5.0
     # via opentelemetry-api
-jinja2==3.1.4
+jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -194,6 +204,7 @@ jinja2==3.1.4
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
+    #   fastapi
 jsonschema==4.23.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -440,8 +451,10 @@ python-engineio==4.10.1
     # via python-socketio
 python-jose==3.3.0
     # via -r requirements/_base.in
-python-multipart==0.0.17
-    # via -r requirements/_base.in
+python-multipart==0.0.20
+    # via
+    #   -r requirements/_base.in
+    #   fastapi
 python-socketio==5.11.4
     # via -r requirements/_base.in
 pyyaml==6.0.2
@@ -503,7 +516,10 @@ rich==13.9.4
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.21.0
     # via
     #   jsonschema
@@ -585,6 +601,7 @@ typer==0.13.1
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
+    #   fastapi-cli
 types-python-dateutil==2.9.0.20241003
     # via arrow
 typing-extensions==4.12.2
@@ -597,6 +614,7 @@ typing-extensions==4.12.2
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   rich-toolkit
     #   typer
 urllib3==2.2.3
     # via
@@ -617,8 +635,8 @@ urllib3==2.2.3
     #   requests
 uvicorn==0.32.1
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
+    #   fastapi-cli
 uvloop==0.21.0
     # via uvicorn
 watchfiles==1.0.0

--- a/services/resource-usage-tracker/requirements/_base.in
+++ b/services/resource-usage-tracker/requirements/_base.in
@@ -17,9 +17,7 @@
 
 
 aiocache
-fastapi
 packaging
 prometheus_api_client
 shortuuid
 typer[all]
-uvicorn[standard]

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -199,7 +199,7 @@ httmock==1.4.0
     # via prometheus-api-client
 httpcore==1.0.4
     # via httpx
-httptools==0.6.1
+httptools==0.6.4
     # via uvicorn
 httpx==0.27.0
     # via
@@ -921,11 +921,11 @@ urllib3==2.2.3
     #   -c requirements/../../../requirements/constraints.txt
     #   botocore
     #   requests
-uvicorn==0.29.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli
-uvloop==0.19.0
+uvloop==0.21.0
     # via uvicorn
 watchfiles==0.21.0
     # via uvicorn

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -138,6 +138,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via
+    #   rich-toolkit
     #   typer
     #   uvicorn
 contourpy==1.2.0
@@ -155,14 +156,17 @@ deprecated==1.2.14
 dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
-    # via pydantic
+    # via
+    #   fastapi
+    #   pydantic
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.5
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
+fastapi-cli==0.0.7
+    # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 faststream==0.5.31
@@ -187,6 +191,10 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httmock==1.4.0
     # via prometheus-api-client
 httpcore==1.0.4
@@ -222,6 +230,9 @@ httpx==0.27.0
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
+    #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.6
     # via
     #   anyio
@@ -231,6 +242,35 @@ idna==3.6
     #   yarl
 importlib-metadata==8.0.0
     # via opentelemetry-api
+jinja2==3.1.6
+    # via
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../requirements/constraints.txt
+    #   fastapi
 jmespath==1.0.1
     # via
     #   aiobotocore
@@ -278,7 +318,9 @@ mako==1.3.2
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.2
-    # via mako
+    # via
+    #   jinja2
+    #   mako
 matplotlib==3.8.3
     # via prometheus-api-client
 mdurl==0.1.2
@@ -600,6 +642,8 @@ python-dotenv==1.0.1
     # via
     #   pydantic-settings
     #   uvicorn
+python-multipart==0.0.20
+    # via fastapi
 pytz==2024.1
     # via
     #   dateparser
@@ -708,7 +752,10 @@ rich==13.7.1
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    #   rich-toolkit
     #   typer
+rich-toolkit==0.14.7
+    # via fastapi-cli
 rpds-py==0.18.0
     # via
     #   jsonschema
@@ -811,6 +858,7 @@ typer==0.12.3
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
+    #   fastapi-cli
 types-aiobotocore==2.19.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 types-aiobotocore-ec2==2.19.0
@@ -833,6 +881,7 @@ typing-extensions==4.12.2
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
+    #   rich-toolkit
     #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
@@ -874,8 +923,8 @@ urllib3==2.2.3
     #   requests
 uvicorn==0.29.0
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
+    #   fastapi
+    #   fastapi-cli
 uvloop==0.19.0
     # via uvicorn
 watchfiles==0.21.0

--- a/services/resource-usage-tracker/requirements/_test.txt
+++ b/services/resource-usage-tracker/requirements/_test.txt
@@ -109,9 +109,10 @@ iniconfig==2.0.0
     # via pytest
 itsdangerous==2.2.0
     # via flask
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
     #   flask
     #   moto
 jmespath==1.0.1

--- a/services/storage/requirements/_base.in
+++ b/services/storage/requirements/_base.in
@@ -19,11 +19,9 @@ aiofiles # i/o
 asgi_lifespan
 asyncpg # database
 celery[redis]
-httpx
 opentelemetry-instrumentation-celery
 opentelemetry-instrumentation-botocore
 packaging
-fastapi[all]
 fastapi-pagination
 orjson
 pydantic[dotenv]

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -177,10 +177,9 @@ exceptiongroup==1.2.2
     # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.8
+fastapi==0.115.12
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi-lifespan-manager
 fastapi-cli==0.0.7
     # via fastapi
@@ -208,6 +207,10 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
+h2==4.2.0
+    # via httpx
+hpack==4.1.0
+    # via h2
 httpcore==1.0.7
     # via httpx
 httptools==0.6.4
@@ -241,8 +244,9 @@ httpx==0.28.1
     #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
-    #   -r requirements/_base.in
     #   fastapi
+hyperframe==6.1.0
+    # via h2
 idna==3.10
     # via
     #   anyio
@@ -252,8 +256,6 @@ idna==3.10
     #   yarl
 importlib-metadata==8.5.0
     # via opentelemetry-api
-itsdangerous==2.2.0
-    # via fastapi
 jinja2==3.1.5
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -491,7 +493,6 @@ orjson==3.10.15
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/_base.in
-    #   fastapi
 packaging==24.2
     # via
     #   -r requirements/_base.in
@@ -598,7 +599,6 @@ pydantic-extra-types==2.10.2
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   fastapi
 pydantic-settings==2.7.0
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -635,7 +635,6 @@ pydantic-settings==2.7.0
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-    #   fastapi
 pygments==2.19.1
     # via rich
 pyinstrument==5.0.1
@@ -684,7 +683,6 @@ pyyaml==6.0.2
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   fastapi
     #   uvicorn
 redis==5.2.1
     # via
@@ -895,35 +893,6 @@ tzdata==2025.1
     # via
     #   celery
     #   kombu
-ujson==5.10.0
-    # via
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/aws-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../requirements/constraints.txt
-    #   fastapi
 urllib3==2.3.0
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -956,7 +925,6 @@ urllib3==2.3.0
     #   requests
 uvicorn==0.34.0
     # via
-    #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   fastapi
     #   fastapi-cli
 uvloop==0.21.0

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -923,7 +923,7 @@ urllib3==2.3.0
     #   -c requirements/../../../requirements/constraints.txt
     #   botocore
     #   requests
-uvicorn==0.34.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -164,9 +164,7 @@ idna==3.10
 iniconfig==2.0.0
     # via pytest
 itsdangerous==2.2.0
-    # via
-    #   -c requirements/_base.txt
-    #   flask
+    # via flask
 jinja2==3.1.5
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -104,7 +104,7 @@ anyio==4.3.0
     #   httpx
 appdirs==1.4.4
     # via pint
-arrow==1.2.3
+arrow==1.3.0
     # via
     #   -r requirements/../../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../../packages/notifications-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -976,6 +976,8 @@ typer==0.12.3
     #   -r requirements/../../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
+types-python-dateutil==2.9.0.20250516
+    # via arrow
 typing-extensions==4.12.2
     # via
     #   aiodebug

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -343,7 +343,7 @@ urllib3==2.2.3
     #   -c requirements/_base.txt
     #   docker
     #   requests
-uvicorn==0.34.0
+uvicorn==0.34.2
     # via
     #   fastapi
     #   fastapi-cli

--- a/tests/swarm-deploy/test_service_images.py
+++ b/tests/swarm-deploy/test_service_images.py
@@ -12,7 +12,6 @@ import pytest
 @pytest.mark.parametrize(
     "package_name,services",
     [
-        ("ujson", {"director"}),
         ("magic", {"webserver"}),
     ],
 )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
Some services were installing just `fastapi` others `fastapi[all]` others `fastapi[standard]`.
The recommended approach is to install `fastapi[standard]` which ensures `uvicorn[standard]` is also installed together with `uvloop` for best performance.
in particular:
- agent
- autoscaling
- clusters-keeper
- dynamic-sidecar
- efs-guardian
- notifications
were missing uvloop.

![image](https://github.com/user-attachments/assets/2612d3e3-3154-4fbe-bc57-c7916a300ceb)


Also this generalizes the installation of `httpx[http2]` instead of `httpx` bringing the option to have a client with http/2 protocol support.

In general I think our layered dependency system is ok, with some pros/cons:
- every library installs everything (since it is done via --requirements) which bloats final docker images uselessly when for example installing some unused libraries.
- We tend to add way too many libraries in the `_base.in` since they are already pre-installed by the dependencies


###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 10
- #packages after ~ 27

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | arrow                     | 1.2.3           | 1.3.0      | *minor*    | 1 | web⬆️ |
|   2 | fastapi                   | 0.115.11, 0.115.5, 0.115.8, 0.115.6, 0.115.0 | 0.115.12   |            | 17 | agent⬆️</br>api-server⬆️🧪</br>aws-library🧪</br>catalog⬆️</br>datcore-adapter⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>helpers🧪</br>invitations⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>storage⬆️ |
|   3 | httptools                 | 0.6.1           | 0.6.4      |            | 2 | datcore-adapter⬆️</br>resource-usage-tracker⬆️ |
|   4 | itsdangerous              | 2.2.0           | 🗑️ removed |  | 5 | api-server⬆️</br>catalog⬆️</br>director-v2⬆️</br>director⬆️</br>storage⬆️ |
|   5 | jinja2                    | 3.1.5, 3.1.4    | 3.1.6      |            | 7 | api-server⬆️🧪🔧</br>director⬆️</br>efs-guardian🧪</br>payments⬆️</br>resource-usage-tracker🧪 |
|   6 | python-multipart          | 0.0.17, 0.0.9   | 0.0.20     |            | 3 | datcore-adapter⬆️</br>director⬆️</br>payments⬆️ |
|   7 | starlette                 | 0.38.6          | 0.46.2     | *minor*    | 1 | helpers🧪 |
|   8 | ujson                     | 5.10.0          | 🗑️ removed |  | 5 | api-server⬆️</br>catalog⬆️</br>director-v2⬆️</br>director⬆️</br>storage⬆️ |
|   9 | uvicorn                   | 0.34.0, 0.32.1, 0.32.0, 0.29.0 | 0.34.2     |            | 16 | agent⬆️</br>api-server⬆️🧪</br>catalog⬆️</br>datcore-adapter⬆️</br>director⬆️</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>storage⬆️</br>web🧪 |
|  10 | uvloop                    | 0.19.0          | 0.21.0     | *minor*    | 2 | datcore-adapter⬆️</br>resource-usage-tracker⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency



<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
