### PR TITLE
🎨 [Frontend] Hide template used to register function

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -151,7 +151,7 @@ qx.Class.define("osparc.data.Resources", {
           },
           postToTemplate: {
             method: "POST",
-            url: statics.API + "/projects?from_study={study_id}&as_template=true&copy_data={copy_data}"
+            url: statics.API + "/projects?from_study={study_id}&as_template=true&copy_data={copy_data}&hidden={hidden}"
           },
           open: {
             method: "POST",

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -303,6 +303,10 @@ qx.Class.define("osparc.data.Resources", {
             method: "POST",
             url: statics.API + "/projects/{studyId}/workspaces/{workspaceId}:move"
           },
+          updateMetadata: {
+            method: "PATCH",
+            url: statics.API + "/projects/{studyId}/metadata"
+          },
         }
       },
       "conversations": {

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPage.js
@@ -240,7 +240,8 @@ qx.Class.define("osparc.desktop.MainPage", {
       const params = {
         url: {
           "study_id": studyId,
-          "copy_data": copyData
+          "copy_data": copyData,
+          "hidden": false,
         },
       };
       const options = {

--- a/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
+++ b/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
@@ -282,11 +282,12 @@ qx.Class.define("osparc.study.CreateFunction", {
     __createFunction: function(exposedInputs, exposedOutputs) {
       this.__createFunctionBtn.setFetching(true);
 
-      // first publish it as a template
+      // first publish it as a hidden template
       const params = {
         url: {
           "study_id": this.__studyData["uuid"],
           "copy_data": true,
+          "hidden": true,
         },
       };
       const options = {
@@ -298,7 +299,7 @@ qx.Class.define("osparc.study.CreateFunction", {
         .then(task => {
           task.addListener("resultReceived", e => {
             const templateData = e.getData();
-            this.__doCreateFunction(templateData, exposedInputs, exposedOutputs);
+            this.__registerFunction(templateData, exposedInputs, exposedOutputs);
           });
         })
         .catch(err => {
@@ -307,13 +308,11 @@ qx.Class.define("osparc.study.CreateFunction", {
         });
     },
 
-    __doCreateFunction: function(templateData, exposedInputs, exposedOutputs) {
+    __registerFunction: function(templateData, exposedInputs, exposedOutputs) {
       const nameField = this.__form.getItem("name");
       const descriptionField = this.__form.getItem("description");
 
       const functionData = this.self().createFunctionData(templateData, nameField.getValue(), descriptionField.getValue(), exposedInputs, exposedOutputs);
-      console.log("functionData", functionData);
-
       const params = {
         data: functionData,
       };

--- a/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
+++ b/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
@@ -311,7 +311,9 @@ qx.Class.define("osparc.study.CreateFunction", {
 
     __updateTemplateMetadata: function(templateData) {
       const patchData = {
-        "hidden": "Base template for function",
+        "custom" : {
+          "hidden": "Base template for function",
+        }
       };
       const params = {
         url: {

--- a/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
+++ b/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
@@ -299,6 +299,7 @@ qx.Class.define("osparc.study.CreateFunction", {
         .then(task => {
           task.addListener("resultReceived", e => {
             const templateData = e.getData();
+            this.__updateTemplateMetadata(templateData);
             this.__registerFunction(templateData, exposedInputs, exposedOutputs);
           });
         })
@@ -306,6 +307,20 @@ qx.Class.define("osparc.study.CreateFunction", {
           this.__createFunctionBtn.setFetching(false);
           osparc.FlashMessenger.logError(err);
         });
+    },
+
+    __updateTemplateMetadata: function(templateData) {
+      const patchData = {
+        "hidden": "Base template for function",
+      };
+      const params = {
+        url: {
+          "studyId": templateData["uuid"],
+        },
+        data: patchData
+      };
+      osparc.data.Resources.fetch("studies", "updateMetadata", params)
+        .catch(err => console.error(err));
     },
 
     __registerFunction: function(templateData, exposedInputs, exposedOutputs) {


### PR DESCRIPTION
## What do these changes do?

As discussed, this PR hides the template that is used to register a function and adds some ``project_metadata`` to it.

![HiddenTemplate](https://github.com/user-attachments/assets/1b38b111-58be-4d3f-93ab-81dc793a305f)


## Related issue/s
- closes https://github.com/ITISFoundation/osparc-issues/issues/1896


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
