### PR TITLE
🎨 [Frontend] Enh: Request services access

### DIFF
--- a/services/static-webserver/client/source/class/osparc/share/RequestServiceAccess.js
+++ b/services/static-webserver/client/source/class/osparc/share/RequestServiceAccess.js
@@ -58,9 +58,9 @@ qx.Class.define("osparc.share.RequestServiceAccess", {
 
       // Populate the grid with the cantReadServicesData
       cantReadServicesData.forEach((cantReadServiceData, idx) => {
-        const group = osparc.store.Groups.getInstance().getGroup(cantReadServiceData["owner"]);
-        if (group) {
-          const username = new qx.ui.basic.Label(group.getLabel()).set({
+        const userGroupId = cantReadServiceData["owner"];
+        if (userGroupId) {
+          const username = new qx.ui.basic.Label().set({
             rich: true,
             selectable: true,
           });
@@ -68,7 +68,7 @@ qx.Class.define("osparc.share.RequestServiceAccess", {
             row: idx+1,
             column: 0
           });
-          const email = new qx.ui.basic.Label(group.getEmail()).set({
+          const email = new qx.ui.basic.Label().set({
             rich: true,
             selectable: true,
           });
@@ -85,6 +85,16 @@ qx.Class.define("osparc.share.RequestServiceAccess", {
             row: idx+1,
             column: 2
           });
+
+          osparc.store.Users.getInstance().getUser(userGroupId)
+            .then(user => {
+              username.setValue(user ? user.getLabel() : this.tr("Unknown user"));
+              email.setValue(user ? user.getEmail() : "Unknown email");
+            })
+            .catch(() => {
+              username.setValue(this.tr("Unknown user"));
+              email.setValue("Unknown email");
+            });
         }
       });
     }


### PR DESCRIPTION
## What do these changes do?

This PR enhances the ``Request apps access`` dialog by asking the backend for the owners information instead of relying on the frontend's cache. This increases the chances to get the table properly populated.

![RequestAccess](https://github.com/user-attachments/assets/561eec8e-ec42-4c37-896e-4fb014fcea5b)


## Related issue/s
- follows https://github.com/ITISFoundation/osparc-simcore/pull/7897
- related to https://github.com/ITISFoundation/osparc-issues/issues/903


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
