### PR TITLE
🐛Increase node testing timeout to wait for website since Github machines are very weak

### DIFF
--- a/tests/e2e/tests/startupCalls.js
+++ b/tests/e2e/tests/startupCalls.js
@@ -47,7 +47,7 @@ module.exports = {
         await auto.register(page, user, pass);
         console.log("Registered");
 
-        await page.waitFor(10000);
+        await page.waitFor(60000);
       }, ourTimeout);
 
       afterAll(async () => {


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
Increased the time waiting for the website to come up. Since it is slow and the machines testing are weak.
now waits 1 minute instead of 10 seconds, which already on my own computer would not be enough.

These tests are impossible to test locally for me. I am tempted to move all this to playwright. or ditch them if it has no value.
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
