### PR TITLE
7799 limit number of accepted jobs in api server map

### DIFF
--- a/packages/models-library/src/models_library/functions.py
+++ b/packages/models-library/src/models_library/functions.py
@@ -75,7 +75,10 @@ FunctionJobClassSpecificData: TypeAlias = FunctionClassSpecificData
 # see here https://github.com/ITISFoundation/osparc-simcore/issues/7659
 FunctionInputs: TypeAlias = dict[str, Any] | None
 
-FunctionInputsList: TypeAlias = list[FunctionInputs]
+FunctionInputsList: TypeAlias = Annotated[
+    list[FunctionInputs],
+    Field(max_length=50),
+]
 
 FunctionOutputs: TypeAlias = dict[str, Any] | None
 

--- a/services/api-server/openapi.json
+++ b/services/api-server/openapi.json
@@ -7699,6 +7699,7 @@
                     }
                   ]
                 },
+                "maxItems": 50,
                 "title": "Function Inputs List"
               }
             }

--- a/tests/performance/locustfiles/functions/map_test_sleeper.py
+++ b/tests/performance/locustfiles/functions/map_test_sleeper.py
@@ -3,7 +3,7 @@
 # dependencies = [
 #     "httpx",
 #     "matplotlib",
-#     "osparc>=0.8.3.post0.dev26",
+#     "osparc>0.8.3.post0.dev26",
 #     "tenacity",
 #     "tqdm",
 # ]


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- Limit the number of inputs passed via the `POST /v0/functions/{function_id}:map` endpoint in the api server to 50
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- closes #7799

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
