### PR TITLE
🐛Improvements on pipeline cancellation and ensure pipeline state is consistent

### DIFF
--- a/packages/models-library/src/models_library/rabbitmq_messages.py
+++ b/packages/models-library/src/models_library/rabbitmq_messages.py
@@ -316,3 +316,13 @@ class WalletCreditsLimitReachedMessage(RabbitMessageBase):
 
     def routing_key(self) -> str | None:
         return f"{self.wallet_id}.{self.credits_limit}"
+
+
+class ComputationalPipelineStatusMessage(RabbitMessageBase, ProjectMessageBase):
+    channel_name: Literal["io.simcore.service.computation.pipeline-status"] = (
+        "io.simcore.service.computation.pipeline-status"
+    )
+    run_result: RunningState
+
+    def routing_key(self) -> str | None:
+        return f"{self.project_id}"

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_manager.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_manager.py
@@ -128,8 +128,7 @@ async def _get_pipeline_at_db(
     project_id: ProjectID, db_engine: AsyncEngine
 ) -> CompPipelineAtDB:
     comp_pipeline_repo = CompPipelinesRepository.instance(db_engine)
-    pipeline_at_db = await comp_pipeline_repo.get_pipeline(project_id)
-    return pipeline_at_db
+    return await comp_pipeline_repo.get_pipeline(project_id)
 
 
 async def _get_pipeline_tasks_at_db(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_publisher.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_publisher.py
@@ -16,6 +16,7 @@ async def request_pipeline_scheduling(
     project_id: ProjectID,
     iteration: Iteration,
 ) -> None:
+    # NOTE: it is important that the DB is set up first before scheduling, in case the worker already schedules before we change the DB
     await CompRunsRepository.instance(db_engine).mark_for_scheduling(
         user_id=user_id, project_id=project_id, iteration=iteration
     )

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_publisher.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_publisher.py
@@ -16,9 +16,9 @@ async def request_pipeline_scheduling(
     project_id: ProjectID,
     iteration: Iteration,
 ) -> None:
-    # NOTE: we should use the transaction and the asyncpg engine here to ensure 100% consistency
-    # https://github.com/ITISFoundation/osparc-simcore/issues/6818
-    # async with transaction_context(get_asyncpg_engine(app)) as connection:
+    await CompRunsRepository.instance(db_engine).mark_for_scheduling(
+        user_id=user_id, project_id=project_id, iteration=iteration
+    )
     await rabbitmq_client.publish(
         SchedulePipelineRabbitMessage.get_channel_name(),
         SchedulePipelineRabbitMessage(
@@ -26,7 +26,4 @@ async def request_pipeline_scheduling(
             project_id=project_id,
             iteration=iteration,
         ),
-    )
-    await CompRunsRepository.instance(db_engine).mark_for_scheduling(
-        user_id=user_id, project_id=project_id, iteration=iteration
     )

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -209,10 +209,13 @@ class BaseCompScheduler(ABC):
         project_id: ProjectID,
         iteration: Iteration,
         pipeline_tasks: dict[NodeIDStr, CompTaskAtDB],
+        current_result: RunningState,
     ) -> RunningState:
         pipeline_state_from_tasks = get_pipeline_state_from_task_states(
             list(pipeline_tasks.values()),
         )
+        if pipeline_state_from_tasks == current_result:
+            return pipeline_state_from_tasks
         _logger.debug(
             "pipeline %s is currently in %s",
             f"{user_id=}_{project_id=}_{iteration=}",
@@ -672,7 +675,7 @@ class BaseCompScheduler(ABC):
 
                 # 6. Update the run result
                 pipeline_result = await self._update_run_result_from_tasks(
-                    user_id, project_id, iteration, comp_tasks
+                    user_id, project_id, iteration, comp_tasks, comp_run.result
                 )
 
                 # 7. Are we done scheduling that pipeline?

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -252,7 +252,7 @@ class BaseCompScheduler(ABC):
             self.rabbitmq_client, user_id, project_id, run_result
         )
 
-    async def _set_schedule_done(
+    async def _set_processing_done(
         self,
         user_id: UserID,
         project_id: ProjectID,
@@ -721,7 +721,7 @@ class BaseCompScheduler(ABC):
             except ComputationalBackendNotConnectedError:
                 _logger.exception("Computational backend is not connected!")
             finally:
-                await self._set_schedule_done(user_id, project_id, iteration)
+                await self._set_processing_done(user_id, project_id, iteration)
 
     async def _schedule_tasks_to_stop(
         self,

--- a/services/director-v2/src/simcore_service_director_v2/utils/rabbitmq.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/rabbitmq.py
@@ -5,6 +5,7 @@ from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.projects_state import RunningState
 from models_library.rabbitmq_messages import (
+    ComputationalPipelineStatusMessage,
     InstrumentationRabbitMessage,
     LoggerRabbitMessage,
     ProgressRabbitMessageNode,
@@ -195,5 +196,19 @@ async def publish_project_log(
         node_id=None,
         messages=[log],
         log_level=log_level,
+    )
+    await rabbitmq_client.publish(message.channel_name, message)
+
+
+async def publish_pipeline_scheduling_state(
+    rabbitmq_client: RabbitMQClient,
+    user_id: UserID,
+    project_id: ProjectID,
+    state: RunningState,
+) -> None:
+    message = ComputationalPipelineStatusMessage.model_construct(
+        user_id=user_id,
+        project_id=project_id,
+        run_result=state,
     )
     await rabbitmq_client.publish(message.channel_name, message)

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations.py
@@ -854,7 +854,7 @@ async def test_get_computation_from_empty_project(
     assert returned_computation
     expected_computation = ComputationGet(
         id=proj.uuid,
-        state=RunningState.UNKNOWN,
+        state=RunningState.NOT_STARTED,
         pipeline_details=PipelineDetails(
             adjacency_list={}, node_states={}, progress=None
         ),

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -6,6 +6,7 @@
 # pylint:disable=too-many-arguments
 # pylint:disable=no-name-in-module
 # pylint:disable=too-many-positional-arguments
+# pylint:disable=too-many-statements
 
 
 import asyncio

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -1471,8 +1471,10 @@ class RebootState:
     expected_task_state_group2: RunningState
     expected_task_progress_group2: float
     expected_run_state: RunningState
+    expected_pipeline_state_notification: int
 
 
+@pytest.mark.testit
 @pytest.mark.parametrize(
     "reboot_state",
     [
@@ -1485,6 +1487,7 @@ class RebootState:
                 expected_task_state_group2=RunningState.ABORTED,
                 expected_task_progress_group2=1,
                 expected_run_state=RunningState.FAILED,
+                expected_pipeline_state_notification=1,
             ),
             id="reboot with lost tasks",
         ),
@@ -1497,6 +1500,7 @@ class RebootState:
                 expected_task_state_group2=RunningState.ABORTED,
                 expected_task_progress_group2=1,
                 expected_run_state=RunningState.ABORTED,
+                expected_pipeline_state_notification=1,
             ),
             id="reboot with aborted tasks",
         ),
@@ -1509,6 +1513,7 @@ class RebootState:
                 expected_task_state_group2=RunningState.ABORTED,
                 expected_task_progress_group2=1,
                 expected_run_state=RunningState.FAILED,
+                expected_pipeline_state_notification=1,
             ),
             id="reboot with failed tasks",
         ),
@@ -1523,6 +1528,7 @@ class RebootState:
                 expected_task_state_group2=RunningState.STARTED,
                 expected_task_progress_group2=0,
                 expected_run_state=RunningState.STARTED,
+                expected_pipeline_state_notification=0,
             ),
             id="reboot with running tasks",
         ),
@@ -1535,6 +1541,7 @@ class RebootState:
                 expected_task_state_group2=RunningState.SUCCESS,
                 expected_task_progress_group2=1,
                 expected_run_state=RunningState.SUCCESS,
+                expected_pipeline_state_notification=1,
             ),
             id="reboot with completed tasks",
         ),
@@ -1636,7 +1643,7 @@ async def test_handling_scheduled_tasks_after_director_reboots(
     )
     await _assert_message_received(
         computational_pipeline_rabbit_client_parser,
-        0,
+        reboot_state.expected_pipeline_state_notification,
         ComputationalPipelineStatusMessage.model_validate_json,
     )
 

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -5,7 +5,7 @@
 # pylint:disable=protected-access
 # pylint:disable=too-many-arguments
 # pylint:disable=no-name-in-module
-# pylint: disable=too-many-statements
+# pylint:disable=too-many-positional-arguments
 
 
 import asyncio

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
@@ -7,6 +7,7 @@ from typing import Final
 from aiohttp import web
 from models_library.groups import GroupID
 from models_library.rabbitmq_messages import (
+    ComputationalPipelineStatusMessage,
     EventRabbitMessage,
     LoggerRabbitMessage,
     ProgressRabbitMessageNode,
@@ -97,6 +98,27 @@ async def _progress_message_parser(app: web.Application, data: bytes) -> bool:
     return True
 
 
+async def _computational_pipeline_status_message_parser(
+    app: web.Application, data: bytes
+) -> bool:
+    rabbit_message = ComputationalPipelineStatusMessage.model_validate_json(data)
+    try:
+        project = await _projects_service.get_project_for_user(
+            app,
+            f"{rabbit_message.project_id}",
+            rabbit_message.user_id,
+            include_state=True,
+        )
+        await _projects_service.notify_project_state_update(app, project)
+    except ProjectNotFoundError:
+        _logger.warning(
+            "Project %s not found for user %s",
+            rabbit_message.project_id,
+            rabbit_message.user_id,
+        )
+    return True
+
+
 async def _log_message_parser(app: web.Application, data: bytes) -> bool:
     rabbit_message = LoggerRabbitMessage.model_validate_json(data)
     await send_message_to_user(
@@ -169,6 +191,11 @@ _EXCHANGE_TO_PARSER_CONFIG: Final[tuple[SubcribeArgumentsTuple, ...]] = (
     SubcribeArgumentsTuple(
         WalletCreditsMessage.get_channel_name(),
         _osparc_credits_message_parser,
+        {"topics": []},
+    ),
+    SubcribeArgumentsTuple(
+        ComputationalPipelineStatusMessage.get_channel_name(),
+        _computational_pipeline_status_message_parser,
         {"topics": []},
     ),
 )

--- a/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_rabbitmq_exclusive_queue_consumers.py
@@ -102,20 +102,14 @@ async def _computational_pipeline_status_message_parser(
     app: web.Application, data: bytes
 ) -> bool:
     rabbit_message = ComputationalPipelineStatusMessage.model_validate_json(data)
-    try:
-        project = await _projects_service.get_project_for_user(
-            app,
-            f"{rabbit_message.project_id}",
-            rabbit_message.user_id,
-            include_state=True,
-        )
-        await _projects_service.notify_project_state_update(app, project)
-    except ProjectNotFoundError:
-        _logger.warning(
-            "Project %s not found for user %s",
-            rabbit_message.project_id,
-            rabbit_message.user_id,
-        )
+    project = await _projects_service.get_project_for_user(
+        app,
+        f"{rabbit_message.project_id}",
+        rabbit_message.user_id,
+        include_state=True,
+    )
+    await _projects_service.notify_project_state_update(app, project)
+
     return True
 
 

--- a/services/web/server/src/simcore_service_webserver/notifications/project_logs.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/project_logs.py
@@ -4,6 +4,7 @@ from typing import Final
 from aiohttp import web
 from models_library.projects import ProjectID
 from models_library.rabbitmq_messages import (
+    ComputationalPipelineStatusMessage,
     LoggerRabbitMessage,
     ProgressRabbitMessageNode,
     ProgressRabbitMessageProject,
@@ -21,6 +22,7 @@ _SUBSCRIBABLE_EXCHANGES: Final[list[type[RabbitMessageBase]]] = [
     LoggerRabbitMessage,
     ProgressRabbitMessageNode,
     ProgressRabbitMessageProject,
+    ComputationalPipelineStatusMessage,
 ]
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## Context
While testing following issues were identified:
- in production, multiple computational pipelines of the same project were found (this should never happen),
- this most likely made the computational scheduler manager stop scheduling
- cancellation of computational pipelines showed an issue where changing some database rows took longer (maybe due to asyncpg migration), and a design issue where a DB row was changed _after_ requesting scheduling to RabbitMQ was effectively commited to the DB after the scheduling was done, thus generating an incorrect DB row. This was inversed, which should make cancelling a pipeline much more reactive.
- the pipeline state that is surfaced to the frontend was generated from the `comp_tasks` table due to the historical way we transmitted events from that table towards the frontend. This lead to inconsistencies where the frontend would already show the _start_ button as enabled even though the computational scheduler was not finished scheduling. This would lead to have multiple times the same pipeline being scheduled, and this would lead to inconsistencies and some undefined behavior. This PR fixes this by always returning the pipeline state from the `comp_runs` table instead so that this becomes the ground truth.
- To this end a new RabbitMQ event was introduced such that the frontend is notified when the computational scheduler changes the run state.


## What do these changes do?
This pull request introduces significant changes to the computation pipeline management and its integration with RabbitMQ messaging. Key updates include the addition of a new RabbitMQ message type for pipeline status, refactoring of pipeline state handling, and improved notification mechanisms for computational pipeline updates.

### RabbitMQ Integration Enhancements:
* Added `ComputationalPipelineStatusMessage` class in `models_library/rabbitmq_messages.py` to represent pipeline status messages, including a routing key based on `project_id`.
* Introduced `publish_pipeline_scheduling_state` function in `utils/rabbitmq.py` to send pipeline status updates via RabbitMQ.
* Integrated a new RabbitMQ message parser `_computational_pipeline_status_message_parser` in `notifications/_rabbitmq_exclusive_queue_consumers.py` to handle pipeline status updates and notify users. [[1]](diffhunk://#diff-f3655a5a5fd42292ed5f0d1457d5382f4aaa6da097746e9fc01e3017723c3558R101-R121) [[2]](diffhunk://#diff-f3655a5a5fd42292ed5f0d1457d5382f4aaa6da097746e9fc01e3017723c3558R196-R200)

### Pipeline State Refactoring:
* Replaced task-based pipeline state computation with `CompRunsRepository` for determining pipeline state across multiple endpoints in `computations.py`. [[1]](diffhunk://#diff-68d42f7c3b213ea2bfa8aff7743104494eddb2d849ec9a922850ba87dd4e706cL96-R104) [[2]](diffhunk://#diff-68d42f7c3b213ea2bfa8aff7743104494eddb2d849ec9a922850ba87dd4e706cL305-R309) [[3]](diffhunk://#diff-68d42f7c3b213ea2bfa8aff7743104494eddb2d849ec9a922850ba87dd4e706cL356-R367) [[4]](diffhunk://#diff-68d42f7c3b213ea2bfa8aff7743104494eddb2d849ec9a922850ba87dd4e706cR462-R472)
* Simplified pipeline state retrieval logic by directly accessing `CompRunsRepository` in various computation-related functions. [[1]](diffhunk://#diff-68d42f7c3b213ea2bfa8aff7743104494eddb2d849ec9a922850ba87dd4e706cL539-R546) [[2]](diffhunk://#diff-68d42f7c3b213ea2bfa8aff7743104494eddb2d849ec9a922850ba87dd4e706cR588-R601) [[3]](diffhunk://#diff-68d42f7c3b213ea2bfa8aff7743104494eddb2d849ec9a922850ba87dd4e706cL637-R636)

### Scheduler Improvements:
* Enhanced `_set_run_result` in `modules/comp_scheduler/_scheduler_base.py` to publish pipeline completion logs and scheduling state updates.
* Refactored `_schedule_tasks_to_stop` to handle tasks that can be instantly marked as aborted and return updated task states.

### Code Cleanup:
* Simplified `_get_pipeline_at_db` in `modules/comp_scheduler/_manager.py` by removing redundant variable assignments.
* Removed outdated comments and redundant code in `request_pipeline_scheduling` in `modules/comp_scheduler/_publisher.py`. [[1]](diffhunk://#diff-aff10a250a524bd42d782d88ed62f70e80e78fd37e133ff85e815fad5da19cdaL19-R21) [[2]](diffhunk://#diff-aff10a250a524bd42d782d88ed62f70e80e78fd37e133ff85e815fad5da19cdaL30-L32)
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- hopefully fixes https://github.com/ITISFoundation/osparc-simcore/issues/7983
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/7985
## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
