### PR TITLE
🎨🔨 AI-assisted prompt to convert pydantic model fields to use Annotated types

### DIFF
--- a/.github/prompts/pydantic-annotated-fields.prompt.md
+++ b/.github/prompts/pydantic-annotated-fields.prompt.md
@@ -1,6 +1,9 @@
-# Prompt
+---
+mode: 'edit'
+description: 'Update user messages'
+---
 
-```
+
 Please convert all pydantic model fields that use `Field()` with default values to use the Annotated pattern instead.
 Follow these guidelines:
 
@@ -10,7 +13,8 @@ Follow these guidelines:
 4. Add the import: `from common_library.basic_types import DEFAULT_FACTORY` if it's not already present.
 5. If `Field()` has no parameters (empty), don't use Annotated at all. Just use: `field_name: field_type = default_value`.
 6. Leave any model validations, `model_config` settings, and `field_validators` untouched.
-```
+
+
 ## Examples
 
 ### Before:
@@ -53,6 +57,7 @@ class ProjectModel(BaseModel):
     id: str = Field(default_factory=uuid.uuid4, description="Unique project identifier")
     name: str = Field(default="Untitled Project", min_length=3, max_length=50)
     created_at: datetime = Field(default_factory=datetime.now)
+    value: int = Field(..., description="Project value")
     config: dict = Field(default={"version": "1.0", "theme": "default"})
 
     @field_validator("name")
@@ -74,6 +79,7 @@ class ProjectModel(BaseModel):
     id: Annotated[str, Field(default_factory=uuid.uuid4, description="Unique project identifier")] = DEFAULT_FACTORY
     name: Annotated[str, Field(min_length=3, max_length=50)] = "Untitled Project"
     created_at: Annotated[datetime, Field(default_factory=datetime.now)] = DEFAULT_FACTORY
+    value: Annotated[int, Field(description="Project value")]
     config: dict = {"version": "1.0", "theme": "default"}
 
     @field_validator("name")

--- a/.github/prompts/pydantic-annotated-fields.prompt.md
+++ b/.github/prompts/pydantic-annotated-fields.prompt.md
@@ -58,13 +58,10 @@ class ProjectModel(BaseModel):
     name: str = Field(default="Untitled Project", min_length=3, max_length=50)
     created_at: datetime = Field(default_factory=datetime.now)
     value: int = Field(..., description="Project value")
+    str_with_default: str = Field(default="foo")
+
     config: dict = Field(default={"version": "1.0", "theme": "default"})
 
-    @field_validator("name")
-    def validate_name(cls, v):
-        if v.isdigit():
-            raise ValueError("Name cannot be only digits")
-        return v
 ```
 
 ### After:
@@ -80,11 +77,8 @@ class ProjectModel(BaseModel):
     name: Annotated[str, Field(min_length=3, max_length=50)] = "Untitled Project"
     created_at: Annotated[datetime, Field(default_factory=datetime.now)] = DEFAULT_FACTORY
     value: Annotated[int, Field(description="Project value")]
+    str_with_default: str = "foo"
+
     config: dict = {"version": "1.0", "theme": "default"}
 
-    @field_validator("name")
-    def validate_name(cls, v):
-        if v.isdigit():
-            raise ValueError("Name cannot be only digits")
-        return v
 ```

--- a/.github/prompts/pydantic-annotated-fields.prompt.md
+++ b/.github/prompts/pydantic-annotated-fields.prompt.md
@@ -1,6 +1,6 @@
 ---
 mode: 'edit'
-description: 'Update user messages'
+description: 'Convert Pydantic model fields to use Annotated pattern'
 ---
 
 

--- a/services/web/server/src/simcore_service_webserver/diagnostics/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/diagnostics/_handlers.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from aiohttp import ClientError, ClientSession, web
 from models_library.app_diagnostics import AppStatusCheck
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from servicelib.aiohttp.client_session import get_client_session
 from servicelib.aiohttp.requests_validation import parse_request_query_parameters_as
 from servicelib.utils import logged_gather
@@ -29,7 +29,7 @@ routes = web.RouteTableDef()
 
 
 class StatusDiagnosticsQueryParam(BaseModel):
-    top_tracemalloc: int | None = Field(default=None)
+    top_tracemalloc: int | None = None
 
 
 class StatusDiagnosticsGet(BaseModel):

--- a/services/web/server/src/simcore_service_webserver/exporter/_formatter/xlsx/code_description.py
+++ b/services/web/server/src/simcore_service_webserver/exporter/_formatter/xlsx/code_description.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
-from typing import Any, ClassVar, Final, cast
+from typing import Annotated, Any, ClassVar, Final, cast
 
+from common_library.basic_types import DEFAULT_FACTORY
 from models_library.services import ServiceKey, ServiceVersion
 from pydantic import BaseModel, Field, StrictStr
 
@@ -10,20 +11,23 @@ from .utils import column_generator, ensure_correct_instance
 
 
 class RRIDEntry(BaseModel):
-    rrid_term: StrictStr = Field(..., description="Associated tools or resources used")
-    rrid_identifier: StrictStr = Field(
-        ..., description="Associated tools or resources identifier (with 'RRID:')"
-    )
+    rrid_term: Annotated[
+        StrictStr, Field(description="Associated tools or resources used")
+    ]
+    rrid_identifier: Annotated[
+        StrictStr,
+        Field(description="Associated tools or resources identifier (with 'RRID:')"),
+    ]
     # the 2 items below are not enabled for now
-    ontological_term: StrictStr = Field(
-        "", description="Associated ontological term (human-readable)"
-    )
-    ontological_identifier: StrictStr = Field(
-        "",
-        description=(
-            "Associated ontological identifier from SciCrunch https://scicrunch.org/sawg"
+    ontological_term: Annotated[
+        StrictStr, Field(description="Associated ontological term (human-readable)")
+    ] = ""
+    ontological_identifier: Annotated[
+        StrictStr,
+        Field(
+            description="Associated ontological identifier from SciCrunch https://scicrunch.org/sawg"
         ),
-    )
+    ] = ""
 
 
 class TSREntry(BaseModel):
@@ -33,99 +37,117 @@ class TSREntry(BaseModel):
 
 
 class CodeDescriptionModel(BaseModel):
-    rrid_entires: list[RRIDEntry] = Field(
-        default_factory=list, description="composed from the classifiers"
-    )
+    rrid_entires: Annotated[
+        list[RRIDEntry],
+        Field(default_factory=list, description="composed from the classifiers"),
+    ] = DEFAULT_FACTORY
 
     # TSR
-    tsr_entries: dict[str, TSREntry] = Field(
-        default_factory=dict, description="list of rules to generate tsr"
-    )
+    tsr_entries: Annotated[
+        dict[str, TSREntry],
+        Field(default_factory=dict, description="list of rules to generate tsr"),
+    ] = DEFAULT_FACTORY
 
 
 class InputsEntryModel(BaseModel):
-    service_alias: StrictStr = Field(
-        ..., description="Name of the service containing this input, given by the user"
-    )
-    service_name: StrictStr = Field(
-        ..., description="Name of the service containing this input"
-    )
-    service_key: ServiceKey = Field(
-        ..., description="Key of the service containing this input"
-    )
-    service_version: ServiceVersion = Field(
-        ..., description="Version of the service containing this input"
-    )
-    input_name: StrictStr = Field(
-        "", description="An input field to the MSoP submission"
-    )
-    input_parameter_description: StrictStr = Field(
-        "", description="Description of what the parameter represents"
-    )
-    input_data_type: StrictStr = Field(
-        "", description="Data type for the input field (in plain text)"
-    )
-    input_data_units: StrictStr = Field(
-        "", description="Units of data for the input field, if applicable"
-    )
-    input_data_default_value: StrictStr = Field(
-        "",
-        description="Default value for the input field, if applicable (doi or value)",
-    )
-    input_data_constraints: StrictStr = Field(
-        "",
-        description="Range [min, max] of acceptable parameter values, or other constraints as formulas / sets",
-    )
+    service_alias: Annotated[
+        StrictStr,
+        Field(
+            description="Name of the service containing this input, given by the user"
+        ),
+    ]
+    service_name: Annotated[
+        StrictStr, Field(description="Name of the service containing this input")
+    ]
+    service_key: Annotated[
+        ServiceKey, Field(description="Key of the service containing this input")
+    ]
+    service_version: Annotated[
+        ServiceVersion,
+        Field(description="Version of the service containing this input"),
+    ]
+    input_name: Annotated[
+        StrictStr, Field(description="An input field to the MSoP submission")
+    ] = ""
+    input_parameter_description: Annotated[
+        StrictStr, Field(description="Description of what the parameter represents")
+    ] = ""
+    input_data_type: Annotated[
+        StrictStr, Field(description="Data type for the input field (in plain text)")
+    ] = ""
+    input_data_units: Annotated[
+        StrictStr, Field(description="Units of data for the input field, if applicable")
+    ] = ""
+    input_data_default_value: Annotated[
+        StrictStr,
+        Field(
+            description="Default value for the input field, if applicable (doi or value)"
+        ),
+    ] = ""
+    input_data_constraints: Annotated[
+        StrictStr,
+        Field(
+            description="Range [min, max] of acceptable parameter values, or other constraints as formulas / sets"
+        ),
+    ] = ""
 
 
 class OutputsEntryModel(BaseModel):
-    service_alias: StrictStr = Field(
-        ..., description="Name of the service producing this output, given by the user"
-    )
-    service_name: StrictStr = Field(
-        ..., description="Name of the service containing this output"
-    )
-    service_key: ServiceKey = Field(
-        ..., description="Key of the service containing this output"
-    )
-    service_version: ServiceVersion = Field(
-        ..., description="Version of the service containing this output"
-    )
-    output_name: StrictStr = Field(
-        "", description="An output field to the MSoP submission"
-    )
-    output_parameter_description: StrictStr = Field(
-        "", description="Description of what the parameter represents"
-    )
-    output_data_ontology_identifier: StrictStr = Field(
-        "",
-        description=(
-            "Ontology identifier for the input field, if applicable , "
-            "https://scicrunch.org/scicrunch/interlex/search?q=NLXOEN&l=NLXOEN&types=term"
+    service_alias: Annotated[
+        StrictStr,
+        Field(
+            description="Name of the service producing this output, given by the user"
         ),
-    )
-    output_data_type: StrictStr = Field(
-        "", description="Data type for the output field"
-    )
-    output_data_units: StrictStr = Field(
-        "", description="Units of data for the output field, if applicable"
-    )
-    output_data_constraints: StrictStr = Field(
-        "",
-        description="Range [min, max] of acceptable parameter values, or other constraints as formulas / sets",
-    )
+    ]
+    service_name: Annotated[
+        StrictStr, Field(description="Name of the service containing this output")
+    ]
+    service_key: Annotated[
+        ServiceKey, Field(description="Key of the service containing this output")
+    ]
+    service_version: Annotated[
+        ServiceVersion,
+        Field(description="Version of the service containing this output"),
+    ]
+    output_name: Annotated[
+        StrictStr, Field(description="An output field to the MSoP submission")
+    ] = ""
+    output_parameter_description: Annotated[
+        StrictStr, Field(description="Description of what the parameter represents")
+    ] = ""
+    output_data_ontology_identifier: Annotated[
+        StrictStr,
+        Field(
+            description="Ontology identifier for the input field, if applicable , https://scicrunch.org/scicrunch/interlex/search?q=NLXOEN&l=NLXOEN&types=term"
+        ),
+    ] = ""
+    output_data_type: Annotated[
+        StrictStr, Field(description="Data type for the output field")
+    ] = ""
+    output_data_units: Annotated[
+        StrictStr,
+        Field(description="Units of data for the output field, if applicable"),
+    ] = ""
+    output_data_constraints: Annotated[
+        StrictStr,
+        Field(
+            description="Range [min, max] of acceptable parameter values, or other constraints as formulas / sets"
+        ),
+    ] = ""
 
 
 class CodeDescriptionParams(BaseModel):
-    code_description: CodeDescriptionModel = Field(
-        ..., description="code description data"
-    )
-    inputs: list[InputsEntryModel] = Field(
-        default_factory=list, description="List of inputs, if any"
-    )
-    outputs: list[OutputsEntryModel] = Field(
-        default_factory=list, description="List of outputs, if any"
-    )
+    code_description: Annotated[
+        CodeDescriptionModel, Field(description="code description data")
+    ]
+    inputs: Annotated[
+        list[InputsEntryModel],
+        Field(default_factory=list, description="List of inputs, if any"),
+    ] = DEFAULT_FACTORY
+    outputs: Annotated[
+        list[OutputsEntryModel],
+        Field(default_factory=list, description="List of outputs, if any"),
+    ] = DEFAULT_FACTORY
 
 
 def _include_ports_from_this_service(service_key: ServiceKey) -> bool:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- 🔨 New prompt to Convert Pydantic model fields to use Annotated pattern
- 🎨 Tuned by applying to some examples. 
  - Run prompt
  - Detect errors/innacuracies
  - Add details to the to the prompt
  - retry
- Everybody should follow up on their own models
 

## How to test

1. select a file
2. run prompt from ![image](https://github.com/user-attachments/assets/9f62cd95-909c-47d4-89fa-08c096e034e2)


## Dev-ops
