### PR TITLE
🐛 [Frontend] Fix: init ui-mode

### DIFF
--- a/services/static-webserver/client/source/class/osparc/study/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/study/Utils.js
@@ -62,7 +62,7 @@ qx.Class.define("osparc.study.Utils", {
             };
             // maybe check it's dynamic
             if (!("mode" in minStudyData["ui"])) {
-              minStudyData["ui"]["mode"] = "standalone";
+              minStudyData["ui"]["mode"] = metadata["key"] && metadata["key"].includes("dynamic") ? "standalone" : "pipeline";
             }
             const inaccessibleServices = osparc.store.Services.getInaccessibleServices(minStudyData["workbench"])
             if (inaccessibleServices.length) {

--- a/services/static-webserver/client/source/class/osparc/study/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/study/Utils.js
@@ -60,9 +60,8 @@ qx.Class.define("osparc.study.Utils", {
                 "y": 100
               }
             };
-            // maybe check it's dynamic
             if (!("mode" in minStudyData["ui"])) {
-              minStudyData["ui"]["mode"] = metadata["key"] && metadata["key"].includes("dynamic") ? "standalone" : "pipeline";
+              minStudyData["ui"]["mode"] = metadata["type"] && metadata["type"] === "dynamic" ? "standalone" : "pipeline";
             }
             const inaccessibleServices = osparc.store.Services.getInaccessibleServices(minStudyData["workbench"])
             if (inaccessibleServices.length) {


### PR DESCRIPTION
## What do these changes do?

reported by @JavierGOrdonnez 

When starting a project from the apps tab, they ``ui`` ``mode`` always gets initialized as ``standalone``. If the started app is a computational service, it should be initialized as ``pipeline``.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
