### PR TITLE
🎨 Send Socket.IO events whenever conversations are created, updated or deleted

### DIFF
--- a/packages/models-library/src/models_library/conversations.py
+++ b/packages/models-library/src/models_library/conversations.py
@@ -1,16 +1,20 @@
 from datetime import datetime
 from enum import auto
-from typing import TypeAlias
+from typing import Annotated, TypeAlias
 from uuid import UUID
 
 from models_library.groups import GroupID
 from models_library.projects import ProjectID
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, StringConstraints
 
 from .products import ProductName
 from .utils.enums import StrAutoEnum
 
 ConversationID: TypeAlias = UUID
+ConversationName: TypeAlias = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=255)
+]
+
 ConversationMessageID: TypeAlias = UUID
 
 
@@ -36,7 +40,7 @@ class ConversationMessageType(StrAutoEnum):
 class ConversationGetDB(BaseModel):
     conversation_id: ConversationID
     product_name: ProductName
-    name: str
+    name: ConversationName
     project_uuid: ProjectID | None
     user_group_id: GroupID
     type: ConversationType
@@ -63,7 +67,7 @@ class ConversationMessageGetDB(BaseModel):
 
 
 class ConversationPatchDB(BaseModel):
-    name: str | None = None
+    name: ConversationName | None = None
 
 
 class ConversationMessagePatchDB(BaseModel):

--- a/services/web/server/src/simcore_service_webserver/conversations/_conversation_message_service.py
+++ b/services/web/server/src/simcore_service_webserver/conversations/_conversation_message_service.py
@@ -16,12 +16,10 @@ from models_library.rest_ordering import OrderBy, OrderDirection
 from models_library.rest_pagination import PageTotalCount
 from models_library.users import UserID
 
-from ..projects._groups_repository import list_project_groups
-from ..users._users_service import get_users_in_group
-
 # Import or define SocketMessageDict
 from ..users.api import get_user_primary_group_id
 from . import _conversation_message_repository
+from ._conversation_service import _get_recipients
 from ._socketio import (
     notify_conversation_message_created,
     notify_conversation_message_deleted,
@@ -29,16 +27,6 @@ from ._socketio import (
 )
 
 _logger = logging.getLogger(__name__)
-
-
-async def _get_recipients(app: web.Application, project_id: ProjectID) -> set[UserID]:
-    groups = await list_project_groups(app, project_id=project_id)
-    return {
-        user
-        for group in groups
-        if group.read
-        for user in await get_users_in_group(app, gid=group.gid)
-    }
 
 
 async def create_message(

--- a/services/web/server/src/simcore_service_webserver/conversations/_conversation_service.py
+++ b/services/web/server/src/simcore_service_webserver/conversations/_conversation_service.py
@@ -16,7 +16,11 @@ from models_library.rest_ordering import OrderBy, OrderDirection
 from models_library.rest_pagination import PageTotalCount
 from models_library.users import UserID
 
-from ..conversations._socketio import notify_conversation_created
+from ..conversations._socketio import (
+    notify_conversation_created,
+    notify_conversation_deleted,
+    notify_conversation_updated,
+)
 from ..projects._groups_repository import list_project_groups
 from ..users._users_service import get_users_in_group
 from ..users.api import get_user_primary_group_id
@@ -83,24 +87,48 @@ async def get_conversation(
 async def update_conversation(
     app: web.Application,
     *,
+    project_id: ProjectID,
     conversation_id: ConversationID,
     # Update attributes
     updates: ConversationPatchDB,
 ) -> ConversationGetDB:
-    return await _conversation_repository.update(
+    updated_conversation = await _conversation_repository.update(
         app,
         conversation_id=conversation_id,
         updates=updates,
     )
 
+    await notify_conversation_updated(
+        app,
+        recipients=await _get_recipients(app, project_id),
+        project_id=project_id,
+        conversation=updated_conversation,
+    )
+
+    return updated_conversation
+
 
 async def delete_conversation(
     app: web.Application,
     *,
+    product_name: ProductName,
+    project_id: ProjectID,
+    user_id: UserID,
     conversation_id: ConversationID,
 ) -> None:
     await _conversation_repository.delete(
         app,
+        conversation_id=conversation_id,
+    )
+
+    _user_group_id = await get_user_primary_group_id(app, user_id=user_id)
+
+    await notify_conversation_deleted(
+        app,
+        recipients=await _get_recipients(app, project_id),
+        product_name=product_name,
+        user_group_id=_user_group_id,
+        project_id=project_id,
         conversation_id=conversation_id,
     )
 

--- a/services/web/server/src/simcore_service_webserver/conversations/_conversation_service.py
+++ b/services/web/server/src/simcore_service_webserver/conversations/_conversation_service.py
@@ -112,8 +112,8 @@ async def delete_conversation(
     app: web.Application,
     *,
     product_name: ProductName,
-    project_id: ProjectID,
     user_id: UserID,
+    project_id: ProjectID,
     conversation_id: ConversationID,
 ) -> None:
     await _conversation_repository.delete(

--- a/services/web/server/src/simcore_service_webserver/conversations/_conversation_service.py
+++ b/services/web/server/src/simcore_service_webserver/conversations/_conversation_service.py
@@ -16,10 +16,23 @@ from models_library.rest_ordering import OrderBy, OrderDirection
 from models_library.rest_pagination import PageTotalCount
 from models_library.users import UserID
 
+from ..conversations._socketio import notify_conversation_created
+from ..projects._groups_repository import list_project_groups
+from ..users._users_service import get_users_in_group
 from ..users.api import get_user_primary_group_id
 from . import _conversation_repository
 
 _logger = logging.getLogger(__name__)
+
+
+async def _get_recipients(app: web.Application, project_id: ProjectID) -> set[UserID]:
+    groups = await list_project_groups(app, project_id=project_id)
+    return {
+        user
+        for group in groups
+        if group.read
+        for user in await get_users_in_group(app, gid=group.gid)
+    }
 
 
 async def create_conversation(
@@ -37,7 +50,7 @@ async def create_conversation(
 
     _user_group_id = await get_user_primary_group_id(app, user_id=user_id)
 
-    return await _conversation_repository.create(
+    created_conversation = await _conversation_repository.create(
         app,
         name=name,
         project_uuid=project_uuid,
@@ -45,6 +58,15 @@ async def create_conversation(
         type_=type_,
         product_name=product_name,
     )
+
+    await notify_conversation_created(
+        app,
+        recipients=await _get_recipients(app, project_uuid),
+        project_id=project_uuid,
+        conversation=created_conversation,
+    )
+
+    return created_conversation
 
 
 async def get_conversation(

--- a/services/web/server/src/simcore_service_webserver/conversations/_socketio.py
+++ b/services/web/server/src/simcore_service_webserver/conversations/_socketio.py
@@ -150,8 +150,8 @@ async def notify_conversation_deleted(
     *,
     recipients: set[UserID],
     product_name: ProductName,
-    project_id: ProjectID,
     user_group_id: GroupID,
+    project_id: ProjectID,
     conversation_id: ConversationID,
 ) -> None:
     notification_message = SocketMessageDict(

--- a/services/web/server/src/simcore_service_webserver/conversations/_socketio.py
+++ b/services/web/server/src/simcore_service_webserver/conversations/_socketio.py
@@ -8,6 +8,7 @@ from models_library.conversations import (
     ConversationMessageGetDB,
     ConversationMessageID,
     ConversationMessageType,
+    ConversationName,
     ConversationType,
 )
 from models_library.groups import GroupID
@@ -57,8 +58,12 @@ class BaseConversationEvent(BaseEvent):
 
 
 class ConversationCreatedOrUpdatedEvent(BaseConversationEvent):
+    name: ConversationName
     created: datetime.datetime
     modified: datetime.datetime
+
+
+class ConversationDeletedEvent(BaseConversationEvent): ...
 
 
 class BaseConversationMessageEvent(BaseEvent):
@@ -92,9 +97,7 @@ async def _send_message_to_recipients(
 ):
     async for _ in limited_as_completed(
         (
-            send_message_to_user(
-                app, recipient, notification_message, ignore_queue=True
-            )
+            send_message_to_user(app, recipient, notification_message)
             for recipient in recipients
         ),
         limit=_MAX_CONCURRENT_SENDS,
@@ -112,10 +115,55 @@ async def notify_conversation_created(
     notification_message = SocketMessageDict(
         event_type=SOCKET_IO_CONVERSATION_CREATED_EVENT,
         data={
-            "projectId": project_id,
-            **ConversationCreatedOrUpdatedEvent(**conversation.model_dump()).model_dump(
-                mode="json", by_alias=True
-            ),
+            **ConversationCreatedOrUpdatedEvent(
+                project_id=project_id,
+                **conversation.model_dump(),
+            ).model_dump(mode="json", by_alias=True),
+        },
+    )
+
+    await _send_message_to_recipients(app, recipients, notification_message)
+
+
+async def notify_conversation_updated(
+    app: web.Application,
+    *,
+    recipients: set[UserID],
+    project_id: ProjectID,
+    conversation: ConversationGetDB,
+) -> None:
+    notification_message = SocketMessageDict(
+        event_type=SOCKET_IO_CONVERSATION_UPDATED_EVENT,
+        data={
+            **ConversationCreatedOrUpdatedEvent(
+                project_id=project_id,
+                **conversation.model_dump(),
+            ).model_dump(mode="json", by_alias=True),
+        },
+    )
+
+    await _send_message_to_recipients(app, recipients, notification_message)
+
+
+async def notify_conversation_deleted(
+    app: web.Application,
+    *,
+    recipients: set[UserID],
+    product_name: ProductName,
+    project_id: ProjectID,
+    user_group_id: GroupID,
+    conversation_id: ConversationID,
+) -> None:
+    notification_message = SocketMessageDict(
+        event_type=SOCKET_IO_CONVERSATION_DELETED_EVENT,
+        data={
+            **ConversationDeletedEvent(
+                product_name=product_name,
+                project_id=project_id,
+                conversation_id=conversation_id,
+                user_group_id=user_group_id,
+                type=ConversationType.PROJECT_STATIC,
+            ).model_dump(mode="json", by_alias=True),
         },
     )
 

--- a/services/web/server/src/simcore_service_webserver/projects/_conversations_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_conversations_service.py
@@ -8,6 +8,7 @@ from models_library.conversations import (
     ConversationMessageID,
     ConversationMessagePatchDB,
     ConversationMessageType,
+    ConversationName,
     ConversationPatchDB,
     ConversationType,
 )
@@ -87,7 +88,7 @@ async def update_project_conversation(
     project_uuid: ProjectID,
     conversation_id: ConversationID,
     # attributes
-    name: str,
+    name: ConversationName,
 ) -> ConversationGetDB:
     await check_user_project_permission(
         app,
@@ -98,6 +99,7 @@ async def update_project_conversation(
     )
     return await conversations_service.update_conversation(
         app,
+        project_id=project_uuid,
         conversation_id=conversation_id,
         updates=ConversationPatchDB(name=name),
     )
@@ -119,7 +121,11 @@ async def delete_project_conversation(
         permission="read",
     )
     await conversations_service.delete_conversation(
-        app, conversation_id=conversation_id
+        app,
+        product_name=product_name,
+        project_id=project_uuid,
+        user_id=user_id,
+        conversation_id=conversation_id,
     )
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR introduces new Socket.IO events sent whenever **conversations** are created, updated or deleted (See this other one for **conversation messages**: #7941).

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/private-issues/issues/215

## How to test
```
cd services/web/server
pytest -vv --pdb tests/unit/with_dbs/02/test_projects_conversations_handlers.py
```
<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
## Dev-ops

Nothing to do
<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
