### PR TITLE
✨ [Frontend] Conversation Messages: Listen to WebSocket

### DIFF
--- a/services/static-webserver/client/source/class/osparc/conversation/AddMessage.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/AddMessage.js
@@ -36,8 +36,8 @@ qx.Class.define("osparc.conversation.AddMessage", {
   },
 
   events: {
-    "commentAdded": "qx.event.type.Data",
-    "messageEdited": "qx.event.type.Data",
+    "messageAdded": "qx.event.type.Data",
+    "messageUpdated": "qx.event.type.Data",
   },
 
   members: {
@@ -227,7 +227,7 @@ qx.Class.define("osparc.conversation.AddMessage", {
       if (content) {
         osparc.study.Conversations.addMessage(this.__studyData["uuid"], this.__conversationId, content)
           .then(data => {
-            this.fireDataEvent("commentAdded", data);
+            this.fireDataEvent("messageAdded", data);
             commentField.getChildControl("text-area").setValue("");
           });
       }
@@ -239,7 +239,7 @@ qx.Class.define("osparc.conversation.AddMessage", {
       if (content) {
         osparc.study.Conversations.editMessage(this.__studyData["uuid"], this.__conversationId, this.__message["messageId"], content)
           .then(data => {
-            this.fireDataEvent("messageEdited", data);
+            this.fireDataEvent("messageUpdated", data);
             commentField.getChildControl("text-area").setValue("");
           });
       }
@@ -249,7 +249,7 @@ qx.Class.define("osparc.conversation.AddMessage", {
       if (userGid) {
         osparc.study.Conversations.notifyUser(this.__studyData["uuid"], this.__conversationId, userGid)
           .then(data => {
-            this.fireDataEvent("commentAdded", data);
+            this.fireDataEvent("messageAdded", data);
             const potentialCollaborators = osparc.store.Groups.getInstance().getPotentialCollaborators();
             if (userGid in potentialCollaborators) {
               if ("getUserId" in potentialCollaborators[userGid]) {

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -263,14 +263,20 @@ qx.Class.define("osparc.conversation.Conversation", {
     },
 
     deleteMessage: function(message) {
+      // remove it from the messages array
       const messageIndex = this.__messages.findIndex(msg => msg["messageId"] === message["messageId"]);
-      if (messageIndex !== -1) {
-        this.__messages.splice(messageIndex, 1);
-
-        this.__updateMessagesNumber();
-
-        console.log(this.__messagesList.getChildren());
+      if (messageIndex === -1) {
+        return;
       }
+      this.__messages.splice(messageIndex, 1);
+
+      // remove the ui element
+      const index = this.__messagesList.getChildren().findIndex(control => ("getMessage" in control && control.getMessage()["messageId"] === message["messageId"]));
+      if (index > -1) {
+        this.__messagesList.getChildren().removeAt(index);
+      }
+
+      this.__updateMessagesNumber();
     },
 
     updateMessage: function(message) {

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -245,9 +245,10 @@ qx.Class.define("osparc.conversation.Conversation", {
       // it's not provided by the backend
       message["projectId"] = this.__studyData["uuid"];
 
+      // Add the message in the messages array
       this.__messages.push(message);
-      this.__updateMessagesNumber();
 
+      // Add the UI element to the messages list
       let control = null;
       switch (message["type"]) {
         case "MESSAGE":
@@ -260,6 +261,8 @@ qx.Class.define("osparc.conversation.Conversation", {
       if (control) {
         this.__messagesList.add(control);
       }
+
+      this.__updateMessagesNumber();
     },
 
     deleteMessage: function(message) {
@@ -283,6 +286,14 @@ qx.Class.define("osparc.conversation.Conversation", {
     },
 
     updateMessage: function(message) {
+      // Replace the message in the messages array
+      const messageIndex = this.__messages.findIndex(msg => msg["messageId"] === message["messageId"]);
+      if (messageIndex === -1) {
+        return;
+      }
+      this.__messages[messageIndex] = message;
+
+      // Update the UI element from the messages list
       this.__messagesList.getChildren().forEach(control => {
         if ("getMessage" in control && control.getMessage()["messageId"] === message["messageId"]) {
           control.setMessage(message);

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -227,18 +227,21 @@ qx.Class.define("osparc.conversation.Conversation", {
         .finally(() => this.__loadMoreMessages.setFetching(false));
     },
 
-    addMessage: function(message) {
-      // it's not provided by the backend
-      message["projectId"] = this.__studyData["uuid"];
-
-      this.__messages.push(message);
-
+    __updateMessagesNumber: function() {
       const nMessages = this.__messages.filter(msg => msg["type"] === "MESSAGE").length;
       if (nMessages === 1) {
         this.__messagesTitle.setValue(this.tr("1 Message"));
       } else if (nMessages > 1) {
         this.__messagesTitle.setValue(nMessages + this.tr(" Messages"));
       }
+    },
+
+    addMessage: function(message) {
+      // it's not provided by the backend
+      message["projectId"] = this.__studyData["uuid"];
+
+      this.__messages.push(message);
+      this.__updateMessagesNumber();
 
       let control = null;
       switch (message["type"]) {
@@ -261,6 +264,7 @@ qx.Class.define("osparc.conversation.Conversation", {
       if (messageIndex !== -1) {
         this.__messages.splice(messageIndex, 1);
       }
+      this.__updateMessagesNumber();
 
       console.log(this.__messagesList.getChildren());
     },

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -242,9 +242,6 @@ qx.Class.define("osparc.conversation.Conversation", {
         return;
       }
 
-      // it's not provided by the backend
-      message["projectId"] = this.__studyData["uuid"];
-
       // Add the message in the messages array
       this.__messages.push(message);
 
@@ -259,7 +256,7 @@ qx.Class.define("osparc.conversation.Conversation", {
           break;
       }
       if (control) {
-        this.__messagesList.add(control);
+        this.__messagesList.addAt(control, 0);
       }
 
       this.__updateMessagesNumber();

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -262,8 +262,8 @@ qx.Class.define("osparc.conversation.Conversation", {
       }
     },
 
-    deleteMessage: function(messageId) {
-      const messageIndex = this.__messages.findIndex(msg => msg["messageId"] === messageId);
+    deleteMessage: function(message) {
+      const messageIndex = this.__messages.findIndex(msg => msg["messageId"] === message["messageId"]);
       if (messageIndex !== -1) {
         this.__messages.splice(messageIndex, 1);
 
@@ -271,6 +271,15 @@ qx.Class.define("osparc.conversation.Conversation", {
 
         console.log(this.__messagesList.getChildren());
       }
+    },
+
+    updateMessage: function(message) {
+      this.__messagesList.getChildren().forEach(control => {
+        if ("getMessage" in control && control.getMessage()["messageId"] === message["messageId"]) {
+          control.setMessage(message);
+          return;
+        }
+      });
     },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -167,10 +167,11 @@ qx.Class.define("osparc.conversation.Conversation", {
       if (osparc.data.model.Study.canIWrite(this.__studyData["accessRights"])) {
         const addMessages = new osparc.conversation.AddMessage(this.__studyData, this.getConversationId());
         addMessages.setPaddingLeft(10);
-        addMessages.addListener("commentAdded", e => {
+        addMessages.addListener("messageAdded", e => {
           const data = e.getData();
           if (data["conversationId"]) {
             this.setConversationId(data["conversationId"]);
+            this.addMessage(data);
           }
         });
         this._add(addMessages);
@@ -259,6 +260,8 @@ qx.Class.define("osparc.conversation.Conversation", {
       switch (message["type"]) {
         case "MESSAGE":
           control = new osparc.conversation.MessageUI(message, this.__studyData);
+          control.addListener("messageUpdated", e => this.updateMessage(e.getData()));
+          control.addListener("messageDeleted", e => this.deleteMessage(e.getData()));
           break;
         case "NOTIFICATION":
           control = new osparc.conversation.NotificationUI(message);

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -242,8 +242,15 @@ qx.Class.define("osparc.conversation.Conversation", {
         return;
       }
 
-      // Add the message in the messages array
-      this.__messages.push(message);
+      // determine insertion index for most‐recent‐first order
+      const newTime = new Date(message["created"]);
+      let insertAt = this.__messages.findIndex(m => new Date(m["created"]) < newTime);
+      if (insertAt === -1) {
+        insertAt = this.__messages.length;
+      }
+
+      // Insert the message in the messages array
+      this.__messages.splice(insertAt, 0, message);
 
       // Add the UI element to the messages list
       let control = null;
@@ -256,7 +263,8 @@ qx.Class.define("osparc.conversation.Conversation", {
           break;
       }
       if (control) {
-        this.__messagesList.addAt(control, 0);
+        // insert into the UI at the same position
+        this.__messagesList.addAt(control, insertAt);
       }
 
       this.__updateMessagesNumber();

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -270,10 +270,13 @@ qx.Class.define("osparc.conversation.Conversation", {
       }
       this.__messages.splice(messageIndex, 1);
 
-      // remove the ui element
-      const index = this.__messagesList.getChildren().findIndex(control => ("getMessage" in control && control.getMessage()["messageId"] === message["messageId"]));
-      if (index > -1) {
-        this.__messagesList.getChildren().removeAt(index);
+      // Remove the UI element from the messages list
+      const children = this.__messagesList.getChildren();
+      const controlIndex = children.findIndex(
+        ctrl => ("getMessage" in ctrl && ctrl.getMessage()["messageId"] === message["messageId"])
+      );
+      if (controlIndex > -1) {
+        this.__messagesList.remove(children[controlIndex]);
       }
 
       this.__updateMessagesNumber();

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -217,6 +217,8 @@ qx.Class.define("osparc.conversation.Conversation", {
       this.__getNextRequest()
         .then(resp => {
           const messages = resp["data"];
+          // backend doesn't provide the projectId
+          messages.forEach(message => message["projectId"] = this.__studyData["uuid"]);
           messages.forEach(message => this.addMessage(message));
           this.__nextRequestParams = resp["_links"]["next"];
           if (this.__nextRequestParams === null) {

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -172,7 +172,6 @@ qx.Class.define("osparc.conversation.Conversation", {
           if (data["conversationId"]) {
             this.setConversationId(data["conversationId"]);
           }
-          this.reloadMessages();
         });
         this._add(addMessages);
       }
@@ -237,6 +236,12 @@ qx.Class.define("osparc.conversation.Conversation", {
     },
 
     addMessage: function(message) {
+      // ignore it if it was already there
+      const messageIndex = this.__messages.findIndex(msg => msg["messageId"] === message["messageId"]);
+      if (messageIndex !== -1) {
+        return;
+      }
+
       // it's not provided by the backend
       message["projectId"] = this.__studyData["uuid"];
 
@@ -247,8 +252,6 @@ qx.Class.define("osparc.conversation.Conversation", {
       switch (message["type"]) {
         case "MESSAGE":
           control = new osparc.conversation.MessageUI(message, this.__studyData);
-          control.addListener("messageEdited", () => this.reloadMessages());
-          control.addListener("messageDeleted", () => this.reloadMessages());
           break;
         case "NOTIFICATION":
           control = new osparc.conversation.NotificationUI(message);
@@ -263,10 +266,11 @@ qx.Class.define("osparc.conversation.Conversation", {
       const messageIndex = this.__messages.findIndex(msg => msg["messageId"] === messageId);
       if (messageIndex !== -1) {
         this.__messages.splice(messageIndex, 1);
-      }
-      this.__updateMessagesNumber();
 
-      console.log(this.__messagesList.getChildren());
+        this.__updateMessagesNumber();
+
+        console.log(this.__messagesList.getChildren());
+      }
     },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -255,5 +255,14 @@ qx.Class.define("osparc.conversation.Conversation", {
         this.__messagesList.add(control);
       }
     },
+
+    deleteMessage: function(messageId) {
+      const messageIndex = this.__messages.findIndex(msg => msg["messageId"] === messageId);
+      if (messageIndex !== -1) {
+        this.__messages.splice(messageIndex, 1);
+      }
+
+      console.log(this.__messagesList.getChildren());
+    },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -218,8 +218,6 @@ qx.Class.define("osparc.conversation.Conversation", {
       this.__getNextRequest()
         .then(resp => {
           const messages = resp["data"];
-          // backend doesn't provide the projectId
-          messages.forEach(message => message["projectId"] = this.__studyData["uuid"]);
           messages.forEach(message => this.addMessage(message));
           this.__nextRequestParams = resp["_links"]["next"];
           if (this.__nextRequestParams === null) {
@@ -239,6 +237,9 @@ qx.Class.define("osparc.conversation.Conversation", {
     },
 
     addMessage: function(message) {
+      // backend doesn't provide the projectId
+      message["projectId"] = this.__studyData["uuid"];
+
       // ignore it if it was already there
       const messageIndex = this.__messages.findIndex(msg => msg["messageId"] === message["messageId"]);
       if (messageIndex !== -1) {
@@ -296,6 +297,9 @@ qx.Class.define("osparc.conversation.Conversation", {
     },
 
     updateMessage: function(message) {
+      // backend doesn't provide the projectId
+      message["projectId"] = this.__studyData["uuid"];
+
       // Replace the message in the messages array
       const messageIndex = this.__messages.findIndex(msg => msg["messageId"] === message["messageId"]);
       if (messageIndex === -1) {

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -47,7 +47,7 @@ qx.Class.define("osparc.conversation.Conversation", {
 
     this.__buildLayout();
 
-    this.reloadMessages();
+    this.__reloadMessages();
   },
 
   properties: {
@@ -161,7 +161,7 @@ qx.Class.define("osparc.conversation.Conversation", {
       });
 
       this.__loadMoreMessages = new osparc.ui.form.FetchButton(this.tr("Load more messages..."));
-      this.__loadMoreMessages.addListener("execute", () => this.reloadMessages(false));
+      this.__loadMoreMessages.addListener("execute", () => this.__reloadMessages(false));
       this._add(this.__loadMoreMessages);
 
       if (osparc.data.model.Study.canIWrite(this.__studyData["accessRights"])) {
@@ -197,7 +197,7 @@ qx.Class.define("osparc.conversation.Conversation", {
       return osparc.data.Resources.fetch("conversations", "getMessagesPage", params, options);
     },
 
-    reloadMessages: function(removeMessages = true) {
+    __reloadMessages: function(removeMessages = true) {
       if (this.getConversationId() === null) {
         this.__messagesTitle.setValue(this.tr("No messages yet"));
         this.__messagesList.hide();

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -198,7 +198,7 @@ qx.Class.define("osparc.conversation.Conversation", {
       this.__getNextRequest()
         .then(resp => {
           const messages = resp["data"];
-          this.__addMessages(messages);
+          messages.forEach(message => this.addMessage(message));
           this.__nextRequestParams = resp["_links"]["next"];
           if (this.__nextRequestParams === null) {
             this.__loadMoreMessages.exclude();
@@ -227,35 +227,33 @@ qx.Class.define("osparc.conversation.Conversation", {
       return osparc.data.Resources.fetch("conversations", "getMessagesPage", params, options);
     },
 
-    __addMessages: function(messages) {
+    addMessage: function(message) {
       // it's not provided by the backend
-      messages.forEach(message => message["projectId"] = this.__studyData["uuid"]);
+      message["projectId"] = this.__studyData["uuid"];
 
-      this.__messages = this.__messages.concat(messages);
+      this.__messages.push(message);
 
-      const nMessages = messages.filter(msg => msg["type"] === "MESSAGE").length;
+      const nMessages = this.__messages.filter(msg => msg["type"] === "MESSAGE").length;
       if (nMessages === 1) {
         this.__messagesTitle.setValue(this.tr("1 Message"));
       } else if (nMessages > 1) {
         this.__messagesTitle.setValue(nMessages + this.tr(" Messages"));
       }
 
-      messages.forEach(message => {
-        let control = null;
-        switch (message["type"]) {
-          case "MESSAGE":
-            control = new osparc.conversation.MessageUI(message, this.__studyData);
-            control.addListener("messageEdited", () => this.fetchMessages());
-            control.addListener("messageDeleted", () => this.fetchMessages());
-            break;
-          case "NOTIFICATION":
-            control = new osparc.conversation.NotificationUI(message);
-            break;
-        }
-        if (control) {
-          this.__messagesList.add(control);
-        }
-      });
+      let control = null;
+      switch (message["type"]) {
+        case "MESSAGE":
+          control = new osparc.conversation.MessageUI(message, this.__studyData);
+          control.addListener("messageEdited", () => this.fetchMessages());
+          control.addListener("messageDeleted", () => this.fetchMessages());
+          break;
+        case "NOTIFICATION":
+          control = new osparc.conversation.NotificationUI(message);
+          break;
+      }
+      if (control) {
+        this.__messagesList.add(control);
+      }
     },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/Conversation.js
@@ -27,6 +27,7 @@ qx.Class.define("osparc.conversation.Conversation", {
     this.base(arguments);
 
     this.__studyData = studyData;
+    this.__messages = [];
 
     if (conversationId) {
       this.setConversationId(conversationId);
@@ -64,6 +65,7 @@ qx.Class.define("osparc.conversation.Conversation", {
 
   members: {
     __studyData: null,
+    __messages: null,
     __nextRequestParams: null,
     __messagesTitle: null,
     __messagesList: null,
@@ -189,14 +191,13 @@ qx.Class.define("osparc.conversation.Conversation", {
       this.__loadMoreMessages.setFetching(true);
 
       if (removeMessages) {
+        this.__messages = [];
         this.__messagesList.removeAll();
       }
 
       this.__getNextRequest()
         .then(resp => {
           const messages = resp["data"];
-          // it's not provided by the backend
-          messages.forEach(message => message["studyId"] = this.__studyData["uuid"]);
           this.__addMessages(messages);
           this.__nextRequestParams = resp["_links"]["next"];
           if (this.__nextRequestParams === null) {
@@ -227,6 +228,11 @@ qx.Class.define("osparc.conversation.Conversation", {
     },
 
     __addMessages: function(messages) {
+      // it's not provided by the backend
+      messages.forEach(message => message["projectId"] = this.__studyData["uuid"]);
+
+      this.__messages = this.__messages.concat(messages);
+
       const nMessages = messages.filter(msg => msg["type"] === "MESSAGE").length;
       if (nMessages === 1) {
         this.__messagesTitle.setValue(this.tr("1 Message"));

--- a/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
@@ -154,10 +154,16 @@ qx.Class.define("osparc.conversation.MessageUI", {
 
       const userName = this.getChildControl("user-name");
 
-      const date = new Date(message["modified"]);
-      const date2 = osparc.utils.Utils.formatDateAndTime(date);
+      const createdDateData = new Date(message["created"]);
+      const createdDate = osparc.utils.Utils.formatDateAndTime(createdDateData);
       const lastUpdate = this.getChildControl("last-updated");
-      lastUpdate.setValue(date2);
+      if (message["created"] === message["modified"]) {
+        lastUpdate.setValue(createdDate);
+      } else {
+        const updatedDateData = new Date(message["modified"]);
+        const updatedDate = osparc.utils.Utils.formatDateAndTime(updatedDateData);
+        lastUpdate.setValue(createdDate + " (" + this.tr("edited") + " "+ updatedDate + ")");
+      }
 
       const messageContent = this.getChildControl("message-content");
       messageContent.setValue(message["content"]);

--- a/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
@@ -211,7 +211,7 @@ qx.Class.define("osparc.conversation.MessageUI", {
       win.open();
       win.addListener("close", () => {
         if (win.getConfirmed()) {
-          osparc.study.Conversations.deleteMessage(this.__message["studyId"], this.__message["conversationId"], this.__message["messageId"])
+          osparc.study.Conversations.deleteMessage(this.__message["projectId"], this.__message["conversationId"], this.__message["messageId"])
             .then(() => this.fireEvent("messageDeleted"))
             .catch(err => osparc.FlashMessenger.logError(err));
         }

--- a/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
@@ -147,8 +147,6 @@ qx.Class.define("osparc.conversation.MessageUI", {
     },
 
     __applyMessage: function(message) {
-      this._removeAll();
-
       const isMyMessage = this.self().isMyMessage(message);
       this._getLayout().setColumnFlex(isMyMessage ? 0 : 2, 3); // spacer
 

--- a/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
@@ -45,8 +45,8 @@ qx.Class.define("osparc.conversation.MessageUI", {
   },
 
   events: {
-    "messageEdited": "qx.event.type.Event",
-    "messageDeleted": "qx.event.type.Event",
+    "messageUpdated": "qx.event.type.Data",
+    "messageDeleted": "qx.event.type.Data",
   },
 
   properties: {
@@ -207,9 +207,9 @@ qx.Class.define("osparc.conversation.MessageUI", {
         resizable: true,
         showClose: true,
       });
-      addMessage.addListener("messageEdited", () => {
+      addMessage.addListener("messageUpdated", e => {
         win.close();
-        this.fireDataEvent("messageEdited");
+        this.fireDataEvent("messageUpdated", e.getData());
       });
     },
 
@@ -225,7 +225,7 @@ qx.Class.define("osparc.conversation.MessageUI", {
       win.addListener("close", () => {
         if (win.getConfirmed()) {
           osparc.study.Conversations.deleteMessage(message)
-            .then(() => this.fireEvent("messageDeleted"))
+            .then(() => this.fireDataEvent("messageDeleted", message))
             .catch(err => osparc.FlashMessenger.logError(err));
         }
       });

--- a/services/static-webserver/client/source/class/osparc/conversation/NotificationUI.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/NotificationUI.js
@@ -25,9 +25,11 @@ qx.Class.define("osparc.conversation.NotificationUI", {
   construct: function(message) {
     this.base(arguments);
 
-    this.__message = message;
+    this.set({
+      message,
+    });
 
-    const isMyMessage = osparc.conversation.MessageUI.isMyMessage(this.__message);
+    const isMyMessage = osparc.conversation.MessageUI.isMyMessage(message);
     const layout = new qx.ui.layout.Grid(4, 4);
     layout.setColumnFlex(isMyMessage ? 0 : 3, 3); // spacer
     layout.setRowAlign(0, "center", "middle");
@@ -37,13 +39,19 @@ qx.Class.define("osparc.conversation.NotificationUI", {
     this.__buildLayout();
   },
 
-  members: {
-    __message: null,
+  properties: {
+    message: {
+      check: "Object",
+      init: null,
+      nullable: false,
+    },
+  },
 
+  members: {
     // spacer - date - content - (thumbnail-spacer)
     // (thumbnail-spacer) - content - date - spacer
     _createChildControlImpl: function(id) {
-      const isMyMessage = osparc.conversation.MessageUI.isMyMessage(this.__message);
+      const isMyMessage = osparc.conversation.MessageUI.isMyMessage(this.getMessage());
       let control;
       switch (id) {
         case "thumbnail-spacer":
@@ -90,16 +98,16 @@ qx.Class.define("osparc.conversation.NotificationUI", {
     __buildLayout: function() {
       this.getChildControl("thumbnail-spacer");
 
-      const isMyMessage = osparc.conversation.MessageUI.isMyMessage(this.__message);
+      const isMyMessage = osparc.conversation.MessageUI.isMyMessage(this.getMessage());
 
-      const modifiedDate = new Date(this.__message["modified"]);
+      const modifiedDate = new Date(this.getMessage()["modified"]);
       const date = osparc.utils.Utils.formatDateAndTime(modifiedDate);
       const lastUpdate = this.getChildControl("last-updated");
       lastUpdate.setValue(isMyMessage ? date + " -" : " - " + date);
 
       const messageContent = this.getChildControl("message-content");
-      const notifierUserGroupId = parseInt(this.__message["userGroupId"]);
-      const notifiedUserGroupId = parseInt(this.__message["content"]);
+      const notifierUserGroupId = parseInt(this.getMessage()["userGroupId"]);
+      const notifiedUserGroupId = parseInt(this.getMessage()["content"]);
       let msgContent = "🔔 ";
       Promise.all([
         osparc.store.Users.getInstance().getUser(notifierUserGroupId),

--- a/services/static-webserver/client/source/class/osparc/conversation/NotificationUI.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/NotificationUI.js
@@ -25,10 +25,6 @@ qx.Class.define("osparc.conversation.NotificationUI", {
   construct: function(message) {
     this.base(arguments);
 
-    this.set({
-      message,
-    });
-
     const isMyMessage = osparc.conversation.MessageUI.isMyMessage(message);
     const layout = new qx.ui.layout.Grid(4, 4);
     layout.setColumnFlex(isMyMessage ? 0 : 3, 3); // spacer
@@ -36,7 +32,9 @@ qx.Class.define("osparc.conversation.NotificationUI", {
     this._setLayout(layout);
     this.setPadding(5);
 
-    this.__buildLayout();
+    this.set({
+      message,
+    });
   },
 
   properties: {
@@ -44,6 +42,7 @@ qx.Class.define("osparc.conversation.NotificationUI", {
       check: "Object",
       init: null,
       nullable: false,
+      apply: "__applyMessage",
     },
   },
 
@@ -95,19 +94,21 @@ qx.Class.define("osparc.conversation.NotificationUI", {
       return control || this.base(arguments, id);
     },
 
-    __buildLayout: function() {
+    __applyMessage: function(message) {
+      this._removeAll();
+
       this.getChildControl("thumbnail-spacer");
 
-      const isMyMessage = osparc.conversation.MessageUI.isMyMessage(this.getMessage());
+      const isMyMessage = osparc.conversation.MessageUI.isMyMessage(message);
 
-      const modifiedDate = new Date(this.getMessage()["modified"]);
+      const modifiedDate = new Date(message["modified"]);
       const date = osparc.utils.Utils.formatDateAndTime(modifiedDate);
       const lastUpdate = this.getChildControl("last-updated");
       lastUpdate.setValue(isMyMessage ? date + " -" : " - " + date);
 
       const messageContent = this.getChildControl("message-content");
-      const notifierUserGroupId = parseInt(this.getMessage()["userGroupId"]);
-      const notifiedUserGroupId = parseInt(this.getMessage()["content"]);
+      const notifierUserGroupId = parseInt(message["userGroupId"]);
+      const notifiedUserGroupId = parseInt(message["content"]);
       let msgContent = "🔔 ";
       Promise.all([
         osparc.store.Users.getInstance().getUser(notifierUserGroupId),

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -113,12 +113,12 @@ qx.Class.define("osparc.study.Conversations", {
         .catch(err => osparc.FlashMessenger.logError(err));
     },
 
-    deleteMessage: function(studyId, conversationId, messageId) {
+    deleteMessage: function(message) {
       const params = {
         url: {
-          studyId,
-          conversationId,
-          messageId,
+          studyId: message["projectId"],
+          conversationId: message["conversationId"],
+          messageId: message["messageId"],
         },
       };
       return osparc.data.Resources.fetch("conversations", "deleteMessage", params)
@@ -170,21 +170,21 @@ qx.Class.define("osparc.study.Conversations", {
         "conversation:message:update",
         "conversation:message:deleted",
       ].forEach(eventName => {
-        socket.on(eventName, data => {
-          console.log("Conversation message", eventName, data);
-          if (data) {
-            const conversationId = data["conversationId"];
+        socket.on(eventName, message => {
+          console.log("Conversation message", eventName, message);
+          if (message) {
+            const conversationId = message["conversationId"];
             const conversation = this.__getConversation(conversationId);
             if (conversation) {
               switch (eventName) {
                 case "conversation:message:created":
-                  conversation.addMessage(data);
+                  conversation.addMessage(message);
                   break;
                 case "conversation:message:update":
-                  conversation.updateMessage(data);
+                  conversation.updateMessage(message);
                   break;
                 case "conversation:message:deleted":
-                  conversation.deleteMessage(data);
+                  conversation.deleteMessage(message);
                   break;
               }
             }

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -173,7 +173,6 @@ qx.Class.define("osparc.study.Conversations", {
         "conversation:message:deleted",
       ].forEach(eventName => {
         const eventHandler = message => {
-          console.log("Conversation message", eventName, message);
           if (message) {
             const conversationId = message["conversationId"];
             const conversation = this.__getConversation(conversationId);

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -41,9 +41,6 @@ qx.Class.define("osparc.study.Conversations", {
       const viewWidth = 600;
       const viewHeight = 700;
       const win = osparc.ui.window.Window.popUpInWindow(conversations, title, viewWidth, viewHeight);
-      win.addListener("close", () => {
-        conversations.dispose(); // this will remove the WebSocket listeners
-      }, this);
       return win;
     },
 

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -169,7 +169,7 @@ qx.Class.define("osparc.study.Conversations", {
       const socket = osparc.wrapper.WebSocket.getInstance();
       [
         "conversation:message:created",
-        "conversation:message:update",
+        "conversation:message:updated",
         "conversation:message:deleted",
       ].forEach(eventName => {
         const eventHandler = message => {
@@ -182,7 +182,7 @@ qx.Class.define("osparc.study.Conversations", {
                 case "conversation:message:created":
                   conversation.addMessage(message);
                   break;
-                case "conversation:message:update":
+                case "conversation:message:updated":
                   conversation.updateMessage(message);
                   break;
                 case "conversation:message:deleted":

--- a/services/static-webserver/client/source/class/osparc/study/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/study/Conversations.js
@@ -41,6 +41,9 @@ qx.Class.define("osparc.study.Conversations", {
       const viewWidth = 600;
       const viewHeight = 700;
       const win = osparc.ui.window.Window.popUpInWindow(conversations, title, viewWidth, viewHeight);
+      win.addListener("close", () => {
+        conversations.dispose(); // this will remove the WebSocket listeners
+      }, this);
       return win;
     },
 


### PR DESCRIPTION
## What do these changes do?

This PR makes the Conversations listen the WebSocket events, reducing the GET messages calls and giving a better UX.
- [x] create
- [x] update
- [x] delete
- [x] Remove the WebSocket listeners

![ConversationMessages](https://github.com/user-attachments/assets/a04b5ee9-cb7a-40fa-bffa-b82cfd7f8e84)


## Related issue/s
- follows https://github.com/ITISFoundation/osparc-simcore/pull/7941


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
