### PR TITLE
🐛 revert to previous long_running_tasks interface

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_routes.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_routes.py
@@ -60,6 +60,7 @@ async def get_task_result(request: web.Request) -> web.Response | Any:
         long_running_manager.tasks_manager,
         long_running_manager.get_task_context(request),
         path_params.task_id,
+        is_fasapi=False,
     )
 
 

--- a/packages/service-library/src/servicelib/fastapi/long_running_tasks/_routes.py
+++ b/packages/service-library/src/servicelib/fastapi/long_running_tasks/_routes.py
@@ -76,7 +76,10 @@ async def get_task_result(
 ) -> TaskResult | Any:
     assert request  # nosec
     return await http_endpoint_responses.get_task_result(
-        long_running_manager.tasks_manager, task_context=None, task_id=task_id
+        long_running_manager.tasks_manager,
+        task_context=None,
+        task_id=task_id,
+        is_fasapi=True,
     )
 
 

--- a/packages/service-library/src/servicelib/long_running_tasks/errors.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/errors.py
@@ -37,3 +37,8 @@ class GenericClientError(BaseLongRunningError):
     msg_template: str = (
         "Unexpected error while '{action}' for '{task_id}': status={status} body={body}"
     )
+
+
+class TaskClientResultError(BaseLongRunningError):
+    code: str = "long_running_task.client.task_raised_error"
+    msg_template: str = "{message}"

--- a/packages/service-library/src/servicelib/long_running_tasks/http_endpoint_responses.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/http_endpoint_responses.py
@@ -27,12 +27,21 @@ def get_task_status(
 
 
 async def get_task_result(
-    tasks_manager: TasksManager, task_context: TaskContext | None, task_id: TaskId
+    tasks_manager: TasksManager,
+    task_context: TaskContext | None,
+    task_id: TaskId,
+    *,
+    is_fasapi: bool,
 ) -> Any:
     try:
-        task_result = tasks_manager.get_task_result(
-            task_id, with_task_context=task_context
-        )
+        if is_fasapi:
+            task_result = tasks_manager.get_task_result_old(
+                task_id, with_task_context=task_context
+            )
+        else:
+            task_result = tasks_manager.get_task_result(
+                task_id, with_task_context=task_context
+            )
         await tasks_manager.remove_task(
             task_id, with_task_context=task_context, reraise_errors=False
         )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?


<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

The interface of `long_running_tasks` got accidentally changed by altering a test, causing director-v2 to no longer tread errors as it should. 

Also task removal was also accidentally changed and not sopped during reviews, this was also reverted, to avoid code raising unexpected errors.


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/7905

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
