### PR TITLE
🎨 [Frontend] Create Functions: Make default input values editable

### DIFF
--- a/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
+++ b/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
@@ -71,7 +71,7 @@ qx.Class.define("osparc.study.CreateFunction", {
             functionData["inputSchema"]["schema_content"]["required"].push(parameterKey);
           }
         }
-        if (defaultInputs[parameterKey]) {
+        if (parameterKey in defaultInputs) {
           functionData["defaultInputs"][parameterKey] = defaultInputs[parameterKey];
         }
       });

--- a/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
+++ b/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
@@ -120,11 +120,12 @@ qx.Class.define("osparc.study.CreateFunction", {
       form.add(description, this.tr("Description"), null, "description");
 
 
+      const defaultInputs = {};
       const exposedInputs = {};
       const exposedOutputs = {};
 
       // INPUTS
-      const inGrid = new qx.ui.layout.Grid(10, 6);
+      const inGrid = new qx.ui.layout.Grid(12, 6);
       const inputsLayout = new qx.ui.container.Composite(inGrid).set({
         allowGrowX: false,
         alignX: "left",
@@ -189,8 +190,15 @@ qx.Class.define("osparc.study.CreateFunction", {
         parameterExposed.addListener("changeValue", e => exposedInputs[parameter["label"]] = e.getData());
         column++;
 
-        const parameterDefaultValue = new qx.ui.basic.Label(String(osparc.service.Utils.getParameterValue(parameter)));
-        inputsLayout.add(parameterDefaultValue, {
+        const paramValue = osparc.service.Utils.getParameterValue(parameter);
+        defaultInputs[parameter["label"]] = paramValue;
+        let ctrl = null;
+        if (parameterMetadata && osparc.service.Utils.getParameterType(parameterMetadata) === "number") {
+          ctrl = new qx.ui.form.TextField(String(paramValue));
+        } else {
+          ctrl = new qx.ui.basic.Label(String(paramValue));
+        }
+        inputsLayout.add(ctrl, {
           row,
           column,
         });

--- a/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
+++ b/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
@@ -33,7 +33,7 @@ qx.Class.define("osparc.study.CreateFunction", {
   },
 
   statics: {
-    createFunctionData: function(projectData, name, description, exposedInputs, exposedOutputs) {
+    createFunctionData: function(projectData, name, description, defaultInputs = {}, exposedInputs = {}, exposedOutputs = {}) {
       const functionData = {
         "projectId": projectData["uuid"],
         "title": name,
@@ -70,8 +70,9 @@ qx.Class.define("osparc.study.CreateFunction", {
             };
             functionData["inputSchema"]["schema_content"]["required"].push(parameterKey);
           }
-        } else {
-          functionData["defaultInputs"][parameterKey] = osparc.service.Utils.getParameterValue(parameter);
+        }
+        if (defaultInputs[parameterKey]) {
+          functionData["defaultInputs"][parameterKey] = defaultInputs[parameterKey];
         }
       });
 
@@ -293,12 +294,12 @@ qx.Class.define("osparc.study.CreateFunction", {
       });
       createFunctionBtn.addListener("execute", () => {
         if (this.__form.validate()) {
-          this.__createFunction(exposedInputs, exposedOutputs);
+          this.__createFunction(defaultInputs, exposedInputs, exposedOutputs);
         }
       }, this);
     },
 
-    __createFunction: function(exposedInputs, exposedOutputs) {
+    __createFunction: function(defaultInputs, exposedInputs, exposedOutputs) {
       this.__createFunctionBtn.setFetching(true);
 
       // first publish it as a hidden template
@@ -319,7 +320,7 @@ qx.Class.define("osparc.study.CreateFunction", {
           task.addListener("resultReceived", e => {
             const templateData = e.getData();
             this.__updateTemplateMetadata(templateData);
-            this.__registerFunction(templateData, exposedInputs, exposedOutputs);
+            this.__registerFunction(templateData, defaultInputs, exposedInputs, exposedOutputs);
           });
         })
         .catch(err => {
@@ -344,11 +345,11 @@ qx.Class.define("osparc.study.CreateFunction", {
         .catch(err => console.error(err));
     },
 
-    __registerFunction: function(templateData, exposedInputs, exposedOutputs) {
+    __registerFunction: function(templateData, defaultInputs, exposedInputs, exposedOutputs) {
       const nameField = this.__form.getItem("name");
       const descriptionField = this.__form.getItem("description");
 
-      const functionData = this.self().createFunctionData(templateData, nameField.getValue(), descriptionField.getValue(), exposedInputs, exposedOutputs);
+      const functionData = this.self().createFunctionData(templateData, nameField.getValue(), descriptionField.getValue(), defaultInputs, exposedInputs, exposedOutputs);
       const params = {
         data: functionData,
       };

--- a/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
+++ b/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
@@ -60,18 +60,18 @@ qx.Class.define("osparc.study.CreateFunction", {
 
       const parameters = osparc.study.Utils.extractFunctionableParameters(projectData["workbench"]);
       parameters.forEach(parameter => {
-        const parameterLabel = parameter["label"];
-        if (exposedInputs[parameterLabel]) {
+        const parameterKey = parameter["label"];
+        if (exposedInputs[parameterKey]) {
           const parameterMetadata = osparc.store.Services.getMetadata(parameter["key"], parameter["version"]);
           if (parameterMetadata) {
             const type = osparc.service.Utils.getParameterType(parameterMetadata);
-            functionData["inputSchema"]["schema_content"]["properties"][parameterLabel] = {
+            functionData["inputSchema"]["schema_content"]["properties"][parameterKey] = {
               "type": type,
             };
-            functionData["inputSchema"]["schema_content"]["required"].push(parameterLabel);
+            functionData["inputSchema"]["schema_content"]["required"].push(parameterKey);
           }
         } else {
-          functionData["defaultInputs"][parameterLabel] = osparc.service.Utils.getParameterValue(parameter);
+          functionData["defaultInputs"][parameterKey] = osparc.service.Utils.getParameterValue(parameter);
         }
       });
 
@@ -164,7 +164,8 @@ qx.Class.define("osparc.study.CreateFunction", {
 
       const parameters = osparc.study.Utils.extractFunctionableParameters(this.__studyData["workbench"]);
       parameters.forEach(parameter => {
-        const parameterLabel = new qx.ui.basic.Label(parameter["label"]);
+        const parameterKey = parameter["label"];
+        const parameterLabel = new qx.ui.basic.Label(parameterKey);
         inputsLayout.add(parameterLabel, {
           row,
           column,
@@ -186,15 +187,25 @@ qx.Class.define("osparc.study.CreateFunction", {
           row,
           column,
         });
-        exposedInputs[parameter["label"]] = true;
-        parameterExposed.addListener("changeValue", e => exposedInputs[parameter["label"]] = e.getData());
+        exposedInputs[parameterKey] = true;
+        parameterExposed.addListener("changeValue", e => exposedInputs[parameterKey] = e.getData());
         column++;
 
         const paramValue = osparc.service.Utils.getParameterValue(parameter);
-        defaultInputs[parameter["label"]] = paramValue;
+        defaultInputs[parameterKey] = paramValue;
         let ctrl = null;
         if (parameterMetadata && osparc.service.Utils.getParameterType(parameterMetadata) === "number") {
           ctrl = new qx.ui.form.TextField(String(paramValue));
+          ctrl.addListener("changeValue", e => {
+            const newValue = e.getData();
+            const oldValue = e.getOldData();
+            if (newValue === oldValue) {
+              return;
+            }
+            const curatedValue = (!isNaN(parseFloat(newValue))) ? parseFloat(newValue) : parseFloat(oldValue);
+            defaultInputs[parameterKey] = curatedValue;
+            ctrl.setValue(String(curatedValue));
+          });
         } else {
           ctrl = new qx.ui.basic.Label(String(paramValue));
         }

--- a/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
+++ b/services/static-webserver/client/source/class/osparc/study/CreateFunction.js
@@ -193,10 +193,10 @@ qx.Class.define("osparc.study.CreateFunction", {
 
         const paramValue = osparc.service.Utils.getParameterValue(parameter);
         defaultInputs[parameterKey] = paramValue;
-        let ctrl = null;
+        let parameterDefaultValue = null;
         if (parameterMetadata && osparc.service.Utils.getParameterType(parameterMetadata) === "number") {
-          ctrl = new qx.ui.form.TextField(String(paramValue));
-          ctrl.addListener("changeValue", e => {
+          parameterDefaultValue = new qx.ui.form.TextField(String(paramValue));
+          parameterDefaultValue.addListener("changeValue", e => {
             const newValue = e.getData();
             const oldValue = e.getOldData();
             if (newValue === oldValue) {
@@ -204,12 +204,12 @@ qx.Class.define("osparc.study.CreateFunction", {
             }
             const curatedValue = (!isNaN(parseFloat(newValue))) ? parseFloat(newValue) : parseFloat(oldValue);
             defaultInputs[parameterKey] = curatedValue;
-            ctrl.setValue(String(curatedValue));
+            parameterDefaultValue.setValue(String(curatedValue));
           });
         } else {
-          ctrl = new qx.ui.basic.Label(String(paramValue));
+          parameterDefaultValue = new qx.ui.basic.Label(String(paramValue));
         }
-        inputsLayout.add(ctrl, {
+        inputsLayout.add(parameterDefaultValue, {
           row,
           column,
         });


### PR DESCRIPTION
## What do these changes do?

This PR makes the default values used for registering a function editable. It also adds all the input values to the ``defaultValues``. 

![DefaultInputs](https://github.com/user-attachments/assets/56d3c489-da95-4481-b248-120c98b7b23e)


## Related issue/s
- closes https://github.com/ITISFoundation/osparc-issues/issues/1931


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
