### PR TITLE
🔨 New gh action to assigns the latest open milestone to a newly opened pull request

### DIFF
--- a/.github/workflows/assign-latest-milestone-to-pr.yml
+++ b/.github/workflows/assign-latest-milestone-to-pr.yml
@@ -1,5 +1,5 @@
 name: Assign latest milestone to new PRs
-
+# This workflow assigns the latest open milestone to a newly opened pull request.
 on:
   pull_request:
     types: [opened]

--- a/.github/workflows/assign-latest-milestone-to-pr.yml.yml
+++ b/.github/workflows/assign-latest-milestone-to-pr.yml.yml
@@ -1,0 +1,39 @@
+name: Assign latest milestone to new PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign-latest-milestone:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Assign latest milestone to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            const milestones = await github.rest.issues.listMilestones({
+              owner,
+              repo,
+              state: 'open',
+              sort: 'due_on', // or 'number' if you prefer
+              direction: 'asc'
+            });
+
+            if (milestones.data.length === 0) {
+              console.log('No open milestones found.');
+              return;
+            }
+
+            const latestMilestone = milestones.data[0]; // earliest due date
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: context.payload.pull_request.number,
+              milestone: latestMilestone.number
+            });


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This gh action should ensure that all PRs are associated to a milestone and we can see them in the standup daily meeting panel. 

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- improving scrum workflow


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
