### PR TITLE
🐛 [Frontend] Fix: service catalog

### DIFF
--- a/services/static-webserver/client/source/class/osparc/workbench/ServiceCatalog.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/ServiceCatalog.js
@@ -212,7 +212,7 @@ qx.Class.define("osparc.workbench.ServiceCatalog", {
       this.__servicesLatest.forEach(service => {
         if (this.__contextLeftNodeId === null && this.__contextRightNodeId === null) {
           filteredServices.push(service);
-        } else {
+        } else if (service.inputs && service.outputs) {
           // filter out services that can't be connected
           const needsInputs = this.__contextLeftNodeId !== null;
           const needsOutputs = this.__contextRightNodeId !== null;


### PR DESCRIPTION
## What do these changes do?

If a service's metadata, which information is not complete (``/project/services``) and this is retired) makes into the catalog, it might 

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
