### PR TITLE
🐛Ensure log/progress queue is restored when websocket connection is restored

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/_controller/projects_slot.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_controller/projects_slot.py
@@ -5,6 +5,7 @@ import logging
 from aiohttp import web
 from models_library.products import ProductName
 from models_library.projects import ProjectID
+from models_library.users import UserID
 from servicelib.aiohttp.observer import (
     registed_observers_report,
     register_observer,
@@ -20,8 +21,40 @@ from .._projects_service import retrieve_and_notify_project_locked_state
 _logger = logging.getLogger(__name__)
 
 
+async def _on_user_connected(
+    user_id: UserID,
+    app: web.Application,
+    product_name: ProductName,
+    client_session_id: str,
+) -> None:
+    assert product_name  # nosec
+    # check if there is a project resource
+    with managed_resource(user_id, client_session_id, app) as user_session:
+        projects: list[str] = await user_session.find(PROJECT_ID_KEY)
+    assert len(projects) <= 1, "At the moment, at most one project per session"  # nosec
+
+    if projects:
+        with log_context(
+            _logger,
+            logging.DEBUG,
+            msg=f"user connects and subscribes to following {projects=}",
+        ):
+            await logged_gather(
+                *[project_logs.subscribe(app, ProjectID(prj)) for prj in projects]
+            )
+
+        await logged_gather(
+            *[
+                retrieve_and_notify_project_locked_state(
+                    user_id, prj, app, notify_only_prj_user=True
+                )
+                for prj in projects
+            ]
+        )
+
+
 async def _on_user_disconnected(
-    user_id: int,
+    user_id: UserID,
     client_session_id: str,
     app: web.Application,
     product_name: ProductName,
@@ -56,6 +89,7 @@ async def _on_user_disconnected(
 def setup_project_observer_events(app: web.Application) -> None:
     setup_observer_registry(app)
 
+    register_observer(app, _on_user_connected, event="SIGNAL_USER_CONNECTED")
     register_observer(app, _on_user_disconnected, event="SIGNAL_USER_DISCONNECTED")
 
     _logger.info(

--- a/services/web/server/src/simcore_service_webserver/resource_usage/_observer.py
+++ b/services/web/server/src/simcore_service_webserver/resource_usage/_observer.py
@@ -4,6 +4,7 @@ import logging
 
 from aiohttp import web
 from models_library.products import ProductName
+from models_library.users import UserID
 from servicelib.aiohttp.observer import (
     registed_observers_report,
     register_observer,
@@ -18,7 +19,7 @@ _logger = logging.getLogger(__name__)
 
 
 async def _on_user_disconnected(
-    user_id: int,
+    user_id: UserID,
     client_session_id: str,
     app: web.Application,
     product_name: ProductName,
@@ -38,8 +39,12 @@ async def _on_user_disconnected(
 
 
 async def _on_user_connected(
-    user_id: int, app: web.Application, product_name: str
+    user_id: UserID,
+    app: web.Application,
+    product_name: ProductName,
+    client_session_id: str,
 ) -> None:
+    assert client_session_id  # nosec
     # Get all user wallets and subscribe
     user_wallet = await wallets_service.list_wallets_for_user(
         app, user_id=user_id, product_name=product_name


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR ensures that re-connection of a user to the websocket re-enables the flow of log/progress messages to the frontend.

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/7969

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
