### PR TITLE
♻️✅ Refactor webserver pytest helpers to isolate user and login setup logic

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_login.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_login.py
@@ -1,48 +1,21 @@
 import contextlib
 import re
 from collections.abc import AsyncIterator
-from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any
 
-from aiohttp import web
 from aiohttp.test_utils import TestClient
-from models_library.users import UserID
 from servicelib.aiohttp import status
-from simcore_service_webserver.db.models import UserRole, UserStatus
-from simcore_service_webserver.groups.api import auto_add_user_to_product_group
 from simcore_service_webserver.login._constants import MSG_LOGGED_IN
 from simcore_service_webserver.login._invitations_service import create_invitation_token
 from simcore_service_webserver.login._login_repository_legacy import (
-    AsyncpgStorage,
     get_plugin_storage,
 )
-from simcore_service_webserver.products.products_service import list_products
 from simcore_service_webserver.security import security_service
 from yarl import URL
 
 from .assert_checks import assert_status
-from .faker_factories import DEFAULT_FAKER, DEFAULT_TEST_PASSWORD, random_user
-
-
-# WARNING: DO NOT use UserDict is already in https://docs.python.org/3/library/collections.html#collections.UserDictclass UserRowDict(TypedDict):
-# NOTE: this is modified dict version of packages/postgres-database/src/simcore_postgres_database/models/users.py for testing purposes
-class _UserInfoDictRequired(TypedDict, total=True):
-    id: int
-    name: str
-    email: str
-    primary_gid: str
-    raw_password: str
-    status: UserStatus
-    role: UserRole
-
-
-class UserInfoDict(_UserInfoDictRequired, total=False):
-    created_at: datetime
-    password_hash: str
-    first_name: str
-    last_name: str
-    phone: str
-
+from .faker_factories import DEFAULT_FAKER
+from .webserver_users import NewUser, UserInfoDict, _create_account_in_db
 
 TEST_MARKS = re.compile(r"TEST (\w+):(.*)")
 
@@ -65,76 +38,21 @@ def parse_link(text):
     return URL(link).path
 
 
-async def _create_user(app: web.Application, data=None) -> UserInfoDict:
-    db: AsyncpgStorage = get_plugin_storage(app)
-
-    # create
-    data = data or {}
-    data.setdefault("status", UserStatus.ACTIVE.name)
-    data.setdefault("role", UserRole.USER.name)
-    data.setdefault("password", DEFAULT_TEST_PASSWORD)
-    user = await db.create_user(random_user(**data))
-
-    # get
-    user = await db.get_user({"id": user["id"]})
-    assert "first_name" in user
-    assert "last_name" in user
-
-    # adds extras
-    extras = {"raw_password": data["password"]}
-
-    return UserInfoDict(
-        **{
-            key: user[key]
-            for key in [
-                "id",
-                "name",
-                "email",
-                "primary_gid",
-                "status",
-                "role",
-                "created_at",
-                "password_hash",
-                "first_name",
-                "last_name",
-                "phone",
-            ]
-        },
-        **extras,
-    )
-
-
-async def _register_user_in_default_product(app: web.Application, user_id: UserID):
-    products = list_products(app)
-    assert products
-    product_name = products[0].name
-
-    return await auto_add_user_to_product_group(app, user_id, product_name=product_name)
-
-
-async def _create_account(
-    app: web.Application,
-    user_data: dict[str, Any] | None = None,
-) -> UserInfoDict:
-    # users, groups in db
-    user = await _create_user(app, user_data)
-    # user has default product
-    await _register_user_in_default_product(app, user_id=user["id"])
-    return user
-
-
 async def log_client_in(
     client: TestClient,
     user_data: dict[str, Any] | None = None,
     *,
-    enable_check=True,
+    exit_stack: contextlib.AsyncExitStack,
+    enable_check: bool = True,
 ) -> UserInfoDict:
     assert client.app
 
     # create account
-    user = await _create_account(client.app, user_data=user_data)
+    user = await _create_account_in_db(
+        client.app, exit_stack=exit_stack, user_data=user_data
+    )
 
-    # login
+    # login (requires)
     url = client.app.router["auth_login"].url_for()
     reponse = await client.post(
         str(url),
@@ -150,26 +68,6 @@ async def log_client_in(
     return user
 
 
-class NewUser:
-    def __init__(
-        self,
-        user_data: dict[str, Any] | None = None,
-        app: web.Application | None = None,
-    ):
-        self.user_data = user_data
-        self.user = None
-        assert app
-        self.db = get_plugin_storage(app)
-        self.app = app
-
-    async def __aenter__(self) -> UserInfoDict:
-        self.user = await _create_account(self.app, self.user_data)
-        return self.user
-
-    async def __aexit__(self, *args):
-        await self.db.delete_user(self.user)
-
-
 class LoggedUser(NewUser):
     def __init__(self, client: TestClient, user_data=None, *, check_if_succeeds=True):
         super().__init__(user_data, client.app)
@@ -179,7 +77,10 @@ class LoggedUser(NewUser):
 
     async def __aenter__(self) -> UserInfoDict:
         self.user = await log_client_in(
-            self.client, self.user_data, enable_check=self.enable_check
+            self.client,
+            self.user_data,
+            exit_stack=self.exit_stack,
+            enable_check=self.enable_check,
         )
         return self.user
 
@@ -231,11 +132,12 @@ class NewInvitation(NewUser):
         self.confirmation = None
         self.trial_days = trial_days
         self.extra_credits_in_usd = extra_credits_in_usd
+        self.db = get_plugin_storage(self.app)
 
     async def __aenter__(self) -> "NewInvitation":
         # creates host user
         assert self.client.app
-        self.user = await _create_user(self.client.app, self.user_data)
+        self.user = await super().__aenter__()
 
         self.confirmation = await create_invitation_token(
             self.db,

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_users.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_users.py
@@ -1,0 +1,142 @@
+import contextlib
+from datetime import datetime
+from typing import Any, TypedDict
+
+from aiohttp import web
+from models_library.users import UserID
+from simcore_postgres_database.models.users import users as users_table
+from simcore_service_webserver.db.models import UserRole, UserStatus
+from simcore_service_webserver.db.plugin import get_asyncpg_engine
+from simcore_service_webserver.groups import api as groups_service
+from simcore_service_webserver.products.products_service import list_products
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from .faker_factories import DEFAULT_TEST_PASSWORD, random_user
+from .postgres_tools import insert_and_get_row_lifespan
+
+
+# WARNING: DO NOT use UserDict is already in https://docs.python.org/3/library/collections.html#collections.UserDictclass UserRowDict(TypedDict):
+# NOTE: this is modified dict version of packages/postgres-database/src/simcore_postgres_database/models/users.py for testing purposes
+class _UserInfoDictRequired(TypedDict, total=True):
+    id: int
+    name: str
+    email: str
+    primary_gid: str
+    raw_password: str
+    status: UserStatus
+    role: UserRole
+
+
+class UserInfoDict(_UserInfoDictRequired, total=False):
+    created_at: datetime
+    password_hash: str
+    first_name: str
+    last_name: str
+    phone: str
+
+
+async def _create_user_in_db(
+    sqlalchemy_async_engine: AsyncEngine,
+    exit_stack: contextlib.AsyncExitStack,
+    data: dict | None = None,
+) -> UserInfoDict:
+
+    # create fake
+    data = data or {}
+    data.setdefault("status", UserStatus.ACTIVE.name)
+    data.setdefault("role", UserRole.USER.name)
+
+    raw_password = DEFAULT_TEST_PASSWORD
+
+    # inject in db
+    user = await exit_stack.enter_async_context(
+        insert_and_get_row_lifespan(  # pylint:disable=contextmanager-generator-missing-cleanup
+            sqlalchemy_async_engine,
+            table=users_table,
+            values=random_user(password=raw_password, **data),
+            pk_col=users_table.c.id,
+        )
+    )
+    assert "first_name" in user
+    assert "last_name" in user
+
+    return UserInfoDict(
+        # required
+        #  - in db
+        id=user["id"],
+        name=user["name"],
+        email=user["email"],
+        primary_gid=user["primary_gid"],
+        status=(
+            UserStatus(user["status"])
+            if not isinstance(user["status"], UserStatus)
+            else user["status"]
+        ),
+        role=(
+            UserRole(user["role"])
+            if not isinstance(user["role"], UserRole)
+            else user["role"]
+        ),
+        # optional
+        #  - in db
+        created_at=(
+            user["created_at"]
+            if isinstance(user["created_at"], datetime)
+            else datetime.fromisoformat(user["created_at"])
+        ),
+        password_hash=user["password_hash"],
+        first_name=user["first_name"],
+        last_name=user["last_name"],
+        phone=user["phone"],
+        # extras
+        raw_password=raw_password,
+    )
+
+
+async def _register_user_in_default_product(app: web.Application, user_id: UserID):
+    products = list_products(app)
+    assert products
+    product_name = products[0].name
+
+    return await groups_service.auto_add_user_to_product_group(
+        app, user_id, product_name=product_name
+    )
+
+
+async def _create_account_in_db(
+    app: web.Application,
+    exit_stack: contextlib.AsyncExitStack,
+    user_data: dict[str, Any] | None = None,
+) -> UserInfoDict:
+    # users, groups in db
+    user = await _create_user_in_db(
+        get_asyncpg_engine(app), exit_stack=exit_stack, data=user_data
+    )
+
+    # user has default product
+    await _register_user_in_default_product(app, user_id=user["id"])
+    return user
+
+
+class NewUser:
+    def __init__(
+        self,
+        user_data: dict[str, Any] | None = None,
+        app: web.Application | None = None,
+    ):
+        self.user_data = user_data
+        self.user = None
+
+        assert app
+        self.app = app
+
+        self.exit_stack = contextlib.AsyncExitStack()
+
+    async def __aenter__(self) -> UserInfoDict:
+        self.user = await _create_account_in_db(
+            self.app, self.exit_stack, self.user_data
+        )
+        return self.user
+
+    async def __aexit__(self, *args):
+        await self.exit_stack.aclose()

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_users.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_users.py
@@ -45,15 +45,16 @@ async def _create_user_in_db(
     data = data or {}
     data.setdefault("status", UserStatus.ACTIVE.name)
     data.setdefault("role", UserRole.USER.name)
+    data.setdefault("password", DEFAULT_TEST_PASSWORD)
 
-    raw_password = DEFAULT_TEST_PASSWORD
+    raw_password = data["password"]
 
     # inject in db
     user = await exit_stack.enter_async_context(
         insert_and_get_row_lifespan(  # pylint:disable=contextmanager-generator-missing-cleanup
             sqlalchemy_async_engine,
             table=users_table,
-            values=random_user(password=raw_password, **data),
+            values=random_user(**data),
             pk_col=users_table.c.id,
         )
     )

--- a/packages/pytest-simcore/src/pytest_simcore/simcore_webserver_groups_fixtures.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_webserver_groups_fixtures.py
@@ -3,9 +3,9 @@
 # pylint: disable=unused-variable
 """
 
-    Fixtures for groups
+Fixtures for groups
 
-    NOTE: These fixtures are used in integration and unit tests
+NOTE: These fixtures are used in integration and unit tests
 """
 
 
@@ -18,7 +18,7 @@ from aiohttp.test_utils import TestClient
 from models_library.api_schemas_webserver.groups import GroupGet
 from models_library.groups import GroupsByTypeTuple, StandardGroupCreate
 from models_library.users import UserID
-from pytest_simcore.helpers.webserver_login import NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from simcore_service_webserver.groups._groups_service import (
     add_user_in_group,
     create_standard_group,

--- a/services/web/server/tests/conftest.py
+++ b/services/web/server/tests/conftest.py
@@ -27,7 +27,8 @@ from models_library.projects_state import ProjectState
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
-from pytest_simcore.helpers.webserver_login import LoggedUser, NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_login import LoggedUser
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from pytest_simcore.simcore_webserver_projects_rest_api import NEW_PROJECT
 from servicelib.aiohttp import status
 from servicelib.common_headers import (

--- a/services/web/server/tests/conftest.py
+++ b/services/web/server/tests/conftest.py
@@ -4,6 +4,7 @@
 # pylint: disable=unused-variable
 
 import asyncio
+import contextlib
 import json
 import logging
 import random
@@ -86,6 +87,13 @@ pytest_plugins = [
     "pytest_simcore.simcore_webserver_groups_fixtures",
     "pytest_simcore.socketio_client",
 ]
+
+
+@pytest.fixture
+async def exit_stack() -> AsyncIterator[contextlib.AsyncExitStack]:
+    """Provides an AsyncExitStack that gets cleaned up after each test"""
+    async with contextlib.AsyncExitStack() as stack:
+        yield stack
 
 
 @pytest.fixture(scope="session")

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -3,6 +3,7 @@
 # pylint: disable=unused-variable
 
 import asyncio
+import contextlib
 import logging
 import re
 from collections.abc import AsyncIterable, Awaitable, Callable
@@ -203,14 +204,20 @@ def disable_garbage_collector_task(mocker: MockerFixture) -> mock.MagicMock:
     )
 
 
-async def login_user(client: TestClient):
+async def login_user(client: TestClient, *, exit_stack: contextlib.AsyncExitStack):
     """returns a logged in regular user"""
-    return await log_client_in(client=client, user_data={"role": UserRole.USER.name})
+    return await log_client_in(
+        client=client, user_data={"role": UserRole.USER.name}, exit_stack=exit_stack
+    )
 
 
-async def login_guest_user(client: TestClient):
+async def login_guest_user(
+    client: TestClient, *, exit_stack: contextlib.AsyncExitStack
+):
     """returns a logged in Guest user"""
-    return await log_client_in(client=client, user_data={"role": UserRole.GUEST.name})
+    return await log_client_in(
+        client=client, user_data={"role": UserRole.GUEST.name}, exit_stack=exit_stack
+    )
 
 
 async def new_project(
@@ -482,10 +489,11 @@ async def test_t1_while_guest_is_connected_no_resources_are_removed(
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """while a GUEST user is connected GC will not remove none of its projects nor the user itself"""
     assert client.app
-    logged_guest_user = await login_guest_user(client)
+    logged_guest_user = await login_guest_user(client, exit_stack=exit_stack)
     empty_guest_user_project = await new_project(
         client, logged_guest_user, osparc_product_name, tests_data_dir
     )
@@ -508,10 +516,11 @@ async def test_t2_cleanup_resources_after_browser_is_closed(
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """After a GUEST users with one opened project closes browser tab regularly (GC cleans everything)"""
     assert client.app
-    logged_guest_user = await login_guest_user(client)
+    logged_guest_user = await login_guest_user(client, exit_stack=exit_stack)
     empty_guest_user_project = await new_project(
         client, logged_guest_user, osparc_product_name, tests_data_dir
     )
@@ -557,11 +566,12 @@ async def test_t3_gc_will_not_intervene_for_regular_users_and_their_resources(
     fake_project: dict,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """after a USER disconnects the GC will remove none of its projects or templates nor the user itself"""
     number_of_projects = 5
     number_of_templates = 5
-    logged_user = await login_user(client)
+    logged_user = await login_user(client, exit_stack=exit_stack)
     user_projects = [
         await new_project(client, logged_user, osparc_product_name, tests_data_dir)
         for _ in range(number_of_projects)
@@ -604,6 +614,7 @@ async def test_t4_project_shared_with_group_transferred_to_user_in_group_on_owne
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """
     USER "u1" creates a GROUP "g1" and invites USERS "u2" and "u3";
@@ -611,9 +622,9 @@ async def test_t4_project_shared_with_group_transferred_to_user_in_group_on_owne
     USER "u1" is manually marked as "GUEST";
     EXPECTED: one of the users in the "g1" will become the new owner of the project and "u1" will be deleted
     """
-    u1 = await login_user(client)
-    u2 = await login_user(client)
-    u3 = await login_user(client)
+    u1 = await login_user(client, exit_stack=exit_stack)
+    u2 = await login_user(client, exit_stack=exit_stack)
+    u3 = await login_user(client, exit_stack=exit_stack)
 
     # creating g1 and inviting u2 and u3
     g1 = await get_group(client, u1)
@@ -648,15 +659,16 @@ async def test_t5_project_shared_with_other_users_transferred_to_one_of_them(
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """
     USER "u1" creates a project and shares it with "u2" and "u3";
     USER "u1" is manually marked as "GUEST";
     EXPECTED: one of "u2" or "u3" will become the new owner of the project and "u1" will be deleted
     """
-    u1 = await login_user(client)
-    u2 = await login_user(client)
-    u3 = await login_user(client)
+    u1 = await login_user(client, exit_stack=exit_stack)
+    u2 = await login_user(client, exit_stack=exit_stack)
+    u3 = await login_user(client, exit_stack=exit_stack)
 
     q_u2 = await fetch_user_from_db(aiopg_engine, u2)
     assert q_u2
@@ -694,6 +706,7 @@ async def test_t6_project_shared_with_group_transferred_to_last_user_in_group_on
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """
     USER "u1" creates a GROUP "g1" and invites USERS "u2" and "u3";
@@ -703,9 +716,9 @@ async def test_t6_project_shared_with_group_transferred_to_last_user_in_group_on
     the new owner either "u2" or "u3" will be manually marked as "GUEST";
     EXPECTED: the GUEST user will be deleted and the project will pass to the last member of "g1"
     """
-    u1 = await login_user(client)
-    u2 = await login_user(client)
-    u3 = await login_user(client)
+    u1 = await login_user(client, exit_stack=exit_stack)
+    u2 = await login_user(client, exit_stack=exit_stack)
+    u3 = await login_user(client, exit_stack=exit_stack)
 
     # creating g1 and inviting u2 and u3
     g1 = await get_group(client, u1)
@@ -765,6 +778,7 @@ async def test_t7_project_shared_with_group_transferred_from_one_member_to_the_l
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """
     USER "u1" creates a GROUP "g1" and invites USERS "u2" and "u3";
@@ -777,9 +791,9 @@ async def test_t7_project_shared_with_group_transferred_from_one_member_to_the_l
     EXPECTED: the last user will be removed and the project will be removed
     """
     assert client.app
-    u1 = await login_user(client)
-    u2 = await login_user(client)
-    u3 = await login_user(client)
+    u1 = await login_user(client, exit_stack=exit_stack)
+    u2 = await login_user(client, exit_stack=exit_stack)
+    u3 = await login_user(client, exit_stack=exit_stack)
 
     # creating g1 and inviting u2 and u3
     g1 = await get_group(client, u1)
@@ -853,6 +867,7 @@ async def test_t8_project_shared_with_other_users_transferred_to_one_of_them_unt
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """
     USER "u1" creates a project and shares it with "u2" and "u3";
@@ -861,9 +876,9 @@ async def test_t8_project_shared_with_other_users_transferred_to_one_of_them_unt
     same as T5 => afterwards afterwards the new owner either "u2" or "u3" will be manually marked as "GUEST";
     EXPECTED: the GUEST user will be deleted and the project will pass to the last member of "g1"
     """
-    u1 = await login_user(client)
-    u2 = await login_user(client)
-    u3 = await login_user(client)
+    u1 = await login_user(client, exit_stack=exit_stack)
+    u2 = await login_user(client, exit_stack=exit_stack)
+    u3 = await login_user(client, exit_stack=exit_stack)
 
     q_u2 = await fetch_user_from_db(aiopg_engine, u2)
     assert q_u2
@@ -927,6 +942,7 @@ async def test_t9_project_shared_with_other_users_transferred_between_them_and_t
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """
     USER "u1" creates a project and shares it with "u2" and "u3";
@@ -937,9 +953,9 @@ async def test_t9_project_shared_with_other_users_transferred_between_them_and_t
     same as T8 => afterwards the last user will be marked as "GUEST";
     EXPECTED: the last user will be removed and the project will be removed
     """
-    u1 = await login_user(client)
-    u2 = await login_user(client)
-    u3 = await login_user(client)
+    u1 = await login_user(client, exit_stack=exit_stack)
+    u2 = await login_user(client, exit_stack=exit_stack)
+    u3 = await login_user(client, exit_stack=exit_stack)
 
     q_u2 = await fetch_user_from_db(aiopg_engine, u2)
     assert q_u2
@@ -1014,6 +1030,7 @@ async def test_t10_owner_and_all_shared_users_marked_as_guests(
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """
     USER "u1" creates a project and shares it with "u2" and "u3";
@@ -1026,9 +1043,9 @@ async def test_t10_owner_and_all_shared_users_marked_as_guests(
     )
     assert not gc_task.done()
 
-    u1 = await login_user(client)
-    u2 = await login_user(client)
-    u3 = await login_user(client)
+    u1 = await login_user(client, exit_stack=exit_stack)
+    u2 = await login_user(client, exit_stack=exit_stack)
+    u3 = await login_user(client, exit_stack=exit_stack)
 
     q_u2 = await fetch_user_from_db(aiopg_engine, u2)
     q_u3 = await fetch_user_from_db(aiopg_engine, u3)
@@ -1067,6 +1084,7 @@ async def test_t11_owner_and_all_users_in_group_marked_as_guests(
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
+    exit_stack: contextlib.AsyncExitStack,
 ):
     """
     USER "u1" creates a group and invites "u2" and "u3";
@@ -1074,9 +1092,9 @@ async def test_t11_owner_and_all_users_in_group_marked_as_guests(
     USER "u1", "u2" and "u3" are manually marked as "GUEST"
     EXPECTED: the project and all the users are removed
     """
-    u1 = await login_user(client)
-    u2 = await login_user(client)
-    u3 = await login_user(client)
+    u1 = await login_user(client, exit_stack=exit_stack)
+    u2 = await login_user(client, exit_stack=exit_stack)
+    u3 = await login_user(client, exit_stack=exit_stack)
 
     # creating g1 and inviting u2 and u3
     g1 = await get_group(client, u1)

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -26,8 +26,8 @@ from aioresponses import aioresponses
 from models_library.groups import EVERYONE_GROUP_ID, StandardGroupCreate
 from models_library.projects_state import RunningState
 from pytest_mock import MockerFixture
-from pytest_simcore.helpers.webserver_login import UserInfoDict, log_client_in
 from pytest_simcore.helpers.webserver_projects import create_project, empty_project_data
+from pytest_simcore.helpers.webserver_users import UserInfoDict, log_client_in
 from servicelib.aiohttp.application import create_safe_application
 from settings_library.rabbit import RabbitSettings
 from settings_library.redis import RedisDatabase, RedisSettings

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -29,6 +29,7 @@ from pytest_mock import MockerFixture
 from pytest_simcore.helpers.webserver_login import log_client_in
 from pytest_simcore.helpers.webserver_projects import create_project, empty_project_data
 from pytest_simcore.helpers.webserver_users import UserInfoDict
+from servicelib.aiohttp import status
 from servicelib.aiohttp.application import create_safe_application
 from settings_library.rabbit import RabbitSettings
 from settings_library.redis import RedisDatabase, RedisSettings

--- a/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
@@ -30,7 +30,7 @@ from models_library.rabbitmq_messages import (
 from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
 from pytest_mock import MockerFixture
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from redis import Redis
 from servicelib.aiohttp.application import create_safe_application
 from servicelib.aiohttp.monitor_services import (

--- a/services/web/server/tests/unit/conftest.py
+++ b/services/web/server/tests/unit/conftest.py
@@ -16,8 +16,8 @@ import yaml
 from aiohttp.test_utils import TestClient
 from models_library.products import ProductName
 from pytest_mock import MockFixture, MockType
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_projects import NewProject, empty_project_data
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from simcore_service_webserver.application_settings_utils import AppConfigDict
 from simcore_service_webserver.constants import FRONTEND_APP_DEFAULT
 from simcore_service_webserver.projects.models import ProjectDict

--- a/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_crud.py
+++ b/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_crud.py
@@ -59,7 +59,7 @@ async def test_list_user_groups_and_try_modify_organizations(
 ):
     assert client.app
     assert logged_user["id"] != standard_groups_owner["id"]
-    assert logged_user["role"] == user_role.value
+    assert logged_user["role"] == user_role
 
     # List all groups (organizations, primary, everyone and products) I belong to
     url = client.app.router["list_groups"].url_for()
@@ -130,7 +130,7 @@ async def test_group_creation_workflow(
 ):
     assert client.app
     assert logged_user["id"] != 0
-    assert logged_user["role"] == user_role.value
+    assert logged_user["role"] == user_role
 
     url = client.app.router["create_group"].url_for()
     new_group_data = {

--- a/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_crud.py
+++ b/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_crud.py
@@ -12,11 +12,11 @@ from aiohttp.test_utils import TestClient
 from models_library.api_schemas_webserver.groups import GroupGet, MyGroupsGet
 from pydantic import TypeAdapter
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     standard_role_response,
 )
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver._meta import API_VTAG

--- a/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_users.py
+++ b/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_users.py
@@ -552,7 +552,7 @@ async def test_create_organization_and_add_users(
 ):
     assert client.app
     assert logged_user["id"] != 0
-    assert logged_user["role"] == user_role.value
+    assert logged_user["role"] == user_role
 
     # CREATE GROUP
     url = client.app.router["create_group"].url_for()

--- a/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_users.py
+++ b/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_users.py
@@ -14,11 +14,12 @@ from models_library.api_schemas_webserver.groups import GroupGet, GroupUserGet
 from models_library.groups import AccessRightsDict, Group, StandardGroupCreate
 from pydantic import TypeAdapter
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import LoggedUser, NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_login import LoggedUser
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     standard_role_response,
 )
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.status_codes_utils import is_2xx_success
 from simcore_postgres_database.models.users import UserRole

--- a/services/web/server/tests/unit/with_dbs/01/storage/test_storage.py
+++ b/services/web/server/tests/unit/with_dbs/01/storage/test_storage.py
@@ -54,7 +54,7 @@ from models_library.projects_nodes_io import LocationID, StorageFileID
 from pydantic import TypeAdapter
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.rabbitmq.rpc_interfaces.async_jobs import async_jobs
 from servicelib.rabbitmq.rpc_interfaces.async_jobs.async_jobs import (

--- a/services/web/server/tests/unit/with_dbs/01/storage/test_storage_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/01/storage/test_storage_handlers.py
@@ -18,7 +18,7 @@ from pydantic import AnyUrl, ByteSize, TypeAdapter
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp.rest_responses import wrap_as_envelope
 from simcore_postgres_database.models.users import UserRole
 

--- a/services/web/server/tests/unit/with_dbs/01/test_api_keys.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_api_keys.py
@@ -22,7 +22,7 @@ from pytest_mock import MockerFixture, MockType
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.api_keys import _repository, api_keys_service
 from simcore_service_webserver.api_keys.models import ApiKey

--- a/services/web/server/tests/unit/with_dbs/01/test_api_keys_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_api_keys_rpc.py
@@ -14,7 +14,7 @@ from models_library.rpc.webserver.auth.api_keys import ApiKeyCreate
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.rabbitmq import RabbitMQRPCClient
 from servicelib.rabbitmq.rpc_interfaces.webserver.auth.api_keys import (
     create_api_key,

--- a/services/web/server/tests/unit/with_dbs/01/test_catalog_handlers__pricing_plan.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_catalog_handlers__pricing_plan.py
@@ -15,7 +15,7 @@ from models_library.api_schemas_resource_usage_tracker.pricing_plans import (
 from models_library.utils.fastapi_encoders import jsonable_encoder
 from pytest_simcore.aioresponses_mocker import AioResponsesMock
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from settings_library.resource_usage_tracker import ResourceUsageTrackerSettings
 from simcore_service_webserver.db.models import UserRole

--- a/services/web/server/tests/unit/with_dbs/01/test_catalog_handlers__services.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_catalog_handlers__services.py
@@ -24,7 +24,7 @@ from pytest_simcore.helpers.catalog_rpc_server import CatalogRpcSideEffects
 from pytest_simcore.helpers.faker_factories import random_icon_url
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.catalog._controller_rest_schemas import (
     ServiceInputGet,

--- a/services/web/server/tests/unit/with_dbs/01/test_catalog_handlers__services_resources.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_catalog_handlers__services_resources.py
@@ -16,7 +16,7 @@ from models_library.services_resources import (
 from pydantic import TypeAdapter
 from pytest_simcore.aioresponses_mocker import AioResponsesMock
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from settings_library.catalog import CatalogSettings
 from simcore_service_webserver.catalog.settings import get_plugin_settings

--- a/services/web/server/tests/unit/with_dbs/01/test_catalog_rest_client.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_catalog_rest_client.py
@@ -10,7 +10,7 @@ from models_library.api_schemas_catalog.service_access_rights import (
 )
 from models_library.api_schemas_catalog.services import ServiceGet
 from pydantic import TypeAdapter
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.catalog._controller_rest_exceptions import (
     DefaultPricingUnitForServiceNotFoundError,

--- a/services/web/server/tests/unit/with_dbs/02/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/02/conftest.py
@@ -29,8 +29,8 @@ from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_projects import NewProject, delete_all_projects
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from settings_library.catalog import CatalogSettings
 from simcore_service_webserver.application_settings import get_application_settings
 from simcore_service_webserver.catalog.settings import get_plugin_settings

--- a/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
@@ -12,7 +12,7 @@ from models_library.api_schemas_webserver.projects_metadata import MetadataDict
 from models_library.products import ProductName
 from models_library.projects import ProjectID
 from models_library.users import UserID
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from simcore_service_webserver.projects._jobs_service import (
     list_my_projects_marked_as_jobs,
     set_project_as_job,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers.py
@@ -23,13 +23,13 @@ from models_library.projects_state import ProjectState
 from pydantic import TypeAdapter
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     MockedStorageSubsystem,
     standard_role_response,
     standard_user_role_response,
 )
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.rest_constants import X_PRODUCT_NAME_HEADER
 from simcore_postgres_database.models.products import products

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone.py
@@ -15,11 +15,11 @@ from faker import Faker
 from models_library.api_schemas_webserver.projects import ProjectGet
 from models_library.projects import ProjectID
 from pydantic import TypeAdapter
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import (
     MockedStorageSubsystem,
     standard_role_response,
 )
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.aiohttp.long_running_tasks.client import long_running_task_request
 from simcore_service_webserver.db.models import UserRole

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone_in_workspace_and_folder.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone_in_workspace_and_folder.py
@@ -14,8 +14,8 @@ from models_library.api_schemas_webserver.projects import ProjectGet
 from models_library.folders import FolderID
 from models_library.projects import ProjectID
 from models_library.workspaces import WorkspaceID
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import MockedStorageSubsystem
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp.long_running_tasks.client import long_running_task_request
 from simcore_postgres_database.models.folders_v2 import folders_v2
 from simcore_postgres_database.models.workspaces import workspaces

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
@@ -22,12 +22,12 @@ from models_library.projects import ProjectID
 from models_library.projects_access import Owner
 from models_library.projects_state import ProjectStatus
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     MockedStorageSubsystem,
     standard_role_response,
 )
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
 from servicelib.redis import with_project_locked

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__list_with_query_params.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__list_with_query_params.py
@@ -20,12 +20,12 @@ from models_library.projects import ProjectID, ProjectTemplateType
 from models_library.users import UserID
 from pydantic import BaseModel, PositiveInt
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     standard_role_response,
 )
 from pytest_simcore.helpers.webserver_projects import create_project
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.folders_v2 import folders_v2
 from simcore_postgres_database.models.projects_to_folders import projects_to_folders

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__patch.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__patch.py
@@ -12,7 +12,7 @@ from http import HTTPStatus
 import pytest
 from aiohttp.test_utils import TestClient
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver._meta import api_version_prefix
 from simcore_service_webserver.db.models import UserRole

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_groups_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_groups_handlers.py
@@ -13,7 +13,7 @@ from models_library.api_schemas_webserver.projects_access_rights import (
     ProjectShareAccepted,
 )
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.projects.models import ProjectDict

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_groups_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_groups_handlers.py
@@ -311,7 +311,7 @@ async def test_share_project_with_roles(
 ):
     assert client.app
 
-    assert logged_user["role"] == user_role.value
+    assert logged_user["role"] == user_role
 
     # Attempt to share the project
     url = client.app.router["share_project"].url_for(

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_metadata_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_metadata_handlers.py
@@ -21,12 +21,12 @@ from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from pydantic import TypeAdapter
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     MockedStorageSubsystem,
     standard_user_role_response,
 )
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.utils_projects_metadata import (
     get as get_db_project_metadata,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
@@ -13,7 +13,7 @@ import pytest
 from aiohttp.test_utils import TestClient
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.rabbitmq.rpc_interfaces.catalog.errors import (
     CatalogForbiddenError,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__services_access.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__services_access.py
@@ -17,7 +17,7 @@ from models_library.api_schemas_catalog.services import MyServiceGet
 from models_library.services_history import ServiceRelease
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.rabbitmq import RPCServerError
 from simcore_service_webserver.db.models import UserRole

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_ports_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_ports_handlers.py
@@ -20,8 +20,8 @@ from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.webserver_fake_ports_data import (
     PROJECTS_METADATA_PORTS_RESPONSE_BODY_DATA,
 )
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import MockedStorageSubsystem
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.aiohttp.long_running_tasks.client import long_running_task_request
 from simcore_service_webserver.db.models import UserRole

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_repository.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_repository.py
@@ -12,7 +12,7 @@ from aiohttp.test_utils import TestClient
 from common_library.users_enums import UserRole
 from models_library.basic_types import IDStr
 from models_library.rest_ordering import OrderBy, OrderDirection
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from simcore_service_webserver.projects import (
     _projects_repository as projects_service_repository,
 )

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_rpc.py
@@ -21,7 +21,7 @@ from models_library.rpc.webserver.projects import (
 from pydantic import ValidationError
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from servicelib.rabbitmq import RabbitMQRPCClient
 from servicelib.rabbitmq.rpc_interfaces.webserver import projects as projects_rpc
 from servicelib.rabbitmq.rpc_interfaces.webserver.errors import (

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
@@ -51,12 +51,13 @@ from pydantic import PositiveInt
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.typing_env import EnvVarsDict
+from pytest_simcore.helpers.webserver_login import log_client_in
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     standard_role_response,
 )
 from pytest_simcore.helpers.webserver_projects import assert_get_same_project
-from pytest_simcore.helpers.webserver_users import UserInfoDict, log_client_in
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
 from simcore_postgres_database.models.products import products

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
@@ -51,12 +51,12 @@ from pydantic import PositiveInt
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict, log_client_in
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     standard_role_response,
 )
 from pytest_simcore.helpers.webserver_projects import assert_get_same_project
+from pytest_simcore.helpers.webserver_users import UserInfoDict, log_client_in
 from servicelib.aiohttp import status
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
 from simcore_postgres_database.models.products import products

--- a/services/web/server/tests/unit/with_dbs/03/invitations/test_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/invitations/test_invitations.py
@@ -95,7 +95,7 @@ async def test_invalid_invitation_if_guest_is_already_registered_in_product(
 
     # user exists, and we skip product registration to do this test
     mocker.patch(
-        "pytest_simcore.helpers.webserver_login.auto_add_user_to_product_group",
+        "pytest_simcore.helpers.webserver_users.groups_service.auto_add_user_to_product_group",
         return_value=f"Mocked in {__file__}. SKIPPED auto_add_user_to_product_group",
         autospec=True,
     )

--- a/services/web/server/tests/unit/with_dbs/03/invitations/test_products_rest_invitations.py
+++ b/services/web/server/tests/unit/with_dbs/03/invitations/test_products_rest_invitations.py
@@ -20,7 +20,7 @@ from pydantic import PositiveInt
 from pytest_simcore.aioresponses_mocker import AioResponsesMock
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.faker_factories import DEFAULT_TEST_PASSWORD
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.users import UserRole
 

--- a/services/web/server/tests/unit/with_dbs/03/login/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/conftest.py
@@ -14,7 +14,7 @@ from faker import Faker
 from models_library.basic_types import IDStr
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
-from pytest_simcore.helpers.webserver_login import NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from simcore_postgres_database.models.users import users
 from simcore_postgres_database.models.wallets import wallets
 from simcore_service_webserver.login._login_repository_legacy import (

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_confirmation_service.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_confirmation_service.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from aiohttp.test_utils import make_mocked_request
 from aiohttp.web import Application
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from simcore_service_webserver.login import _confirmation_service, _confirmation_web
 from simcore_service_webserver.login._login_repository_legacy import AsyncpgStorage
 from simcore_service_webserver.login.settings import LoginOptions

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_controller_confirmation_rest.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_controller_confirmation_rest.py
@@ -11,7 +11,7 @@ import pytest
 from aiohttp.test_utils import TestClient
 from common_library.users_enums import UserStatus
 from models_library.products import ProductName
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.login._login_repository_legacy import (
     ActionLiteralStr,

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_preregistration.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_preregistration.py
@@ -14,7 +14,7 @@ from faker import Faker
 from models_library.api_schemas_webserver.auth import AccountRequestInfo
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver.login._constants import MSG_USER_DELETED

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_twofa_resend.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_twofa_resend.py
@@ -9,7 +9,7 @@ from aiohttp.test_utils import TestClient
 from pytest_mock import MockFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.products import ProductLoginSettingsDict, products
 from simcore_service_webserver.application_settings import ApplicationSettings

--- a/services/web/server/tests/unit/with_dbs/03/resource_usage/test_admin_pricing_plans.py
+++ b/services/web/server/tests/unit/with_dbs/03/resource_usage/test_admin_pricing_plans.py
@@ -14,7 +14,7 @@ from faker import Faker
 from models_library.resource_tracker import PricingPlanClassification
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 

--- a/services/web/server/tests/unit/with_dbs/03/resource_usage/test_list_osparc_credits_aggregated_usages.py
+++ b/services/web/server/tests/unit/with_dbs/03/resource_usage/test_list_osparc_credits_aggregated_usages.py
@@ -19,7 +19,7 @@ from models_library.api_schemas_resource_usage_tracker.service_runs import (
     OsparcCreditsAggregatedUsagesPage,
 )
 from pytest_mock.plugin import MockerFixture
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.wallets import wallets
 from simcore_service_webserver.db.models import UserRole

--- a/services/web/server/tests/unit/with_dbs/03/resource_usage/test_pricing_plans.py
+++ b/services/web/server/tests/unit/with_dbs/03/resource_usage/test_pricing_plans.py
@@ -18,7 +18,7 @@ from models_library.api_schemas_webserver import resource_usage as webserver_api
 from models_library.utils.fastapi_encoders import jsonable_encoder
 from pytest_simcore.aioresponses_mocker import AioResponsesMock
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from settings_library.resource_usage_tracker import ResourceUsageTrackerSettings
 from simcore_service_webserver.db.models import UserRole
@@ -77,7 +77,7 @@ async def test_get_pricing_plan_user_role_access(
     await assert_status(resp, expected)
 
 
-@pytest.mark.parametrize("user_role", [(UserRole.USER)])
+@pytest.mark.parametrize("user_role", [UserRole.USER])
 async def test_get_pricing_plan(
     client: TestClient,
     logged_user: UserInfoDict,
@@ -104,7 +104,7 @@ async def test_get_pricing_plan(
     assert len(data["pricingUnits"]) == 1
 
 
-@pytest.mark.parametrize("user_role", [(UserRole.USER)])
+@pytest.mark.parametrize("user_role", [UserRole.USER])
 async def test_list_pricing_plans(
     client: TestClient,
     logged_user: UserInfoDict,

--- a/services/web/server/tests/unit/with_dbs/03/resource_usage/test_usage_services__export.py
+++ b/services/web/server/tests/unit/with_dbs/03/resource_usage/test_usage_services__export.py
@@ -18,7 +18,7 @@ from models_library.resource_tracker import ServiceResourceUsagesFilters
 from models_library.rest_ordering import OrderBy
 from pydantic import AnyUrl, TypeAdapter
 from pytest_mock.plugin import MockerFixture
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.wallets import wallets
 from simcore_service_webserver.db.models import UserRole

--- a/services/web/server/tests/unit/with_dbs/03/resource_usage/test_usage_services__list.py
+++ b/services/web/server/tests/unit/with_dbs/03/resource_usage/test_usage_services__list.py
@@ -19,7 +19,7 @@ from models_library.api_schemas_resource_usage_tracker.service_runs import (
 )
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.wallets import wallets
 from simcore_service_webserver.db.models import UserRole
@@ -112,7 +112,7 @@ async def test_list_service_usage_user_role_access(
     await assert_status(resp, expected)
 
 
-@pytest.mark.parametrize("user_role", [(UserRole.USER)])
+@pytest.mark.parametrize("user_role", [UserRole.USER])
 async def test_list_service_usage(
     client: TestClient,
     logged_user: UserInfoDict,
@@ -159,7 +159,7 @@ async def test_list_service_usage(
     assert mock_list_usage_services.call_args[1]["access_all_wallet_usage"] is False
 
 
-@pytest.mark.parametrize("user_role", [(UserRole.USER)])
+@pytest.mark.parametrize("user_role", [UserRole.USER])
 async def test_list_service_usage_with_order_by_query_param(
     client: TestClient,
     logged_user: UserInfoDict,
@@ -269,7 +269,7 @@ async def test_list_service_usage_with_order_by_query_param(
     assert error["errors"][0]["field"] == "order_by.field"
 
 
-@pytest.mark.parametrize("user_role", [(UserRole.USER)])
+@pytest.mark.parametrize("user_role", [UserRole.USER])
 async def test_list_service_usage_with_filters_query_param(
     client: TestClient,
     logged_user: UserInfoDict,

--- a/services/web/server/tests/unit/with_dbs/03/tags/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/03/tags/conftest.py
@@ -10,8 +10,8 @@ import pytest
 from aioresponses import aioresponses
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_projects import NewProject, delete_all_projects
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp.application import create_safe_application
 from simcore_service_webserver.application_settings import setup_settings
 from simcore_service_webserver.db.plugin import setup_db

--- a/services/web/server/tests/unit/with_dbs/03/tags/test_tags.py
+++ b/services/web/server/tests/unit/with_dbs/03/tags/test_tags.py
@@ -24,8 +24,8 @@ from models_library.projects_state import (
 from models_library.utils.fastapi_encoders import jsonable_encoder
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.postgres_tags import create_tag, delete_tag
-from pytest_simcore.helpers.webserver_login import NewUser, UserInfoDict
 from pytest_simcore.helpers.webserver_projects import assert_get_same_project
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.tags import tags
 from simcore_service_webserver.db.models import UserRole

--- a/services/web/server/tests/unit/with_dbs/03/test_email.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_email.py
@@ -116,7 +116,7 @@ async def test_email_handlers(
     mocked_aiosmtplib: MagicMock,
     mocked_send_email: MagicMock,
 ):
-    assert logged_user["role"] == user_role.name
+    assert logged_user["role"] == user_role
     destination_email = faker.email()
 
     response = await client.post(

--- a/services/web/server/tests/unit/with_dbs/03/test_email.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_email.py
@@ -15,13 +15,14 @@ from unittest.mock import MagicMock
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, make_mocked_request
+from common_library.users_enums import UserRole
 from faker import Faker
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict, UserRole
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from settings_library.email import EmailProtocol, SMTPSettings
 from simcore_service_webserver._meta import API_VTAG

--- a/services/web/server/tests/unit/with_dbs/03/test_project_db.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_project_db.py
@@ -24,7 +24,7 @@ from models_library.projects_nodes_io import NodeID, NodeIDStr
 from psycopg2.errors import UniqueViolation
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict, log_client_in
+from pytest_simcore.helpers.webserver_users import UserInfoDict, log_client_in
 from servicelib.utils import logged_gather
 from simcore_postgres_database.models.projects import ProjectType, projects
 from simcore_postgres_database.models.projects_to_products import projects_to_products

--- a/services/web/server/tests/unit/with_dbs/03/test_project_db.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_project_db.py
@@ -5,6 +5,7 @@
 # pylint: disable=unused-variable
 
 import asyncio
+import contextlib
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from copy import deepcopy
 from random import randint
@@ -805,12 +806,13 @@ async def test_has_permission(
     client: TestClient,
     aiopg_engine: aiopg.sa.engine.Engine,
     insert_project_in_db: Callable[..., Awaitable[dict[str, Any]]],
+    exit_stack: contextlib.AsyncExitStack,
 ):
     project_id = faker.uuid4(cast_to=None)
     owner_id = logged_user["id"]
 
     second_user: UserInfoDict = await log_client_in(
-        client=client, user_data={"role": UserRole.USER.name}
+        client=client, user_data={"role": UserRole.USER.name}, exit_stack=exit_stack
     )
 
     new_project = deepcopy(fake_project)

--- a/services/web/server/tests/unit/with_dbs/03/test_project_db.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_project_db.py
@@ -24,7 +24,8 @@ from models_library.projects_nodes_io import NodeID, NodeIDStr
 from psycopg2.errors import UniqueViolation
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_users import UserInfoDict, log_client_in
+from pytest_simcore.helpers.webserver_login import log_client_in
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.utils import logged_gather
 from simcore_postgres_database.models.projects import ProjectType, projects
 from simcore_postgres_database.models.projects_to_products import projects_to_products

--- a/services/web/server/tests/unit/with_dbs/03/test_socketio.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_socketio.py
@@ -10,7 +10,7 @@ from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver.application_settings import ApplicationSettings

--- a/services/web/server/tests/unit/with_dbs/03/test_users__notifications.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_users__notifications.py
@@ -22,7 +22,7 @@ from models_library.products import ProductName
 from pydantic import TypeAdapter
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver.redis import get_redis_user_notifications_client
@@ -234,7 +234,7 @@ async def test_create_user_notification(
         assert error is not None
 
 
-@pytest.mark.parametrize("user_role", [(UserRole.USER)])
+@pytest.mark.parametrize("user_role", [UserRole.USER])
 @pytest.mark.parametrize(
     "notification_count",
     [
@@ -290,7 +290,7 @@ async def test_create_user_notification_capped_list_length(
     assert len(user_notifications) <= MAX_NOTIFICATIONS_FOR_USER_TO_KEEP
 
 
-@pytest.mark.parametrize("user_role", [(UserRole.USER)])
+@pytest.mark.parametrize("user_role", [UserRole.USER])
 async def test_create_user_notification_per_product(
     logged_user: UserInfoDict,
     notification_redis_client: aioredis.Redis,

--- a/services/web/server/tests/unit/with_dbs/03/test_users__preferences_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_users__preferences_handlers.py
@@ -15,7 +15,7 @@ from models_library.user_preferences import FrontendUserPreference, PreferenceId
 from models_library.users import UserID
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
-from pytest_simcore.helpers.webserver_login import NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.users import UserRole, UserStatus
 from simcore_service_webserver.users._preferences_models import ALL_FRONTEND_PREFERENCES

--- a/services/web/server/tests/unit/with_dbs/03/test_users__tokens.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_users__tokens.py
@@ -17,12 +17,12 @@ from aiohttp.test_utils import TestClient
 from faker import Faker
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_tokens import (
     create_token_in_db,
     delete_all_tokens_from_db,
     get_token_from_db,
 )
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver.db.plugin import get_database_engine

--- a/services/web/server/tests/unit/with_dbs/03/test_users_rest_profiles.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_users_rest_profiles.py
@@ -27,10 +27,9 @@ from pydantic import TypeAdapter
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
 from pytest_simcore.helpers.webserver_login import (
-    NewUser,
-    UserInfoDict,
     switch_client_session_to,
 )
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.rest_constants import RESPONSE_MODEL_POLICY
 from simcore_service_webserver.users._preferences_service import (
@@ -143,7 +142,7 @@ async def test_search_users_by_partial_fullname(
     public_user: UserInfoDict,
 ):
     assert client.app
-    assert user_role.value == logged_user["role"]
+    assert user_role == logged_user["role"]
 
     # logged_user has default settings
     assert private_user["id"] != logged_user["id"]
@@ -286,7 +285,7 @@ async def test_get_user_by_group_id(
     private_user: UserInfoDict,
 ):
     assert client.app
-    assert user_role.value == logged_user["role"]
+    assert user_role == logged_user["role"]
 
     assert private_user["id"] != logged_user["id"]
     assert public_user["id"] != logged_user["id"]

--- a/services/web/server/tests/unit/with_dbs/03/trash/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/03/trash/conftest.py
@@ -19,9 +19,9 @@ from pytest_mock import MockerFixture
 from pytest_simcore.helpers.logging_tools import log_context
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import NewUser, UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import MockedStorageSubsystem
 from pytest_simcore.helpers.webserver_projects import NewProject
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from simcore_service_webserver.projects.models import ProjectDict
 
 _logger = logging.getLogger(__name__)

--- a/services/web/server/tests/unit/with_dbs/03/trash/test_trash_rest.py
+++ b/services/web/server/tests/unit/with_dbs/03/trash/test_trash_rest.py
@@ -22,8 +22,8 @@ from models_library.api_schemas_webserver.workspaces import WorkspaceGet
 from models_library.rest_pagination import Page
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_projects import create_project
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.folders_v2 import folders_v2
 from simcore_postgres_database.models.projects import projects

--- a/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_function_job_collections_controller_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_function_job_collections_controller_rpc.py
@@ -21,7 +21,7 @@ from models_library.functions_errors import (
     FunctionJobIDNotFoundError,
 )
 from models_library.products import ProductName
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.rabbitmq import RabbitMQRPCClient
 from servicelib.rabbitmq.rpc_interfaces.webserver.functions import (
     functions_rpc_interface as functions_rpc,

--- a/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_function_jobs_controller_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_function_jobs_controller_rpc.py
@@ -18,7 +18,7 @@ from models_library.functions_errors import (
     FunctionJobWriteAccessDeniedError,
 )
 from models_library.products import ProductName
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.rabbitmq import RabbitMQRPCClient
 from servicelib.rabbitmq.rpc_interfaces.webserver.functions import (
     functions_rpc_interface as functions_rpc,

--- a/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_functions_controller_rest.py
+++ b/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_functions_controller_rest.py
@@ -19,7 +19,7 @@ from models_library.api_schemas_webserver.functions import (
 )
 from models_library.api_schemas_webserver.users import MyFunctionPermissionsGet
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 

--- a/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_functions_controller_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/04/functions_rpc/test_functions_controller_rpc.py
@@ -22,7 +22,7 @@ from models_library.functions_errors import (
     FunctionWriteAccessDeniedError,
 )
 from models_library.products import ProductName
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.rabbitmq import RabbitMQRPCClient
 from servicelib.rabbitmq.rpc_interfaces.webserver.functions import (
     functions_rpc_interface as functions_rpc,

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py
@@ -28,9 +28,9 @@ from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import MockedStorageSubsystem
 from pytest_simcore.helpers.webserver_projects import NewProject
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from redis.asyncio import Redis
 from servicelib.aiohttp import status
 from servicelib.aiohttp.application import create_safe_application

--- a/services/web/server/tests/unit/with_dbs/04/licenses/test_licensed_items_checkouts_rest.py
+++ b/services/web/server/tests/unit/with_dbs/04/licenses/test_licensed_items_checkouts_rest.py
@@ -16,7 +16,7 @@ from models_library.api_schemas_webserver.licensed_items_checkouts import (
 )
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 

--- a/services/web/server/tests/unit/with_dbs/04/licenses/test_licensed_items_purchases_rest.py
+++ b/services/web/server/tests/unit/with_dbs/04/licenses/test_licensed_items_purchases_rest.py
@@ -16,7 +16,7 @@ from models_library.api_schemas_webserver.licensed_items_purchases import (
 )
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 

--- a/services/web/server/tests/unit/with_dbs/04/licenses/test_licensed_items_repository.py
+++ b/services/web/server/tests/unit/with_dbs/04/licenses/test_licensed_items_repository.py
@@ -14,7 +14,7 @@ from models_library.licenses import (
     LicensedResourceType,
 )
 from models_library.rest_ordering import OrderBy
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from simcore_postgres_database.models.licensed_item_to_resource import (
     licensed_item_to_resource,
 )

--- a/services/web/server/tests/unit/with_dbs/04/licenses/test_licensed_items_rest.py
+++ b/services/web/server/tests/unit/with_dbs/04/licenses/test_licensed_items_rest.py
@@ -23,7 +23,7 @@ from models_library.api_schemas_webserver.wallets import WalletGetWithAvailableC
 from models_library.licenses import VIP_DETAILS_EXAMPLE, LicensedResourceType
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.licensed_item_to_resource import (
     licensed_item_to_resource,

--- a/services/web/server/tests/unit/with_dbs/04/licenses/test_licensed_resources_repository.py
+++ b/services/web/server/tests/unit/with_dbs/04/licenses/test_licensed_resources_repository.py
@@ -11,7 +11,7 @@ from models_library.licenses import (
     LicensedResourcePatchDB,
     LicensedResourceType,
 )
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.licenses import _licensed_resources_repository
 from simcore_service_webserver.projects.models import ProjectDict

--- a/services/web/server/tests/unit/with_dbs/04/licenses/test_licenses_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/04/licenses/test_licenses_rpc.py
@@ -16,7 +16,7 @@ from models_library.products import ProductName
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.rabbitmq import RabbitMQRPCClient
 from servicelib.rabbitmq.rpc_interfaces.webserver.licenses.licensed_items import (
     checkout_licensed_item_for_wallet,

--- a/services/web/server/tests/unit/with_dbs/04/notifications/test_notifications__db_comp_tasks_listening_task.py
+++ b/services/web/server/tests/unit/with_dbs/04/notifications/test_notifications__db_comp_tasks_listening_task.py
@@ -22,7 +22,7 @@ from faker import Faker
 from models_library.projects import ProjectAtDB
 from pytest_mock import MockType
 from pytest_mock.plugin import MockerFixture
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from simcore_postgres_database.models.comp_pipeline import StateType
 from simcore_postgres_database.models.comp_tasks import NodeClass, comp_tasks
 from simcore_postgres_database.models.users import UserRole

--- a/services/web/server/tests/unit/with_dbs/04/products/test_products_rest.py
+++ b/services/web/server/tests/unit/with_dbs/04/products/test_products_rest.py
@@ -13,7 +13,7 @@ from aiohttp.test_utils import TestClient
 from models_library.api_schemas_webserver.products import ProductGet, ProductUIGet
 from models_library.products import ProductName
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.rest_constants import X_PRODUCT_NAME_HEADER
 from servicelib.status_codes_utils import is_2xx_success

--- a/services/web/server/tests/unit/with_dbs/04/products/test_products_rest.py
+++ b/services/web/server/tests/unit/with_dbs/04/products/test_products_rest.py
@@ -135,7 +135,7 @@ async def test_get_current_product_ui(
     user_role: UserRole,
     expected_status_code: int,
 ):
-    assert logged_user["role"] == user_role.value
+    assert logged_user["role"] == user_role
     assert product_name in app_products_names
 
     # give access to user to this product

--- a/services/web/server/tests/unit/with_dbs/04/products/test_products_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/04/products/test_products_rpc.py
@@ -15,7 +15,7 @@ from pydantic import TypeAdapter
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.rabbitmq import RabbitMQRPCClient, RPCServerError
 from settings_library.rabbit import RabbitSettings
 from simcore_postgres_database.models.users import UserRole

--- a/services/web/server/tests/unit/with_dbs/04/studies_dispatcher/test_studies_dispatcher_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/04/studies_dispatcher/test_studies_dispatcher_handlers.py
@@ -15,11 +15,12 @@ import sqlalchemy as sa
 from aiohttp import ClientResponse, ClientSession
 from aiohttp.test_utils import TestClient, TestServer
 from aioresponses import aioresponses
+from common_library.users_enums import UserRole
 from models_library.projects_state import ProjectLocked, ProjectStatus
 from pydantic import BaseModel, ByteSize, TypeAdapter
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict, UserRole
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from pytest_simcore.pydantic_models import (
     assert_validation_model,
     walk_model_examples_in_package,

--- a/services/web/server/tests/unit/with_dbs/04/studies_dispatcher/test_studies_dispatcher_studies_access.py
+++ b/services/web/server/tests/unit/with_dbs/04/studies_dispatcher/test_studies_dispatcher_studies_access.py
@@ -17,6 +17,7 @@ import pytest
 import redis.asyncio as aioredis
 from aiohttp import ClientResponse, ClientSession, web
 from aiohttp.test_utils import TestClient, TestServer
+from common_library.users_enums import UserRole
 from faker import Faker
 from models_library.api_schemas_rpc_async_jobs.async_jobs import AsyncJobStatus
 from models_library.progress_bar import ProgressReport
@@ -25,9 +26,9 @@ from models_library.users import UserID
 from pytest_mock import MockerFixture
 from pytest_simcore.aioresponses_mocker import AioResponsesMock
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict, UserRole
 from pytest_simcore.helpers.webserver_parametrizations import MockedStorageSubsystem
 from pytest_simcore.helpers.webserver_projects import NewProject, delete_all_projects
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
 from servicelib.rabbitmq.rpc_interfaces.async_jobs.async_jobs import (

--- a/services/web/server/tests/unit/with_dbs/04/wallets/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/04/wallets/conftest.py
@@ -13,8 +13,8 @@ from aioresponses import aioresponses
 from faker import Faker
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_projects import NewProject, delete_all_projects
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from simcore_postgres_database.models.wallets import wallets
 from simcore_service_webserver.application_settings import ApplicationSettings
 

--- a/services/web/server/tests/unit/with_dbs/04/wallets/payments/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/04/wallets/payments/conftest.py
@@ -32,7 +32,7 @@ from models_library.wallets import WalletID
 from pydantic import EmailStr, HttpUrl
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.payments_transactions import payments_transactions
 from simcore_postgres_database.models.users_details import (

--- a/services/web/server/tests/unit/with_dbs/04/wallets/payments/test_payments.py
+++ b/services/web/server/tests/unit/with_dbs/04/wallets/payments/test_payments.py
@@ -20,7 +20,8 @@ from models_library.rest_pagination import Page
 from pydantic import TypeAdapter
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import LoggedUser, NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_login import LoggedUser
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.payments_transactions import (
     PaymentTransactionState,

--- a/services/web/server/tests/unit/with_dbs/04/wallets/payments/test_payments_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/04/wallets/payments/test_payments_rpc.py
@@ -15,7 +15,7 @@ from models_library.rabbitmq_basic_types import RPCMethodName
 from pydantic import TypeAdapter
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.rabbitmq import RabbitMQRPCClient
 from settings_library.rabbit import RabbitSettings
 from simcore_service_webserver.application_settings import ApplicationSettings

--- a/services/web/server/tests/unit/with_dbs/04/wallets/test_wallets_groups.py
+++ b/services/web/server/tests/unit/with_dbs/04/wallets/test_wallets_groups.py
@@ -10,7 +10,7 @@ from http import HTTPStatus
 import pytest
 from aiohttp.test_utils import TestClient
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.projects.models import ProjectDict

--- a/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces.py
+++ b/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces.py
@@ -12,11 +12,11 @@ from aiohttp.test_utils import TestClient
 from models_library.api_schemas_webserver.workspaces import WorkspaceGet
 from models_library.rest_ordering import OrderDirection
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     standard_role_response,
 )
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.projects.models import ProjectDict

--- a/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__delete_workspace_with_content.py
+++ b/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__delete_workspace_with_content.py
@@ -14,8 +14,8 @@ from aiohttp.test_utils import TestClient
 from models_library.api_schemas_webserver.workspaces import WorkspaceGet
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_projects import create_project
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.projects.models import ProjectDict

--- a/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__list_folders_full_search.py
+++ b/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__list_folders_full_search.py
@@ -10,7 +10,7 @@ from http import HTTPStatus
 import pytest
 from aiohttp.test_utils import TestClient
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 

--- a/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__list_projects_full_search.py
+++ b/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__list_projects_full_search.py
@@ -12,8 +12,8 @@ from http import HTTPStatus
 import pytest
 from aiohttp.test_utils import TestClient
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_projects import create_project
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.projects.models import ProjectDict

--- a/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__moving_folders_between_workspaces.py
+++ b/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__moving_folders_between_workspaces.py
@@ -11,8 +11,8 @@ from http.client import NO_CONTENT
 import pytest
 from aiohttp.test_utils import TestClient
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_projects import create_project
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.db.plugin import setup_db

--- a/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__moving_projects_between_workspaces.py
+++ b/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__moving_projects_between_workspaces.py
@@ -12,12 +12,12 @@ import pytest
 import sqlalchemy as sa
 from aiohttp.test_utils import TestClient
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     standard_role_response,
 )
 from pytest_simcore.helpers.webserver_projects import create_project
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_postgres_database.models.projects_to_folders import projects_to_folders
 from simcore_service_webserver.db.models import UserRole

--- a/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces_groups.py
+++ b/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces_groups.py
@@ -10,7 +10,7 @@ from http import HTTPStatus
 import pytest
 from aiohttp.test_utils import TestClient
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.webserver_login import NewUser, UserInfoDict
+from pytest_simcore.helpers.webserver_users import NewUser, UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.projects.models import ProjectDict

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -49,9 +49,9 @@ from pytest_simcore.helpers import postgres_tools
 from pytest_simcore.helpers.faker_factories import random_product
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_login import UserInfoDict
 from pytest_simcore.helpers.webserver_parametrizations import MockedStorageSubsystem
 from pytest_simcore.helpers.webserver_projects import NewProject
+from pytest_simcore.helpers.webserver_users import UserInfoDict
 from redis import Redis
 from servicelib.aiohttp.application_keys import APP_AIOPG_ENGINE_KEY
 from servicelib.common_aiopg_utils import DSN


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This PR refactors the `pytest_simcore.helpers.webserver_*` module by splitting it into two focused helper modules:

* `pytest_simcore.helpers.webserver_users`: for setting up/tearing down user accounts (direct DB access).
* `pytest_simcore.helpers.webserver_login`: for handling signed-in user setup/teardown.

This separation reduces interdependencies and fixture requirements, making test setup more modular and maintainable.

It also eliminates legacy dependencies on `simcore_service_webserver.login._login_repository_legacy`, which is deprecated.

**NOTE**: A new `exit_stack` fixture is introduced. It can be used to create unit-of-work contexts for test setup/teardown within the test.


## Related issue/s

- Prerequisite for https://github.com/ITISFoundation/osparc-simcore/pull/7818
- Dropping dependencies with `simcore_service_webserver.login._login_repository_legacy`  is part of https://github.com/ITISFoundation/osparc-simcore/issues/4529

## How to test

```
cd services/web/server
make install-dev
make test-dev-unit
```

## Dev-ops
None