### PR TITLE
🎨 Reduce the number of acquisition/release of DB connection inside function repository

### DIFF
--- a/packages/models-library/src/models_library/functions.py
+++ b/packages/models-library/src/models_library/functions.py
@@ -227,6 +227,8 @@ class FunctionJobDB(BaseModel):
     class_specific_data: FunctionJobClassSpecificData
     function_class: FunctionClass
 
+    model_config = ConfigDict(from_attributes=True)
+
 
 class RegisteredFunctionJobDB(FunctionJobDB):
     uuid: FunctionJobID
@@ -242,6 +244,8 @@ class FunctionDB(BaseModel):
     default_inputs: FunctionInputs
     class_specific_data: FunctionClassSpecificData
 
+    model_config = ConfigDict(from_attributes=True)
+
 
 class RegisteredFunctionDB(FunctionDB):
     uuid: FunctionID
@@ -251,6 +255,8 @@ class RegisteredFunctionDB(FunctionDB):
 class FunctionJobCollectionDB(BaseModel):
     title: str = ""
     description: str = ""
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class RegisteredFunctionJobCollectionDB(FunctionJobCollectionDB):

--- a/services/web/server/src/simcore_service_webserver/functions/_controller/_functions_rpc.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_controller/_functions_rpc.py
@@ -22,6 +22,7 @@ from models_library.functions_errors import (
     FunctionJobCollectionReadAccessDeniedError,
     FunctionJobCollectionsReadApiAccessDeniedError,
     FunctionJobCollectionsWriteApiAccessDeniedError,
+    FunctionJobCollectionWriteAccessDeniedError,
     FunctionJobIDNotFoundError,
     FunctionJobReadAccessDeniedError,
     FunctionJobsReadApiAccessDeniedError,
@@ -283,6 +284,7 @@ async def delete_function_job(
     reraise_if_error_type=(
         FunctionJobCollectionIDNotFoundError,
         FunctionJobCollectionReadAccessDeniedError,
+        FunctionJobCollectionWriteAccessDeniedError,
         FunctionJobCollectionsWriteApiAccessDeniedError,
     )
 )
@@ -305,6 +307,7 @@ async def delete_function_job_collection(
     reraise_if_error_type=(
         FunctionIDNotFoundError,
         FunctionReadAccessDeniedError,
+        FunctionWriteAccessDeniedError,
     )
 )
 async def update_function_title(
@@ -325,7 +328,11 @@ async def update_function_title(
 
 
 @router.expose(
-    reraise_if_error_type=(FunctionIDNotFoundError, FunctionReadAccessDeniedError)
+    reraise_if_error_type=(
+        FunctionIDNotFoundError,
+        FunctionReadAccessDeniedError,
+        FunctionWriteAccessDeniedError,
+    )
 )
 async def update_function_description(
     app: web.Application,

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
@@ -1100,7 +1100,7 @@ async def get_user_permissions(
         # Combine permissions for all groups the user belongs to
         result = await conn.stream(
             access_rights_table.select()
-            .with_only_columns(cols)
+            .with_only_columns(*cols)
             .where(
                 getattr(access_rights_table.c, f"{object_type}_uuid") == object_id,
                 access_rights_table.c.product_name == product_name,
@@ -1114,9 +1114,9 @@ async def get_user_permissions(
 
         # Combine permissions across all rows
         combined_permissions = {
-            "read": any(row["read"] for row in rows),
-            "write": any(row["write"] for row in rows),
-            "execute": any(row["execute"] for row in rows),
+            "read": any(row.read for row in rows),
+            "write": any(row.write for row in rows),
+            "execute": any(row.execute for row in rows),
         }
 
         return FunctionAccessRightsDB.model_validate(combined_permissions)

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
@@ -206,18 +206,18 @@ async def create_function_job(  # noqa: PLR0913
 
         registered_function_job = RegisteredFunctionJobDB.model_validate(row)
 
-    user_primary_group_id = await get_user_primary_group_id(app, user_id=user_id)
-    await set_group_permissions(
-        app,
-        connection=transaction,
-        group_id=user_primary_group_id,
-        product_name=product_name,
-        object_type="function_job",
-        object_ids=[registered_function_job.uuid],
-        read=True,
-        write=True,
-        execute=True,
-    )
+        user_primary_group_id = await get_user_primary_group_id(app, user_id=user_id)
+        await set_group_permissions(
+            app,
+            connection=transaction,
+            group_id=user_primary_group_id,
+            product_name=product_name,
+            object_type="function_job",
+            object_ids=[registered_function_job.uuid],
+            read=True,
+            write=True,
+            execute=True,
+        )
 
     return registered_function_job
 

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
@@ -467,7 +467,7 @@ async def list_function_jobs(
             )
 
         return [
-            RegisteredFunctionJobDB.model_validate(dict(row)) for row in rows
+            RegisteredFunctionJobDB.model_validate(row) for row in rows
         ], PageMetaInfoLimitOffset(
             total=total_count_result,
             offset=pagination_offset,
@@ -568,7 +568,7 @@ async def list_function_job_collections(
 
         collections = []
         for row in rows:
-            collection = RegisteredFunctionJobCollectionDB.model_validate(dict(row))
+            collection = RegisteredFunctionJobCollectionDB.model_validate(row)
             job_result = await conn.stream(
                 function_job_collections_to_function_jobs_table.select().where(
                     function_job_collections_to_function_jobs_table.c.function_job_collection_uuid
@@ -678,7 +678,7 @@ async def update_function_title(
             if row is None:
                 raise FunctionIDNotFoundError(function_id=function_id)
 
-            return RegisteredFunctionDB.model_validate(dict(row))
+            return RegisteredFunctionDB.model_validate(row)
 
 
 async def update_function_description(
@@ -763,7 +763,7 @@ async def get_function_job(
             if row is None:
                 raise FunctionJobIDNotFoundError(function_job_id=function_job_id)
 
-            return RegisteredFunctionJobDB.model_validate(dict(row))
+            return RegisteredFunctionJobDB.model_validate(row)
 
 
 async def delete_function_job(
@@ -919,7 +919,7 @@ async def get_function_job_collection(
             [job_row["function_job_uuid"] for job_row in job_rows] if job_rows else []
         )
 
-        job_collection = RegisteredFunctionJobCollectionDB.model_validate(dict(row))
+        job_collection = RegisteredFunctionJobCollectionDB.model_validate(row)
 
     return job_collection, job_ids
 

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
@@ -893,7 +893,7 @@ async def get_function_job_collection(
             async for job_row in await conn.stream(
                 function_job_collections_to_function_jobs_table.select().where(
                     function_job_collections_to_function_jobs_table.c.function_job_collection_uuid
-                    == row["uuid"]
+                    == row.uuid
                 )
             )
         ]

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
@@ -565,11 +565,11 @@ async def list_function_job_collections(
         ):
             collection = RegisteredFunctionJobCollectionDB.model_validate(row)
             job_ids = [
-                job_row["function_job_uuid"]
+                job_row.function_job_uuid
                 async for job_row in await conn.stream(
                     function_job_collections_to_function_jobs_table.select().where(
                         function_job_collections_to_function_jobs_table.c.function_job_collection_uuid
-                        == row["uuid"]
+                        == row.uuid
                     )
                 )
             ]

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
@@ -889,7 +889,7 @@ async def get_function_job_collection(
 
         # Retrieve associated job ids from the join table
         job_ids = [
-            job_row["function_job_uuid"]
+            job_row.function_job_uuid
             async for job_row in await conn.stream(
                 function_job_collections_to_function_jobs_table.select().where(
                     function_job_collections_to_function_jobs_table.c.function_job_collection_uuid

--- a/services/web/server/tests/unit/with_dbs/04/functions_rpc/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/04/functions_rpc/conftest.py
@@ -9,6 +9,7 @@ from typing import Any
 from uuid import uuid4
 
 import pytest
+import sqlalchemy
 from aiohttp.test_utils import TestClient
 from models_library.api_schemas_webserver.functions import (
     Function,
@@ -188,7 +189,7 @@ async def add_user_function_api_access_rights(
     async with asyncpg_engine.begin() as conn:
         for group_id in (logged_user["primary_gid"], other_logged_user["primary_gid"]):
             await conn.execute(
-                funcapi_api_access_rights_table.delete(  # type: ignore[union-attr]
+                sqlalchemy.delete(funcapi_api_access_rights_table).where(
                     funcapi_api_access_rights_table.c.group_id == group_id
                 )
             )

--- a/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_function_job_collections_controller_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_function_job_collections_controller_rpc.py
@@ -17,6 +17,7 @@ from models_library.functions import FunctionJobCollectionsListFilters
 from models_library.functions_errors import (
     FunctionJobCollectionReadAccessDeniedError,
     FunctionJobCollectionsReadApiAccessDeniedError,
+    FunctionJobCollectionWriteAccessDeniedError,
     FunctionJobIDNotFoundError,
 )
 from models_library.products import ProductName
@@ -137,7 +138,7 @@ async def test_function_job_collection(
         )
 
     # Attempt to delete the function job collection by another user
-    with pytest.raises(FunctionJobCollectionReadAccessDeniedError):
+    with pytest.raises(FunctionJobCollectionWriteAccessDeniedError):
         await functions_rpc.delete_function_job_collection(
             rabbitmq_rpc_client=rpc_client,
             function_job_collection_id=registered_collection.uid,

--- a/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_function_jobs_controller_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_function_jobs_controller_rpc.py
@@ -15,6 +15,7 @@ from models_library.functions_errors import (
     FunctionJobIDNotFoundError,
     FunctionJobReadAccessDeniedError,
     FunctionJobsReadApiAccessDeniedError,
+    FunctionJobWriteAccessDeniedError,
 )
 from models_library.products import ProductName
 from pytest_simcore.helpers.webserver_login import UserInfoDict
@@ -104,7 +105,7 @@ async def test_register_get_delete_function_job(
             product_name="this_is_not_osparc",
         )
 
-    with pytest.raises(FunctionJobReadAccessDeniedError):
+    with pytest.raises(FunctionJobWriteAccessDeniedError):
         # Attempt to delete the function job by another user
         await functions_rpc.delete_function_job(
             rabbitmq_rpc_client=rpc_client,
@@ -301,7 +302,6 @@ async def test_find_cached_function_jobs(
     mock_function: ProjectFunction,
     clean_functions: None,
 ):
-
     # Register the function first
     registered_function = await functions_rpc.register_function(
         rabbitmq_rpc_client=rpc_client,

--- a/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_functions_controller_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_functions_controller_rpc.py
@@ -19,6 +19,7 @@ from models_library.functions_errors import (
     FunctionIDNotFoundError,
     FunctionReadAccessDeniedError,
     FunctionsReadApiAccessDeniedError,
+    FunctionWriteAccessDeniedError,
 )
 from models_library.products import ProductName
 from pytest_simcore.helpers.webserver_login import UserInfoDict
@@ -88,7 +89,7 @@ async def test_register_get_delete_function(
             product_name=osparc_product_name,
         )
 
-    with pytest.raises(FunctionReadAccessDeniedError):
+    with pytest.raises(FunctionWriteAccessDeniedError):
         # Attempt to delete the function by another user
         await functions_rpc.delete_function(
             rabbitmq_rpc_client=rpc_client,
@@ -374,7 +375,7 @@ async def test_update_function_title(
     # Update the function's title by other user
     updated_title = "Updated Function Title by Other User"
     registered_function.title = updated_title
-    with pytest.raises(FunctionReadAccessDeniedError):
+    with pytest.raises(FunctionWriteAccessDeniedError):
         updated_function = await functions_rpc.update_function_title(
             rabbitmq_rpc_client=rpc_client,
             function_id=registered_function.uid,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
As spotted with @bisgaard-itis we discovered that running under load some functions would timeout while trying to acquire a DB connection. This should improve that situation.
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-issues/issues/1913
- fixes https://github.com/ITISFoundation/osparc-issues/issues/1920

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
