### PR TITLE
🎨 Extend locust tests for testing individual endpoints

### DIFF
--- a/tests/performance/common/pyproject.toml
+++ b/tests/performance/common/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "common"
+version = "0.1.0"
+description = "Common utilities for performance tests"
+requires-python = ">=3.11"
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/tests/performance/locustfiles/deployment_max_rps_single_endpoint.py
+++ b/tests/performance/locustfiles/deployment_max_rps_single_endpoint.py
@@ -12,7 +12,7 @@
 from collections.abc import Callable
 
 from common.base_user import OsparcWebUserBase
-from locust import events, task
+from locust import events, run_single_user, task
 from locust.argument_parser import LocustArgumentParser
 
 
@@ -52,3 +52,7 @@ class WebApiUser(OsparcWebUserBase):
         if len(self.environment.parsed_options.body) > 0:
             kwargs["data"] = self.environment.parsed_options.body
         method(self.environment.parsed_options.endpoint, **kwargs)
+
+
+if __name__ == "__main__":
+    run_single_user(WebApiUser)

--- a/tests/performance/locustfiles/deployment_max_rps_single_endpoint.py
+++ b/tests/performance/locustfiles/deployment_max_rps_single_endpoint.py
@@ -9,6 +9,8 @@
 #
 
 
+from collections.abc import Callable
+
 from common.base_user import OsparcWebUserBase
 from locust import events, task
 from locust.argument_parser import LocustArgumentParser
@@ -23,9 +25,30 @@ def _(parser: LocustArgumentParser) -> None:
         default="/",
         help="The endpoint to test (e.g., /v0/health)",
     )
+    parser.add_argument(
+        "--http-method",
+        type=str,
+        default="GET",
+        help="The HTTP method to test ('GET', 'POST', 'PUT', 'PATCH' or 'DELETE')",
+    )
+    parser.add_argument(
+        "--body",
+        type=str,
+        default="",
+        help="The optional HTTP body as json string",
+    )
 
 
 class WebApiUser(OsparcWebUserBase):
     @task
     def get_endpoint(self) -> None:
-        self.authenticated_get(self.environment.parsed_options.endpoint)
+        http_method = self.environment.parsed_options.http_method.lower()
+        method = getattr(self, f"authenticated_{http_method}")
+        if not isinstance(method, Callable):
+            msg = f"Unsupported HTTP method: {http_method}"
+            raise TypeError(msg)
+
+        kwargs = {}
+        if len(self.environment.parsed_options.body) > 0:
+            kwargs["data"] = self.environment.parsed_options.body
+        method(self.environment.parsed_options.endpoint, **kwargs)

--- a/tests/performance/locustfiles/deployment_max_rps_single_endpoint.py
+++ b/tests/performance/locustfiles/deployment_max_rps_single_endpoint.py
@@ -9,6 +9,7 @@
 #
 
 
+import json
 from collections.abc import Callable
 
 from common.base_user import OsparcWebUserBase
@@ -50,7 +51,7 @@ class WebApiUser(OsparcWebUserBase):
 
         kwargs = {}
         if len(self.environment.parsed_options.body) > 0:
-            kwargs["data"] = self.environment.parsed_options.body
+            kwargs["json"] = json.loads(self.environment.parsed_options.body)
         method(self.environment.parsed_options.endpoint, **kwargs)
 
 

--- a/tests/performance/requirements/dev.txt
+++ b/tests/performance/requirements/dev.txt
@@ -21,3 +21,4 @@
 --requirement _tools.txt
 
 # installs this repo's packages
+--editable ./common/


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- Allow user (meaning an `osparc-simcore`-developer) to hit endpoints by specifying a HTTP body and HTTP method in `tests/performance/locustfiles/deployment_max_rps_single_endpoint.py`
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
