### PR TITLE
♻️ Refactor `app_module_setup` into Composable Decorators to Enable Modular and Idempotent App Setups

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -2,9 +2,12 @@ import functools
 import inspect
 import logging
 from collections.abc import Callable
+from contextlib import ContextDecorator
 from copy import deepcopy
+from datetime import datetime
 from enum import Enum
-from typing import Any, Protocol
+from types import TracebackType
+from typing import Any, Final, Protocol
 
 import arrow
 from aiohttp import web
@@ -15,21 +18,19 @@ from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard
 
 from .application_keys import APP_CONFIG_KEY, APP_SETTINGS_KEY
 
-log = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
-APP_SETUP_COMPLETED_KEY = f"{__name__ }.setup"
+APP_SETUP_COMPLETED_KEY: Final[str] = f"{__name__ }.setup"
 
 
 class _SetupFunc(Protocol):
     __name__: str
 
-    def __call__(self, app: web.Application, *args: Any, **kwds: Any) -> bool:
-        ...
+    def __call__(self, app: web.Application, *args: Any, **kwds: Any) -> bool: ...
 
 
 class _ApplicationSettings(Protocol):
-    def is_enabled(self, field_name: str) -> bool:
-        ...
+    def is_enabled(self, field_name: str) -> bool: ...
 
 
 class ModuleCategory(Enum):
@@ -46,12 +47,10 @@ class SkipModuleSetupError(Exception):
         super().__init__(reason)
 
 
-class ApplicationSetupError(Exception):
-    ...
+class ApplicationSetupError(Exception): ...
 
 
-class DependencyError(ApplicationSetupError):
-    ...
+class DependencyError(ApplicationSetupError): ...
 
 
 class SetupMetadataDict(TypedDict):
@@ -134,11 +133,113 @@ def _get_app_settings_and_field_name(
     return app_settings, settings_field_name
 
 
+class _SetupTimingContext(ContextDecorator):
+    """Context manager/decorator for timing and logging module setup operations."""
+
+    def __init__(
+        self,
+        module_name: str,
+        *,
+        logger: logging.Logger,
+        category: ModuleCategory | None = None,
+        depends: list[str] | None = None,
+    ) -> None:
+        """Initialize timing context.
+
+        :param module_name: Name of the module being set up
+        :param category: Optional module category for detailed logging
+        :param depends: Optional dependencies for detailed logging
+        """
+        self.module_name = module_name
+        self.category = category
+        self.depends = depends
+        self.started: datetime | None = None
+        self.head_msg = f"Setup of {module_name}"
+        self.logger = logger
+
+    def __enter__(self) -> None:
+        self.started = arrow.utcnow().datetime
+        if self.category is not None:
+            self.logger.info(
+                "%s (%s, %s) started ... ",
+                self.head_msg,
+                f"{self.category.name=}",
+                f"{self.depends}",
+            )
+        else:
+            self.logger.info("%s started ...", self.head_msg)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self.started:
+            elapsed = (arrow.utcnow() - self.started).total_seconds()
+            _logger.info("%s completed [Elapsed: %3.1f secs]", self.head_msg, elapsed)
+
+
 # PUBLIC API ------------------------------------------------------------------
 
 
 def is_setup_completed(module_name: str, app: web.Application) -> bool:
     return module_name in app[APP_SETUP_COMPLETED_KEY]
+
+
+def ensure_single_setup(
+    module_name: str,
+    *,
+    logger: logging.Logger,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Ensures a setup function is executed only once per application and handles completion.
+
+    :param module_name: Name of the module being set up
+    """
+
+    def _log_skip(reason: str) -> bool:
+        logger.info("Skipping '%s' setup: %s", module_name, reason)
+        return False
+
+    def decorator(setup_func: _SetupFunc) -> _SetupFunc:
+
+        @functools.wraps(setup_func)
+        def _wrapper(app: web.Application, *args: Any, **kwargs: Any) -> bool:
+
+            # pre-setup init
+            if APP_SETUP_COMPLETED_KEY not in app:
+                app[APP_SETUP_COMPLETED_KEY] = []
+
+            # check
+            if is_setup_completed(module_name, app):
+                _log_skip(
+                    f"'{module_name}' was already initialized in {app}."
+                    " Setup can only be executed once per app."
+                )
+                return False
+
+            try:
+                completed = setup_func(app, *args, **kwargs)
+
+                # post-setup handling
+                if completed is None:
+                    completed = True
+
+                if completed:  # registers completed setup
+                    app[APP_SETUP_COMPLETED_KEY].append(module_name)
+                    return completed
+
+                assert not completed  # nosec
+                _log_skip("Undefined (setup function returned false)")
+                return False
+
+            except SkipModuleSetupError as err:
+                _log_skip(err.reason)
+                return False
+
+        return _wrapper
+
+    return decorator
 
 
 def app_module_setup(
@@ -147,7 +248,7 @@ def app_module_setup(
     *,
     settings_name: str | None = None,
     depends: list[str] | None = None,
-    logger: logging.Logger = log,
+    logger: logging.Logger = _logger,
     # TODO: SEE https://github.com/ITISFoundation/osparc-simcore/issues/2008
     # TODO: - settings_name becomes module_name!!
     # TODO: - plugin base should be aware of setup and settings -> model instead of function?
@@ -190,35 +291,27 @@ def app_module_setup(
         module_name, depends, config_section, config_enabled
     )
 
-    def _decorate(setup_func: _SetupFunc):
-        if "setup" not in setup_func.__name__:
-            logger.warning("Rename '%s' to contain 'setup'", setup_func.__name__)
+    # metadata info
+    def _setup_metadata() -> SetupMetadataDict:
+        return SetupMetadataDict(
+            module_name=module_name,
+            dependencies=depends,
+            config_section=section,
+            config_enabled=config_enabled,
+        )
 
-        # metadata info
-        def setup_metadata() -> SetupMetadataDict:
-            return SetupMetadataDict(
-                module_name=module_name,
-                dependencies=depends,
-                config_section=section,
-                config_enabled=config_enabled,
-            )
+    def decorator(setup_func: _SetupFunc) -> _SetupFunc:
 
-        # wrapper
+        assert setup_func.__name__.startswith(  # nosec
+            "setup_"
+        ), f"Rename '{setup_func.__name__}' start with 'setup_$(plugin-name)'"
+
         @functools.wraps(setup_func)
+        @ensure_single_setup(module_name, logger=logger)
+        @_SetupTimingContext(
+            module_name, category=category, depends=depends, logger=logger
+        )
         def _wrapper(app: web.Application, *args, **kargs) -> bool:
-            # pre-setup
-            head_msg = f"Setup of {module_name}"
-            started = arrow.utcnow()
-            logger.info(
-                "%s (%s, %s) started ... ",
-                head_msg,
-                f"{category.name=}",
-                f"{depends}",
-            )
-
-            if APP_SETUP_COMPLETED_KEY not in app:
-                app[APP_SETUP_COMPLETED_KEY] = []
-
             if category == ModuleCategory.ADDON:
                 # ONLY addons can be enabled/disabled
 
@@ -258,7 +351,6 @@ def app_module_setup(
                     return False
 
             if depends:
-                # TODO: no need to enforce. Use to deduce order instead.
                 uninitialized = [
                     dep for dep in depends if not is_setup_completed(dep, app)
                 ]
@@ -266,48 +358,20 @@ def app_module_setup(
                     msg = f"Cannot setup app module '{module_name}' because the following dependencies are still uninitialized: {uninitialized}"
                     raise DependencyError(msg)
 
-            # execution of setup
-            try:
-                if is_setup_completed(module_name, app):
-                    raise SkipModuleSetupError(  # noqa: TRY301
-                        reason=f"'{module_name}' was already initialized in {app}."
-                        " Setup can only be executed once per app."
-                    )
+            # execution of setup with module name
+            completed: bool = setup_func(app, *args, **kargs)
 
-                completed = setup_func(app, *args, **kargs)
-
-                # post-setup
-                if completed is None:
-                    completed = True
-
-                if completed:  # registers completed setup
-                    app[APP_SETUP_COMPLETED_KEY].append(module_name)
-                else:
-                    raise SkipModuleSetupError(  # noqa: TRY301
-                        reason="Undefined (setup function returned false)"
-                    )
-
-            except SkipModuleSetupError as exc:
-                logger.info("Skipping '%s' setup: %s", module_name, exc.reason)
-                completed = False
-
-            elapsed = arrow.utcnow() - started
-            logger.info(
-                "%s %s [Elapsed: %3.1f secs]",
-                head_msg,
-                "completed" if completed else "skipped",
-                elapsed.total_seconds(),
-            )
             return completed
 
-        _wrapper.metadata = setup_metadata  # type: ignore[attr-defined]
+        _wrapper.metadata = _setup_metadata  # type: ignore[attr-defined]
         _wrapper.mark_as_simcore_servicelib_setup_func = True  # type: ignore[attr-defined]
-        # NOTE: this is added by functools.wraps decorated
-        assert _wrapper.__wrapped__ == setup_func  # nosec
+        assert (
+            _wrapper.__wrapped__ == setup_func
+        ), "this is added by functools.wraps decorator"  # nosec
 
         return _wrapper
 
-    return _decorate
+    return decorator
 
 
 def is_setup_function(fun: Callable) -> bool:

--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -302,9 +302,9 @@ def app_module_setup(
 
     def decorator(setup_func: _SetupFunc) -> _SetupFunc:
 
-        assert setup_func.__name__.startswith(  # nosec
-            "setup_"
-        ), f"Rename '{setup_func.__name__}' start with 'setup_$(plugin-name)'"
+        assert (  # nosec
+            "setup_" in setup_func.__name__
+        ), f"Rename '{setup_func.__name__}' like 'setup_$(plugin-name)'"
 
         @functools.wraps(setup_func)
         @ensure_single_setup(module_name, logger=logger)

--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import logging
+import warnings
 from collections.abc import Callable
 from contextlib import ContextDecorator
 from copy import deepcopy
@@ -257,42 +258,27 @@ def app_module_setup(
     config_section: str | None = None,
     config_enabled: str | None = None,
 ) -> Callable:
-    """Decorator that marks a function as 'a setup function' for a given module in an application
+    """Decorator marking a function as a module setup for an application.
 
-        - Marks a function as 'setup' of a given module in an application
-        - Ensures setup executed ONLY ONCE per app
-        - Addon modules:
-            - toggles run using 'enabled' entry in config file
-        - logs execution
+    Ensures one-time execution and tracks setup completion. For addons, setup can be
+    toggled via config [deprecated] or settings.
 
-    See packages/service-library/tests/test_application_setup.py
-
-    :param module_name: typically __name__
-    :param depends: list of module_names that must be called first, defaults to None
-    :param config_section: explicit configuration section, defaults to None (i.e. the name of the module, or last entry of the name if dotted)
-    :param config_enabled: option in config to enable, defaults to None which is '$(module-section).enabled' (config_section and config_enabled are mutually exclusive)
-    :param settings_name: field name in the app's settings that corresponds to this module. Defaults to the name of the module with app prefix.
-    :raises DependencyError
-    :raises ApplicationSetupError
-    :return: True if setup was completed or False if setup was skipped
+    :param settings_name: Field name in app settings for this module
+    :raises DependencyError: If required dependent modules are not initialized
+    :raises ApplicationSetupError: If setup fails
+    :return: True if setup completed, False if skipped
     :rtype: bool
 
     :Example:
-        from servicelib.aiohttp.application_setup import app_module_setup
-
         @app_module_setup('mysubsystem', ModuleCategory.SYSTEM, logger=log)
-        def setup(app: web.Application):
+        def setup_mysubsystem(app: web.Application):
             ...
     """
-    # TODO: resilience to failure. if this setup fails, then considering dependencies, is it fatal or app can start?
-    # TODO: enforce signature as def setup(app: web.Application, **kwargs) -> web.Application
-
     module_name, depends, section, config_enabled = _parse_and_validate_arguments(
         module_name, depends, config_section, config_enabled
     )
 
-    # metadata info
-    def _setup_metadata() -> SetupMetadataDict:
+    def _get_metadata() -> SetupMetadataDict:
         return SetupMetadataDict(
             module_name=module_name,
             dependencies=depends,
@@ -317,7 +303,11 @@ def app_module_setup(
 
                 if settings_name is None:
                     # Fall back to config if settings_name is not explicitly defined
-                    # TODO: deprecate
+                    warnings.warn(
+                        f"Using config-based enabling/disabling for addon '{module_name}' is deprecated. Please use settings instead.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
                     cfg = app[APP_CONFIG_KEY]
                     is_enabled = _is_addon_enabled_from_config(
                         cfg, config_enabled, section
@@ -367,7 +357,7 @@ def app_module_setup(
             _wrapper.__wrapped__ == setup_func
         ), "this is added by functools.wraps decorator"  # nosec
 
-        setattr(_wrapper, "metadata", _setup_metadata)  # noqa: B010
+        setattr(_wrapper, "metadata", _get_metadata)  # noqa: B010
         setattr(_wrapper, "mark_as_simcore_servicelib_setup_func", True)  # noqa: B010
 
         return _wrapper
@@ -376,7 +366,6 @@ def app_module_setup(
 
 
 def is_setup_function(fun: Callable) -> bool:
-    # TODO: use _SetupFunc protocol to check in runtime
     return (
         inspect.isfunction(fun)
         and hasattr(fun, "mark_as_simcore_servicelib_setup_func")

--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -363,11 +363,12 @@ def app_module_setup(
 
             return completed
 
-        _wrapper.metadata = _setup_metadata  # type: ignore[attr-defined]
-        _wrapper.mark_as_simcore_servicelib_setup_func = True  # type: ignore[attr-defined]
         assert (
             _wrapper.__wrapped__ == setup_func
         ), "this is added by functools.wraps decorator"  # nosec
+
+        setattr(_wrapper, "metadata", _setup_metadata)  # noqa: B010
+        setattr(_wrapper, "mark_as_simcore_servicelib_setup_func", True)  # noqa: B010
 
         return _wrapper
 

--- a/packages/service-library/src/servicelib/aiohttp/application_setup.py
+++ b/packages/service-library/src/servicelib/aiohttp/application_setup.py
@@ -260,7 +260,7 @@ def app_module_setup(
 ) -> Callable:
     """Decorator marking a function as a module setup for an application.
 
-    Ensures one-time execution and tracks setup completion. For addons, setup can be
+    Ensures one-time execution (idempotent) and tracks setup completion. For addons, setup can be
     toggled via config [deprecated] or settings.
 
     :param settings_name: Field name in app settings for this module

--- a/packages/service-library/tests/aiohttp/test_application_setup.py
+++ b/packages/service-library/tests/aiohttp/test_application_setup.py
@@ -1,52 +1,29 @@
-# pylint:disable=unused-variable
-# pylint:disable=unused-argument
-# pylint:disable=redefined-outer-name
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
 
-from unittest.mock import Mock
+
+from collections.abc import Callable
 
 import pytest
 from aiohttp import web
+from pytest_mock import MockerFixture, MockType
 from servicelib.aiohttp.application_keys import APP_CONFIG_KEY
 from servicelib.aiohttp.application_setup import (
     DependencyError,
     ModuleCategory,
     SkipModuleSetupError,
     app_module_setup,
+    ensure_single_setup,
     is_setup_completed,
 )
 
-log = Mock()
 
-
-@app_module_setup("package.bar", ModuleCategory.ADDON, logger=log)
-def setup_bar(app: web.Application, arg1, *, raise_skip: bool = False):
-    return True
-
-
-@app_module_setup("package.foo", ModuleCategory.ADDON, logger=log)
-def setup_foo(app: web.Application, arg1, kargs=33, *, raise_skip: bool = False):
-    if raise_skip:
-        raise SkipModuleSetupError(reason="explicit skip")
-    return True
-
-
-@app_module_setup(
-    "package.zee", ModuleCategory.ADDON, config_enabled="main.zee_enabled", logger=log
-)
-def setup_zee(app: web.Application, arg1, kargs=55):
-    return True
-
-
-@app_module_setup(
-    "package.needs_foo",
-    ModuleCategory.SYSTEM,
-    depends=[
-        "package.foo",
-    ],
-    logger=log,
-)
-def setup_needs_foo(app: web.Application, arg1, kargs=55):
-    return True
+@pytest.fixture
+def mock_logger(mocker: MockerFixture) -> MockType:
+    return mocker.patch("logging.getLogger", autospec=True)
 
 
 @pytest.fixture
@@ -59,36 +36,107 @@ def app_config() -> dict:
 
 
 @pytest.fixture
-def app(app_config):
+def app(app_config) -> web.Application:
     _app = web.Application()
     _app[APP_CONFIG_KEY] = app_config
     return _app
 
 
-def test_setup_config_enabled(app_config, app):
-    assert setup_zee(app, 1)
+@pytest.fixture
+def create_setup_bar() -> Callable[[web.Application, str, bool], bool]:
+    @app_module_setup("package.bar", ModuleCategory.ADDON)
+    def _setup_bar(
+        app: web.Application, arg1: str, *, raise_skip: bool = False
+    ) -> bool:
+        return True
 
+    return _setup_bar
+
+
+@pytest.fixture
+def create_setup_foo() -> Callable[[web.Application, str, bool], bool]:
+    @app_module_setup("package.foo", ModuleCategory.ADDON)
+    def _setup_foo(
+        app: web.Application, arg1: str, *, raise_skip: bool = False, **kwargs
+    ) -> bool:
+        if raise_skip:
+            raise SkipModuleSetupError(reason="explicit skip")
+        return True
+
+    return _setup_foo
+
+
+@pytest.fixture
+def create_setup_zee() -> Callable[[web.Application, str, int], bool]:
+    @app_module_setup(
+        "package.zee", ModuleCategory.ADDON, config_enabled="main.zee_enabled"
+    )
+    def _setup_zee(app: web.Application, arg1: str, kargs: int = 55) -> bool:
+        return True
+
+    return _setup_zee
+
+
+@pytest.fixture
+def create_setup_needs_foo() -> Callable[[web.Application, str, int], bool]:
+    @app_module_setup(
+        "package.needs_foo",
+        ModuleCategory.SYSTEM,
+        depends=[
+            "package.foo",
+        ],
+    )
+    def _setup_needs_foo(app: web.Application, arg1: str, kargs: int = 55) -> bool:
+        return True
+
+    return _setup_needs_foo
+
+
+def setup_basic(app: web.Application) -> bool:
+    return True
+
+
+def setup_that_raises(app: web.Application) -> bool:
+    error_msg = "Setup failed"
+    raise ValueError(error_msg)
+
+
+def test_setup_config_enabled(
+    app_config: dict, app: web.Application, create_setup_zee: Callable
+):
+    setup_zee = create_setup_zee()
+
+    assert setup_zee(app, 1)
     assert setup_zee.metadata()["config_enabled"] == "main.zee_enabled"
     app_config["main"]["zee_enabled"] = False
     assert not setup_zee(app, 2)
 
 
-def test_setup_dependencies(app_config, app):
+def test_setup_dependencies(
+    app: web.Application,
+    create_setup_needs_foo: Callable,
+    create_setup_foo: Callable,
+) -> None:
+    setup_needs_foo = create_setup_needs_foo()
+    setup_foo = create_setup_foo()
 
     with pytest.raises(DependencyError):
-        setup_needs_foo(app, 1)
+        setup_needs_foo(app, "1")
 
-    assert setup_foo(app, 1)
-    assert setup_needs_foo(app, 2)
+    assert setup_foo(app, "1")
+    assert setup_needs_foo(app, "2")
 
     assert setup_needs_foo.metadata()["dependencies"] == [
         setup_foo.metadata()["module_name"],
     ]
 
 
-def test_marked_setup(app_config, app):
-    assert setup_foo(app, 1)
+def test_marked_setup(
+    app_config: dict, app: web.Application, create_setup_foo: Callable
+):
+    setup_foo = create_setup_foo()
 
+    assert setup_foo(app, 1)
     assert setup_foo.metadata()["module_name"] == "package.foo"
     assert is_setup_completed(setup_foo.metadata()["module_name"], app)
 
@@ -96,18 +144,48 @@ def test_marked_setup(app_config, app):
     assert not setup_foo(app, 2)
 
 
-def test_skip_setup(app_config, app):
-    try:
-        log.reset_mock()
+def test_skip_setup(
+    app: web.Application, mock_logger: MockType, create_setup_foo: Callable
+):
+    setup_foo = create_setup_foo()
+    assert not setup_foo(app, 1, raise_skip=True)
+    assert setup_foo(app, 1)
+    mock_logger.info.assert_called()
 
-        assert not setup_foo(app, 1, raise_skip=True)
 
-        # FIXME: mock logger
-        # assert log.warning.called
-        # warn_msg = log.warning.call_args()[0]
-        # assert "package.foo" in warn_msg
-        # assert "explicit skip" in warn_msg
+def test_ensure_single_setup_runs_once(app: web.Application, mock_logger: Mock) -> None:
+    decorated = ensure_single_setup("test.module", logger=mock_logger)(setup_basic)
 
-        assert setup_foo(app, 1)
-    finally:
-        log.reset_mock()
+    # First call succeeds
+    assert decorated(app)
+    assert is_setup_completed("test.module", app)
+
+    # Second call skips
+    assert not decorated(app)
+    mock_logger.info.assert_called_with(
+        "Skipping '%s' setup: %s",
+        "test.module",
+        "'test.module' was already initialized in <Application. Avoid logging objects like this>. Setup can only be executed once per app.",
+    )
+
+
+def test_ensure_single_setup_error_handling(
+    app: web.Application, mock_logger: Mock
+) -> None:
+    decorated = ensure_single_setup("test.error", logger=mock_logger)(setup_that_raises)
+
+    with pytest.raises(ValueError, match="Setup failed"):
+        decorated(app)
+    assert not is_setup_completed("test.error", app)
+
+
+def test_ensure_single_setup_multiple_modules(
+    app: web.Application, mock_logger: Mock
+) -> None:
+    decorated1 = ensure_single_setup("module1", logger=mock_logger)(setup_basic)
+    decorated2 = ensure_single_setup("module2", logger=mock_logger)(setup_basic)
+
+    assert decorated1(app)
+    assert decorated2(app)
+    assert is_setup_completed("module1", app)
+    assert is_setup_completed("module2", app)

--- a/services/web/server/src/simcore_service_webserver/login/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/login/plugin.py
@@ -4,7 +4,11 @@ import logging
 import asyncpg
 from aiohttp import web
 from pydantic import ValidationError
-from servicelib.aiohttp.application_setup import ModuleCategory, app_module_setup
+from servicelib.aiohttp.application_setup import (
+    ModuleCategory,
+    app_module_setup,
+    ensure_single_setup,
+)
 from settings_library.email import SMTPSettings
 from settings_library.postgres import PostgresSettings
 
@@ -61,11 +65,13 @@ async def _setup_login_storage_ctx(app: web.Application):
         yield  # ----------------
 
 
+@ensure_single_setup(f"{__name__}.setup_login_storage", logger=log)
 def setup_login_storage(app: web.Application):
     if _setup_login_storage_ctx not in app.cleanup_ctx:
         app.cleanup_ctx.append(_setup_login_storage_ctx)
 
 
+@ensure_single_setup(f"{__name__}._setup_login_options", logger=log)
 def _setup_login_options(app: web.Application):
     settings: SMTPSettings = get_email_plugin_settings(app)
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

The `app_module_setup` decorator is typically used in web applications (like those built with `aiohttp`) to define *setup functions* that initialize parts of the application — e.g., routes, background tasks, signals, middleware, etc. These setup functions **must be idempotent**: they should only run once, even if they are called multiple times (e.g., by different parts of the app or due to reuse of shared components).


### ✅ Purpose of `app_module_setup`

* Marks a function as a **module setup** function.
* Ensures it only runs **once per app** instance.
* Used to **register or configure** aspects of the application.
* May allow toggle/setup through config (e.g., optional plugins).


### ♻️ Why Refactor into Smaller Decorators (e.g., `ensure_single_setup`)

Refactoring `app_module_setup` into smaller decorators makes it:

* **Composable**: Combine different setup constraints or conditions.
* **Re-usable**: Use `ensure_single_setup` to guard *any* function (not just module setup) against multiple calls.
* **Split-friendly**: Break one big setup into logically separated functions while still ensuring each part only runs once.


### 🧩 Example: Split Setup with Reusable Guarantees

```python
# Split setup parts
@ensure_single_setup
def setup_routes(app):
    # register routes
    app.router.add_get("/", lambda request: web.Response(text="Hello"))
    
@ensure_single_setup
def setup_events(app):
    # register startup/shutdown signals
    async def on_startup(app): ...
    app.on_startup.append(on_startup)

# High-level setup composed from parts
@app_module_setup("A", ModuleCategory.ADDON, settings_name="WEBSERVER_A")
def setup_module_a(app):
    setup_module_b(app)
    setup_routes(app)
    setup_events(app)
  

# Then during application bootstrapping:
app = web.Application()
setup_module_a(app)
setup_module_b(app) # this is not executed because it was exectued in a
```

## Related issue/s

- Prerequisite for https://github.com/ITISFoundation/osparc-simcore/pull/7818
- Implements parts of https://github.com/ITISFoundation/osparc-simcore/issues/2008

## How to test


```
cd packages/service-lib
make "install-dev[aiohttp]"
pytest -vv tests/aiohttp/test_application_setup.py
```

## Dev-ops
None
<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
