### PR TITLE
🎨 [Frontend] Enh: Preferred Wallet

### DIFF
--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -385,16 +385,20 @@ qx.Class.define("osparc.store.Store", {
     },
 
     __applyWallets: function(wallets) {
+      console.log("wallets", wallets);
+
       const preferenceSettings = osparc.Preferences.getInstance();
-      const preferenceWalletId = preferenceSettings.getPreferredWalletId();
+      const defaultWalletId = preferenceSettings.getPreferredWalletId();
       if (
-        (preferenceWalletId === null || osparc.desktop.credits.Utils.getWallet(preferenceWalletId) === null) &&
-        wallets.length === 1
+        (defaultWalletId === null || osparc.desktop.credits.Utils.getWallet(defaultWalletId) === null) &&
+        wallets.length
       ) {
-        // If there is only one wallet available, make it default
+        // If there is no default wallet set in preferences or the default wallet is not available anymore:
+        // select the personal wallet if it exists
+        // wallets = wallets.filter(wallet => wallet.getType() === "personal");
         preferenceSettings.requestChangePreferredWalletId(wallets[0].getWalletId());
-      } else if (preferenceWalletId) {
-        const walletFound = wallets.find(wallet => wallet.getWalletId() === preferenceWalletId);
+      } else if (defaultWalletId) {
+        const walletFound = wallets.find(wallet => wallet.getWalletId() === defaultWalletId);
         if (walletFound) {
           this.setPreferredWallet(walletFound);
         }

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -394,9 +394,15 @@ qx.Class.define("osparc.store.Store", {
         wallets.length
       ) {
         // If there is no default wallet set in preferences or the default wallet is not available anymore:
-        // select the personal wallet if it exists
-        // wallets = wallets.filter(wallet => wallet.getType() === "personal");
-        preferenceSettings.requestChangePreferredWalletId(wallets[0].getWalletId());
+        const myGroupId = osparc.auth.Data.getInstance().getGroupId();
+        const myWallet = wallets.filter(wallet => wallet.getOwner() === myGroupId);
+        if (myWallet) {
+          // select the personal wallet if it exists
+          preferenceSettings.requestChangePreferredWalletId(myWallet.getWalletId());
+        } else {
+          // otherwise select the first wallet available
+          preferenceSettings.requestChangePreferredWalletId(wallets[0].getWalletId());
+        }
       } else if (defaultWalletId) {
         const walletFound = wallets.find(wallet => wallet.getWalletId() === defaultWalletId);
         if (walletFound) {

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -385,12 +385,10 @@ qx.Class.define("osparc.store.Store", {
     },
 
     __applyWallets: function(wallets) {
-      console.log("wallets", wallets);
-
       const preferenceSettings = osparc.Preferences.getInstance();
-      const defaultWalletId = preferenceSettings.getPreferredWalletId();
+      const preferenceWalletId = preferenceSettings.getPreferredWalletId();
       if (
-        (defaultWalletId === null || osparc.desktop.credits.Utils.getWallet(defaultWalletId) === null) &&
+        (preferenceWalletId === null || osparc.desktop.credits.Utils.getWallet(preferenceWalletId) === null) &&
         wallets.length
       ) {
         // If there is no default wallet set in preferences or the default wallet is not available anymore:
@@ -403,8 +401,8 @@ qx.Class.define("osparc.store.Store", {
           // otherwise select the first wallet available
           preferenceSettings.requestChangePreferredWalletId(wallets[0].getWalletId());
         }
-      } else if (defaultWalletId) {
-        const walletFound = wallets.find(wallet => wallet.getWalletId() === defaultWalletId);
+      } else if (preferenceWalletId) {
+        const walletFound = wallets.find(wallet => wallet.getWalletId() === preferenceWalletId);
         if (walletFound) {
           this.setPreferredWallet(walletFound);
         }

--- a/services/static-webserver/client/source/class/osparc/store/Store.js
+++ b/services/static-webserver/client/source/class/osparc/store/Store.js
@@ -393,7 +393,7 @@ qx.Class.define("osparc.store.Store", {
       ) {
         // If there is no default wallet set in preferences or the default wallet is not available anymore:
         const myGroupId = osparc.auth.Data.getInstance().getGroupId();
-        const myWallet = wallets.filter(wallet => wallet.getOwner() === myGroupId);
+        const myWallet = wallets.find(wallet => wallet.getOwner() === myGroupId);
         if (myWallet) {
           // select the personal wallet if it exists
           preferenceSettings.requestChangePreferredWalletId(myWallet.getWalletId());


### PR DESCRIPTION
## What do these changes do?

Reported by @bisgaard-itis ft. @matusdrobuliak66 

This PR fixes a ~~hacky~~ situation where the wallets are created manually in the DB.

If the user gets access to two wallets without having a preferred wallet, this PR improves the logic by traying to choose the personal one.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
