### PR TITLE
🐛Sticky connection: Ensure emitted socketio messages for logs, progress, status updates and payments are not lost

### DIFF
--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -895,7 +895,7 @@ services:
           PathRegexp(`^/v0/storage/locations/[0-9]+/export-data`) ||
           PathRegexp(`^/v0/tasks-legacy/.+`)
         # NOTE: the sticky router must have a higher priority than the webserver router but below dy-proxies
-        - traefik.http.routers.${SWARM_STACK_NAME}_webserver_sticky.priority=7
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver_sticky.priority=8
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_sticky.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_sticky.service=${SWARM_STACK_NAME}_webserver_sticky
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_sticky.middlewares=${SWARM_STACK_NAME}_gzip@swarm, ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader@swarm, ${SWARM_STACK_NAME}_webserver_retry

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -888,10 +888,14 @@ services:
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_sticky.rule=Path(`/v0/projects`) ||
           Path(`/v0/projects:clone`) ||
           PathRegexp(`^/v0/projects/[0-9a-fA-F-]+/nodes/[0-9a-fA-F-]+:stop`) ||
+          PathRegexp(`^/v0/projects/[0-9a-fA-F-]+/nodes/[0-9a-fA-F-]+:open`) ||
+          PathRegexp(`^/v0/projects/[0-9a-fA-F-]+/nodes/[0-9a-fA-F-]+:close`) ||
           PathRegexp(`^/v0/storage/locations/[0-9]+/paths/.+:size`) ||
           PathRegexp(`^/v0/storage/locations/[0-9]+/-/paths:batchDelete`) ||
           PathRegexp(`^/v0/storage/locations/[0-9]+/export-data`) ||
           PathRegexp(`^/v0/tasks-legacy/.+`)
+        # NOTE: the sticky router must have a higher priority than the webserver router but below dy-proxies
+        - traefik.http.routers.${SWARM_STACK_NAME}_webserver_sticky.priority=7
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_sticky.entrypoints=http
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_sticky.service=${SWARM_STACK_NAME}_webserver_sticky
         - traefik.http.routers.${SWARM_STACK_NAME}_webserver_sticky.middlewares=${SWARM_STACK_NAME}_gzip@swarm, ${SWARM_STACK_NAME_NO_HYPHEN}_sslheader@swarm, ${SWARM_STACK_NAME}_webserver_retry

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
@@ -93,7 +93,6 @@ async def _progress_message_parser(app: web.Application, data: bytes) -> bool:
             app,
             rabbit_message.user_id,
             message=message,
-            ignore_queue=False,
         )
     return True
 
@@ -107,7 +106,6 @@ async def _log_message_parser(app: web.Application, data: bytes) -> bool:
             event_type=SOCKET_IO_LOG_EVENT,
             data=rabbit_message.model_dump(exclude={"user_id", "channel_name"}),
         ),
-        ignore_queue=False,
     )
     return True
 
@@ -124,7 +122,6 @@ async def _events_message_parser(app: web.Application, data: bytes) -> bool:
                 "node_id": f"{rabbit_message.node_id}",
             },
         ),
-        ignore_queue=False,
     )
     return True
 

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
@@ -93,7 +93,7 @@ async def _progress_message_parser(app: web.Application, data: bytes) -> bool:
             app,
             rabbit_message.user_id,
             message=message,
-            ignore_queue=True,
+            ignore_queue=False,
         )
     return True
 
@@ -107,7 +107,7 @@ async def _log_message_parser(app: web.Application, data: bytes) -> bool:
             event_type=SOCKET_IO_LOG_EVENT,
             data=rabbit_message.model_dump(exclude={"user_id", "channel_name"}),
         ),
-        ignore_queue=True,
+        ignore_queue=False,
     )
     return True
 
@@ -124,7 +124,7 @@ async def _events_message_parser(app: web.Application, data: bytes) -> bool:
                 "node_id": f"{rabbit_message.node_id}",
             },
         ),
-        ignore_queue=True,
+        ignore_queue=False,
     )
     return True
 
@@ -178,9 +178,10 @@ _EXCHANGE_TO_PARSER_CONFIG: Final[tuple[SubcribeArgumentsTuple, ...]] = (
 
 
 async def _unsubscribe_from_rabbitmq(app) -> None:
-    with log_context(
-        _logger, logging.INFO, msg="Unsubscribing from rabbitmq channels"
-    ), log_catch(_logger, reraise=False):
+    with (
+        log_context(_logger, logging.INFO, msg="Unsubscribing from rabbitmq channels"),
+        log_catch(_logger, reraise=False),
+    ):
         rabbit_client: RabbitMQClient = get_rabbitmq_client(app)
         await logged_gather(
             *(

--- a/services/web/server/src/simcore_service_webserver/payments/_socketio.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_socketio.py
@@ -29,7 +29,6 @@ async def notify_payment_completed(
             event_type=SOCKET_IO_PAYMENT_COMPLETED_EVENT,
             data=jsonable_encoder(payment, by_alias=True),
         ),
-        ignore_queue=False,
     )
 
 
@@ -46,5 +45,4 @@ async def notify_payment_method_acked(
             event_type=SOCKET_IO_PAYMENT_METHOD_ACKED_EVENT,
             data=jsonable_encoder(payment_method_transaction, by_alias=True),
         ),
-        ignore_queue=False,
     )

--- a/services/web/server/src/simcore_service_webserver/payments/_socketio.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_socketio.py
@@ -29,7 +29,7 @@ async def notify_payment_completed(
             event_type=SOCKET_IO_PAYMENT_COMPLETED_EVENT,
             data=jsonable_encoder(payment, by_alias=True),
         ),
-        ignore_queue=True,
+        ignore_queue=False,
     )
 
 
@@ -46,5 +46,5 @@ async def notify_payment_method_acked(
             event_type=SOCKET_IO_PAYMENT_METHOD_ACKED_EVENT,
             data=jsonable_encoder(payment_method_transaction, by_alias=True),
         ),
-        ignore_queue=True,
+        ignore_queue=False,
     )

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -1961,7 +1961,7 @@ async def notify_project_state_update(
             app,
             user_id=notify_only_user,
             message=message,
-            ignore_queue=True,
+            ignore_queue=False,
         )
     else:
         rooms_to_notify: Generator[GroupID, None, None] = (

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -1961,7 +1961,6 @@ async def notify_project_state_update(
             app,
             user_id=notify_only_user,
             message=message,
-            ignore_queue=False,
         )
     else:
         rooms_to_notify: Generator[GroupID, None, None] = (

--- a/services/web/server/src/simcore_service_webserver/socketio/messages.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/messages.py
@@ -62,12 +62,12 @@ async def send_message_to_user(
     user_id: UserID,
     message: SocketMessageDict,
     *,
-    ignore_queue: bool,
+    ignore_queue: bool = False,
 ) -> None:
     """
     Keyword Arguments:
-        ignore_queue -- set to False when this message is delivered from a server that has no direct connection to the client (default: {True})
-        An example where this is value is False, is sending messages to a user in the GC
+        ignore_queue -- set to True when this message is delivered from a server that has no direct connection to the user client (default: {False})
+        Be careful with this option, as it can lead to message loss if the user is not connected to this server!!
     """
     sio: AsyncServer = get_socket_server(app)
 

--- a/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
@@ -290,7 +290,6 @@ async def test_log_workflow_only_receives_messages_if_subscribed(
                 "event_type": SOCKET_IO_LOG_EVENT,
                 "data": log_message.model_dump(exclude={"user_id", "channel_name"}),
             },
-            ignore_queue=False,
         ),
     )
     mocked_send_messages.reset_mock()

--- a/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
@@ -290,7 +290,7 @@ async def test_log_workflow_only_receives_messages_if_subscribed(
                 "event_type": SOCKET_IO_LOG_EVENT,
                 "data": log_message.model_dump(exclude={"user_id", "channel_name"}),
             },
-            ignore_queue=True,
+            ignore_queue=False,
         ),
     )
     mocked_send_messages.reset_mock()


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
Since https://github.com/ITISFoundation/osparc-simcore/pull/7839 (>2 weeks ago), the flow of logs/progresses was broken, as messages sent via SocketIO were not sent through the socketIO RabbitMQ Pub/Sub system but purposely ignoring the queuing since with a sticky connection it was unnecessary.

A second identified problem is that subscription/unsubscription to the project logs/progress RabbitMQ queue needs to be sticky as otherwise the webserver replica will not properly unsubscribe from a topic.

This PR fixes this issue.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/7960

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
