### PR TITLE
🎨 [Frontend] Enh: Visible input ports

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -147,17 +147,15 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
       const toolbar = this.self().createToolbar();
       page.addToHeader(toolbar);
 
-      if (this.__resourceData["resourceType"] === "study") {
+      if (["study", "template"].includes(this.__resourceData["resourceType"])) {
         const payDebtButton = new qx.ui.form.Button(this.tr("Credits required"));
         page.payDebtButton = payDebtButton;
         osparc.dashboard.resources.pages.BasePage.decorateHeaderButton(payDebtButton);
         payDebtButton.addListener("execute", () => this.openBillingSettings());
-        if (this.__resourceData["resourceType"] === "study") {
-          const studyData = this.__resourceData;
-          payDebtButton.set({
-            visibility: osparc.study.Utils.isInDebt(studyData) ? "visible" : "excluded"
-          });
-        }
+        const studyData = this.__resourceData;
+        payDebtButton.set({
+          visibility: osparc.study.Utils.isInDebt(studyData) ? "visible" : "excluded"
+        });
         toolbar.add(payDebtButton);
       }
 
@@ -183,10 +181,10 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
       });
       openButton.addListener("execute", () => this.__openTapped(openButton));
 
-      if (this.__resourceData["resourceType"] === "study") {
+      if (["study", "template"].includes(this.__resourceData["resourceType"])) {
         const studyData = this.__resourceData;
-        const canBeOpened = osparc.study.Utils.canBeOpened(studyData);
-        openButton.setEnabled(canBeOpened);
+        const enabled = osparc.study.Utils.canBeOpened(studyData);
+        openButton.setEnabled(enabled);
       }
 
       toolbar.add(openButton);
@@ -458,13 +456,11 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
         const lazyLoadContent = () => {
           const billingSettings = new osparc.study.BillingSettings(resourceData);
           billingSettings.addListener("debtPayed", () => {
-            if (resourceData["resourceType"] === "study") {
-              page.payDebtButton.set({
-                visibility: osparc.study.Utils.isInDebt(resourceData) ? "visible" : "excluded"
-              });
-              const canBeOpened = osparc.study.Utils.canBeOpened(resourceData);
-              page.openButton.setEnabled(canBeOpened);
-            }
+            page.payDebtButton.set({
+              visibility: osparc.study.Utils.isInDebt(resourceData) ? "visible" : "excluded"
+            });
+            const enabled = osparc.study.Utils.canBeOpened(resourceData);
+            page.openButton.setEnabled(enabled);
           })
           const billingScroll = new qx.ui.container.Scroll(billingSettings);
           page.addToContent(billingScroll);
@@ -508,11 +504,9 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
       const page = new osparc.dashboard.resources.pages.BasePage(title, iconSrc, id);
       this.__addOpenButton(page);
 
-      if (this.__resourceData["resourceType"] === "study") {
-        const studyData = this.__resourceData;
-        const canBeOpened = osparc.study.Utils.canShowPreview(studyData);
-        page.setEnabled(canBeOpened);
-      }
+      const studyData = this.__resourceData;
+      const enabled = osparc.study.Utils.canShowPreview(studyData);
+      page.setEnabled(enabled);
 
       const lazyLoadContent = () => {
         const resourceModel = this.__resourceModel;
@@ -689,11 +683,9 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
       const page = this.__servicesUpdatePage = new osparc.dashboard.resources.pages.BasePage(title, iconSrc, id);
       this.__addOpenButton(page);
 
-      if (this.__resourceData["resourceType"] === "study") {
-        const studyData = this.__resourceData;
-        const canBeOpened = osparc.study.Utils.canShowServiceUpdates(studyData);
-        page.setEnabled(canBeOpened);
-      }
+      const studyData = this.__resourceData;
+      const enabled = osparc.study.Utils.canShowServiceUpdates(studyData);
+      page.setEnabled(enabled);
 
       const lazyLoadContent = () => {
         const servicesUpdate = new osparc.metadata.ServicesInStudyUpdate(resourceData);
@@ -723,11 +715,9 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
       const page = new osparc.dashboard.resources.pages.BasePage(title, iconSrc, id);
       this.__addOpenButton(page);
 
-      if (this.__resourceData["resourceType"] === "study") {
-        const studyData = this.__resourceData;
-        const canBeOpened = osparc.study.Utils.canShowServiceBootOptions(studyData);
-        page.setEnabled(canBeOpened);
-      }
+      const studyData = this.__resourceData;
+      const enabled = osparc.study.Utils.canShowServiceBootOptions(studyData);
+      page.setEnabled(enabled);
 
       const lazyLoadContent = () => {
         const servicesBootOpts = new osparc.metadata.ServicesInStudyBootOpts(resourceData);
@@ -776,11 +766,9 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
         const title = this.tr("Publish");
         const page = new osparc.dashboard.resources.pages.BasePage(title, iconSrc, id);
 
-        if (this.__resourceData["resourceType"] === "study") {
-          const studyData = this.__resourceData;
-          const canBeOpened = osparc.study.Utils.canBeDuplicated(studyData);
-          page.setEnabled(canBeOpened);
-        }
+        const studyData = this.__resourceData;
+        const enabled = osparc.study.Utils.canBeDuplicated(studyData);
+        page.setEnabled(enabled);
 
         const lazyLoadContent = () => {
           const makeItPublic = true;
@@ -817,11 +805,9 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
         const title = this.tr("Template");
         const page = new osparc.dashboard.resources.pages.BasePage(title, iconSrc, id);
 
-        if (this.__resourceData["resourceType"] === "study") {
-          const studyData = this.__resourceData;
-          const canBeOpened = osparc.study.Utils.canBeDuplicated(studyData);
-          page.setEnabled(canBeOpened);
-        }
+        const studyData = this.__resourceData;
+        const enabled = osparc.study.Utils.canBeDuplicated(studyData);
+        page.setEnabled(enabled);
 
         const lazyLoadContent = () => {
           const makeItPublic = false;

--- a/services/static-webserver/client/source/class/osparc/form/renderer/PropForm.js
+++ b/services/static-webserver/client/source/class/osparc/form/renderer/PropForm.js
@@ -162,7 +162,6 @@ qx.Class.define("osparc.form.renderer.PropForm", {
           break;
         }
       }
-      console.log("hideablePorts", hideablePorts);
       return hideablePorts;
     },
 

--- a/services/static-webserver/client/source/class/osparc/form/renderer/PropForm.js
+++ b/services/static-webserver/client/source/class/osparc/form/renderer/PropForm.js
@@ -138,12 +138,14 @@ qx.Class.define("osparc.form.renderer.PropForm", {
     //
     __getHideablePorts: function() {
       const hideablePorts = [];
-      const portIds = this.getPortIds();
-      // if there is no minVisibleInputs defined, make at least 4 visible
-      const minVisibleInputs = this.getNode().getMinVisibleInputs() || 4;
+      const minVisibleInputs = this.getNode().getMinVisibleInputs();
+      if (minVisibleInputs === null) {
+        return hideablePorts;
+      }
       // start from the last port and check the port types
       // if all last ports are the same type, then mark them as hideable
       let hideablePortType = null;
+      const portIds = this.getPortIds();
       for (let i=portIds.length-1; i>=minVisibleInputs; i--) {
         const portId = portIds[i];
         const ctrl = this._form.getControl(portId);

--- a/services/static-webserver/client/source/class/osparc/form/renderer/PropForm.js
+++ b/services/static-webserver/client/source/class/osparc/form/renderer/PropForm.js
@@ -135,58 +135,68 @@ qx.Class.define("osparc.form.renderer.PropForm", {
     /*
      * <-- Dynamic inputs -->
      */
-    __getEmptyDataLastPorts: function() {
-      let emptyDataPorts = [];
-      const minVisibleInputs = this.getNode().getMinVisibleInputs();
-      if (minVisibleInputs === null) {
-        return emptyDataPorts;
-      }
+    //
+    __getHideablePorts: function() {
+      const hideablePorts = [];
       const portIds = this.getPortIds();
-      // it will always show 1 more, so: -1
-      for (let i=minVisibleInputs-1; i<portIds.length; i++) {
+      // if there is no minVisibleInputs defined, make at least 4 visible
+      const minVisibleInputs = this.getNode().getMinVisibleInputs() || 4;
+      // start from the last port and check the port types
+      // if all last ports are the same type, then mark them as hideable
+      let hideablePortType = null;
+      for (let i=portIds.length-1; i>=minVisibleInputs; i--) {
         const portId = portIds[i];
         const ctrl = this._form.getControl(portId);
-        if (ctrl && ctrl.type.includes("data:") && !("link" in ctrl)) {
-          emptyDataPorts.push(portId);
+        if (ctrl && hideablePortType === null) {
+          hideablePortType = ctrl.type;
+        }
+        if (ctrl &&
+          ctrl.type === hideablePortType &&
+          // make sure it's not linked
+          !("link" in ctrl)
+        ) {
+          hideablePorts.unshift(portId);
         } else {
-          emptyDataPorts = [];
+          break;
         }
       }
-      return emptyDataPorts;
+      console.log("hideablePorts", hideablePorts);
+      return hideablePorts;
     },
 
-    __getVisibleEmptyDataLastPort: function() {
-      let emptyDataPorts = null;
-      this.getPortIds().forEach(portId => {
-        const ctrl = this._form.getControl(portId);
+    __getVisibleEmptyLastPort: function() {
+      let emptyPorts = null;
+      const hideablePorts = this.__getHideablePorts();
+      for (let i=hideablePorts.length-1; i>=0; i--) {
+        const portId = hideablePorts[i]
         const label = this._getLabelFieldChild(portId).child;
         if (
-          ctrl && ctrl.type.includes("data:") && !("link" in ctrl) &&
-          label && label.isVisible()
+          label && label.isVisible() &&
+          emptyPorts === null
         ) {
-          emptyDataPorts = portId;
+          emptyPorts = portId;
         }
-      });
-      return emptyDataPorts;
+      }
+      return emptyPorts;
     },
 
     __addInputPortButtonClicked: function() {
-      const emptyDataPorts = this.__getEmptyDataLastPorts();
-      const lastEmptyDataPort = this.__getVisibleEmptyDataLastPort();
-      if (emptyDataPorts.length>1 && lastEmptyDataPort) {
-        const idx = emptyDataPorts.indexOf(lastEmptyDataPort);
-        if (idx+1 < emptyDataPorts.length) {
-          this.__showPort(emptyDataPorts[idx+1]);
+      const emptyPorts = this.__getHideablePorts();
+      const lastEmptyPort = this.__getVisibleEmptyLastPort();
+      if (emptyPorts.length>1 && lastEmptyPort) {
+        const idx = emptyPorts.indexOf(lastEmptyPort);
+        if (idx+1 < emptyPorts.length) {
+          this.__showPort(emptyPorts[idx+1]);
         }
         this.__addInputPortButton.setVisibility(this.__checkAddInputPortButtonVisibility());
       }
     },
 
     __checkAddInputPortButtonVisibility: function() {
-      const emptyDataPorts = this.__getEmptyDataLastPorts();
-      const lastEmptyDataPort = this.__getVisibleEmptyDataLastPort();
-      const idx = emptyDataPorts.indexOf(lastEmptyDataPort);
-      if (idx < emptyDataPorts.length-1) {
+      const emptyPorts = this.__getHideablePorts();
+      const lastEmptyPort = this.__getVisibleEmptyLastPort();
+      const idx = emptyPorts.indexOf(lastEmptyPort);
+      if (idx < emptyPorts.length-1) {
         return "visible";
       }
       return "excluded";
@@ -225,9 +235,9 @@ qx.Class.define("osparc.form.renderer.PropForm", {
     makeInputsDynamic: function() {
       this.getPortIds().forEach(portId => this.__showPort(portId));
 
-      const emptyDataPorts = this.__getEmptyDataLastPorts();
-      for (let i=1; i<emptyDataPorts.length; i++) {
-        const hidePortId = emptyDataPorts[i];
+      const emptyPorts = this.__getHideablePorts();
+      for (let i=1; i<emptyPorts.length; i++) {
+        const hidePortId = emptyPorts[i];
         this.__excludePort(hidePortId);
       }
 


### PR DESCRIPTION
## What do these changes do?

Only ``data`` type ports were hideable in the node input ports view, this PR enhances this feature by supporting any type.

![VisibleInputs](https://github.com/user-attachments/assets/395d786a-f738-408a-98f6-e810b7ee2cb7)

### Bonus:
- Enable/Disable sections also for templates

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
