### PR TITLE
🐛 Fixed director-v2 getting stuck when removing service

### DIFF
--- a/packages/service-library/src/servicelib/fastapi/long_running_tasks/_client.py
+++ b/packages/service-library/src/servicelib/fastapi/long_running_tasks/_client.py
@@ -120,7 +120,7 @@ class Client:
         """
         self.app = app
         self._async_client = async_client
-        self._base_url = base_url
+        self.base_url = base_url
 
     @property
     def _client_configuration(self) -> ClientConfiguration:
@@ -129,7 +129,7 @@ class Client:
 
     def _get_url(self, path: str) -> str:
         url_path = f"{self._client_configuration.router_prefix}{path}".lstrip("/")
-        url = TypeAdapter(AnyHttpUrl).validate_python(f"{self._base_url}{url_path}")
+        url = TypeAdapter(AnyHttpUrl).validate_python(f"{self.base_url}{url_path}")
         return f"{url}"
 
     @retry_on_http_errors

--- a/packages/service-library/src/servicelib/fastapi/long_running_tasks/_context_manager.py
+++ b/packages/service-library/src/servicelib/fastapi/long_running_tasks/_context_manager.py
@@ -132,5 +132,5 @@ async def periodic_task_result(
             exception=e,
             traceback=f"check remote side for logs, HINT: service replying to: '{client._base_url}' for '{task_id=}'",  # noqa: SLF001  # pylint:disable=protected-access
         )
-        _logger.warning(f"{error}")
+        _logger.warning("%s", error)
         raise error from e

--- a/packages/service-library/src/servicelib/fastapi/long_running_tasks/_context_manager.py
+++ b/packages/service-library/src/servicelib/fastapi/long_running_tasks/_context_manager.py
@@ -119,14 +119,6 @@ async def periodic_task_result(
         _logger.debug("%s, %s", f"{task_id=}", f"{result=}")
 
         yield result
-    except Exception as e:
-        error = TaskExceptionError(
-            task_id=task_id,
-            exception=e,
-            traceback=f"check remote side for logs, HINT: service replying to: '{client._base_url}' for '{task_id=}'",
-        )
-        _logger.warning(f"{error}")
-        raise error from e
     except TimeoutError as e:
         await client.cancel_and_delete_task(task_id)
         raise TaskClientTimeoutError(
@@ -134,3 +126,11 @@ async def periodic_task_result(
             timeout=task_timeout,
             exception=e,
         ) from e
+    except Exception as e:
+        error = TaskExceptionError(
+            task_id=task_id,
+            exception=e,
+            traceback=f"check remote side for logs, HINT: service replying to: '{client._base_url}' for '{task_id=}'",  # noqa: SLF001  # pylint:disable=protected-access
+        )
+        _logger.warning(f"{error}")
+        raise error from e

--- a/packages/service-library/src/servicelib/long_running_tasks/http_endpoint_responses.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/http_endpoint_responses.py
@@ -1,7 +1,12 @@
+import logging
+import traceback
 from typing import Any
 
+from .errors import TaskNotCompletedError, TaskNotFoundError
 from .models import TaskBase, TaskId, TaskStatus
 from .task import TaskContext, TasksManager, TrackedTask
+
+_logger = logging.getLogger(__name__)
 
 
 def list_tasks(
@@ -25,14 +30,25 @@ async def get_task_result(
     tasks_manager: TasksManager, task_context: TaskContext | None, task_id: TaskId
 ) -> Any:
     try:
-        return tasks_manager.get_task_result(
-            task_id=task_id, with_task_context=task_context
+        task_result = tasks_manager.get_task_result(
+            task_id, with_task_context=task_context
         )
-    finally:
-        # the task is always removed even if an error occurs
         await tasks_manager.remove_task(
             task_id, with_task_context=task_context, reraise_errors=False
         )
+        return task_result
+    except (TaskNotFoundError, TaskNotCompletedError):
+        raise
+    except Exception as exc:
+        # the task raised an exception
+        formatted_traceback = "".join(traceback.format_exception(exc))
+        _logger.info("Task '%s' raised an exception: %s", task_id, formatted_traceback)
+
+        # the task shall be removed in this case
+        await tasks_manager.remove_task(
+            task_id, with_task_context=task_context, reraise_errors=False
+        )
+        raise
 
 
 async def remove_task(

--- a/packages/service-library/tests/fastapi/long_running_tasks/test_long_running_tasks_context_manager.py
+++ b/packages/service-library/tests/fastapi/long_running_tasks/test_long_running_tasks_context_manager.py
@@ -18,6 +18,7 @@ from servicelib.fastapi.long_running_tasks.server import get_long_running_manage
 from servicelib.fastapi.long_running_tasks.server import setup as setup_server
 from servicelib.long_running_tasks.errors import (
     TaskClientTimeoutError,
+    TaskExceptionError,
 )
 from servicelib.long_running_tasks.models import (
     ProgressMessage,
@@ -148,7 +149,7 @@ async def test_task_result_task_result_is_an_error(
 
     url = TypeAdapter(AnyHttpUrl).validate_python("http://backgroud.testserver.io/")
     client = Client(app=bg_task_app, async_client=async_client, base_url=url)
-    with pytest.raises(RuntimeError, match="I am failing as requested"):
+    with pytest.raises(TaskExceptionError, match="I am failing as requested"):
         async with periodic_task_result(
             client,
             task_id,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
@@ -21,7 +21,7 @@ from models_library.user_preferences import FrontendUserPreference
 from models_library.users import UserID
 from servicelib.fastapi.http_client_thin import BaseHttpClientError
 from servicelib.logging_utils import log_context
-from servicelib.long_running_tasks.errors import GenericClientError
+from servicelib.long_running_tasks.errors import TaskExceptionError
 from servicelib.long_running_tasks.models import ProgressCallback, TaskProgress
 from servicelib.rabbitmq import RabbitMQClient
 from servicelib.rabbitmq._client_rpc import RabbitMQRPCClient
@@ -135,7 +135,7 @@ async def service_remove_containers(
         await sidecars_client.stop_service(
             scheduler_data.endpoint, progress_callback=progress_callback
         )
-    except (BaseHttpClientError, GenericClientError) as e:
+    except (BaseHttpClientError, TaskExceptionError) as e:
         _logger.info(
             (
                 "Could not remove service containers for %s. "
@@ -152,7 +152,7 @@ async def service_free_reserved_disk_space(
     scheduler_data: SchedulerData = _get_scheduler_data(app, node_id)
     try:
         await sidecars_client.free_reserved_disk_space(scheduler_data.endpoint)
-    except BaseHttpClientError as e:
+    except (BaseHttpClientError, TaskExceptionError) as e:
         _logger.info(
             (
                 "Could not remove service containers for %s. "
@@ -370,7 +370,7 @@ async def attempt_pod_removal_and_data_saving(
             scheduler_data.dynamic_sidecar.were_state_and_outputs_saved = True
 
             _logger.info("dynamic-sidecar saved: state and output ports")
-        except (BaseHttpClientError, GenericClientError) as e:
+        except (BaseHttpClientError, TaskExceptionError) as e:
             _logger.error(  # noqa: TRY400
                 (
                     "Could not contact dynamic-sidecar to save service "

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
@@ -21,6 +21,7 @@ from models_library.user_preferences import FrontendUserPreference
 from models_library.users import UserID
 from servicelib.fastapi.http_client_thin import BaseHttpClientError
 from servicelib.logging_utils import log_context
+from servicelib.long_running_tasks.errors import GenericClientError
 from servicelib.long_running_tasks.models import ProgressCallback, TaskProgress
 from servicelib.rabbitmq import RabbitMQClient
 from servicelib.rabbitmq._client_rpc import RabbitMQRPCClient
@@ -134,7 +135,7 @@ async def service_remove_containers(
         await sidecars_client.stop_service(
             scheduler_data.endpoint, progress_callback=progress_callback
         )
-    except BaseHttpClientError as e:
+    except (BaseHttpClientError, GenericClientError) as e:
         _logger.info(
             (
                 "Could not remove service containers for %s. "
@@ -369,7 +370,7 @@ async def attempt_pod_removal_and_data_saving(
             scheduler_data.dynamic_sidecar.were_state_and_outputs_saved = True
 
             _logger.info("dynamic-sidecar saved: state and output ports")
-        except BaseHttpClientError as e:
+        except (BaseHttpClientError, GenericClientError) as e:
             _logger.error(  # noqa: TRY400
                 (
                     "Could not contact dynamic-sidecar to save service "

--- a/services/dynamic-sidecar/tests/unit/test_api_rest_containers_long_running_tasks.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_rest_containers_long_running_tasks.py
@@ -30,6 +30,7 @@ from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict
 from servicelib.fastapi.long_running_tasks.client import Client, periodic_task_result
 from servicelib.fastapi.long_running_tasks.client import setup as client_setup
+from servicelib.long_running_tasks.errors import TaskExceptionError
 from servicelib.long_running_tasks.models import TaskId
 from simcore_sdk.node_ports_common.exceptions import NodeNotFound
 from simcore_service_dynamic_sidecar._meta import API_VTAG
@@ -42,10 +43,7 @@ from simcore_service_dynamic_sidecar.models.schemas.containers import (
 from simcore_service_dynamic_sidecar.models.shared_store import SharedStore
 from simcore_service_dynamic_sidecar.modules.inputs import enable_inputs_pulling
 from simcore_service_dynamic_sidecar.modules.outputs._context import OutputsContext
-from simcore_service_dynamic_sidecar.modules.outputs._manager import (
-    OutputsManager,
-    UploadPortsFailedError,
-)
+from simcore_service_dynamic_sidecar.modules.outputs._manager import OutputsManager
 
 FAST_STATUS_POLL: Final[float] = 0.1
 CREATE_SERVICE_CONTAINERS_TIMEOUT: Final[float] = 60
@@ -681,7 +679,7 @@ async def test_container_push_output_ports_missing_node(
     if not mock_port_keys:
         await _test_code()
     else:
-        with pytest.raises(UploadPortsFailedError) as exec_info:
+        with pytest.raises(TaskExceptionError) as exec_info:
             await _test_code()
         assert f"the node id {missing_node_uuid} was not found" in f"{exec_info.value}"
 

--- a/services/dynamic-sidecar/tests/unit/test_api_rest_workflow_service_metrics.py
+++ b/services/dynamic-sidecar/tests/unit/test_api_rest_workflow_service_metrics.py
@@ -34,6 +34,7 @@ from pytest_mock import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
 from servicelib.fastapi.long_running_tasks.client import Client, periodic_task_result
 from servicelib.fastapi.long_running_tasks.client import setup as client_setup
+from servicelib.long_running_tasks.errors import TaskExceptionError
 from servicelib.long_running_tasks.models import TaskId
 from simcore_service_dynamic_sidecar._meta import API_VTAG
 from simcore_service_dynamic_sidecar.core.docker_utils import get_container_states
@@ -258,7 +259,7 @@ async def test_user_services_fail_to_start(
     with_compose_down: bool,
     mock_user_services_fail_to_start: None,
 ):
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TaskExceptionError):
         async with periodic_task_result(
             client=client,
             task_id=await _get_task_id_create_service_containers(
@@ -314,7 +315,7 @@ async def test_user_services_fail_to_stop_or_save_data(
     # in case of manual intervention multiple stops will be sent
     _EXPECTED_STOP_MESSAGES = 4
     for _ in range(_EXPECTED_STOP_MESSAGES):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(TaskExceptionError):
             async with periodic_task_result(
                 client=client,
                 task_id=await _get_task_id_docker_compose_down(httpx_async_client),


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

Fixed a corner case where the `director-v2` could not remove a sidecar due to an unhandled error raised by the long_running_tasks client. Task `attempt_pod_removal_and_data_saving` is allowed to raise only under certain situations. Added exception handling for unforeseen errors which addresses the below linked issue.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- closes https://github.com/ITISFoundation/osparc-simcore/pull/7903 in favour of this PR
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/7905

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
