### PR TITLE
🐛CI: Fix timeout value in CI e2e system test 

### DIFF
--- a/tests/e2e/jest.config.js
+++ b/tests/e2e/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   globals: {
     url: "http://127.0.0.1.nip.io:9081/", // For local testing, set your deployed url here
     apiVersion: 'v0/',
-    ourTimeout: 40000,
+    ourTimeout: 120000,
   },
   maxWorkers: 1,
   maxConcurrency: 1

--- a/tests/e2e/tests/startupCalls.js
+++ b/tests/e2e/tests/startupCalls.js
@@ -39,7 +39,7 @@ module.exports = {
           } else if (url.includes('catalog/services/-/latest')) {
             responses.services = response.json();
           }
-        }, 120000);
+        });
 
         await page.goto(url);
 

--- a/tests/e2e/tests/startupCalls.js
+++ b/tests/e2e/tests/startupCalls.js
@@ -20,7 +20,7 @@ module.exports = {
       };
 
       beforeAll(async () => {
-        console.log("Start:", new Date().toUTCString());
+        console.log("Start:", new Date().toUTCString(), 120000);
 
         page.on('response', response => {
           const url = response.url();

--- a/tests/e2e/tests/startupCalls.js
+++ b/tests/e2e/tests/startupCalls.js
@@ -20,7 +20,7 @@ module.exports = {
       };
 
       beforeAll(async () => {
-        console.log("Start:", new Date().toUTCString(), 120000);
+        console.log("Start:", new Date().toUTCString());
 
         page.on('response', response => {
           const url = response.url();
@@ -39,7 +39,7 @@ module.exports = {
           } else if (url.includes('catalog/services/-/latest')) {
             responses.services = response.json();
           }
-        });
+        }, 120000);
 
         await page.goto(url);
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
In Jest befereAll functions have a timeout that is set to 40s but we wait 60s in the function. so the timeout is set to 2 minutes.
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
