### PR TITLE
🐛 Fix app server mock in `celery-library`

### DIFF
--- a/packages/celery-library/tests/conftest.py
+++ b/packages/celery-library/tests/conftest.py
@@ -32,7 +32,8 @@ pytest_plugins = [
 
 class FakeAppServer(BaseAppServer):
     async def lifespan(self, startup_completed_event: threading.Event) -> None:
-        pass
+        startup_completed_event.set()
+        await self.shutdown_event.wait()  # wait for shutdown
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR fixes hanging tests due to a missing initialization of AppServer mock in Celery tests.

![image](https://github.com/user-attachments/assets/fab9fe94-bce6-41ad-b66a-a0b9a72eb7d0)


The main issue here is that CI didn't detect the problem, since a cancelled test gave Unit Test passing.

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test
```
cd packages/celery-library
make tests
```

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
