### PR TITLE
🐛 [Frontend] Fix: un-synced frontend's and backend's study objects

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/Study.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Study.js
@@ -699,8 +699,9 @@ qx.Class.define("osparc.data.model.Study", {
     /**
      * Call patch Study, but the changes were already applied on the frontend
      * @param studyDiffs {Object} Diff Object coming from the JsonDiffPatch lib. Use only the keys, not the changes.
+     * @param sourceStudy {Object} Study object that was used to apply the diffs on the frontend.
      */
-    patchStudyDelayed: function(studyDiffs) {
+    patchStudyDelayed: function(studyDiffs, sourceStudy) {
       const promises = [];
       let workbenchDiffs = {};
       if ("workbench" in studyDiffs) {
@@ -730,12 +731,7 @@ qx.Class.define("osparc.data.model.Study", {
       }
       return Promise.all(promises)
         .then(() => {
-          // A bit hacky, but it's not sent back to the backend
-          this.set({
-            lastChangeDate: new Date()
-          });
-          const studyData = this.serialize();
-          return studyData;
+          return sourceStudy;
         });
     }
   }


### PR DESCRIPTION
## What do these changes do?

This PR fixes a bug in the front-end regarding the study patch handler.

The frontend keeps a json object of the latest state of the Study, and it relies on this object to know whether sometinhg changed. **After** patching a study or node, the frontend assumes that that is the latest state of the study in the backend. This assumption is not true: if the study changes during the PATCHing process there is the desynchronization between backend and frontend.

This is more reproducible in AWS, and it's even more noticeable when using the file picker, specially, when the file upload completion happens: the fronted patched the state of the file picker at progress 99%, and it is patching this state, the file uploading process gets completed (100%), when the patch is finished, the frontend think that the 100% was already reported, and it won't patch it. This has two consequences:
- The node connected downstream thinks the file upload didn't finish so it won't pull anything (not 100% about this one)
- Next time you open the study, the File Picker is in 99 (not a valid file)

The fix consists of assuming that the backend's study state is the one it was used to compute the delta used in the patch.

## Related issue/s

- closes https://github.com/ITISFoundation/osparc-issues/issues/1892
- closes https://github.com/ITISFoundation/osparc-issues/issues/1894


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
