### PR TITLE
🐛 [Frontend] Fix: Tutorials tab link

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/NewPlusMenu.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/NewPlusMenu.js
@@ -244,9 +244,9 @@ qx.Class.define("osparc.dashboard.NewPlusMenu", {
 
       const permissions = osparc.data.Permissions.getInstance();
       if (permissions.canDo("dashboard.templates.read")) {
-        const templatesButton = this.self().createMenuButton("@FontAwesome5Solid/copy/16", this.tr("Tutorials..."));
-        templatesButton.addListener("execute", () => this.fireDataEvent("changeTab", "templatesTab"), this);
-        moreMenu.add(templatesButton);
+        const tutorialsButton = this.self().createMenuButton("@FontAwesome5Solid/copy/16", this.tr("Tutorials..."));
+        tutorialsButton.addListener("execute", () => this.fireDataEvent("changeTab", "tutorialsTab"), this);
+        moreMenu.add(tutorialsButton);
       }
 
       if (permissions.canDo("dashboard.services.read")) {


### PR DESCRIPTION
## What do these changes do?

This link was broken:
![Fixed](https://github.com/user-attachments/assets/3ea94b5d-3597-44a7-9879-861ea8fec375)


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
