### PR TITLE
🐛 [Frontend] Fix in_debt tracking

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
@@ -1044,9 +1044,6 @@ qx.Class.define("osparc.dashboard.CardBase", {
         win.close();
         this.fireDataEvent("publishTemplate", e.getData());
       });
-      resourceDetails.addListener("closeWindow", () => {
-        win.close();
-      });
       resourceDetails.addListener("openStudy", e => {
         const openCB = () => win.close();
         const studyId = e.getData()["uuid"];

--- a/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
@@ -1044,6 +1044,9 @@ qx.Class.define("osparc.dashboard.CardBase", {
         win.close();
         this.fireDataEvent("publishTemplate", e.getData());
       });
+      resourceDetails.addListener("closeWindow", () => {
+        win.close();
+      });
       resourceDetails.addListener("openStudy", e => {
         const openCB = () => win.close();
         const studyId = e.getData()["uuid"];

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -59,7 +59,7 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
           case "hypertool":
             // when getting the latest study data, the debt information was lost
             if (osparc.study.Utils.isInDebt(this.__resourceData)) {
-              const mainStore = qx.store.Store.getInstance();
+              const mainStore = osparc.store.Store.getInstance();
               this.__resourceData["debt"] = mainStore.getStudyDebt(this.__resourceData["uuid"]);
             }
             osparc.store.Services.getStudyServicesMetadata(latestResourceData)

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -51,16 +51,16 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
           return;
         }
         this.__resourceData = osparc.utils.Utils.deepCloneObject(latestResourceData);
-        // quick solution
-        if ("debt" in resourceData) {
-          this.__resourceData["debt"] = resourceData["debt"];
-        }
         this.__resourceData["resourceType"] = resourceData["resourceType"];
         switch (resourceData["resourceType"]) {
           case "study":
           case "template":
           case "tutorial":
           case "hypertool":
+            const mainStore = qx.store.Store.getInstance();
+            if (mainStore.getStudyDebt(this.__resourceData["uuid"])) {
+              this.__resourceData["debt"] = mainStore.getStudyDebt(this.__resourceData["uuid"]);
+            }
             osparc.store.Services.getStudyServicesMetadata(latestResourceData)
               .finally(() => {
                 this.__resourceModel = new osparc.data.model.Study(latestResourceData);

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -58,7 +58,7 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
           case "tutorial":
           case "hypertool":
             // when getting the latest study data, the debt information was lost
-            if (osparc.study.Utils.isInDebt(this.__studyData)) {
+            if (osparc.study.Utils.isInDebt(this.__resourceData)) {
               const mainStore = qx.store.Store.getInstance();
               this.__resourceData["debt"] = mainStore.getStudyDebt(this.__resourceData["uuid"]);
             }

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -57,8 +57,8 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
           case "template":
           case "tutorial":
           case "hypertool":
-            const mainStore = qx.store.Store.getInstance();
-            if (mainStore.getStudyDebt(this.__resourceData["uuid"])) {
+            if (osparc.study.Utils.isInDebt(this.__studyData)) {
+              const mainStore = qx.store.Store.getInstance();
               this.__resourceData["debt"] = mainStore.getStudyDebt(this.__resourceData["uuid"]);
             }
             osparc.store.Services.getStudyServicesMetadata(latestResourceData)

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -113,6 +113,9 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
         width: this.WIDTH,
         height: this.HEIGHT,
       });
+      resourceDetails.addListener("closeWindow", () => {
+        win.close();
+      });
       return win;
     },
 
@@ -487,7 +490,7 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
           })
           billingSettings.addListener("closeWindow", () => {
             this.fireEvent("closeWindow");
-          });
+          }, this);
           const billingScroll = new qx.ui.container.Scroll(billingSettings);
           page.addToContent(billingScroll);
         }

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -94,6 +94,7 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
     "updateService": "qx.event.type.Data",
     "updateHypertool": "qx.event.type.Data",
     "publishTemplate": "qx.event.type.Data",
+    "closeWindow": "qx.event.type.Event",
   },
 
 
@@ -484,6 +485,9 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
             const enabled = osparc.study.Utils.canBeOpened(resourceData);
             page.openButton.setEnabled(enabled);
           })
+          billingSettings.addListener("closeWindow", () => {
+            this.fireEvent("closeWindow");
+          });
           const billingScroll = new qx.ui.container.Scroll(billingSettings);
           page.addToContent(billingScroll);
         }

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -51,6 +51,10 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
           return;
         }
         this.__resourceData = osparc.utils.Utils.deepCloneObject(latestResourceData);
+        // quick solution
+        if ("debt" in resourceData) {
+          this.__resourceData["debt"] = resourceData["debt"];
+        }
         this.__resourceData["resourceType"] = resourceData["resourceType"];
         switch (resourceData["resourceType"]) {
           case "study":

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceDetails.js
@@ -57,6 +57,7 @@ qx.Class.define("osparc.dashboard.ResourceDetails", {
           case "template":
           case "tutorial":
           case "hypertool":
+            // when getting the latest study data, the debt information was lost
             if (osparc.study.Utils.isInDebt(this.__studyData)) {
               const mainStore = qx.store.Store.getInstance();
               this.__resourceData["debt"] = mainStore.getStudyDebt(this.__resourceData["uuid"]);

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -179,20 +179,7 @@ qx.Class.define("osparc.desktop.StudyEditor", {
           if ("status" in err && err["status"]) {
             if (err["status"] == 402) {
               msg = err["message"];
-              // The backend might have thrown a 402 because the wallet was negative
-              const match = msg.match(/last transaction of\s([-]?\d+(\.\d+)?)\sresulted/);
-              let debt = null;
-              if ("debtAmount" in err) {
-                // the study has some debt that needs to be paid
-                debt = err["debtAmount"];
-              } else if (match) {
-                // the study has some debt that needs to be paid
-                debt = parseFloat(match[1]); // Convert the captured string to a number
-              }
-              if (debt) {
-                // if get here, it means that the 402 was thrown due to the debt
-                osparc.store.Store.getInstance().setStudyDebt(study.getUuid(), debt);
-              }
+              osparc.study.Utils.extractDebtFromError(study.getUuid(), err);
             } else if (err["status"] == 409) { // max_open_studies_per_user
               msg = err["message"];
             } else if (err["status"] == 423) { // Locked

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -253,6 +253,8 @@ qx.Class.define("osparc.store.Store", {
   },
 
   members: {
+    __studiesInDebt: null,
+
     // fetch resources that do not require log in
     preloadCalls: async function() {
       await osparc.data.Resources.get("config");
@@ -454,6 +456,15 @@ qx.Class.define("osparc.store.Store", {
     },
 
     setStudyDebt: function(studyId, debt) {
+      if (this.__studiesInDebt === null) {
+        this.__studiesInDebt = {};
+      }
+      if (debt) {
+        this.__studiesInDebt[studyId] = debt;
+      } else {
+        delete this.__studiesInDebt[studyId];
+      }
+
       const studiesWStateCache = this.getStudies();
       const idx = studiesWStateCache.findIndex(studyWStateCache => studyWStateCache["uuid"] === studyId);
       if (idx !== -1) {
@@ -468,6 +479,13 @@ qx.Class.define("osparc.store.Store", {
         studyId,
         debt,
       });
+    },
+
+    getStudyDebt: function(studyId) {
+      if (this.__studiesInDebt && studyId in this.__studiesInDebt) {
+        return this.__studiesInDebt[studyId];
+      }
+      return null;
     },
 
     trashStudy: function(studyId) {

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -488,6 +488,10 @@ qx.Class.define("osparc.store.Store", {
       return null;
     },
 
+    isStudyInDebt: function(studyId) {
+      return Boolean(this.getStudyDebt(studyId));
+    },
+
     trashStudy: function(studyId) {
       const params = {
         url: {

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -456,6 +456,7 @@ qx.Class.define("osparc.store.Store", {
     },
 
     setStudyDebt: function(studyId, debt) {
+      // init object if it does not exist
       if (this.__studiesInDebt === null) {
         this.__studiesInDebt = {};
       }

--- a/services/static-webserver/client/source/class/osparc/study/BillingSettings.js
+++ b/services/static-webserver/client/source/class/osparc/study/BillingSettings.js
@@ -286,7 +286,12 @@ qx.Class.define("osparc.study.BillingSettings", {
           const msg = this.tr("Credit Account saved");
           osparc.FlashMessenger.logAs(msg, "INFO");
         })
-        .catch(err => osparc.FlashMessenger.logError(err))
+        .catch(err => {
+          if ("status" in err && err["status"] == 402) {
+            osparc.study.Utils.extractDebtFromError(this.__studyData["uuid"], err);
+          }
+          osparc.FlashMessenger.logError(err);
+        })
         .finally(() => {
           creditAccountBox.setEnabled(true);
         });

--- a/services/static-webserver/client/source/class/osparc/study/BillingSettings.js
+++ b/services/static-webserver/client/source/class/osparc/study/BillingSettings.js
@@ -33,6 +33,7 @@ qx.Class.define("osparc.study.BillingSettings", {
 
   events: {
     "debtPayed": "qx.event.type.Event",
+    "closeWindow": "qx.event.type.Event",
   },
 
   members: {
@@ -291,6 +292,7 @@ qx.Class.define("osparc.study.BillingSettings", {
             osparc.study.Utils.extractDebtFromError(this.__studyData["uuid"], err);
           }
           osparc.FlashMessenger.logError(err);
+          this.fireEvent("closeWindow");
         })
         .finally(() => {
           creditAccountBox.setEnabled(true);

--- a/services/static-webserver/client/source/class/osparc/study/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/study/Utils.js
@@ -347,6 +347,25 @@ qx.Class.define("osparc.study.Utils", {
       return osparc.store.Store.getInstance().isStudyInDebt(studyData["uuid"]);
     },
 
+    extractDebtFromError: function(studyId, err) {
+      const msg = err["message"];
+      // The backend might have thrown a 402 because the wallet was negative
+      const match = msg.match(/last transaction of\s([-]?\d+(\.\d+)?)\sresulted/);
+      let debt = null;
+      if ("debtAmount" in err) {
+        // the study has some debt that needs to be paid
+        debt = err["debtAmount"];
+      } else if (match) {
+        // the study has some debt that needs to be paid
+        debt = parseFloat(match[1]); // Convert the captured string to a number
+      }
+      if (debt) {
+        // if get here, it means that the 402 was thrown due to the debt
+        osparc.store.Store.getInstance().setStudyDebt(studyId, debt);
+      }
+      return debt;
+    },
+
     getUiMode: function(studyData) {
       if ("ui" in studyData && "mode" in studyData["ui"]) {
         return studyData["ui"]["mode"];

--- a/services/static-webserver/client/source/class/osparc/study/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/study/Utils.js
@@ -344,7 +344,7 @@ qx.Class.define("osparc.study.Utils", {
     },
 
     isInDebt: function(studyData) {
-      return Boolean("debt" in studyData && studyData["debt"] < 0);
+      return osparc.store.Store.getInstance().isStudyInDebt(studyData["uuid"]);
     },
 
     getUiMode: function(studyData) {


### PR DESCRIPTION
## What do these changes do?

When opening the project card, the frontend was loosing the ``IN_DEBT`` information of it, not letting the users pay the debt and keeping the project embargoed until the fix was manually made in the DB. This PR fixes that situation by tracking the debts in the Store.

### Bonus:
- Found another way to get the project_in_debt response. So far it was only traced in the :open study call. In the animation, the information is received when trying to switch wallet. ~~@matusdrobuliak66 is there any other call where you attach the project_in_debt info?~~ All good

Buggy:
![Buggy](https://github.com/user-attachments/assets/1f8383a5-71e0-4314-9c56-64d5fe90d722)

Fixed:
![Fixed](https://github.com/user-attachments/assets/d55486c5-13ae-4478-8775-dd8d75d5dbe6)


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
