### PR TITLE
 🎨 Improves webserver's  exception handling to enhance diagnoses of catalog's client errors 

### DIFF
--- a/services/web/server/src/simcore_service_webserver/catalog/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_constants.py
@@ -1,7 +1,12 @@
 from typing import Final
 
-MSG_CATALOG_SERVICE_UNAVAILABLE: Final[
-    str
-] = "Currently catalog service is unavailable, please try again later"
+from ..constants import MSG_TRY_AGAIN_OR_SUPPORT
+
+MSG_CATALOG_SERVICE_UNAVAILABLE: Final[str] = (
+    # Most likely the director service is down or misconfigured so the user is asked to try again later.
+    "This service is temporarily unavailable. The incident was logged and will be investigated. "
+    + MSG_TRY_AGAIN_OR_SUPPORT
+)
+
 
 MSG_CATALOG_SERVICE_NOT_FOUND: Final[str] = "Not Found"

--- a/services/web/server/src/simcore_service_webserver/catalog/_controller_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/_controller_rest_exceptions.py
@@ -1,23 +1,82 @@
 """Defines the different exceptions that may arise in the catalog subpackage"""
 
+import logging
+
+from aiohttp import web
+from common_library.error_codes import create_error_code
+from models_library.rest_error import ErrorGet
 from servicelib.aiohttp import status
+from servicelib.logging_errors import create_troubleshotting_log_kwargs
 from servicelib.rabbitmq.rpc_interfaces.catalog.errors import (
     CatalogForbiddenError,
     CatalogItemNotFoundError,
 )
 
 from ..exception_handling import (
+    ExceptionHandlersMap,
     ExceptionToHttpErrorMap,
     HttpErrorInfo,
+    create_error_context_from_request,
+    create_error_response,
     exception_handling_decorator,
     to_exceptions_handlers_map,
 )
 from ..resource_usage.errors import DefaultPricingPlanNotFoundError
-from .errors import DefaultPricingUnitForServiceNotFoundError
+from ._constants import MSG_CATALOG_SERVICE_NOT_FOUND, MSG_CATALOG_SERVICE_UNAVAILABLE
+from .errors import (
+    CatalogConnectionError,
+    CatalogResponseError,
+    DefaultPricingUnitForServiceNotFoundError,
+)
 
 # mypy: disable-error-code=truthy-function
 assert CatalogForbiddenError  # nosec
 assert CatalogItemNotFoundError  # nosec
+
+
+_logger = logging.getLogger(__name__)
+
+
+async def _handler_catalog_response_errors(
+    request: web.Request, exception: Exception
+) -> web.Response:
+
+    assert isinstance(  # nosec
+        exception, CatalogResponseError | CatalogConnectionError
+    ), f"check mapping, got {exception=}"
+
+    if (
+        isinstance(exception, CatalogResponseError)
+        and exception.status == status.HTTP_404_NOT_FOUND
+    ):
+        error = ErrorGet(
+            status=status.HTTP_404_NOT_FOUND,
+            message=MSG_CATALOG_SERVICE_NOT_FOUND,
+        )
+
+    else:
+        # NOTE: The remaining errors are mapped to 503
+        status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        user_msg = MSG_CATALOG_SERVICE_UNAVAILABLE
+
+        # Log for further investigation
+        oec = create_error_code(exception)
+        _logger.exception(
+            **create_troubleshotting_log_kwargs(
+                user_msg,
+                error=exception,
+                error_code=oec,
+                error_context={
+                    **create_error_context_from_request(request),
+                    "error_code": oec,
+                },
+            )
+        )
+        error = ErrorGet.model_construct(
+            message=user_msg, support_id=oec, status=status_code
+        )
+
+    return create_error_response(error, status_code=error.status)
 
 
 _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
@@ -37,8 +96,15 @@ _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
     ),
 }
 
+
+_exceptions_handlers_map: ExceptionHandlersMap = {
+    CatalogResponseError: _handler_catalog_response_errors,
+    CatalogConnectionError: _handler_catalog_response_errors,
+}
+_exceptions_handlers_map.update(to_exceptions_handlers_map(_TO_HTTP_ERROR_MAP))
+
 handle_plugin_requests_exceptions = exception_handling_decorator(
-    to_exceptions_handlers_map(_TO_HTTP_ERROR_MAP)
+    _exceptions_handlers_map
 )
 
 

--- a/services/web/server/src/simcore_service_webserver/catalog/errors.py
+++ b/services/web/server/src/simcore_service_webserver/catalog/errors.py
@@ -1,5 +1,3 @@
-"""Defines the different exceptions that may arise in the catalog subpackage"""
-
 from ..errors import WebServerBaseError
 
 
@@ -23,3 +21,14 @@ class DefaultPricingUnitForServiceNotFoundError(BaseCatalogError):
         super().__init__(**ctxs)
         self.service_key = service_key
         self.service_version = service_version
+
+
+class CatalogResponseError(BaseCatalogError):
+    msg_template = "Catalog response with error status {status} and message '{message}'"
+    status: int
+    message: str
+
+
+class CatalogConnectionError(BaseCatalogError):
+    msg_template = "Catalog connection or timeout error: {message}"
+    message: str


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This PR refines the error handling logic using `catalog._cotnroller_rest_excetpions._handler_catalog_client_errors` to **log detail troubleshooting information** for diagnostics while keeping (for now), the current behavior:
* If the catalog service responds with a `404`, the webserver REST API returns a `404`.
* If the catalog service responds with **any other error**, it is translated into a `503` by the webserver REST API

IMO the current logic is overly coarse—many `4XX` errors may indicate client-side issues rather than catalog unavailability, but we will wait until we see the errors to enhance that.


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- Improves error mapping to better diagnose the issue reported in #7814


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
