### PR TITLE
🎨♻️ Enhances web-server's error middle-ware for safe status-line and refactors aiohttp response helpers

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/rest_middlewares.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_middlewares.py
@@ -186,10 +186,7 @@ def envelope_middleware_factory(
             return resp
 
         if not isinstance(resp, StreamResponse):
-            resp = create_data_response(
-                data=resp,
-                skip_internal_error_details=_is_prod,
-            )
+            resp = create_data_response(data=resp)
 
         assert isinstance(resp, web.StreamResponse)  # nosec
         return resp

--- a/packages/service-library/src/servicelib/aiohttp/rest_responses.py
+++ b/packages/service-library/src/servicelib/aiohttp/rest_responses.py
@@ -36,7 +36,7 @@ def create_data_response(data: Any, *, status: int = HTTP_200_OK) -> web.Respons
     return web.json_response(enveloped_payload, dumps=json_dumps, status=status)
 
 
-MAX_STATUS_MESSAGE_LENGTH: Final[int] = 50
+MAX_STATUS_MESSAGE_LENGTH: Final[int] = 100
 
 
 def safe_status_message(

--- a/packages/service-library/tests/aiohttp/test_rest_responses.py
+++ b/packages/service-library/tests/aiohttp/test_rest_responses.py
@@ -17,7 +17,11 @@ from aiohttp.web_exceptions import (
     HTTPOk,
 )
 from common_library.error_codes import ErrorCodeStr, create_error_code
-from servicelib.aiohttp.rest_responses import create_http_error, exception_to_response
+from servicelib.aiohttp.rest_responses import (
+    MAX_STATUS_MESSAGE_LENGTH,
+    create_http_error,
+    exception_to_response,
+)
 from servicelib.aiohttp.web_exceptions_extension import (
     _STATUS_CODE_TO_HTTP_ERRORS,
     get_http_error_class_or_none,
@@ -136,10 +140,13 @@ def tests_exception_to_response(
             "Message\nwith\nnewlines",
             "Message with newlines",
         ),  # Newlines are replaced with spaces
-        ("A" * 100, "A" * 47 + "..."),  # Long message gets truncated with ellipsis
         (
-            "Line1\nLine2\nLine3" + "X" * 100,
-            "Line1 Line2 Line3" + "X" * 30 + "...",
+            "A" * (MAX_STATUS_MESSAGE_LENGTH + 1),
+            "A" * (MAX_STATUS_MESSAGE_LENGTH - 3) + "...",
+        ),  # Long message gets truncated with ellipsis
+        (
+            "Line1\nLine2\nLine3" + "X" * (MAX_STATUS_MESSAGE_LENGTH + 1),
+            "Line1 Line2 Line3" + "X" * (MAX_STATUS_MESSAGE_LENGTH - 20) + "...",
         ),  # Combined case: newlines and truncation with ellipsis
     ],
     ids=[

--- a/packages/service-library/tests/aiohttp/test_rest_responses.py
+++ b/packages/service-library/tests/aiohttp/test_rest_responses.py
@@ -63,12 +63,14 @@ def test_collected_http_errors_map(status_code: int, http_error_cls: type[HTTPEr
 @pytest.mark.parametrize("error_code", [None, create_error_code(Exception("fake"))])
 def tests_exception_to_response(skip_details: bool, error_code: ErrorCodeStr | None):
 
-    expected_reason = "Something whent wrong !"
+    expected_status_reason = "SHORT REASON"
+    expected_error_message = "Something whent wrong !"
     expected_exceptions: list[Exception] = [RuntimeError("foo")]
 
     http_error = create_http_error(
         errors=expected_exceptions,
-        reason=expected_reason,
+        error_message=expected_error_message,
+        status_reason="SHORT REASON",
         http_error_cls=web.HTTPInternalServerError,
         skip_internal_error_details=skip_details,
         error_code=error_code,
@@ -94,7 +96,7 @@ def tests_exception_to_response(skip_details: bool, error_code: ErrorCodeStr | N
     # checks response model
     response_json = json.loads(response.text)
     assert response_json["data"] is None
-    assert response_json["error"]["message"] == expected_reason
+    assert response_json["error"]["message"] == expected_error_message
     assert response_json["error"]["supportId"] == error_code
     assert response_json["error"]["status"] == response.status
 

--- a/services/web/server/src/simcore_service_webserver/director_v2/_controller/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2/_controller/_rest_exceptions.py
@@ -30,6 +30,10 @@ _logger = logging.getLogger(__name__)
 async def _handler_director_service_error_as_503_or_4xx(
     request: web.Request, exception: Exception
 ) -> web.Response:
+    """
+        Handles DirectorV2ServiceError exceptions by returning a 503 Service Unavailable if it's a server error (5XX),
+        or a 4XX client error if it's a client error (4XX).
+    """
     assert isinstance(exception, DirectorV2ServiceError)  # nosec
     assert status_codes_utils.is_error(
         exception.status

--- a/services/web/server/src/simcore_service_webserver/director_v2/_controller/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2/_controller/_rest_exceptions.py
@@ -31,8 +31,9 @@ async def _handler_director_service_error_as_503_or_4xx(
     request: web.Request, exception: Exception
 ) -> web.Response:
     """
-        Handles DirectorV2ServiceError exceptions by returning a 503 Service Unavailable if it's a server error (5XX),
-        or a 4XX client error if it's a client error (4XX).
+    Handles DirectorV2ServiceError exceptions by responding with
+        - 503 Service Unavailable if the directorv2 reponds with a server error (5XX),
+        - or bypass with the same error if it's a client error (4XX).
     """
     assert isinstance(exception, DirectorV2ServiceError)  # nosec
     assert status_codes_utils.is_error(

--- a/services/web/server/src/simcore_service_webserver/director_v2/_controller/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/director_v2/_controller/_rest_exceptions.py
@@ -31,9 +31,9 @@ async def _handler_director_service_error_as_503_or_4xx(
     request: web.Request, exception: Exception
 ) -> web.Response:
     """
-    Handles DirectorV2ServiceError exceptions by responding with
-        - 503 Service Unavailable if the directorv2 reponds with a server error (5XX),
-        - or bypass with the same error if it's a client error (4XX).
+    Handles DirectorV2ServiceError exceptions by returning:
+      - HTTP 503 Service Unavailable if the underlying director-v2 service returns a 5XX server error,
+      - or the original 4XX client error status and message if it is a client error.
     """
     assert isinstance(exception, DirectorV2ServiceError)  # nosec
     assert status_codes_utils.is_error(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This pull request introduces improvements to error handling and response generation in the `servicelib.aiohttp` package. The changes focus on enhancing the robustness and clarity of HTTP error responses, simplifying the codebase, and updating tests to reflect the new functionality.

### Error Handling Enhancements:
* [`packages/service-library/src/servicelib/aiohttp/rest_middlewares.py`](diffhunk://#diff-ab323d5214684fb5d6a4db66c41cb80514b21dfca664abc79e51ec70e588aeefR91-R92): Added logic to truncate and sanitize HTTP error reasons using `safe_status_message` to prevent issues like excessively long status lines or multiline reasons. [[1]](diffhunk://#diff-ab323d5214684fb5d6a4db66c41cb80514b21dfca664abc79e51ec70e588aeefR91-R92) [[2]](diffhunk://#diff-ab323d5214684fb5d6a4db66c41cb80514b21dfca664abc79e51ec70e588aeefR112-R114)
* [`packages/service-library/src/servicelib/aiohttp/rest_responses.py`](diffhunk://#diff-ba7b81ca6b4890feae0bbe5398fd165370de38a5d8e0a2ab57b08920006a2405L67-R100): Introduced `safe_status_message` to truncate HTTP reason phrases and added `status_reason` as a separate parameter for `create_http_error` to distinguish between internal error messages and HTTP status reasons. [[1]](diffhunk://#diff-ba7b81ca6b4890feae0bbe5398fd165370de38a5d8e0a2ab57b08920006a2405L67-R100) [[2]](diffhunk://#diff-ba7b81ca6b4890feae0bbe5398fd165370de38a5d8e0a2ab57b08920006a2405L95-R121)

### Response Generation Simplification:
* [`packages/service-library/src/servicelib/aiohttp/rest_responses.py`](diffhunk://#diff-ba7b81ca6b4890feae0bbe5398fd165370de38a5d8e0a2ab57b08920006a2405L16-R77): Refactored `create_data_response` to simplify its implementation by removing error handling logic and ensuring all responses are enveloped.
* Removed unused code and redundant logic, including the `_collect_http_exceptions` function and its related imports.

### Test Updates:
* [`packages/service-library/tests/aiohttp/test_rest_responses.py`](diffhunk://#diff-d040f6205882e3f56b656892f9d54595a39412ac2500ffddca42d6f6f2398cb7L64-R99): Updated tests for `create_http_error` to validate the new `status_reason` parameter and ensure proper handling of various HTTP error classes. [[1]](diffhunk://#diff-d040f6205882e3f56b656892f9d54595a39412ac2500ffddca42d6f6f2398cb7L64-R99) [[2]](diffhunk://#diff-d040f6205882e3f56b656892f9d54595a39412ac2500ffddca42d6f6f2398cb7L90-R126)

### Integration Fixes:
* [`services/web/server/src/simcore_service_webserver/director_v2/_controller/_rest_exceptions.py`](diffhunk://#diff-5c4669d6cc07e37652d26eaccd5ed10b362fab00cbeb9f77aea0527806be22c4L28-R28): Updated the `status_reason` parameter in `create_http_error` calls for better alignment with the new error handling structure.


## Related issue/s

- Follows up from https://github.com/ITISFoundation/osparc-simcore/pull/7760

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```
cd packages/service-library
make "install-dev[aiohttp]"
pytest -vv tests/aiohttp/test_rest_responses.py
```

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
