### PR TITLE
🎨Computational backend: Fail fast in case of malformed input syntax and improve unzipping

### DIFF
--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/errors.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/errors.py
@@ -18,14 +18,8 @@ class ServiceRuntimeError(OsparcErrorMixin, RuntimeError):
     )
 
 
-class ServiceInputsBadlyFormattedError(OsparcErrorMixin, RuntimeError):
-    msg_template = (
-        "The service {service_key}:{service_version} contains badly formatted inputs"
-    )
-
-
 class ServiceInputsUseFileToKeyMapButReceivesZipDataError(
-    ServiceInputsBadlyFormattedError
+    OsparcErrorMixin, RuntimeError
 ):
     msg_template = (
         "The service {service_key}:{service_version} {input} uses a file-to-key {file_to_key_map} map but receives zip data instead. "

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/errors.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/errors.py
@@ -1,11 +1,9 @@
-""" Dask task exceptions
+"""Dask task exceptions"""
 
-"""
 from common_library.errors_classes import OsparcErrorMixin
 
 
-class TaskValueError(OsparcErrorMixin, ValueError):
-    ...
+class TaskValueError(OsparcErrorMixin, ValueError): ...
 
 
 class TaskCancelledError(OsparcErrorMixin, RuntimeError):
@@ -17,4 +15,19 @@ class ServiceRuntimeError(OsparcErrorMixin, RuntimeError):
         "The service {service_key}:{service_version}"
         " running in container {container_id} failed with code"
         " {exit_code}. Last logs:\n{service_logs}"
+    )
+
+
+class ServiceInputsBadlyFormattedError(OsparcErrorMixin, RuntimeError):
+    msg_template = (
+        "The service {service_key}:{service_version} contains badly formatted inputs"
+    )
+
+
+class ServiceInputsUseFileToKeyMapButReceivesZipDataError(
+    ServiceInputsBadlyFormattedError
+):
+    msg_template = (
+        "The service {service_key}:{service_version} {input} uses a file-to-key {file_to_key_map} map but receives zip data instead. "
+        "TIP: either pass a single file or zip file and remove the file-to-key map parameter."
     )

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -82,10 +82,10 @@ class ComputationalSidecar:
 
                 destination_path = task_volumes.inputs_folder / file_name
 
-                need_extraction = check_need_unzipping(
+                need_unzipping = check_need_unzipping(
                     input_params.url, input_params.file_mime_type, destination_path
                 )
-                if input_params.file_mapping and need_extraction:
+                if input_params.file_mapping and need_unzipping:
                     raise ServiceInputsUseFileToKeyMapButReceivesZipDataError(
                         service_key=self.task_parameters.image,
                         service_version=self.task_parameters.tag,

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/task_shared_volume.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/task_shared_volume.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import shutil
 from dataclasses import dataclass
@@ -22,7 +23,7 @@ class TaskSharedVolumes:
 
             assert not folder_path.exists()  # nosec
             folder_path.mkdir(parents=True)
-            logger.critical(
+            logger.info(
                 "created %s in %s",
                 f"{folder=}",
                 f"{self.base_path=}",
@@ -60,5 +61,4 @@ class TaskSharedVolumes:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        ...
-        # await asyncio.get_event_loop().run_in_executor(None, self.cleanup)
+        await asyncio.get_event_loop().run_in_executor(None, self.cleanup)

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/task_shared_volume.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/task_shared_volume.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import shutil
 from dataclasses import dataclass
@@ -23,7 +22,7 @@ class TaskSharedVolumes:
 
             assert not folder_path.exists()  # nosec
             folder_path.mkdir(parents=True)
-            logger.debug(
+            logger.critical(
                 "created %s in %s",
                 f"{folder=}",
                 f"{self.base_path=}",
@@ -61,4 +60,5 @@ class TaskSharedVolumes:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        await asyncio.get_event_loop().run_in_executor(None, self.cleanup)
+        ...
+        # await asyncio.get_event_loop().run_in_executor(None, self.cleanup)

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
@@ -150,7 +150,8 @@ def check_need_unzipping(
     Checks if the source URL points to a zip file and if the target mime type is not zip.
     If so, extraction is needed.
     """
-    src_mime_type, _ = mimetypes.guess_type(f"{src_url.path}")
+    assert src_url.path  # nosec
+    src_mime_type, _ = mimetypes.guess_type(src_url.path)
     dst_mime_type = target_mime_type
     if not dst_mime_type:
         dst_mime_type, _ = mimetypes.guess_type(dst_path)

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
@@ -177,9 +177,9 @@ async def pull_file_from_remote(
     if s3_settings and src_url.scheme in S3_FILE_SYSTEM_SCHEMES:
         storage_kwargs = _s3fs_settings_from_s3_settings(s3_settings)
 
-    need_extraction = check_need_unzipping(src_url, target_mime_type, dst_path)
+    need_unzipping = check_need_unzipping(src_url, target_mime_type, dst_path)
     async with AsyncExitStack() as exit_stack:
-        if need_extraction:
+        if need_unzipping:
             # we need to extract the file, so we create a temporary directory
             # where the file will be downloaded and extracted
             tmp_dir = await exit_stack.enter_async_context(
@@ -203,7 +203,7 @@ async def pull_file_from_remote(
             logging.INFO,
         )
 
-        if need_extraction:
+        if need_unzipping:
             await log_publishing_cb(
                 f"Uncompressing '{download_dst_path.name}'...", logging.INFO
             )

--- a/services/dask-sidecar/tests/unit/test_computational_sidecar_tasks.py
+++ b/services/dask-sidecar/tests/unit/test_computational_sidecar_tasks.py
@@ -23,7 +23,10 @@ import fsspec
 import pytest
 from common_library.json_serialization import json_dumps
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
-from dask_task_models_library.container_tasks.errors import ServiceRuntimeError
+from dask_task_models_library.container_tasks.errors import (
+    ServiceInputsUseFileToKeyMapButReceivesZipDataError,
+    ServiceRuntimeError,
+)
 from dask_task_models_library.container_tasks.events import TaskProgressEvent
 from dask_task_models_library.container_tasks.io import (
     FileUrl,
@@ -417,7 +420,9 @@ def sidecar_task(
     task_owner: TaskOwner,
     s3_settings: S3Settings,
 ) -> Callable[..., ServiceExampleParam]:
-    def _creator(command: list[str] | None = None) -> ServiceExampleParam:
+    def _creator(
+        command: list[str] | None = None, input_data: TaskInputData | None = None
+    ) -> ServiceExampleParam:
         return ServiceExampleParam(
             docker_basic_auth=DockerBasicAuth(
                 server_address="docker.io", username="pytest", password=SecretStr("")
@@ -426,7 +431,7 @@ def sidecar_task(
             service_version="latest",
             command=command
             or ["/bin/bash", "-c", "echo 'hello I'm an empty ubuntu task!"],
-            input_data=TaskInputData.model_validate({}),
+            input_data=input_data or TaskInputData.model_validate({}),
             output_data_keys=TaskOutputDataSchema.model_validate({}),
             log_file_url=s3_remote_file_url(file_path="log.dat"),
             expected_output_data=TaskOutputData.model_validate({}),
@@ -454,6 +459,30 @@ def sleeper_task_unexpected_output(
 ) -> ServiceExampleParam:
     sleeper_task.command = ["/bin/bash", "-c", "echo we create nothingness"]
     return sleeper_task
+
+
+@pytest.fixture()
+def task_with_file_to_key_map_in_input_data(
+    sidecar_task: Callable[..., ServiceExampleParam],
+) -> ServiceExampleParam:
+    """This task has a file-to-key map in the input data but receives zip data instead"""
+    return sidecar_task(
+        command=["/bin/bash", "-c", "echo we create nothingness"],
+        input_data=TaskInputData.model_validate(
+            {
+                "input_1": 23,
+                "input_23": "a string input",
+                "the_input_43": 15.0,
+                "the_bool_input_54": False,
+                "some_file_input_with_mapping": FileUrl(
+                    url=TypeAdapter(AnyUrl).validate_python(
+                        "s3://myserver/some_file_url.zip"
+                    ),
+                    file_mapping="some_file_mapping",
+                ),
+            }
+        ),
+    )
 
 
 @pytest.fixture()
@@ -806,6 +835,21 @@ def test_running_service_that_generates_unexpected_data_raises_exception(
     with pytest.raises(ServiceBadFormattedOutputError):
         run_computational_sidecar(
             **sleeper_task_unexpected_output.sidecar_params(),
+        )
+
+
+@pytest.mark.parametrize(
+    "integration_version, boot_mode", [("1.0.0", BootMode.CPU)], indirect=True
+)
+def test_running_service_with_incorrect_zip_data_that_uses_a_file_to_key_map_raises_exception(
+    caplog_info_level: pytest.LogCaptureFixture,
+    app_environment: EnvVarsDict,
+    dask_subsystem_mock: dict[str, mock.Mock],
+    task_with_file_to_key_map_in_input_data: ServiceExampleParam,
+):
+    with pytest.raises(ServiceInputsUseFileToKeyMapButReceivesZipDataError):
+        run_computational_sidecar(
+            **task_with_file_to_key_map_in_input_data.sidecar_params(),
         )
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
As part of the issues found by @wvangeit where a service would define file_to_key mapping for input and pass in a zip file.
![image](https://github.com/user-attachments/assets/061e2077-d67f-4976-9841-dd5be7bdb1f1)

Having a service input port defining a `file_to_key` mapping and at the same time passing a `zip` file at runtime produces confusing results:
1. the dask-sidecar downloads the input file which is a zip file,
2. renames the zip file to the key map (here `values.json`)
3. then since it's a zip file unzips the file which happened to also contain a `values.json` file which overrides the original `values.json` zip file
4. the dask-sidecar then removes the original zip file, which means deletes the `values.json` file
--> the jsonifier service would actually run with an empty input data and will not complain as it can run with no inputs.

This PR improves the dask-sidecar to raise an exception if it detects:
- that an input port defines a _file_to_key_ mapping
- and that the user passes a zip file and does not set the file mime type explicitely to `application/zip`

On the other hand the unzipping process is enhanced by:
- in case extraction is needed
- downloads the zip file to a temporary folder
- and extracts the zip file to the destination path


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates with https://github.com/ITISFoundation/osparc-issues/issues/1889

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
