### PR TITLE
🐛Ensure Dask client reference is uniquely defined for reference counting

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -56,7 +56,7 @@ from ._utils import (
 
 _logger = logging.getLogger(__name__)
 
-_DASK_CLIENT_RUN_REF: Final[str] = "{user_id}:{run_id}"
+_DASK_CLIENT_RUN_REF: Final[str] = "{user_id}:{project_id}:{run_id}"
 
 
 @asynccontextmanager
@@ -65,6 +65,7 @@ async def _cluster_dask_client(
     scheduler: "DaskScheduler",
     *,
     use_on_demand_clusters: bool,
+    project_id: ProjectID,
     run_id: PositiveInt,
     run_metadata: RunMetadataDict,
 ) -> AsyncIterator[DaskClient]:
@@ -76,7 +77,10 @@ async def _cluster_dask_client(
             wallet_id=run_metadata.get("wallet_id"),
         )
     async with scheduler.dask_clients_pool.acquire(
-        cluster, ref=_DASK_CLIENT_RUN_REF.format(user_id=user_id, run_id=run_id)
+        cluster,
+        ref=_DASK_CLIENT_RUN_REF.format(
+            user_id=user_id, project_id=project_id, run_id=run_id
+        ),
     ) as client:
         yield client
 
@@ -106,6 +110,7 @@ class DaskScheduler(BaseCompScheduler):
             user_id,
             self,
             use_on_demand_clusters=comp_run.use_on_demand_clusters,
+            project_id=comp_run.project_uuid,
             run_id=comp_run.run_id,
             run_metadata=comp_run.metadata,
         ) as client:
@@ -157,6 +162,7 @@ class DaskScheduler(BaseCompScheduler):
                 user_id,
                 self,
                 use_on_demand_clusters=comp_run.use_on_demand_clusters,
+                project_id=comp_run.project_uuid,
                 run_id=comp_run.run_id,
                 run_metadata=comp_run.metadata,
             ) as client:
@@ -178,6 +184,7 @@ class DaskScheduler(BaseCompScheduler):
                 user_id,
                 self,
                 use_on_demand_clusters=comp_run.use_on_demand_clusters,
+                project_id=comp_run.project_uuid,
                 run_id=comp_run.run_id,
                 run_metadata=comp_run.metadata,
             ) as client:
@@ -238,7 +245,9 @@ class DaskScheduler(BaseCompScheduler):
             ),
         ):
             await self.dask_clients_pool.release_client_ref(
-                ref=_DASK_CLIENT_RUN_REF.format(user_id=user_id, run_id=comp_run.run_id)
+                ref=_DASK_CLIENT_RUN_REF.format(
+                    user_id=user_id, project_id=project_id, run_id=comp_run.run_id
+                )
             )
 
     async def _stop_tasks(
@@ -250,6 +259,7 @@ class DaskScheduler(BaseCompScheduler):
                 user_id,
                 self,
                 use_on_demand_clusters=comp_run.use_on_demand_clusters,
+                project_id=comp_run.project_uuid,
                 run_id=comp_run.run_id,
                 run_metadata=comp_run.metadata,
             ) as client:
@@ -284,6 +294,7 @@ class DaskScheduler(BaseCompScheduler):
                 user_id,
                 self,
                 use_on_demand_clusters=comp_run.use_on_demand_clusters,
+                project_id=comp_run.project_uuid,
                 run_id=comp_run.run_id,
                 run_metadata=comp_run.metadata,
             ) as client:
@@ -304,6 +315,7 @@ class DaskScheduler(BaseCompScheduler):
                 user_id,
                 self,
                 use_on_demand_clusters=comp_run.use_on_demand_clusters,
+                project_id=comp_run.project_uuid,
                 run_id=comp_run.run_id,
                 run_metadata=comp_run.metadata,
             ) as client:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
A director-v2 replica keeps a dask-clients pool, each client is referenced counted since https://github.com/ITISFoundation/osparc-simcore/issues/7880.
The reference counting is using a reference that was defined using `user_id` and `run_id`. The `run_id` is an integer which does not ensure uniqueness. This means that some clients could maybe get deleted before the need. This would explain why restarting the director-v2 would fix it.

This PR fixes this issue by adding the `project_uuid` into the reference. Therefore it is now really unique.

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/private-issues/issues/213

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
