### PR TITLE
🐛 Use context manager for app server lifecycle in Celery workers

### DIFF
--- a/packages/celery-library/src/celery_library/signals.py
+++ b/packages/celery-library/src/celery_library/signals.py
@@ -4,7 +4,7 @@ import threading
 
 from celery import Celery  # type: ignore[import-untyped]
 from celery.worker.worker import WorkController  # type: ignore[import-untyped]
-from servicelib.celery.app_server import STARTUP_TIMEOUT, BaseAppServer
+from servicelib.celery.app_server import BaseAppServer
 from servicelib.logging_utils import log_context
 from settings_library.celery import CelerySettings
 
@@ -55,7 +55,7 @@ def on_worker_init(
     )
     thread.start()
 
-    startup_complete_event.wait(STARTUP_TIMEOUT * 1.1)
+    startup_complete_event.wait()
 
 
 def on_worker_shutdown(sender, **_kwargs) -> None:

--- a/packages/celery-library/tests/conftest.py
+++ b/packages/celery-library/tests/conftest.py
@@ -2,6 +2,7 @@
 # pylint: disable=unused-argument
 
 import datetime
+import threading
 from collections.abc import AsyncIterator, Callable
 from functools import partial
 from typing import Any
@@ -30,10 +31,7 @@ pytest_plugins = [
 
 
 class FakeAppServer(BaseAppServer):
-    async def on_startup(self) -> None:
-        pass
-
-    async def on_shutdown(self) -> None:
+    async def lifespan(self, startup_completed_event: threading.Event) -> None:
         pass
 
 

--- a/packages/service-library/src/servicelib/celery/app_server.py
+++ b/packages/service-library/src/servicelib/celery/app_server.py
@@ -1,13 +1,10 @@
 import asyncio
-import datetime
 import threading
 from abc import ABC, abstractmethod
 from asyncio import AbstractEventLoop
-from typing import Final, Generic, TypeVar
+from typing import Generic, TypeVar
 
 from servicelib.celery.task_manager import TaskManager
-
-STARTUP_TIMEOUT: Final[float] = datetime.timedelta(minutes=1).total_seconds()
 
 T = TypeVar("T")
 
@@ -42,11 +39,11 @@ class BaseAppServer(ABC, Generic[T]):
         raise NotImplementedError
 
     async def startup(
-        self, completed_event: threading.Event, shutdown_event: asyncio.Event
+        self, startup_completed_event: threading.Event, shutdown_event: asyncio.Event
     ) -> None:
         self._shutdown_event = shutdown_event
-        completed_event.set()
         await self.on_startup()
+        startup_completed_event.set()
         await self._shutdown_event.wait()
 
     @abstractmethod

--- a/packages/service-library/src/servicelib/fastapi/celery/app_server.py
+++ b/packages/service-library/src/servicelib/fastapi/celery/app_server.py
@@ -28,6 +28,6 @@ class FastAPIAppServer(BaseAppServer[FastAPI]):
             try:
                 _logger.info("fastapi app initialized")
                 startup_completed_event.set()
-                await self.shutdown_event.wait()
+                await self.shutdown_event.wait()  # NOTE: wait here until shutdown is requested
             except asyncio.CancelledError:
                 _logger.warning("lifespan task cancelled")

--- a/packages/service-library/src/servicelib/fastapi/celery/app_server.py
+++ b/packages/service-library/src/servicelib/fastapi/celery/app_server.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 import logging
 import threading
@@ -25,9 +24,6 @@ class FastAPIAppServer(BaseAppServer[FastAPI]):
             startup_timeout=None,  # waits for full app initialization (DB migrations, etc.)
             shutdown_timeout=_SHUTDOWN_TIMEOUT,
         ):
-            try:
-                _logger.info("fastapi app initialized")
-                startup_completed_event.set()
-                await self.shutdown_event.wait()  # NOTE: wait here until shutdown is requested
-            except asyncio.CancelledError:
-                _logger.warning("lifespan task cancelled")
+            _logger.info("fastapi app initialized")
+            startup_completed_event.set()
+            await self.shutdown_event.wait()  # NOTE: wait here until shutdown is requested

--- a/packages/service-library/src/servicelib/fastapi/celery/app_server.py
+++ b/packages/service-library/src/servicelib/fastapi/celery/app_server.py
@@ -1,7 +1,12 @@
+import datetime
+from typing import Final
+
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 
 from ...celery.app_server import BaseAppServer
+
+_SHUTDOWN_TIMEOUT: Final[float] = datetime.timedelta(seconds=10).total_seconds()
 
 
 class FastAPIAppServer(BaseAppServer[FastAPI]):
@@ -13,7 +18,7 @@ class FastAPIAppServer(BaseAppServer[FastAPI]):
         self._lifespan_manager = LifespanManager(
             self.app,
             startup_timeout=None,  # waits for full app initialization (DB migrations, etc.)
-            shutdown_timeout=None,
+            shutdown_timeout=_SHUTDOWN_TIMEOUT,
         )
         await self._lifespan_manager.__aenter__()
 

--- a/packages/service-library/src/servicelib/fastapi/celery/app_server.py
+++ b/packages/service-library/src/servicelib/fastapi/celery/app_server.py
@@ -1,13 +1,7 @@
-from datetime import timedelta
-from typing import Final
-
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 
 from ...celery.app_server import BaseAppServer
-
-_SHUTDOWN_TIMEOUT: Final[float] = timedelta(seconds=10).total_seconds()
-_STARTUP_TIMEOUT: Final[float] = timedelta(minutes=1).total_seconds()
 
 
 class FastAPIAppServer(BaseAppServer[FastAPI]):
@@ -18,8 +12,8 @@ class FastAPIAppServer(BaseAppServer[FastAPI]):
     async def on_startup(self) -> None:
         self._lifespan_manager = LifespanManager(
             self.app,
-            startup_timeout=_STARTUP_TIMEOUT,
-            shutdown_timeout=_SHUTDOWN_TIMEOUT,
+            startup_timeout=None,
+            shutdown_timeout=None,
         )
         await self._lifespan_manager.__aenter__()
 

--- a/packages/service-library/src/servicelib/fastapi/celery/app_server.py
+++ b/packages/service-library/src/servicelib/fastapi/celery/app_server.py
@@ -1,4 +1,7 @@
+import asyncio
 import datetime
+import logging
+import threading
 from typing import Final
 
 from asgi_lifespan import LifespanManager
@@ -8,21 +11,23 @@ from ...celery.app_server import BaseAppServer
 
 _SHUTDOWN_TIMEOUT: Final[float] = datetime.timedelta(seconds=10).total_seconds()
 
+_logger = logging.getLogger(__name__)
+
 
 class FastAPIAppServer(BaseAppServer[FastAPI]):
     def __init__(self, app: FastAPI):
         super().__init__(app)
         self._lifespan_manager: LifespanManager | None = None
 
-    async def on_startup(self) -> None:
-        self._lifespan_manager = LifespanManager(
+    async def lifespan(self, startup_completed_event: threading.Event) -> None:
+        async with LifespanManager(
             self.app,
             startup_timeout=None,  # waits for full app initialization (DB migrations, etc.)
             shutdown_timeout=_SHUTDOWN_TIMEOUT,
-        )
-        await self._lifespan_manager.__aenter__()
-
-    async def on_shutdown(self) -> None:
-        if self._lifespan_manager is None:
-            return
-        await self._lifespan_manager.__aexit__(None, None, None)
+        ):
+            try:
+                _logger.info("fastapi app initialized")
+                startup_completed_event.set()
+                await self.shutdown_event.wait()
+            except asyncio.CancelledError:
+                _logger.warning("lifespan task cancelled")

--- a/packages/service-library/src/servicelib/fastapi/celery/app_server.py
+++ b/packages/service-library/src/servicelib/fastapi/celery/app_server.py
@@ -12,7 +12,7 @@ class FastAPIAppServer(BaseAppServer[FastAPI]):
     async def on_startup(self) -> None:
         self._lifespan_manager = LifespanManager(
             self.app,
-            startup_timeout=None,
+            startup_timeout=None,  # waits for full app initialization (DB migrations, etc.)
             shutdown_timeout=None,
         )
         await self._lifespan_manager.__aenter__()


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR removes timeouts on startup so that App Server initialisation can complete before starting the Celery worker itself.
Compared to the previous version, all slow initialisation procedures (e.g. DB migration) can complete... while the `worker_init` waits for the `startup_completed_event` to finalize the execution.

Clean shutdown:

<img width="1047" alt="image" src="https://github.com/user-attachments/assets/607e551b-718a-4c10-99cb-ef937d71b0d8" />

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes #7957
- fixes #7968

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
