### PR TITLE
🎨 [Frontend] Redirect anonymous users to the "account request form" instead of asking them to send an email

### DIFF
--- a/services/static-webserver/client/source/class/osparc/store/Support.js
+++ b/services/static-webserver/client/source/class/osparc/store/Support.js
@@ -149,6 +149,16 @@ qx.Class.define("osparc.store.Support", {
       return textLink;
     },
 
+    requestAccountLink: function(centered = true) {
+      const color = qx.theme.manager.Color.getInstance().resolve("text");
+      const link = window.location.origin + "/request-account";
+      let textLink = `<a href="${link}" style='color: ${color}' target='_blank'>Request Account</a>`;
+      if (centered) {
+        textLink = `<center>${textLink}</center>`
+      }
+      return textLink;
+    },
+
     getMailToLabel: function(email, subject) {
       const mailto = new qx.ui.basic.Label(this.mailToLink(email, subject, false)).set({
         font: "text-14",

--- a/services/static-webserver/client/source/class/osparc/store/Support.js
+++ b/services/static-webserver/client/source/class/osparc/store/Support.js
@@ -151,7 +151,7 @@ qx.Class.define("osparc.store.Support", {
 
     requestAccountLink: function(centered = true) {
       const color = qx.theme.manager.Color.getInstance().resolve("text");
-      const link = window.location.origin + "/request-account";
+      const link = window.location.origin + "/#/request-account";
       let textLink = `<a href="${link}" style='color: ${color}' target='_blank'>Request Account</a>`;
       if (centered) {
         textLink = `<center>${textLink}</center>`

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -645,7 +645,8 @@ qx.Class.define("osparc.utils.Utils", {
       const manuals = osparc.store.Support.getManuals();
       const manualLink = (manuals && manuals.length) ? manuals[0].url : "";
       let msg = "";
-      msg += qx.locale.Manager.tr("To use all ") + this.createHTMLLink(productName + " features", manualLink);
+      msg += qx.locale.Manager.tr("To use all ");
+      msg += this.createHTMLLink(productName + " features", manualLink);
 
       if (osparc.product.Utils.getCreateAccountAction() === "REQUEST_ACCOUNT_FORM") {
         // if the product is configured to show a form to request an account,

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -650,9 +650,9 @@ qx.Class.define("osparc.utils.Utils", {
       if (osparc.product.Utils.getCreateAccountAction() === "REQUEST_ACCOUNT_FORM") {
         // if the product is configured to show a form to request an account,
         // then show a link to it in the message
-        msg += qx.locale.Manager.tr(", please send us an e-mail to create an account:");
+        msg += qx.locale.Manager.tr(", please request an account in the following link:");
         msg += "</br>";
-        msg += mailto;
+        msg += osparc.store.Support.requestAccountLink();
         return msg;
       }
       msg += qx.locale.Manager.tr(", please send us an e-mail to create an account:");

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -644,13 +644,21 @@ qx.Class.define("osparc.utils.Utils", {
       const productName = osparc.store.StaticInfo.getInstance().getDisplayName();
       const manuals = osparc.store.Support.getManuals();
       const manualLink = (manuals && manuals.length) ? manuals[0].url : "";
-      const supportEmail = osparc.store.VendorInfo.getInstance().getSupportEmail();
-      const mailto = osparc.store.Support.mailToLink(supportEmail, "Request Account " + productName);
       let msg = "";
-      msg += qx.locale.Manager.tr("To use all ");
-      msg += this.createHTMLLink(productName + " features", manualLink);
+      msg += qx.locale.Manager.tr("To use all ") + this.createHTMLLink(productName + " features", manualLink);
+
+      if (osparc.product.Utils.getCreateAccountAction() === "REQUEST_ACCOUNT_FORM") {
+        // if the product is configured to show a form to request an account,
+        // then show a link to it in the message
+        msg += qx.locale.Manager.tr(", please send us an e-mail to create an account:");
+        msg += "</br>";
+        msg += mailto;
+        return msg;
+      }
       msg += qx.locale.Manager.tr(", please send us an e-mail to create an account:");
       msg += "</br>";
+      const supportEmail = osparc.store.VendorInfo.getInstance().getSupportEmail();
+      const mailto = osparc.store.Support.mailToLink(supportEmail, "Request Account " + productName);
       msg += mailto;
       return msg;
     },


### PR DESCRIPTION
## What do these changes do?

If the product is configured to request an account via the form, the "Request account" flash message shown to the guest users will show a link to the request-account form instead of the send-us-an-email approach.

When request account goes through the form:
![RequestAccount1](https://github.com/user-attachments/assets/75fcbd40-66a8-49d4-be14-dffc0792758d)

When the product config expects an email:
![RequestAccount](https://github.com/user-attachments/assets/bf179b1d-6792-472a-aa4b-c04f6e7cbdde)

## Related issue/s
- closes https://github.com/ITISFoundation/osparc-simcore/issues/7713


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
