### PR TITLE
🎨 [Frontend] UX Enh: Starting osparc

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/AppBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/AppBrowser.js
@@ -42,6 +42,7 @@ qx.Class.define("osparc.dashboard.AppBrowser", {
       }
       this._resourcesInitialized = true;
 
+      this._showLoadingPage(this.tr("Loading Apps..."));
       this._resourcesList = [];
       Promise.all([
         osparc.store.Services.getServicesLatest(),
@@ -63,13 +64,15 @@ qx.Class.define("osparc.dashboard.AppBrowser", {
 
           this.getChildControl("resources-layout");
           this.reloadResources();
-          this._hideLoadingPage();
         });
     },
 
     reloadResources: function(useCache = true) {
-      this.__loadServices();
-      this.__loadHypertools(useCache);
+      Promise.all([
+        this.__loadServices(),
+        this.__loadHypertools(useCache),
+      ])
+        .finally(() => this._hideLoadingPage());
     },
 
     __loadServices: function() {

--- a/services/static-webserver/client/source/class/osparc/dashboard/AppBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/AppBrowser.js
@@ -130,10 +130,7 @@ qx.Class.define("osparc.dashboard.AppBrowser", {
       });
       osparc.filter.UIFilterController.dispatch("searchBarFilter");
 
-      this._resourcesContainer.getNoResourcesFoundLabel().set({
-        value: this.tr("No Apps found"),
-        visibility: cards.length === 0 ? "visible" : "excluded",
-      });
+      this._resourcesContainer.evaluateNoResourcesFoundLabel(cards, this._resourceType);
     },
 
     __itemClicked: function(card) {

--- a/services/static-webserver/client/source/class/osparc/dashboard/AppBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/AppBrowser.js
@@ -129,6 +129,11 @@ qx.Class.define("osparc.dashboard.AppBrowser", {
         this._populateCardMenu(card);
       });
       osparc.filter.UIFilterController.dispatch("searchBarFilter");
+
+      this._resourcesContainer.getNoResourcesFoundLabel().set({
+        value: this.tr("No Apps found"),
+        visibility: this._resourcesList.length === 0 ? "visible" : "excluded",
+      });
     },
 
     __itemClicked: function(card) {

--- a/services/static-webserver/client/source/class/osparc/dashboard/AppBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/AppBrowser.js
@@ -75,7 +75,7 @@ qx.Class.define("osparc.dashboard.AppBrowser", {
     __loadServices: function() {
       const excludeFrontend = true;
       const excludeDeprecated = true
-      osparc.store.Services.getServicesLatestList(excludeFrontend, excludeDeprecated)
+      return osparc.store.Services.getServicesLatestList(excludeFrontend, excludeDeprecated)
         .then(servicesList => {
           servicesList.forEach(service => service["resourceType"] = "service");
           this._resourcesList.push(...servicesList.filter(service => service !== null));
@@ -84,7 +84,7 @@ qx.Class.define("osparc.dashboard.AppBrowser", {
     },
 
     __loadHypertools: function(useCache = true) {
-      osparc.store.Templates.getHypertools(useCache)
+      return osparc.store.Templates.getHypertools(useCache)
         .then(hypertoolsList => {
           hypertoolsList.forEach(hypertool => hypertool["resourceType"] = "hypertool");
           this._resourcesList.push(...hypertoolsList.filter(hypertool => hypertool !== null));

--- a/services/static-webserver/client/source/class/osparc/dashboard/AppBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/AppBrowser.js
@@ -132,7 +132,7 @@ qx.Class.define("osparc.dashboard.AppBrowser", {
 
       this._resourcesContainer.getNoResourcesFoundLabel().set({
         value: this.tr("No Apps found"),
-        visibility: this._resourcesList.length === 0 ? "visible" : "excluded",
+        visibility: cards.length === 0 ? "visible" : "excluded",
       });
     },
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/Dashboard.js
@@ -209,7 +209,7 @@ qx.Class.define("osparc.dashboard.Dashboard", {
             selectedTab.resourceBrowser.initResources();
           } else {
             const initTab = () => {
-              selectedTab.resourceBrowser.initResources()
+              selectedTab.resourceBrowser.initResources();
               this.removeListener("preResourcesLoaded", initTab);
             };
             this.addListener("preResourcesLoaded", initTab, this);

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
@@ -153,7 +153,7 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
           case "public":
             text = this.tr("No Public Projects found");
             break;
-          case "tutorial":
+          case "template":
             text = this.tr("No Tutorials found");
             break;
           case "service":

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
@@ -139,8 +139,32 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
     __nonGroupedContainer: null,
     __groupedContainers: null,
 
-    getNoResourcesFoundLabel: function() {
-      return this.__noResourcesFound;
+    evaluateNoResourcesFoundLabel: function(cards, context) {
+      if (this.__noResourcesFound) {
+        let text = null;
+        switch (context) {
+          case "studiesAndFolders":
+          case "search":
+            text = this.tr("No Projects found");
+            break;
+          case "templates":
+            text = this.tr("No Templates found");
+            break;
+          case "public":
+            text = this.tr("No Public Projects found");
+            break;
+          case "tutorial":
+            text = this.tr("No Tutorials found");
+            break;
+          case "service":
+            text = this.tr("No Apps found");
+            break;
+        }
+        this.__noResourcesFound.set({
+          value: text,
+          visibility: text && cards.length === 0 ? "visible" : "excluded",
+        });
+      }
     },
 
     addNonResourceCard: function(card) {

--- a/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ResourceContainerManager.js
@@ -42,6 +42,13 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
       this._add(foldersContainer);
     }
 
+    const noResourcesFound = this.__noResourcesFound = new qx.ui.basic.Label("No resources found").set({
+      visibility: "excluded",
+      font: "text-14"
+    });
+    noResourcesFound.exclude();
+    this._add(noResourcesFound);
+
     const nonGroupedContainer = this.__nonGroupedContainer = this.__createFlatList();
     this._add(nonGroupedContainer);
 
@@ -128,8 +135,13 @@ qx.Class.define("osparc.dashboard.ResourceContainerManager", {
     __groupedContainersList: null,
     __foldersContainer: null,
     __workspacesContainer: null,
+    __noResourcesFound: null,
     __nonGroupedContainer: null,
     __groupedContainers: null,
+
+    getNoResourcesFoundLabel: function() {
+      return this.__noResourcesFound;
+    },
 
     addNonResourceCard: function(card) {
       if (osparc.dashboard.CardContainer.isValidCard(card)) {

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -95,7 +95,6 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
     __foldersList: null,
     __loadingFolders: null,
     __loadingWorkspaces: null,
-    __dragWidget: null,
 
     // overridden
     initResources: function() {

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -269,6 +269,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
       this._loadingResourcesBtn.setFetching(true);
       this._loadingResourcesBtn.setVisibility("visible");
+      this._resourcesContainer.getNoResourcesFoundLabel().setVisibility("excluded");
       return this.__getNextStudiesRequest()
         .then(resp => {
           // Context might have been changed while waiting for the response.
@@ -431,6 +432,11 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       this.__configureStudyCards(cards);
 
       osparc.filter.UIFilterController.dispatch("searchBarFilter");
+
+      this._resourcesContainer.getNoResourcesFoundLabel().set({
+        value: this.tr("No Tutorials found"),
+        visibility: cards.length === 0 ? "visible" : "excluded",
+      });
     },
 
     // WORKSPACES

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -421,7 +421,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
       this._resourcesContainer.getNoResourcesFoundLabel().set({
         value: this.tr("No Projects found"),
-        visibility: this._resourcesList.length === 0 ? "visible" : "excluded"
+        visibility: cards.length === 0 ? "visible" : "excluded",
       });
     },
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -235,7 +235,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
       this.__loadingFolders = true;
       this.__setFoldersToList([]);
-      request
+      return request
         .then(folders => {
           this.__setFoldersToList(folders);
           if (this.getCurrentContext() === "trash") {
@@ -267,7 +267,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
       this._loadingResourcesBtn.setFetching(true);
       this._loadingResourcesBtn.setVisibility("visible");
-      this.__getNextStudiesRequest()
+      return this.__getNextStudiesRequest()
         .then(resp => {
           // Context might have been changed while waiting for the response.
           // The new call is on the way, therefore this response can be ignored.

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -269,7 +269,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
       this._loadingResourcesBtn.setFetching(true);
       this._loadingResourcesBtn.setVisibility("visible");
-      this._resourcesContainer.getNoResourcesFoundLabel().setVisibility("excluded");
+      this._resourcesContainer.evaluateNoResourcesFoundLabel([]);
       return this.__getNextStudiesRequest()
         .then(resp => {
           // Context might have been changed while waiting for the response.
@@ -420,10 +420,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
       osparc.filter.UIFilterController.dispatch("searchBarFilter");
 
-      this._resourcesContainer.getNoResourcesFoundLabel().set({
-        value: this.tr("No Projects found"),
-        visibility: cards.length === 0 ? "visible" : "excluded",
-      });
+      this._resourcesContainer.evaluateNoResourcesFoundLabel(cards, this.getCurrentContext());
     },
 
     __reloadNewCards: function() {
@@ -433,10 +430,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
 
       osparc.filter.UIFilterController.dispatch("searchBarFilter");
 
-      this._resourcesContainer.getNoResourcesFoundLabel().set({
-        value: this.tr("No Tutorials found"),
-        visibility: cards.length === 0 ? "visible" : "excluded",
-      });
+      this._resourcesContainer.evaluateNoResourcesFoundLabel(cards, this.getCurrentContext());
     },
 
     // WORKSPACES

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -418,6 +418,11 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       this._resourcesContainer.addNonResourceCard(loadMoreBtn);
 
       osparc.filter.UIFilterController.dispatch("searchBarFilter");
+
+      this._resourcesContainer.getNoResourcesFoundLabel().set({
+        value: this.tr("No Projects found"),
+        visibility: this._resourcesList.length === 0 ? "visible" : "excluded"
+      });
     },
 
     __reloadNewCards: function() {

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -345,7 +345,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
             this._loadingResourcesBtn.setVisibility(this._resourcesContainer.getFlatList().nextRequest === null ? "excluded" : "visible");
           }
           // delay the next request to avoid flooding the server
-          setTimeout(() => this._moreResourcesRequired(), 200);
+          setTimeout(() => this._moreResourcesRequired(), 100);
         });
     },
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
@@ -119,7 +119,7 @@ qx.Class.define("osparc.dashboard.TutorialBrowser", {
 
       this._resourcesContainer.getNoResourcesFoundLabel().set({
         value: this.tr("No Tutorials found"),
-        visibility: this._resourcesList.length === 0 ? "visible" : "excluded"
+        visibility: cards.length === 0 ? "visible" : "excluded",
       });
     },
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
@@ -83,9 +83,9 @@ qx.Class.define("osparc.dashboard.TutorialBrowser", {
     __reloadTutorials: function(useCache) {
       this.__tasksToCards();
 
-        osparc.store.Templates.getTutorials(useCache)
-          .then(tutorials => this.__setResourcesToList(tutorials))
-          .catch(() => this.__setResourcesToList([]));
+      return osparc.store.Templates.getTutorials(useCache)
+        .then(tutorials => this.__setResourcesToList(tutorials))
+        .catch(() => this.__setResourcesToList([]));
     },
 
     _updateTutorialData: function(templateData) {

--- a/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
@@ -34,21 +34,23 @@ qx.Class.define("osparc.dashboard.TutorialBrowser", {
       }
       this._resourcesInitialized = true;
 
+      this._showLoadingPage(this.tr("Loading Tutorials..."));
       osparc.store.Templates.getTutorials()
         .then(() => {
           this._resourcesList = [];
           this.getChildControl("resources-layout");
           this.reloadResources();
           this.__attachEventHandlers();
-          this._hideLoadingPage();
         });
     },
 
     reloadResources: function(useCache = true) {
       if (osparc.data.Permissions.getInstance().canDo("studies.templates.read")) {
-        this.__reloadTutorials(useCache);
+        this.__reloadTutorials(useCache)
+          .finally(() => this._hideLoadingPage());
       } else {
         this.__setResourcesToList([]);
+        this._hideLoadingPage();
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
@@ -67,8 +67,6 @@ qx.Class.define("osparc.dashboard.TutorialBrowser", {
     },
 
     __tutorialStateReceived: function(templateId, state, errors) {
-      osparc.store.Templates.getTutorials()
-      // OM follow here
       const idx = this._resourcesList.findIndex(study => study["uuid"] === templateId);
       if (idx > -1) {
         this._resourcesList[idx]["state"] = state;

--- a/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
@@ -117,10 +117,7 @@ qx.Class.define("osparc.dashboard.TutorialBrowser", {
       this.__evaluateUpdateAllButton();
       osparc.filter.UIFilterController.dispatch("searchBarFilter");
 
-      this._resourcesContainer.getNoResourcesFoundLabel().set({
-        value: this.tr("No Tutorials found"),
-        visibility: cards.length === 0 ? "visible" : "excluded",
-      });
+      this._resourcesContainer.evaluateNoResourcesFoundLabel(cards, this._resourceType);
     },
 
     __itemClicked: function(card) {

--- a/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
@@ -116,6 +116,11 @@ qx.Class.define("osparc.dashboard.TutorialBrowser", {
       });
       this.__evaluateUpdateAllButton();
       osparc.filter.UIFilterController.dispatch("searchBarFilter");
+
+      this._resourcesContainer.getNoResourcesFoundLabel().set({
+        value: this.tr("No Tutorials found"),
+        visibility: this._resourcesList.length === 0 ? "visible" : "excluded"
+      });
     },
 
     __itemClicked: function(card) {


### PR DESCRIPTION
## What do these changes do?

This PR improves the UX of the "Starting osparc" message.

- We now say first "Starting osparc" while the resources that need to be fetched before the dashboard resources are fetched.
- Then each tab will say "Loading its {$resource}". 
- If there are no {$resources} found a message will be displayed.
- The loading page is now removed when the cards are renderer (avoiding the potential empty list that was shown while the backend resources were renderer as cards).

![LoadingPages](https://github.com/user-attachments/assets/5a7d310d-3ad8-4266-8da5-596c90ae1d37)


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
