### PR TITLE
♻️ web-server: Upgrade GC periodic tasks to new `servicelib.background_task`

### DIFF
--- a/packages/service-library/src/servicelib/background_task.py
+++ b/packages/service-library/src/servicelib/background_task.py
@@ -58,7 +58,7 @@ def periodic(
     """
 
     def _decorator(
-        coro: Callable[P, Coroutine[Any, Any, None]],
+        async_fun: Callable[P, Coroutine[Any, Any, None]],
     ) -> Callable[P, Coroutine[Any, Any, None]]:
         class _InternalTryAgain(TryAgain):
             # Local exception to prevent reacting to similarTryAgain exceptions raised by the wrapped func
@@ -82,10 +82,10 @@ def periodic(
             ),
             before_sleep=before_sleep_log(_logger, logging.DEBUG),
         )
-        @functools.wraps(coro)
+        @functools.wraps(async_fun)
         async def _wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
             with log_catch(_logger, reraise=True):
-                await coro(*args, **kwargs)
+                await async_fun(*args, **kwargs)
             raise _InternalTryAgain
 
         return _wrapper

--- a/packages/service-library/src/servicelib/background_task.py
+++ b/packages/service-library/src/servicelib/background_task.py
@@ -38,10 +38,7 @@ def periodic(
     *,
     interval: datetime.timedelta,
     raise_on_error: bool = False,
-    early_wake_up_event: (
-        asyncio.Event | None
-    ) = None,  # TODO: i would argue that this should be a different decorator instead of an optional arguments since with this event,
-    # the funciton is not periodic anymore but rahter repeatedly triggered by the event
+    early_wake_up_event: asyncio.Event | None = None,
 ) -> Callable[
     [Callable[P, Coroutine[Any, Any, None]]], Callable[P, Coroutine[Any, Any, None]]
 ]:

--- a/packages/service-library/src/servicelib/background_task_utils.py
+++ b/packages/service-library/src/servicelib/background_task_utils.py
@@ -54,6 +54,8 @@ def exclusive_periodic(
         async def _wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
             return await coro(*args, **kwargs)
 
+        # Marks with an identifier (mostly to assert a function has been decorated with this decorator)
+        setattr(_wrapper, "__exclusive_periodic__", True)  # noqa: B010
         return _wrapper
 
     return _decorator

--- a/packages/service-library/src/servicelib/background_task_utils.py
+++ b/packages/service-library/src/servicelib/background_task_utils.py
@@ -43,7 +43,7 @@ def exclusive_periodic(
             # Replicas will raise CouldNotAcquireLockError
             # SEE https://github.com/ITISFoundation/osparc-simcore/issues/7574
             (CouldNotAcquireLockError,),
-            reason="Multiple instances of the periodic task `{coro.__module__}.{coro.__name__}` are running.",
+            reason=f"Multiple instances of the periodic task `{coro.__module__}.{coro.__name__}` are running.",
         )
         @exclusive(
             redis_client,

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
@@ -33,12 +33,13 @@ def create_background_task_to_prune_api_keys(
 ) -> CleanupContextFunc:
 
     async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
+        interval = timedelta(seconds=wait_period_s)
 
         @exclusive_periodic(
             # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
             get_redis_lock_manager_client_sdk(app),
-            task_interval=timedelta(seconds=wait_period_s),
-            retry_after=timedelta(minutes=5),
+            task_interval=interval,
+            retry_after=interval,
         )
         async def _prune_expired_api_keys_periodically() -> None:
             with log_context(_logger, logging.INFO, "Pruning expired API keys"):

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
@@ -3,26 +3,22 @@ Scheduled task that periodically runs prune in the garbage collector service
 
 """
 
-import asyncio
 import logging
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator
 from datetime import timedelta
 
 from aiohttp import web
-from servicelib.async_utils import cancel_wait_task
 from servicelib.background_task_utils import exclusive_periodic
 from servicelib.logging_utils import log_context
 from simcore_service_webserver.redis import get_redis_lock_manager_client_sdk
 
 from ..api_keys import api_keys_service
+from ._tasks_utils import CleanupContextFunc, setup_periodic_task
 
 _logger = logging.getLogger(__name__)
 
-CleanupContextFunc = Callable[[web.Application], AsyncIterator[None]]
 
-
-async def _run_task(app: web.Application):
-    """Checks expiration dates and updates user status"""
+async def _prune_expired_api_keys(app: web.Application):
     if deleted := await api_keys_service.prune_expired_api_keys(app):
         # broadcast force logout of user_id
         for api_key in deleted:
@@ -46,24 +42,9 @@ def create_background_task_to_prune_api_keys(
         )
         async def _prune_expired_api_keys_periodically() -> None:
             with log_context(_logger, logging.INFO, "Pruning expired API keys"):
-                await _run_task(app)
+                await _prune_expired_api_keys(app)
 
-        # setup
-        task_name = _prune_expired_api_keys_periodically.__name__
-
-        task = asyncio.create_task(
-            _prune_expired_api_keys_periodically(),
-            name=task_name,
-        )
-
-        # prevents premature garbage collection of the task
-        app_task_key = f"tasks.{task_name}"
-        app[app_task_key] = task
-
-        yield
-
-        # tear-down
-        await cancel_wait_task(task)
-        app.pop(app_task_key, None)
+        async for _ in setup_periodic_task(app, _prune_expired_api_keys_periodically):
+            yield
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
@@ -13,7 +13,7 @@ from servicelib.logging_utils import log_context
 from simcore_service_webserver.redis import get_redis_lock_manager_client_sdk
 
 from ..api_keys import api_keys_service
-from ._tasks_utils import CleanupContextFunc, setup_periodic_task
+from ._tasks_utils import CleanupContextFunc, periodic_task_lifespan
 
 _logger = logging.getLogger(__name__)
 
@@ -45,7 +45,9 @@ def create_background_task_to_prune_api_keys(
             with log_context(_logger, logging.INFO, "Pruning expired API keys"):
                 await _prune_expired_api_keys(app)
 
-        async for _ in setup_periodic_task(app, _prune_expired_api_keys_periodically):
+        async for _ in periodic_task_lifespan(
+            app, _prune_expired_api_keys_periodically
+        ):
             yield
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
@@ -39,7 +39,7 @@ def create_background_task_to_prune_api_keys(
             # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
             get_redis_lock_manager_client_sdk(app),
             task_interval=interval,
-            retry_after=interval,
+            retry_after=min(timedelta(seconds=10), interval / 10),
         )
         async def _prune_expired_api_keys_periodically() -> None:
             with log_context(_logger, logging.INFO, "Pruning expired API keys"):

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
@@ -32,7 +32,7 @@ def create_background_task_for_garbage_collection() -> CleanupContextFunc:
             # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
             get_redis_lock_manager_client_sdk(app),
             task_interval=interval,
-            retry_after=interval,
+            retry_after=min(timedelta(seconds=10), interval / 10),
         )
         async def _collect_garbage_periodically() -> None:
             with log_context(_logger, logging.INFO, "Garbage collect cycle"):

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
@@ -24,12 +24,13 @@ def create_background_task_for_garbage_collection() -> CleanupContextFunc:
 
     async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
         settings: GarbageCollectorSettings = get_plugin_settings(app)
+        interval = timedelta(seconds=settings.GARBAGE_COLLECTOR_INTERVAL_S)
 
         @exclusive_periodic(
             # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
             get_redis_lock_manager_client_sdk(app),
-            task_interval=timedelta(seconds=settings.GARBAGE_COLLECTOR_INTERVAL_S),
-            retry_after=timedelta(minutes=5),
+            task_interval=interval,
+            retry_after=interval,
         )
         async def _collect_garbage_periodically() -> None:
             with log_context(_logger, logging.INFO, "Garbage collect cycle"):

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
@@ -19,6 +19,8 @@ from .settings import GarbageCollectorSettings, get_plugin_settings
 
 _logger = logging.getLogger(__name__)
 
+_GC_TASK_NAME = f"{__name__}._collect_garbage_periodically"
+
 
 def create_background_task_for_garbage_collection() -> CleanupContextFunc:
 
@@ -36,7 +38,9 @@ def create_background_task_for_garbage_collection() -> CleanupContextFunc:
             with log_context(_logger, logging.INFO, "Garbage collect cycle"):
                 await collect_garbage(app)
 
-        async for _ in setup_periodic_task(app, _collect_garbage_periodically):
+        async for _ in setup_periodic_task(
+            app, _collect_garbage_periodically, task_name=_GC_TASK_NAME
+        ):
             yield
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
@@ -1,4 +1,4 @@
-""" Setup and running of periodic background task
+"""Setup and running of periodic background task
 
 
 Specifics of the gc implementation should go into garbage_collector_core.py
@@ -6,98 +6,54 @@ Specifics of the gc implementation should go into garbage_collector_core.py
 
 import asyncio
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncIterator, Callable
+from datetime import timedelta
 
 from aiohttp import web
+from servicelib.async_utils import cancel_wait_task
+from servicelib.background_task_utils import exclusive_periodic
 from servicelib.logging_utils import log_context
+from simcore_service_webserver.redis import get_redis_lock_manager_client_sdk
 
 from ._core import collect_garbage
 from .settings import GarbageCollectorSettings, get_plugin_settings
 
 _logger = logging.getLogger(__name__)
 
-
-_GC_TASK_NAME = f"background-task.{__name__}.collect_garbage_periodically"
-_GC_TASK_CONFIG = f"{_GC_TASK_NAME}.config"
-_GC_TASK = f"{_GC_TASK_NAME}.task"
+CleanupContextFunc = Callable[[web.Application], AsyncIterator[None]]
 
 
-async def run_background_task(app: web.Application) -> AsyncGenerator:
-    # SETUP ------
-    # create a background task to collect garbage periodically
-    assert not any(  # nosec
-        t.get_name() == _GC_TASK_NAME for t in asyncio.all_tasks()
-    ), "Garbage collector task already running. ONLY ONE expected"  # nosec
+def create_background_task_for_garbage_collection() -> CleanupContextFunc:
 
-    gc_bg_task = asyncio.create_task(
-        _collect_garbage_periodically(app), name=_GC_TASK_NAME
-    )
-    # attaches variable to the app's lifetime
-    app[_GC_TASK] = gc_bg_task
+    async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
+        settings: GarbageCollectorSettings = get_plugin_settings(app)
 
-    # FIXME: added this config to overcome the state in which the
-    # task cancelation is ignored and the exceptions enter in a loop
-    # that never stops the background task. This flag is an additional
-    # mechanism to enforce stopping the background task
-    #
-    # Implemented with a mutable dict to avoid
-    #   DeprecationWarning: Changing state of started or joined application is deprecated
-    #
-    app[_GC_TASK_CONFIG] = {"force_stop": False, "name": _GC_TASK_NAME}
+        @exclusive_periodic(
+            # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
+            get_redis_lock_manager_client_sdk(app),
+            task_interval=timedelta(seconds=settings.GARBAGE_COLLECTOR_INTERVAL_S),
+            retry_after=timedelta(minutes=5),
+        )
+        async def _collect_garbage_periodically() -> None:
+            with log_context(_logger, logging.INFO, "Garbage collect cycle"):
+                await collect_garbage(app)
 
-    yield
+        # setup
+        task_name = _collect_garbage_periodically.__name__
 
-    # TEAR-DOWN -----
-    # controlled cancelation of the gc task
-    try:
-        _logger.info("Stopping garbage collector...")
+        task = asyncio.create_task(
+            _collect_garbage_periodically(),
+            name=task_name,
+        )
 
-        ack = gc_bg_task.cancel()
-        assert ack  # nosec
+        # prevents premature garbage collection of the task
+        app_task_key = f"tasks.{task_name}"
+        app[app_task_key] = task
 
-        app[_GC_TASK_CONFIG]["force_stop"] = True
+        yield
 
-        await gc_bg_task
+        # tear-down
+        await cancel_wait_task(task)
+        app.pop(app_task_key, None)
 
-    except asyncio.CancelledError:
-        assert gc_bg_task.cancelled()  # nosec
-
-
-async def _collect_garbage_periodically(app: web.Application):
-    settings: GarbageCollectorSettings = get_plugin_settings(app)
-    interval = settings.GARBAGE_COLLECTOR_INTERVAL_S
-
-    while True:
-        try:
-            while True:
-                with log_context(_logger, logging.INFO, "Garbage collect cycle"):
-                    await collect_garbage(app)
-
-                    if app[_GC_TASK_CONFIG].get("force_stop", False):
-                        msg = "Forced to stop garbage collection"
-                        raise RuntimeError(msg)
-
-                _logger.info("Garbage collect cycle pauses %ss", interval)
-                await asyncio.sleep(interval)
-
-        except asyncio.CancelledError:  # EXIT  # noqa: PERF203
-            _logger.info(
-                "Stopped: Garbage collection task was cancelled, it will not restart!"
-            )
-            # do not catch Cancellation errors
-            raise
-
-        except Exception:  # RESILIENT restart # pylint: disable=broad-except
-            _logger.warning(
-                "Stopped: There was an error during garbage collection, restarting...",
-                exc_info=True,
-            )
-
-            if app[_GC_TASK_CONFIG].get("force_stop", False):
-                _logger.warning("Forced to stop garbage collection")
-                break
-
-            # will wait 5 seconds to recover before restarting to avoid restart loops
-            # - it might be that db/redis is down, etc
-            #
-            await asyncio.sleep(5)
+    return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
@@ -14,7 +14,7 @@ from servicelib.logging_utils import log_context
 from simcore_service_webserver.redis import get_redis_lock_manager_client_sdk
 
 from ._core import collect_garbage
-from ._tasks_utils import CleanupContextFunc, setup_periodic_task
+from ._tasks_utils import CleanupContextFunc, periodic_task_lifespan
 from .settings import GarbageCollectorSettings, get_plugin_settings
 
 _logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ def create_background_task_for_garbage_collection() -> CleanupContextFunc:
             with log_context(_logger, logging.INFO, "Garbage collect cycle"):
                 await collect_garbage(app)
 
-        async for _ in setup_periodic_task(
+        async for _ in periodic_task_lifespan(
             app, _collect_garbage_periodically, task_name=_GC_TASK_NAME
         ):
             yield

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_trash.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_trash.py
@@ -21,12 +21,13 @@ _logger = logging.getLogger(__name__)
 def create_background_task_to_prune_trash(wait_s: float) -> CleanupContextFunc:
 
     async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
+        interval = timedelta(seconds=wait_s)
 
         @exclusive_periodic(
             # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
             get_redis_lock_manager_client_sdk(app),
-            task_interval=timedelta(seconds=wait_s),
-            retry_after=timedelta(minutes=5),
+            task_interval=interval,
+            retry_after=interval,
         )
         async def _prune_trash_periodically() -> None:
             with log_context(_logger, logging.INFO, "Deleting expired trashed items"):

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_trash.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_trash.py
@@ -27,7 +27,7 @@ def create_background_task_to_prune_trash(wait_s: float) -> CleanupContextFunc:
             # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
             get_redis_lock_manager_client_sdk(app),
             task_interval=interval,
-            retry_after=interval,
+            retry_after=min(timedelta(seconds=10), interval / 10),
         )
         async def _prune_trash_periodically() -> None:
             with log_context(_logger, logging.INFO, "Deleting expired trashed items"):

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_trash.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_trash.py
@@ -13,7 +13,7 @@ from servicelib.logging_utils import log_context
 from simcore_service_webserver.redis import get_redis_lock_manager_client_sdk
 
 from ..trash import trash_service
-from ._tasks_utils import CleanupContextFunc, setup_periodic_task
+from ._tasks_utils import CleanupContextFunc, periodic_task_lifespan
 
 _logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ def create_background_task_to_prune_trash(wait_s: float) -> CleanupContextFunc:
             with log_context(_logger, logging.INFO, "Deleting expired trashed items"):
                 await trash_service.safe_delete_expired_trash_as_admin(app)
 
-        async for _ in setup_periodic_task(app, _prune_trash_periodically):
+        async for _ in periodic_task_lifespan(app, _prune_trash_periodically):
             yield
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_trash.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_trash.py
@@ -1,17 +1,18 @@
 """
-    Scheduled tasks addressing users
+Scheduled tasks addressing users
 
 """
 
 import asyncio
 import logging
 from collections.abc import AsyncIterator, Callable
+from datetime import timedelta
 
 from aiohttp import web
+from servicelib.async_utils import cancel_wait_task
+from servicelib.background_task_utils import exclusive_periodic
 from servicelib.logging_utils import log_context
-from tenacity import retry
-from tenacity.before_sleep import before_sleep_log
-from tenacity.wait import wait_exponential
+from simcore_service_webserver.redis import get_redis_lock_manager_client_sdk
 
 from ..trash import trash_service
 
@@ -20,45 +21,36 @@ _logger = logging.getLogger(__name__)
 CleanupContextFunc = Callable[[web.Application], AsyncIterator[None]]
 
 
-_PERIODIC_TASK_NAME = f"{__name__}"
-_APP_TASK_KEY = f"{_PERIODIC_TASK_NAME}.task"
+def create_background_task_to_prune_trash(wait_s: float) -> CleanupContextFunc:
 
+    async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
 
-@retry(
-    wait=wait_exponential(min=5, max=20),
-    before_sleep=before_sleep_log(_logger, logging.WARNING),
-)
-async def _run_task(app: web.Application):
-    with log_context(_logger, logging.INFO, "Deleting expired trashed items"):
-        await trash_service.safe_delete_expired_trash_as_admin(app)
+        @exclusive_periodic(
+            # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
+            get_redis_lock_manager_client_sdk(app),
+            task_interval=timedelta(seconds=wait_s),
+            retry_after=timedelta(minutes=5),
+        )
+        async def _prune_trash_periodically() -> None:
+            with log_context(_logger, logging.INFO, "Deleting expired trashed items"):
+                await trash_service.safe_delete_expired_trash_as_admin(app)
 
-
-async def _run_periodically(app: web.Application, wait_interval_s: float):
-    while True:
-        await _run_task(app)
-        await asyncio.sleep(wait_interval_s)
-
-
-def create_background_task_to_prune_trash(
-    wait_s: float, task_name: str = _PERIODIC_TASK_NAME
-) -> CleanupContextFunc:
-    async def _cleanup_ctx_fun(
-        app: web.Application,
-    ) -> AsyncIterator[None]:
         # setup
+        task_name = _prune_trash_periodically.__name__
+
         task = asyncio.create_task(
-            _run_periodically(app, wait_s),
+            _prune_trash_periodically(),
             name=task_name,
         )
-        app[_APP_TASK_KEY] = task
+
+        # prevents premature garbage collection of the task
+        app_task_key = f"tasks.{task_name}"
+        app[app_task_key] = task
 
         yield
 
         # tear-down
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            assert task.cancelled()  # nosec
+        await cancel_wait_task(task)
+        app.pop(app_task_key, None)
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
@@ -4,7 +4,7 @@ Scheduled tasks addressing users
 """
 
 import logging
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator
 from datetime import timedelta
 
 from aiohttp import web
@@ -19,8 +19,6 @@ from ..users.api import update_expired_users
 from ._tasks_utils import CleanupContextFunc, setup_periodic_task
 
 _logger = logging.getLogger(__name__)
-
-CleanupContextFunc = Callable[[web.Application], AsyncIterator[None]]
 
 
 async def notify_user_logout_all_sessions(

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
@@ -76,7 +76,7 @@ def create_background_task_for_trial_accounts(wait_s: float) -> CleanupContextFu
             # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
             get_redis_lock_manager_client_sdk(app),
             task_interval=interval,
-            retry_after=interval,
+            retry_after=min(timedelta(seconds=10), interval / 10),
         )
         async def _update_expired_users_periodically() -> None:
             with log_context(_logger, logging.INFO, "Updating expired users"):

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
@@ -16,7 +16,7 @@ from simcore_service_webserver.redis import get_redis_lock_manager_client_sdk
 from ..login import login_service
 from ..security import security_service
 from ..users.api import update_expired_users
-from ._tasks_utils import CleanupContextFunc, setup_periodic_task
+from ._tasks_utils import CleanupContextFunc, periodic_task_lifespan
 
 _logger = logging.getLogger(__name__)
 
@@ -82,7 +82,7 @@ def create_background_task_for_trial_accounts(wait_s: float) -> CleanupContextFu
             with log_context(_logger, logging.INFO, "Updating expired users"):
                 await _update_expired_users(app)
 
-        async for _ in setup_periodic_task(app, _update_expired_users_periodically):
+        async for _ in periodic_task_lifespan(app, _update_expired_users_periodically):
             yield
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
@@ -6,13 +6,14 @@ Scheduled tasks addressing users
 import asyncio
 import logging
 from collections.abc import AsyncIterator, Callable
+from datetime import timedelta
 
 from aiohttp import web
 from models_library.users import UserID
+from servicelib.async_utils import cancel_wait_task
+from servicelib.background_task_utils import exclusive_periodic
 from servicelib.logging_utils import get_log_record_extra, log_context
-from tenacity import retry
-from tenacity.before_sleep import before_sleep_log
-from tenacity.wait import wait_exponential
+from simcore_service_webserver.redis import get_redis_lock_manager_client_sdk
 
 from ..login import login_service
 from ..security import security_service
@@ -21,10 +22,6 @@ from ..users.api import update_expired_users
 _logger = logging.getLogger(__name__)
 
 CleanupContextFunc = Callable[[web.Application], AsyncIterator[None]]
-
-
-_PERIODIC_TASK_NAME = f"{__name__}.update_expired_users_periodically"
-_APP_TASK_KEY = f"{_PERIODIC_TASK_NAME}.task"
 
 
 async def notify_user_logout_all_sessions(
@@ -49,15 +46,7 @@ async def notify_user_logout_all_sessions(
             )
 
 
-@retry(
-    wait=wait_exponential(min=5, max=20),
-    before_sleep=before_sleep_log(_logger, logging.WARNING),
-    # NOTE: this function does suppresses all exceptions and retry indefinitly
-)
 async def _update_expired_users(app: web.Application):
-    """
-    It is resilient, i.e. if update goes wrong, it waits a bit and retries
-    """
 
     if updated := await update_expired_users(app):
         # expired users might be cached in the auth. If so, any request
@@ -81,36 +70,36 @@ async def _update_expired_users(app: web.Application):
         _logger.info("No users expired")
 
 
-async def _update_expired_users_periodically(
-    app: web.Application, wait_interval_s: float
-):
-    """Periodically checks expiration dates and updates user status"""
+def create_background_task_for_trial_accounts(wait_s: float) -> CleanupContextFunc:
 
-    while True:
-        await _update_expired_users(app)
-        await asyncio.sleep(wait_interval_s)
+    async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
 
+        @exclusive_periodic(
+            # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
+            get_redis_lock_manager_client_sdk(app),
+            task_interval=timedelta(seconds=wait_s),
+            retry_after=timedelta(minutes=5),
+        )
+        async def _update_expired_users_periodically() -> None:
+            with log_context(_logger, logging.INFO, "Updating expired users"):
+                await _update_expired_users(app)
 
-def create_background_task_for_trial_accounts(
-    wait_s: float, task_name: str = _PERIODIC_TASK_NAME
-) -> CleanupContextFunc:
-    async def _cleanup_ctx_fun(
-        app: web.Application,
-    ) -> AsyncIterator[None]:
         # setup
+        task_name = _update_expired_users_periodically.__name__
+
         task = asyncio.create_task(
-            _update_expired_users_periodically(app, wait_s),
+            _update_expired_users_periodically(),
             name=task_name,
         )
-        app[_APP_TASK_KEY] = task
+
+        # prevents premature garbage collection of the task
+        app_task_key = f"tasks.{task_name}"
+        app[app_task_key] = task
 
         yield
 
         # tear-down
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            assert task.cancelled()  # nosec
+        await cancel_wait_task(task)
+        app.pop(app_task_key, None)
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
@@ -70,12 +70,13 @@ async def _update_expired_users(app: web.Application):
 def create_background_task_for_trial_accounts(wait_s: float) -> CleanupContextFunc:
 
     async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
+        interval = timedelta(seconds=wait_s)
 
         @exclusive_periodic(
             # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
             get_redis_lock_manager_client_sdk(app),
-            task_interval=timedelta(seconds=wait_s),
-            retry_after=timedelta(minutes=5),
+            task_interval=interval,
+            retry_after=interval,
         )
         async def _update_expired_users_periodically() -> None:
             with log_context(_logger, logging.INFO, "Updating expired users"):

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
@@ -21,7 +21,7 @@ def create_task_name(coro: Callable) -> str:
 
 async def periodic_task_lifespan(
     app: web.Application,
-    periodic_task_coro: Callable[[], Coroutine[None, None, None]],
+    periodic_async_func: Callable[[], Coroutine[None, None, None]],
     *,
     task_name: str | None = None,
 ) -> AsyncIterator[None]:
@@ -30,13 +30,15 @@ async def periodic_task_lifespan(
 
     Args:
         app: The aiohttp web application
-        periodic_task_coro: The periodic task coroutine function (already decorated with @exclusive_periodic)
+        periodic_async_func: The periodic coroutine function (already decorated with @exclusive_periodic)
     """
+    assert getattr(periodic_async_func, "__exclusive_periodic__", False)  # nosec
+
     # setup
-    task_name = task_name or create_task_name(periodic_task_coro)
+    task_name = task_name or create_task_name(periodic_async_func)
 
     task = asyncio.create_task(
-        periodic_task_coro(),
+        periodic_async_func(),
         name=task_name,
     )
 

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
@@ -1,0 +1,41 @@
+"""
+Common utilities for background task management in garbage collector
+"""
+
+import asyncio
+from collections.abc import AsyncIterator, Callable, Coroutine
+
+from aiohttp import web
+from servicelib.async_utils import cancel_wait_task
+
+CleanupContextFunc = Callable[[web.Application], AsyncIterator[None]]
+
+
+async def setup_periodic_task(
+    app: web.Application,
+    periodic_task_coro: Callable[[], Coroutine[None, None, None]],
+) -> AsyncIterator[None]:
+    """
+    Generic setup and teardown for periodic background tasks.
+
+    Args:
+        app: The aiohttp web application
+        periodic_task_coro: The periodic task coroutine function (already decorated with @exclusive_periodic)
+    """
+    # setup
+    task_name = periodic_task_coro.__name__
+
+    task = asyncio.create_task(
+        periodic_task_coro(),
+        name=task_name,
+    )
+
+    # prevents premature garbage collection of the task
+    app_task_key = f"tasks.{task_name}"
+    app[app_task_key] = task
+
+    yield
+
+    # tear-down
+    await cancel_wait_task(task)
+    app.pop(app_task_key, None)

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
@@ -23,7 +23,7 @@ async def setup_periodic_task(
         periodic_task_coro: The periodic task coroutine function (already decorated with @exclusive_periodic)
     """
     # setup
-    task_name = periodic_task_coro.__name__
+    task_name = f"{periodic_task_coro.__module__}.{periodic_task_coro.__name__}"
 
     task = asyncio.create_task(
         periodic_task_coro(),
@@ -32,6 +32,10 @@ async def setup_periodic_task(
 
     # prevents premature garbage collection of the task
     app_task_key = f"tasks.{task_name}"
+    if app_task_key in app:
+        msg = f"Task {task_name} is already registered in the app state"
+        raise ValueError(msg)
+
     app[app_task_key] = task
 
     yield

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
@@ -11,9 +11,19 @@ from servicelib.async_utils import cancel_wait_task
 CleanupContextFunc = Callable[[web.Application], AsyncIterator[None]]
 
 
+def create_task_name(coro: Callable) -> str:
+    """
+    Returns a unique name for the task based on its module and function name.
+    This is useful for logging and debugging purposes.
+    """
+    return f"{coro.__module__}.{coro.__name__}"
+
+
 async def setup_periodic_task(
     app: web.Application,
     periodic_task_coro: Callable[[], Coroutine[None, None, None]],
+    *,
+    task_name: str | None = None,
 ) -> AsyncIterator[None]:
     """
     Generic setup and teardown for periodic background tasks.
@@ -23,7 +33,7 @@ async def setup_periodic_task(
         periodic_task_coro: The periodic task coroutine function (already decorated with @exclusive_periodic)
     """
     # setup
-    task_name = f"{periodic_task_coro.__module__}.{periodic_task_coro.__name__}"
+    task_name = task_name or create_task_name(periodic_task_coro)
 
     task = asyncio.create_task(
         periodic_task_coro(),
@@ -31,7 +41,7 @@ async def setup_periodic_task(
     )
 
     # prevents premature garbage collection of the task
-    app_task_key = f"tasks.{task_name}"
+    app_task_key = f"gc-tasks/{task_name}"
     if app_task_key in app:
         msg = f"Task {task_name} is already registered in the app state"
         raise ValueError(msg)

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
@@ -40,7 +40,7 @@ async def periodic_task_lifespan(
         name=task_name,
     )
 
-    # prevents premature garbage collection of the task
+    # Keeping a reference in app's state to prevent premature garbage collection of the task
     app_task_key = f"gc-tasks/{task_name}"
     if app_task_key in app:
         msg = f"Task {task_name} is already registered in the app state"

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import AsyncIterator, Callable, Coroutine
 
 from aiohttp import web
-from servicelib.async_utils import cancel_wait_task
+from common_library.async_tools import cancel_wait_task
 
 CleanupContextFunc = Callable[[web.Application], AsyncIterator[None]]
 
@@ -19,7 +19,7 @@ def create_task_name(coro: Callable) -> str:
     return f"{coro.__module__}.{coro.__name__}"
 
 
-async def setup_periodic_task(
+async def periodic_task_lifespan(
     app: web.Application,
     periodic_task_coro: Callable[[], Coroutine[None, None, None]],
     *,

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/plugin.py
@@ -34,7 +34,7 @@ def setup_garbage_collector(app: web.Application) -> None:
 
     settings = get_plugin_settings(app)
 
-    app.cleanup_ctx.append(_tasks_core.run_background_task)
+    app.cleanup_ctx.append(_tasks_core.create_background_task_for_garbage_collection())
 
     set_parent_module_log_level(
         _logger.name, min(logging.INFO, get_application_settings(app).log_level)

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/plugin.py
@@ -3,6 +3,7 @@ import logging
 from aiohttp import web
 from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
 from servicelib.logging_utils import set_parent_module_log_level
+from simcore_service_webserver.redis import setup_redis
 
 from ..application_settings import get_application_settings
 from ..login.plugin import setup_login_storage
@@ -31,6 +32,8 @@ def setup_garbage_collector(app: web.Application) -> None:
     setup_socketio(app)
     # - project needs access to user-api that is connected to login plugin
     setup_login_storage(app)
+
+    setup_redis(app)
 
     settings = get_plugin_settings(app)
 

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/plugin.py
@@ -23,11 +23,11 @@ _logger = logging.getLogger(__name__)
     logger=_logger,
 )
 def setup_garbage_collector(app: web.Application) -> None:
-    # distributed exclusive periodic tasks
-    setup_redis(app)
-
     # for trashing
     setup_products(app)
+
+    # distributed exclusive periodic tasks
+    setup_redis(app)
 
     # - project-api needs access to db
     setup_projects_db(app)

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/settings.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/settings.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from aiohttp import web
 from pydantic import Field, PositiveInt
 from servicelib.aiohttp.application_keys import APP_SETTINGS_KEY
@@ -13,20 +15,28 @@ _HOUR = 60 * _MINUTE
 
 
 class GarbageCollectorSettings(BaseCustomSettings):
-    GARBAGE_COLLECTOR_INTERVAL_S: PositiveInt = Field(
-        30 * _SEC,
-        description="Waiting time between consecutive runs of the garbage-colector",
+    GARBAGE_COLLECTOR_INTERVAL_S: Annotated[
+        PositiveInt,
+        Field(
+            description="Waiting time between consecutive runs of the garbage-colector"
+        ),
+    ] = (
+        30 * _SEC
     )
 
-    GARBAGE_COLLECTOR_EXPIRED_USERS_CHECK_INTERVAL_S: PositiveInt = Field(
-        1 * _HOUR,
-        description="Time period between checks of expiration dates for trial users",
+    GARBAGE_COLLECTOR_EXPIRED_USERS_CHECK_INTERVAL_S: Annotated[
+        PositiveInt,
+        Field(
+            description="Time period between checks of expiration dates for trial users"
+        ),
+    ] = (
+        1 * _HOUR
     )
 
-    GARBAGE_COLLECTOR_PRUNE_APIKEYS_INTERVAL_S: PositiveInt = Field(
-        _HOUR,
-        description="Wait time between periodic pruning of expired API keys",
-    )
+    GARBAGE_COLLECTOR_PRUNE_APIKEYS_INTERVAL_S: Annotated[
+        PositiveInt,
+        Field(description="Wait time between periodic pruning of expired API keys"),
+    ] = _HOUR
 
 
 def get_plugin_settings(app: web.Application) -> GarbageCollectorSettings:

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -72,9 +72,8 @@ pytest_simcore_core_services_selection = [
 ]
 pytest_simcore_ops_services_selection = [
     "minio",
-    # Only for development purposes
-    # "adminer",
-    # "redis-commander",
+    "adminer",
+    "redis-commander",
 ]
 
 

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -177,7 +177,9 @@ async def client(
     setup_socketio(app)
     setup_projects(app)
     setup_director_v2(app)
+
     assert setup_resource_manager(app)
+
     setup_garbage_collector(app)
 
     return await aiohttp_client(

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -72,8 +72,9 @@ pytest_simcore_core_services_selection = [
 ]
 pytest_simcore_ops_services_selection = [
     "minio",
-    "adminer",
-    "redis-commander",
+    # Only for development purposes
+    # "adminer",
+    # "redis-commander",
 ]
 
 

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -198,7 +198,7 @@ def disable_garbage_collector_task(mocker: MockerFixture) -> mock.MagicMock:
         await asyncio.sleep(0.1)
 
     return mocker.patch(
-        "simcore_service_webserver.garbage_collector.plugin._tasks_core.run_background_task",
+        "simcore_service_webserver.garbage_collector.plugin._tasks_core.create_background_task_for_garbage_collection",
         side_effect=_fake_background_task,
     )
 

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -27,6 +27,7 @@ from models_library.projects_state import RunningState
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.webserver_login import UserInfoDict, log_client_in
 from pytest_simcore.helpers.webserver_projects import create_project, empty_project_data
+from servicelib.aiohttp import status
 from servicelib.aiohttp.application import create_safe_application
 from settings_library.rabbit import RabbitSettings
 from settings_library.redis import RedisDatabase, RedisSettings
@@ -63,15 +64,16 @@ from tenacity import AsyncRetrying, stop_after_delay, wait_fixed
 log = logging.getLogger(__name__)
 
 pytest_simcore_core_services_selection = [
-    "migration",
+    "migration",  # NOTE: rebuild!
     "postgres",
     "rabbit",
     "redis",
-    "storage",
+    "storage",  # NOTE: rebuild!
 ]
 pytest_simcore_ops_services_selection = [
     "minio",
     "adminer",
+    "redis-commander",
 ]
 
 
@@ -96,11 +98,6 @@ async def _delete_all_redis_keys(redis_settings: RedisSettings):
     )
     await client.flushall()
     await client.aclose(close_connection_pool=True)
-
-
-@pytest.fixture(scope="session")
-def osparc_product_name() -> str:
-    return "osparc"
 
 
 @pytest.fixture
@@ -130,7 +127,7 @@ async def director_v2_service_mock(
     with aioresponses(passthrough=PASSTHROUGH_REQUESTS_PREFIXES) as mock:
         mock.get(
             get_computation_pattern,
-            status=202,
+            status=status.HTTP_202_ACCEPTED,
             payload={"state": str(RunningState.NOT_STARTED.value)},
             repeat=True,
         )
@@ -192,16 +189,19 @@ async def client(
 def disable_garbage_collector_task(mocker: MockerFixture) -> mock.MagicMock:
     """patch the setup of the garbage collector so we can call it manually"""
 
-    async def _fake_background_task(app: web.Application):
-        # startup
-        await asyncio.sleep(0.1)
-        yield
-        # teardown
-        await asyncio.sleep(0.1)
+    def _fake_factory():
+        async def _cleanup_ctx_fun(app: web.Application):
+            # startup
+            await asyncio.sleep(0.1)
+            yield
+            # teardown
+            await asyncio.sleep(0.1)
+
+        return _cleanup_ctx_fun
 
     return mocker.patch(
         "simcore_service_webserver.garbage_collector.plugin._tasks_core.create_background_task_for_garbage_collection",
-        side_effect=_fake_background_task,
+        side_effect=_fake_factory,
     )
 
 

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -124,7 +124,7 @@ async def test_remove_orphaned_services_with_no_running_services_does_nothing(
 def faker_dynamic_service_get() -> Callable[[], DynamicServiceGet]:
     def _() -> DynamicServiceGet:
         return DynamicServiceGet.model_validate(
-            DynamicServiceGet.model_config["json_schema_extra"]["examples"][1]
+            DynamicServiceGet.model_json_schema()["examples"][1]
         )
 
     return _


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?


This PR unifies how the peridoic background tasks are setup in the garbage-collector domain of the web-server

### Highlights

- create a safe function template for the `cleanup_ctx` event in `tasks_utils.py`
- All background tasks within the garbage-collector are executed using exclusive periodic decorators ( `servicelib.baground_tasks.exclusive_periodic` )


### Follow ups

Possible follow-ups (to discuss with @sanderegg ) in order to resolve https://github.com/ITISFoundation/osparc-simcore/issues/7931

- split "core" task into independent background tasks?
- increase test coverage
- refactor tests
- refactor garbage-collector domain skeleton
- add a gc stand-alone boot app


## Related issue/s

- resolves #7961 
- part of https://github.com/ITISFoundation/osparc-simcore/issues/7931

## How to test

These are the (few) tests we have for the GC
- services/web/server/tests/unit/isolated/test_garbage_collector_core.py
- services/web/server/tests/integration/01/test_garbage_collection.py
- services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py

```
make build-devel
make up-devel
```
- open redis commander
![image](https://github.com/user-attachments/assets/6de01fbd-ede3-4000-939e-8e7d4462be20)
- tests
  - increase number of replicas
  - pause one and observe how the other takes over the background tasks


## Dev-ops
None
