### PR TITLE
⬆️ upgrade efs service requirements

### DIFF
--- a/services/efs-guardian/requirements/_base.txt
+++ b/services/efs-guardian/requirements/_base.txt
@@ -1,10 +1,10 @@
-aio-pika==9.4.3
+aio-pika==9.5.5
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aioboto3==14.3.0
+aioboto3==15.0.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-aiobotocore==2.22.0
+aiobotocore==2.23.0
     # via aioboto3
 aiocache==0.12.3
     # via
@@ -15,7 +15,7 @@ aiodebug==2.3.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-aiodocker==0.23.0
+aiodocker==0.24.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -26,7 +26,7 @@ aiofiles==24.1.0
     #   aioboto3
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.12.12
+aiohttp==3.12.13
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -60,13 +60,13 @@ aioitertools==0.12.0
     # via aiobotocore
 aiormq==6.8.1
     # via aio-pika
-aiosignal==1.3.1
+aiosignal==1.3.2
     # via aiohttp
-alembic==1.13.3
+alembic==1.16.2
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
 annotated-types==0.7.0
     # via pydantic
-anyio==4.6.2.post1
+anyio==4.9.0
     # via
     #   fast-depends
     #   faststream
@@ -84,25 +84,23 @@ arrow==1.3.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
-async-timeout==4.0.3
-    # via asyncpg
-asyncpg==0.29.0
+asyncpg==0.30.0
     # via sqlalchemy
-attrs==24.2.0
+attrs==25.3.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
-boto3==1.37.3
+boto3==1.38.27
     # via aiobotocore
-botocore==1.37.3
+botocore==1.38.27
     # via
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.35.43
+botocore-stubs==1.38.46
     # via types-aiobotocore
-certifi==2024.8.30
+certifi==2025.6.15
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -133,28 +131,24 @@ certifi==2024.8.30
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via requests
-click==8.1.7
+click==8.2.1
     # via
     #   rich-toolkit
     #   typer
     #   uvicorn
-deprecated==1.2.14
-    # via
-    #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-    #   opentelemetry-semantic-conventions
 dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via
     #   fastapi
     #   pydantic
+exceptiongroup==1.3.0
+    # via aio-pika
 fast-depends==2.4.12
     # via faststream
-fastapi==0.115.12
+fastapi==0.115.14
     # via
     #   -r requirements/../../../packages/service-library/requirements/_fastapi.in
     #   fastapi-lifespan-manager
@@ -162,23 +156,23 @@ fastapi-cli==0.0.7
     # via fastapi
 fastapi-lifespan-manager==0.1.4
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-faststream==0.5.31
+faststream==0.5.43
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-frozenlist==1.4.1
+frozenlist==1.7.0
     # via
     #   aiohttp
     #   aiosignal
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.70.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-greenlet==3.1.1
+greenlet==3.2.3
     # via sqlalchemy
-grpcio==1.67.0
+grpcio==1.73.1
     # via opentelemetry-exporter-otlp-proto-grpc
-h11==0.14.0
+h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
@@ -186,11 +180,11 @@ h2==4.2.0
     # via httpx
 hpack==4.1.0
     # via h2
-httpcore==1.0.6
+httpcore==1.0.9
     # via httpx
 httptools==0.6.4
     # via uvicorn
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -229,7 +223,7 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.4.0
+importlib-metadata==8.7.0
     # via opentelemetry-api
 jinja2==3.1.6
     # via
@@ -265,15 +259,15 @@ jmespath==1.0.1
     #   aiobotocore
     #   boto3
     #   botocore
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
-mako==1.3.5
+mako==1.3.10
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -310,12 +304,12 @@ markupsafe==3.0.2
     #   mako
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.1.0
+multidict==6.6.2
     # via
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.27.0
+opentelemetry-api==1.34.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -334,19 +328,19 @@ opentelemetry-api==1.27.0
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.27.0
+opentelemetry-exporter-otlp==1.34.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.27.0
+opentelemetry-exporter-otlp-proto-common==1.34.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.27.0
+opentelemetry-exporter-otlp-proto-grpc==1.34.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.27.0
+opentelemetry-exporter-otlp-proto-http==1.34.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.48b0
+opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -357,47 +351,48 @@ opentelemetry-instrumentation==0.48b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.48b0
+opentelemetry-instrumentation-aio-pika==0.55b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.48b0
+opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.48b0
+opentelemetry-instrumentation-asyncpg==0.55b1
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.48b0
+opentelemetry-instrumentation-botocore==0.55b1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.48b0
+opentelemetry-instrumentation-httpx==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-logging==0.48b0
+opentelemetry-instrumentation-logging==0.55b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.48b0
+opentelemetry-instrumentation-redis==0.55b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.48b0
+opentelemetry-instrumentation-requests==0.55b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-propagator-aws-xray==1.0.1
+opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.27.0
+opentelemetry-proto==1.34.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.27.0
+opentelemetry-sdk==1.34.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.48b0
+opentelemetry-semantic-conventions==0.55b1
     # via
+    #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
@@ -406,13 +401,13 @@ opentelemetry-semantic-conventions==0.48b0
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.48b0
+opentelemetry-util-http==0.55b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
-orjson==3.10.7
+orjson==3.10.18
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -457,29 +452,31 @@ orjson==3.10.7
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.1
-    # via -r requirements/_base.in
+packaging==25.0
+    # via
+    #   -r requirements/_base.in
+    #   opentelemetry-instrumentation
 pamqp==3.3.0
     # via aiormq
-prometheus-client==0.21.0
+prometheus-client==0.22.1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-propcache==0.3.1
+propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
-protobuf==4.25.5
+protobuf==5.29.5
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.1.0
+psutil==7.0.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 psycopg2-binary==2.9.10
     # via sqlalchemy
-pycryptodome==3.21.0
+pycryptodome==3.23.0
     # via stream-zip
-pydantic==2.10.2
+pydantic==2.11.7
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -536,9 +533,9 @@ pydantic==2.10.2
     #   fastapi
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.27.1
+pydantic-core==2.33.2
     # via pydantic
-pydantic-extra-types==2.9.0
+pydantic-extra-types==2.10.5
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -557,7 +554,7 @@ pydantic-extra-types==2.9.0
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-pydantic-settings==2.6.1
+pydantic-settings==2.7.0
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -593,9 +590,9 @@ pydantic-settings==2.6.1
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
-pygments==2.18.0
+pygments==2.19.2
     # via rich
-pyinstrument==5.0.0
+pyinstrument==5.0.2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -604,7 +601,7 @@ python-dateutil==2.9.0.post0
     #   aiobotocore
     #   arrow
     #   botocore
-python-dotenv==1.0.1
+python-dotenv==1.1.1
     # via
     #   pydantic-settings
     #   uvicorn
@@ -641,7 +638,7 @@ pyyaml==6.0.2
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   uvicorn
-redis==5.2.1
+redis==6.2.0
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -671,7 +668,7 @@ redis==5.2.1
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-referencing==0.29.3
+referencing==0.35.1
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -701,9 +698,9 @@ referencing==0.29.3
     #   -c requirements/../../../requirements/constraints.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.3
+requests==2.32.4
     # via opentelemetry-exporter-otlp-proto-http
-rich==13.9.2
+rich==14.0.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
@@ -713,24 +710,20 @@ rich==13.9.2
     #   typer
 rich-toolkit==0.14.7
     # via fastapi-cli
-rpds-py==0.20.0
+rpds-py==0.25.1
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.11.3
+s3transfer==0.13.0
     # via boto3
-setuptools==75.2.0
-    # via opentelemetry-instrumentation
-sh==2.1.0
+sh==2.2.2
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 shellingham==1.5.4
     # via typer
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -761,7 +754,7 @@ sqlalchemy==1.4.54
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
     #   alembic
-starlette==0.41.2
+starlette==0.46.2
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -794,7 +787,7 @@ stream-zip==0.0.83
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -802,45 +795,55 @@ toolz==1.0.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-tqdm==4.66.5
+tqdm==4.67.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-typer==0.12.5
+typer==0.16.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   fastapi-cli
-types-aiobotocore==2.19.0
+types-aiobotocore==2.23.0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-types-aiobotocore-ec2==2.19.0
+types-aiobotocore-ec2==2.23.0
     # via types-aiobotocore
-types-aiobotocore-s3==2.19.0
+types-aiobotocore-s3==2.23.0
     # via types-aiobotocore
-types-aiobotocore-ssm==2.19.0
+types-aiobotocore-ssm==2.23.0
     # via types-aiobotocore
-types-awscrt==0.22.0
+types-awscrt==0.27.4
     # via botocore-stubs
-types-python-dateutil==2.9.0.20241003
+types-python-dateutil==2.9.0.20250516
     # via arrow
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   aiodebug
     #   alembic
+    #   anyio
+    #   exceptiongroup
     #   fastapi
     #   faststream
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   rich-toolkit
     #   typer
     #   types-aiobotocore
     #   types-aiobotocore-ec2
     #   types-aiobotocore-s3
     #   types-aiobotocore-ssm
-urllib3==2.2.3
+    #   typing-inspection
+typing-inspection==0.4.1
+    # via pydantic
+urllib3==2.5.0
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -870,24 +873,24 @@ urllib3==2.2.3
     #   -c requirements/../../../requirements/constraints.txt
     #   botocore
     #   requests
-uvicorn==0.34.2
+uvicorn==0.35.0
     # via
     #   fastapi
     #   fastapi-cli
 uvloop==0.21.0
     # via uvicorn
-watchfiles==1.0.5
+watchfiles==1.1.0
     # via uvicorn
 websockets==15.0.1
     # via uvicorn
-wrapt==1.16.0
+wrapt==1.17.2
     # via
     #   aiobotocore
-    #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
-yarl==1.20.0
+yarl==1.20.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -895,5 +898,5 @@ yarl==1.20.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.20.2
+zipp==3.23.0
     # via importlib-metadata

--- a/services/efs-guardian/requirements/_test.txt
+++ b/services/efs-guardian/requirements/_test.txt
@@ -1,4 +1,4 @@
-aiodocker==0.23.0
+aiodocker==0.24.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -6,12 +6,12 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.12.12
+aiohttp==3.12.13
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aiodocker
-aiosignal==1.3.1
+aiosignal==1.3.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -21,37 +21,37 @@ annotated-types==0.7.0
     #   pydantic
 antlr4-python3-runtime==4.13.2
     # via moto
-anyio==4.6.2.post1
+anyio==4.9.0
     # via
     #   -c requirements/_base.txt
     #   httpx
 asgi-lifespan==2.1.0
     # via -r requirements/_test.in
-attrs==24.2.0
+attrs==25.3.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   jsonschema
     #   referencing
-aws-sam-translator==1.95.0
+aws-sam-translator==1.99.0
     # via cfn-lint
 aws-xray-sdk==2.14.0
     # via moto
 blinker==1.9.0
     # via flask
-boto3==1.37.3
+boto3==1.38.27
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
     #   moto
-botocore==1.37.3
+botocore==1.38.27
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
-certifi==2024.8.30
+certifi==2025.6.15
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -60,59 +60,59 @@ certifi==2024.8.30
     #   requests
 cffi==1.17.1
     # via cryptography
-cfn-lint==1.27.0
+cfn-lint==1.36.1
     # via moto
-charset-normalizer==3.4.0
+charset-normalizer==3.4.2
     # via
     #   -c requirements/_base.txt
     #   requests
-click==8.1.7
+click==8.2.1
     # via
     #   -c requirements/_base.txt
     #   flask
-coverage==7.6.12
+coverage==7.9.1
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-cryptography==44.0.2
+cryptography==45.0.4
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   joserfc
     #   moto
-debugpy==1.8.12
+debugpy==1.8.14
     # via -r requirements/_test.in
-deepdiff==8.2.0
+deepdiff==8.5.0
     # via -r requirements/_test.in
 docker==7.1.0
     # via
     #   -r requirements/_test.in
     #   moto
-faker==36.1.1
+faker==37.4.0
     # via -r requirements/_test.in
-fakeredis==2.27.0
+fakeredis==2.30.1
     # via -r requirements/_test.in
-flask==3.1.0
+flask==3.1.1
     # via
     #   flask-cors
     #   moto
-flask-cors==5.0.1
+flask-cors==6.0.1
     # via moto
-frozenlist==1.4.1
+frozenlist==1.7.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
 graphql-core==3.2.6
     # via moto
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
-httpcore==1.0.6
+httpcore==1.0.9
     # via
     #   -c requirements/_base.txt
     #   httpx
-httpx==0.27.2
+httpx==0.28.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -125,7 +125,7 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
 itsdangerous==2.2.0
     # via flask
@@ -140,7 +140,7 @@ jmespath==1.0.1
     #   -c requirements/_base.txt
     #   boto3
     #   botocore
-joserfc==1.0.4
+joserfc==1.1.0
     # via moto
 jsonpatch==1.33
     # via cfn-lint
@@ -148,7 +148,7 @@ jsonpath-ng==1.7.0
     # via moto
 jsonpointer==3.0.0
     # via jsonpatch
-jsonschema==4.23.0
+jsonschema==4.24.0
     # via
     #   -c requirements/_base.txt
     #   aws-sam-translator
@@ -156,38 +156,39 @@ jsonschema==4.23.0
     #   openapi-spec-validator
 jsonschema-path==0.3.4
     # via openapi-spec-validator
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2025.4.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
     #   openapi-schema-validator
-lazy-object-proxy==1.10.0
+lazy-object-proxy==1.11.0
     # via openapi-spec-validator
-lupa==2.4
+lupa==2.5
     # via fakeredis
 markupsafe==3.0.2
     # via
     #   -c requirements/_base.txt
+    #   flask
     #   jinja2
     #   werkzeug
-moto==5.1.4
+moto==5.1.6
     # via -r requirements/_test.in
 mpmath==1.3.0
     # via sympy
-multidict==6.1.0
+multidict==6.6.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-networkx==3.4.2
+networkx==3.5
     # via cfn-lint
 openapi-schema-validator==0.6.3
     # via openapi-spec-validator
-openapi-spec-validator==0.7.1
+openapi-spec-validator==0.7.2
     # via moto
-orderly-set==5.3.0
+orderly-set==5.4.1
     # via deepdiff
-packaging==24.1
+packaging==25.0
     # via
     #   -c requirements/_base.txt
     #   pytest
@@ -195,16 +196,18 @@ parse==1.20.2
     # via -r requirements/_test.in
 pathable==0.4.4
     # via jsonschema-path
-pluggy==1.5.0
-    # via pytest
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
 ply==3.11
     # via jsonpath-ng
-propcache==0.3.1
+propcache==0.3.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-psutil==6.1.0
+psutil==7.0.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -212,28 +215,32 @@ py-partiql-parser==0.6.1
     # via moto
 pycparser==2.22
     # via cffi
-pydantic==2.10.2
+pydantic==2.11.7
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aws-sam-translator
-pydantic-core==2.27.1
+pydantic-core==2.33.2
     # via
     #   -c requirements/_base.txt
     #   pydantic
-pyparsing==3.2.1
+pygments==2.19.2
+    # via
+    #   -c requirements/_base.txt
+    #   pytest
+pyparsing==3.2.3
     # via moto
-pytest==8.3.5
+pytest==8.4.1
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
-pytest-asyncio==0.26.0
+pytest-asyncio==1.0.0
     # via -r requirements/_test.in
-pytest-cov==6.0.0
+pytest-cov==6.2.1
     # via -r requirements/_test.in
-pytest-mock==3.14.0
+pytest-mock==3.14.1
     # via -r requirements/_test.in
 pytest-runner==6.0.1
     # via -r requirements/_test.in
@@ -242,7 +249,7 @@ python-dateutil==2.9.0.post0
     #   -c requirements/_base.txt
     #   botocore
     #   moto
-python-dotenv==1.0.1
+python-dotenv==1.1.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -254,12 +261,12 @@ pyyaml==6.0.2
     #   jsonschema-path
     #   moto
     #   responses
-redis==5.2.1
+redis==6.2.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   fakeredis
-referencing==0.29.3
+referencing==0.35.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -268,33 +275,31 @@ referencing==0.29.3
     #   jsonschema-specifications
 regex==2024.11.6
     # via cfn-lint
-requests==2.32.3
+requests==2.32.4
     # via
     #   -c requirements/_base.txt
     #   docker
     #   jsonschema-path
     #   moto
     #   responses
-responses==0.25.6
+responses==0.25.7
     # via moto
 respx==0.22.0
     # via -r requirements/_test.in
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rpds-py==0.20.0
+rpds-py==0.25.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.11.3
+s3transfer==0.13.0
     # via
     #   -c requirements/_base.txt
     #   boto3
-setuptools==75.2.0
-    # via
-    #   -c requirements/_base.txt
-    #   moto
-six==1.16.0
+setuptools==80.9.0
+    # via moto
+six==1.17.0
     # via
     #   -c requirements/_base.txt
     #   python-dateutil
@@ -304,21 +309,26 @@ sniffio==1.3.1
     #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
-    #   httpx
 sortedcontainers==2.4.0
     # via fakeredis
-sympy==1.13.3
+sympy==1.14.0
     # via cfn-lint
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -c requirements/_base.txt
+    #   anyio
     #   aws-sam-translator
     #   cfn-lint
     #   pydantic
     #   pydantic-core
-tzdata==2025.1
+    #   typing-inspection
+typing-inspection==0.4.1
+    # via
+    #   -c requirements/_base.txt
+    #   pydantic
+tzdata==2025.2
     # via faker
-urllib3==2.2.3
+urllib3==2.5.0
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -331,13 +341,13 @@ werkzeug==3.1.3
     #   flask
     #   flask-cors
     #   moto
-wrapt==1.16.0
+wrapt==1.17.2
     # via
     #   -c requirements/_base.txt
     #   aws-xray-sdk
 xmltodict==0.14.2
     # via moto
-yarl==1.20.0
+yarl==1.20.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/services/efs-guardian/requirements/_tools.txt
+++ b/services/efs-guardian/requirements/_tools.txt
@@ -1,4 +1,4 @@
-astroid==3.3.8
+astroid==3.3.10
     # via pylint
 black==25.1.0
     # via -r requirements/../../../requirements/devenv.txt
@@ -8,19 +8,19 @@ bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
-click==8.1.7
+click==8.2.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-dill==0.3.9
+dill==0.4.0
     # via pylint
 distlib==0.3.9
     # via virtualenv
-filelock==3.17.0
+filelock==3.18.0
     # via virtualenv
-identify==2.6.8
+identify==2.6.12
     # via pre-commit
 isort==6.0.1
     # via
@@ -28,34 +28,36 @@ isort==6.0.1
     #   pylint
 mccabe==0.7.0
     # via pylint
-mypy==1.15.0
+mypy==1.16.1
     # via -r requirements/../../../requirements/devenv.txt
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via
     #   black
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==25.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   build
 pathspec==0.12.1
-    # via black
-pip==25.0.1
+    # via
+    #   black
+    #   mypy
+pip==25.1.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements/../../../requirements/devenv.txt
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
     #   black
     #   pylint
     #   virtualenv
-pre-commit==4.1.0
+pre-commit==4.2.0
     # via -r requirements/../../../requirements/devenv.txt
-pylint==3.3.4
+pylint==3.3.7
     # via -r requirements/../../../requirements/devenv.txt
 pyproject-hooks==1.2.0
     # via
@@ -68,21 +70,20 @@ pyyaml==6.0.2
     #   -c requirements/_test.txt
     #   pre-commit
     #   watchdog
-ruff==0.9.9
+ruff==0.12.1
     # via -r requirements/../../../requirements/devenv.txt
-setuptools==75.2.0
+setuptools==80.9.0
     # via
-    #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pip-tools
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via pylint
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.29.2
+virtualenv==20.31.2
     # via pre-commit
 watchdog==6.0.0
     # via -r requirements/_tools.in


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 132
- #packages after ~ 132

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.4.3           | 9.5.5      | *minor*    | 1 | efs-guardian⬆️ |
|   2 | aioboto3                  | 14.3.0          | 15.0.0     | **MAJOR**  | 1 | efs-guardian⬆️ |
|   3 | aiobotocore               | 2.22.0          | 2.23.0     | *minor*    | 1 | efs-guardian⬆️ |
|   4 | aiodocker                 | 0.23.0          | 0.24.0     | *minor*    | 2 | efs-guardian⬆️🧪 |
|   5 | aiohttp                   | 3.12.12         | 3.12.13    |            | 2 | efs-guardian⬆️🧪 |
|   6 | aiosignal                 | 1.3.1           | 1.3.2      |            | 2 | efs-guardian⬆️🧪 |
|   7 | alembic                   | 1.13.3          | 1.16.2     | *minor*    | 1 | efs-guardian⬆️ |
|   8 | anyio                     | 4.6.2.post1     | 4.9.0      | *minor*    | 2 | efs-guardian⬆️🧪 |
|   9 | astroid                   | 3.3.8           | 3.3.10     |            | 1 | efs-guardian🔧 |
|  10 | async-timeout             | 4.0.3           | 🗑️ removed |  | 1 | efs-guardian⬆️ |
|  11 | asyncpg                   | 0.29.0          | 0.30.0     | *minor*    | 1 | efs-guardian⬆️ |
|  12 | attrs                     | 24.2.0          | 25.3.0     | **MAJOR**  | 2 | efs-guardian⬆️🧪 |
|  13 | aws-sam-translator        | 1.95.0          | 1.99.0     | *minor*    | 1 | efs-guardian🧪 |
|  14 | boto3                     | 1.37.3          | 1.38.27    | *minor*    | 2 | efs-guardian⬆️🧪 |
|  15 | botocore                  | 1.37.3          | 1.38.27    | *minor*    | 2 | efs-guardian⬆️🧪 |
|  16 | botocore-stubs            | 1.35.43         | 1.38.46    | *minor*    | 1 | efs-guardian⬆️ |
|  17 | certifi                   | 2024.8.30       | 2025.6.15  | **MAJOR**  | 2 | efs-guardian⬆️🧪 |
|  18 | cfn-lint                  | 1.27.0          | 1.36.1     | *minor*    | 1 | efs-guardian🧪 |
|  19 | charset-normalizer        | 3.4.0           | 3.4.2      |            | 2 | efs-guardian⬆️🧪 |
|  20 | click                     | 8.1.7           | 8.2.1      | *minor*    | 3 | efs-guardian⬆️🧪🔧 |
|  21 | coverage                  | 7.6.12          | 7.9.1      | *minor*    | 1 | efs-guardian🧪 |
|  22 | cryptography              | 44.0.2          | 45.0.4     | **MAJOR**  | 1 | efs-guardian🧪 |
|  23 | debugpy                   | 1.8.12          | 1.8.14     |            | 1 | efs-guardian🧪 |
|  24 | deepdiff                  | 8.2.0           | 8.5.0      | *minor*    | 1 | efs-guardian🧪 |
|  25 | deprecated                | 1.2.14          | 🗑️ removed |  | 1 | efs-guardian⬆️ |
|  26 | dill                      | 0.3.9           | 0.4.0      | *minor*    | 1 | efs-guardian🔧 |
|  27 | faker                     | 36.1.1          | 37.4.0     | **MAJOR**  | 1 | efs-guardian🧪 |
|  28 | fakeredis                 | 2.27.0          | 2.30.1     | *minor*    | 1 | efs-guardian🧪 |
|  29 | fastapi                   | 0.115.12        | 0.115.14   |            | 1 | efs-guardian⬆️ |
|  30 | faststream                | 0.5.31          | 0.5.43     |            | 1 | efs-guardian⬆️ |
|  31 | filelock                  | 3.17.0          | 3.18.0     | *minor*    | 1 | efs-guardian🔧 |
|  32 | flask                     | 3.1.0           | 3.1.1      |            | 1 | efs-guardian🧪 |
|  33 | flask-cors                | 5.0.1           | 6.0.1      | **MAJOR**  | 1 | efs-guardian🧪 |
|  34 | frozenlist                | 1.4.1           | 1.7.0      | *minor*    | 2 | efs-guardian⬆️🧪 |
|  35 | googleapis-common-protos  | 1.65.0          | 1.70.0     | *minor*    | 1 | efs-guardian⬆️ |
|  36 | greenlet                  | 3.1.1           | 3.2.3      | *minor*    | 1 | efs-guardian⬆️ |
|  37 | grpcio                    | 1.67.0          | 1.73.1     | *minor*    | 1 | efs-guardian⬆️ |
|  38 | h11                       | 0.14.0          | 0.16.0     | *minor*    | 2 | efs-guardian⬆️🧪 |
|  39 | httpcore                  | 1.0.6           | 1.0.9      |            | 2 | efs-guardian⬆️🧪 |
|  40 | httpx                     | 0.27.2          | 0.28.1     | *minor*    | 2 | efs-guardian⬆️🧪 |
|  41 | identify                  | 2.6.8           | 2.6.12     |            | 1 | efs-guardian🔧 |
|  42 | importlib-metadata        | 8.4.0           | 8.7.0      | *minor*    | 1 | efs-guardian⬆️ |
|  43 | iniconfig                 | 2.0.0           | 2.1.0      | *minor*    | 1 | efs-guardian🧪 |
|  44 | joserfc                   | 1.0.4           | 1.1.0      | *minor*    | 1 | efs-guardian🧪 |
|  45 | jsonschema                | 4.23.0          | 4.24.0     | *minor*    | 2 | efs-guardian⬆️🧪 |
|  46 | jsonschema-specifications | 2023.7.1        | 2025.4.1   | **MAJOR**  | 2 | efs-guardian⬆️🧪 |
|  47 | lazy-object-proxy         | 1.10.0          | 1.11.0     | *minor*    | 1 | efs-guardian🧪 |
|  48 | lupa                      | 2.4             | 2.5        | *minor*    | 1 | efs-guardian🧪 |
|  49 | mako                      | 1.3.5           | 1.3.10     |            | 1 | efs-guardian⬆️ |
|  50 | moto                      | 5.1.4           | 5.1.6      |            | 1 | efs-guardian🧪 |
|  51 | multidict                 | 6.1.0           | 6.6.2      | *minor*    | 2 | efs-guardian⬆️🧪 |
|  52 | mypy                      | 1.15.0          | 1.16.1     | *minor*    | 1 | efs-guardian🔧 |
|  53 | mypy-extensions           | 1.0.0           | 1.1.0      | *minor*    | 1 | efs-guardian🔧 |
|  54 | networkx                  | 3.4.2           | 3.5        | *minor*    | 1 | efs-guardian🧪 |
|  55 | openapi-spec-validator    | 0.7.1           | 0.7.2      |            | 1 | efs-guardian🧪 |
|  56 | opentelemetry-api         | 1.27.0          | 1.34.1     | *minor*    | 1 | efs-guardian⬆️ |
|  57 | opentelemetry-exporter-otlp | 1.27.0          | 1.34.1     | *minor*    | 1 | efs-guardian⬆️ |
|  58 | opentelemetry-exporter-otlp-proto-common | 1.27.0          | 1.34.1     | *minor*    | 1 | efs-guardian⬆️ |
|  59 | opentelemetry-exporter-otlp-proto-grpc | 1.27.0          | 1.34.1     | *minor*    | 1 | efs-guardian⬆️ |
|  60 | opentelemetry-exporter-otlp-proto-http | 1.27.0          | 1.34.1     | *minor*    | 1 | efs-guardian⬆️ |
|  61 | opentelemetry-instrumentation | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  62 | opentelemetry-instrumentation-aio-pika | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  63 | opentelemetry-instrumentation-asgi | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  64 | opentelemetry-instrumentation-asyncpg | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  65 | opentelemetry-instrumentation-botocore | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  66 | opentelemetry-instrumentation-fastapi | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  67 | opentelemetry-instrumentation-httpx | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  68 | opentelemetry-instrumentation-logging | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  69 | opentelemetry-instrumentation-redis | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  70 | opentelemetry-instrumentation-requests | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  71 | opentelemetry-propagator-aws-xray | 1.0.1           | 1.0.2      |            | 1 | efs-guardian⬆️ |
|  72 | opentelemetry-proto       | 1.27.0          | 1.34.1     | *minor*    | 1 | efs-guardian⬆️ |
|  73 | opentelemetry-sdk         | 1.27.0          | 1.34.1     | *minor*    | 1 | efs-guardian⬆️ |
|  74 | opentelemetry-semantic-conventions | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  75 | opentelemetry-util-http   | 0.48            | 0.55       | *minor*    | 1 | efs-guardian⬆️ |
|  76 | orderly-set               | 5.3.0           | 5.4.1      | *minor*    | 1 | efs-guardian🧪 |
|  77 | orjson                    | 3.10.7          | 3.10.18    |            | 1 | efs-guardian⬆️ |
|  78 | packaging                 | 24.1            | 25.0       | **MAJOR**  | 3 | efs-guardian⬆️🧪🔧 |
|  79 | pip                       | 25.0.1          | 25.1.1     | *minor*    | 1 | efs-guardian🔧 |
|  80 | platformdirs              | 4.3.6           | 4.3.8      |            | 1 | efs-guardian🔧 |
|  81 | pluggy                    | 1.5.0           | 1.6.0      | *minor*    | 1 | efs-guardian🧪 |
|  82 | pre-commit                | 4.1.0           | 4.2.0      | *minor*    | 1 | efs-guardian🔧 |
|  83 | prometheus-client         | 0.21.0          | 0.22.1     | *minor*    | 1 | efs-guardian⬆️ |
|  84 | propcache                 | 0.3.1           | 0.3.2      |            | 2 | efs-guardian⬆️🧪 |
|  85 | protobuf                  | 4.25.5          | 5.29.5     | **MAJOR**  | 1 | efs-guardian⬆️ |
|  86 | psutil                    | 6.1.0           | 7.0.0      | **MAJOR**  | 2 | efs-guardian⬆️🧪 |
|  87 | pycryptodome              | 3.21.0          | 3.23.0     | *minor*    | 1 | efs-guardian⬆️ |
|  88 | pydantic                  | 2.10.2          | 2.11.7     | *minor*    | 2 | efs-guardian⬆️🧪 |
|  89 | pydantic-core             | 2.27.1          | 2.33.2     | *minor*    | 2 | efs-guardian⬆️🧪 |
|  90 | pydantic-extra-types      | 2.9.0           | 2.10.5     | *minor*    | 1 | efs-guardian⬆️ |
|  91 | pydantic-settings         | 2.6.1           | 2.7.0      | *minor*    | 1 | efs-guardian⬆️ |
|  92 | pygments                  | 2.18.0          | 2.19.2     | *minor*    | 1 | efs-guardian⬆️ |
|  93 | pyinstrument              | 5.0.0           | 5.0.2      |            | 1 | efs-guardian⬆️ |
|  94 | pylint                    | 3.3.4           | 3.3.7      |            | 1 | efs-guardian🔧 |
|  95 | pyparsing                 | 3.2.1           | 3.2.3      |            | 1 | efs-guardian🧪 |
|  96 | pytest                    | 8.3.5           | 8.4.1      | *minor*    | 1 | efs-guardian🧪 |
|  97 | pytest-asyncio            | 0.26.0          | 1.0.0      | **MAJOR**  | 1 | efs-guardian🧪 |
|  98 | pytest-cov                | 6.0.0           | 6.2.1      | *minor*    | 1 | efs-guardian🧪 |
|  99 | pytest-mock               | 3.14.0          | 3.14.1     |            | 1 | efs-guardian🧪 |
| 100 | python-dotenv             | 1.0.1           | 1.1.1      | *minor*    | 2 | efs-guardian⬆️🧪 |
| 101 | redis                     | 5.2.1           | 6.2.0      | **MAJOR**  | 2 | efs-guardian⬆️🧪 |
| 102 | referencing               | 0.29.3          | 0.35.1     | *minor*    | 2 | efs-guardian⬆️🧪 |
| 103 | requests                  | 2.32.3          | 2.32.4     |            | 2 | efs-guardian⬆️🧪 |
| 104 | responses                 | 0.25.6          | 0.25.7     |            | 1 | efs-guardian🧪 |
| 105 | rich                      | 13.9.2          | 14.0.0     | **MAJOR**  | 1 | efs-guardian⬆️ |
| 106 | rpds-py                   | 0.20.0          | 0.25.1     | *minor*    | 2 | efs-guardian⬆️🧪 |
| 107 | ruff                      | 0.9.9           | 0.12.1     | *minor*    | 1 | efs-guardian🔧 |
| 108 | s3transfer                | 0.11.3          | 0.13.0     | *minor*    | 2 | efs-guardian⬆️🧪 |
| 109 | setuptools                | 75.2.0          | 80.9.0     | **MAJOR**  | 3 | efs-guardian⬆️🧪🔧 |
| 110 | sh                        | 2.1.0           | 2.2.2      | *minor*    | 1 | efs-guardian⬆️ |
| 111 | six                       | 1.16.0          | 1.17.0     | *minor*    | 2 | efs-guardian⬆️🧪 |
| 112 | starlette                 | 0.41.2          | 0.46.2     | *minor*    | 1 | efs-guardian⬆️ |
| 113 | sympy                     | 1.13.3          | 1.14.0     | *minor*    | 1 | efs-guardian🧪 |
| 114 | tenacity                  | 9.0.0           | 9.1.2      | *minor*    | 1 | efs-guardian⬆️ |
| 115 | tomlkit                   | 0.13.2          | 0.13.3     |            | 1 | efs-guardian🔧 |
| 116 | tqdm                      | 4.66.5          | 4.67.1     | *minor*    | 1 | efs-guardian⬆️ |
| 117 | typer                     | 0.12.5          | 0.16.0     | *minor*    | 1 | efs-guardian⬆️ |
| 118 | types-aiobotocore         | 2.19.0          | 2.23.0     | *minor*    | 1 | efs-guardian⬆️ |
| 119 | types-aiobotocore-ec2     | 2.19.0          | 2.23.0     | *minor*    | 1 | efs-guardian⬆️ |
| 120 | types-aiobotocore-s3      | 2.19.0          | 2.23.0     | *minor*    | 1 | efs-guardian⬆️ |
| 121 | types-aiobotocore-ssm     | 2.19.0          | 2.23.0     | *minor*    | 1 | efs-guardian⬆️ |
| 122 | types-awscrt              | 0.22.0          | 0.27.4     | *minor*    | 1 | efs-guardian⬆️ |
| 123 | types-python-dateutil     | 2.9.0.20241003  | 2.9.0.20250516 |            | 1 | efs-guardian⬆️ |
| 124 | typing-extensions         | 4.12.2          | 4.14.0     | *minor*    | 3 | efs-guardian⬆️🧪🔧 |
| 125 | tzdata                    | 2025.1          | 2025.2     | *minor*    | 1 | efs-guardian🧪 |
| 126 | urllib3                   | 2.2.3           | 2.5.0      | *minor*    | 2 | efs-guardian⬆️🧪 |
| 127 | uvicorn                   | 0.34.2          | 0.35.0     | *minor*    | 1 | efs-guardian⬆️ |
| 128 | virtualenv                | 20.29.2         | 20.31.2    | *minor*    | 1 | efs-guardian🔧 |
| 129 | watchfiles                | 1.0.5           | 1.1.0      | *minor*    | 1 | efs-guardian⬆️ |
| 130 | wrapt                     | 1.16.0          | 1.17.2     | *minor*    | 2 | efs-guardian⬆️🧪 |
| 131 | yarl                      | 1.20.0          | 1.20.1     |            | 2 | efs-guardian⬆️🧪 |
| 132 | zipp                      | 3.20.2          | 3.23.0     | *minor*    | 1 | efs-guardian⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 107

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.1.2, 9.4.1, 9.5.1, 9.5.3, 9.5.4, 9.5.5 | 9.5.5                     |                           |
|   2 | aioboto3                  | 14.3.0, 15.0.0            | 14.3.0                    |                           |
|   3 | aiobotocore               | 2.22.0, 2.23.0            | 2.22.0                    |                           |
|   4 | aiocache                  | 0.11.1, 0.12.2, 0.12.3    | 0.12.3                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0, 0.24.0            | 0.24.0                    |                           |
|   7 | aiofiles                  | 0.8.0, 23.2.1, 24.1.0     | 24.1.0                    |                           |
|   8 | aiohappyeyeballs          | 2.5.0, 2.6.1              | 2.5.0, 2.6.1              |                           |
|   9 | aiohttp                   | 3.11.18, 3.12.12, 3.12.13 | 3.12.12, 3.12.13          |                           |
|  10 | aiohttp-jinja2            | 1.5                       |                           |                           |
|  11 | aiohttp-security          | 0.4.0                     |                           |                           |
|  12 | aiohttp-session           | 2.11.0                    |                           |                           |
|  13 | aioitertools              | 0.11.0, 0.12.0            | 0.12.0                    |                           |
|  14 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  15 | aioprocessing             | 2.0.1                     |                           |                           |
|  16 | aioresponses              |                           | 0.7.8                     |                           |
|  17 | aiormq                    | 6.7.6, 6.8.0, 6.8.1       | 6.8.1                     |                           |
|  18 | aiosignal                 | 1.2.0, 1.3.1, 1.3.2       | 1.2.0, 1.3.1, 1.3.2       |                           |
|  19 | aiosmtplib                | 1.1.6, 3.0.2, 4.0.0       |                           |                           |
|  20 | alembic                   | 1.8.1, 1.13.1, 1.14.0, 1.14.1, 1.15.1, 1.15.2, 1.16.2 | 1.8.1, 1.13.1, 1.14.0, 1.14.1, 1.15.1, 1.15.2 |                           |
|  21 | amqp                      | 5.3.1                     | 5.3.1                     |                           |
|  22 | annotated-types           | 0.7.0                     | 0.7.0                     |                           |
|  23 | antlr4-python3-runtime    |                           | 4.13.2                    |                           |
|  24 | anyio                     | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0, 4.9.0 | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0, 4.9.0 |                           |
|  25 | appdirs                   | 1.4.4                     |                           |                           |
|  26 | arrow                     | 1.3.0                     | 1.3.0                     |                           |
|  27 | asgi-lifespan             | 2.1.0                     | 2.1.0                     |                           |
|  28 | asgiref                   | 3.8.1                     |                           |                           |
|  29 | astroid                   |                           |                           | 3.3.8, 3.3.9, 3.3.10      |
|  30 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  31 | async-timeout             | 4.0.3                     | 4.0.3                     |                           |
|  32 | asyncpg                   | 0.27.0, 0.29.0, 0.30.0    | 0.27.0, 0.30.0            |                           |
|  33 | asyncpg-stubs             |                           | 0.27.1, 0.30.0            |                           |
|  34 | attrs                     | 21.4.0, 23.2.0, 24.2.0, 25.1.0, 25.2.0, 25.3.0 | 21.4.0, 23.2.0, 24.2.0, 25.1.0, 25.2.0, 25.3.0 |                           |
|  35 | aws-sam-translator        |                           | 1.55.0, 1.95.0, 1.97.0, 1.99.0 |                           |
|  36 | aws-xray-sdk              |                           | 2.14.0                    |                           |
|  37 | bidict                    | 0.22.0, 0.23.1            | 0.23.1                    |                           |
|  38 | billiard                  | 4.2.1                     | 4.2.1                     |                           |
|  39 | binaryornot               | 0.4.4                     |                           |                           |
|  40 | black                     |                           |                           | 25.1.0                    |
|  41 | blinker                   |                           | 1.9.0                     |                           |
|  42 | blosc                     | 1.11.3                    |                           |                           |
|  43 | bokeh                     | 3.7.3                     | 3.7.3                     |                           |
|  44 | boto3                     | 1.37.3, 1.38.1, 1.38.27   | 1.37.3, 1.38.1, 1.38.27   |                           |
|  45 | boto3-stubs               |                           | 1.37.4                    |                           |
|  46 | botocore                  | 1.37.3, 1.38.1, 1.38.27   | 1.37.3, 1.38.1, 1.38.27   |                           |
|  47 | botocore-stubs            | 1.34.69, 1.36.17, 1.37.4, 1.38.19, 1.38.46 | 1.37.4, 1.38.19           |                           |
|  48 | brotli                    |                           | 1.1.0                     |                           |
|  49 | build                     |                           |                           | 1.2.2.post1               |
|  50 | bump2version              |                           |                           | 1.0.1                     |
|  51 | captcha                   | 0.5.0                     |                           |                           |
|  52 | celery                    | 5.5.2                     | 5.5.2                     |                           |
|  53 | certifi                   | 2023.7.22, 2024.2.2, 2024.8.30, 2025.1.31, 2025.4.26, 2025.6.15 | 2023.7.22, 2024.2.2, 2024.8.30, 2025.1.31, 2025.4.26, 2025.6.15 |                           |
|  54 | cffi                      | 1.17.1                    | 1.17.1                    |                           |
|  55 | cfgv                      |                           |                           | 3.4.0                     |
|  56 | cfn-lint                  |                           | 0.72.0, 1.27.0, 1.28.0, 1.35.1, 1.36.1 |                           |
|  57 | change-case               |                           |                           | 0.5.2                     |
|  58 | chardet                   | 5.2.0                     |                           |                           |
|  59 | charset-normalizer        | 2.0.12, 3.3.2, 3.4.0, 3.4.1, 3.4.2 | 2.0.12, 3.3.2, 3.4.0, 3.4.1, 3.4.2 |                           |
|  60 | click                     | 8.1.3, 8.1.7, 8.1.8, 8.2.1 | 8.1.3, 8.1.7, 8.1.8, 8.2.1 | 8.1.3, 8.1.7, 8.1.8, 8.2.1 |
|  61 | click-didyoumean          | 0.3.1                     | 0.3.1                     |                           |
|  62 | click-plugins             | 1.1.1                     | 1.1.1                     |                           |
|  63 | click-repl                | 0.3.0                     | 0.3.0                     |                           |
|  64 | cloudpickle               | 3.1.1                     | 3.1.1                     |                           |
|  65 | configargparse            |                           | 1.7.1                     |                           |
|  66 | contourpy                 | 1.2.0, 1.3.2              | 1.3.2                     |                           |
|  67 | cookiecutter              | 2.6.0                     |                           |                           |
|  68 | coverage                  |                           | 7.6.12, 7.7.1, 7.8.0, 7.9.1 |                           |
|  69 | cryptography              | 41.0.7, 44.0.0, 44.0.2    | 44.0.0, 44.0.2, 45.0.2, 45.0.4 |                           |
|  70 | cycler                    | 0.12.1                    |                           |                           |
|  71 | dask                      | 2025.5.0                  | 2025.5.0                  |                           |
|  72 | dateparser                | 1.2.0                     |                           |                           |
|  73 | debugpy                   |                           | 1.8.12, 1.8.14            |                           |
|  74 | deepdiff                  | 8.1.1                     | 8.5.0                     |                           |
|  75 | deprecated                | 1.2.14, 1.2.15, 1.2.18    | 1.2.18                    |                           |
|  76 | dill                      |                           |                           | 0.3.9, 0.4.0              |
|  77 | distlib                   |                           |                           | 0.3.9                     |
|  78 | distributed               | 2025.5.0                  | 2025.5.0                  |                           |
|  79 | dnspython                 | 2.2.1, 2.6.1, 2.7.0       | 2.2.1, 2.7.0              |                           |
|  80 | docker                    | 7.1.0                     | 7.1.0                     |                           |
|  81 | docutils                  | 0.21.2                    |                           |                           |
|  82 | ecdsa                     | 0.19.0                    | 0.19.0                    |                           |
|  83 | email-validator           | 2.1.1, 2.2.0              | 2.2.0                     |                           |
|  84 | et-xmlfile                | 1.1.0                     |                           |                           |
|  85 | exceptiongroup            | 1.2.2, 1.3.0              | 1.2.2, 1.3.0              |                           |
|  86 | execnet                   |                           | 2.1.1                     |                           |
|  87 | faker                     | 19.6.1                    | 19.6.1, 36.1.1, 36.2.2, 37.0.0, 37.1.0, 37.3.0, 37.4.0 |                           |
|  88 | fakeredis                 |                           | 2.27.0, 2.29.0, 2.30.1    |                           |
|  89 | fast-depends              | 2.4.12                    | 2.4.12                    |                           |
|  90 | fastapi                   | 0.115.12, 0.115.14        | 0.115.6, 0.115.12         |                           |
|  91 | fastapi-cli               | 0.0.6, 0.0.7              | 0.0.5                     |                           |
|  92 | fastapi-lifespan-manager  | 0.1.4                     | 0.1.4                     |                           |
|  93 | fastapi-pagination        | 0.12.31, 0.12.32, 0.12.34 | 0.12.34                   |                           |
|  94 | faststream                | 0.5.31, 0.5.33, 0.5.34, 0.5.35, 0.5.37, 0.5.41, 0.5.43 | 0.5.35                    |                           |
|  95 | filelock                  |                           |                           | 3.17.0, 3.18.0            |
|  96 | flaky                     |                           | 3.8.1                     |                           |
|  97 | flask                     |                           | 2.1.3, 3.1.0, 3.1.1       |                           |
|  98 | flask-cors                |                           | 5.0.1, 6.0.0, 6.0.1       |                           |
|  99 | flask-login               |                           | 0.6.3                     |                           |
| 100 | flexcache                 | 0.3                       | 0.3                       |                           |
| 101 | flexparser                | 0.3.1, 0.4                | 0.4                       |                           |
| 102 | fonttools                 | 4.50.0                    |                           |                           |
| 103 | frozenlist                | 1.4.1, 1.5.0, 1.6.0, 1.7.0 | 1.4.1, 1.5.0, 1.6.0, 1.7.0 |                           |
| 104 | fsspec                    | 2025.3.2                  | 2025.3.2                  |                           |
| 105 | gevent                    |                           | 24.11.1                   |                           |
| 106 | geventhttpclient          |                           | 2.3.3                     |                           |
| 107 | googleapis-common-protos  | 1.65.0, 1.66.0, 1.68.0, 1.69.1, 1.69.2, 1.70.0 | 1.68.0                    |                           |
| 108 | graphql-core              |                           | 3.2.6                     |                           |
| 109 | greenlet                  | 2.0.2, 3.0.3, 3.1.1, 3.2.2, 3.2.3 | 2.0.2, 3.0.3, 3.1.1, 3.2.2 |                           |
| 110 | grpcio                    | 1.66.0, 1.68.0, 1.68.1, 1.70.0, 1.71.0, 1.73.1 | 1.70.0                    |                           |
| 111 | gunicorn                  | 23.0.0                    |                           |                           |
| 112 | h11                       | 0.14.0, 0.16.0            | 0.14.0, 0.16.0            |                           |
| 113 | h2                        | 4.1.0, 4.2.0              | 4.2.0                     |                           |
| 114 | hpack                     | 4.0.0, 4.1.0              | 4.1.0                     |                           |
| 115 | httmock                   | 1.4.0                     |                           |                           |
| 116 | httpcore                  | 1.0.4, 1.0.5, 1.0.7, 1.0.9 | 1.0.4, 1.0.5, 1.0.7, 1.0.9 |                           |
| 117 | httptools                 | 0.6.4                     | 0.6.4                     |                           |
| 118 | httpx                     | 0.27.0, 0.27.2, 0.28.1    | 0.27.0, 0.27.2, 0.28.1    |                           |
| 119 | hypercorn                 |                           | 0.17.3                    |                           |
| 120 | hyperframe                | 6.0.1, 6.1.0              | 6.1.0                     |                           |
| 121 | hypothesis                |                           | 6.91.0, 6.129.0           |                           |
| 122 | icdiff                    |                           | 2.0.7                     |                           |
| 123 | identify                  |                           |                           | 2.6.8, 2.6.9, 2.6.10, 2.6.12 |
| 124 | idna                      | 3.3, 3.6, 3.10            | 3.3, 3.6, 3.10            |                           |
| 125 | ifaddr                    | 0.2.0                     |                           |                           |
| 126 | importlib-metadata        | 8.0.0, 8.5.0, 8.6.1, 8.7.0 | 8.5.0, 8.6.1              |                           |
| 127 | iniconfig                 | 2.0.0                     | 2.0.0, 2.1.0              |                           |
| 128 | inotify                   |                           |                           | 0.2.10                    |
| 129 | isort                     |                           |                           | 6.0.1                     |
| 130 | itsdangerous              | 2.2.0                     | 2.2.0                     |                           |
| 131 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 132 | jinja2                    | 3.1.2, 3.1.5, 3.1.6       | 3.1.2, 3.1.5, 3.1.6       | 3.1.6                     |
| 133 | jinja2-time               | 0.2.0                     |                           |                           |
| 134 | jmespath                  | 1.0.1                     | 1.0.1                     |                           |
| 135 | joserfc                   |                           | 1.0.4, 1.1.0              |                           |
| 136 | jschema-to-python         |                           | 1.2.3                     |                           |
| 137 | jsondiff                  | 2.0.0                     | 2.2.1                     |                           |
| 138 | jsonpatch                 |                           | 1.33                      |                           |
| 139 | jsonpath-ng               |                           | 1.7.0                     |                           |
| 140 | jsonpickle                |                           | 4.0.2                     |                           |
| 141 | jsonpointer               |                           | 3.0.0                     |                           |
| 142 | jsonref                   |                           | 1.1.0                     |                           |
| 143 | jsonschema                | 3.2.0, 4.21.1, 4.23.0, 4.24.0 | 3.2.0, 4.21.1, 4.23.0, 4.24.0 |                           |
| 144 | jsonschema-path           |                           | 0.3.4                     |                           |
| 145 | jsonschema-specifications | 2023.7.1, 2024.10.1, 2025.4.1 | 2023.7.1, 2024.10.1, 2025.4.1 |                           |
| 146 | junit-xml                 |                           | 1.9                       |                           |
| 147 | kiwisolver                | 1.4.5                     |                           |                           |
| 148 | kombu                     | 5.5.3                     | 5.5.3                     |                           |
| 149 | lazy-object-proxy         |                           | 1.10.0, 1.11.0            |                           |
| 150 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 151 | locust                    |                           | 2.37.5                    |                           |
| 152 | locust-cloud              |                           | 1.21.8                    |                           |
| 153 | locust-plugins            |                           | 4.7.0                     |                           |
| 154 | lupa                      |                           | 2.4, 2.5                  |                           |
| 155 | lz4                       | 4.4.4                     |                           |                           |
| 156 | mako                      | 1.2.2, 1.3.2, 1.3.6, 1.3.7, 1.3.9, 1.3.10 | 1.2.2, 1.3.2, 1.3.7, 1.3.9, 1.3.10 |                           |
| 157 | markdown-it-py            | 3.0.0                     | 3.0.0                     | 3.0.0                     |
| 158 | markdown2                 | 2.5.3                     |                           |                           |
| 159 | markupsafe                | 3.0.2                     | 3.0.2                     | 3.0.2                     |
| 160 | matplotlib                | 3.8.3                     |                           |                           |
| 161 | mccabe                    |                           |                           | 0.7.0                     |
| 162 | mdurl                     | 0.1.2                     | 0.1.2                     | 0.1.2                     |
| 163 | moto                      |                           | 4.0.1, 5.1.4, 5.1.6       |                           |
| 164 | mpmath                    |                           | 1.3.0                     |                           |
| 165 | msgpack                   | 1.1.0                     | 1.1.0                     |                           |
| 166 | multidict                 | 6.0.5, 6.1.0, 6.2.0, 6.4.3, 6.4.4, 6.6.2 | 6.1.0, 6.4.4, 6.6.2       |                           |
| 167 | mypy                      |                           | 1.15.0                    | 1.15.0, 1.16.1            |
| 168 | mypy-extensions           |                           | 1.0.0, 1.1.0              | 1.0.0, 1.1.0              |
| 169 | narwhals                  | 1.40.0                    | 1.40.0                    |                           |
| 170 | nest-asyncio              | 1.6.0                     |                           |                           |
| 171 | networkx                  | 3.4.2                     | 2.8.8, 3.4.2, 3.5         |                           |
| 172 | nicegui                   | 2.12.1                    |                           |                           |
| 173 | nodeenv                   |                           |                           | 1.9.1                     |
| 174 | nose                      |                           |                           | 1.3.7                     |
| 175 | numpy                     | 1.26.4, 2.2.6             | 2.2.3, 2.2.6              |                           |
| 176 | openapi-schema-validator  |                           | 0.2.3, 0.6.3              |                           |
| 177 | openapi-spec-validator    |                           | 0.4.0, 0.7.1, 0.7.2       |                           |
| 178 | openpyxl                  | 3.0.9                     |                           |                           |
| 179 | opentelemetry-api         | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 180 | opentelemetry-exporter-otlp | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 181 | opentelemetry-exporter-otlp-proto-common | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 182 | opentelemetry-exporter-otlp-proto-grpc | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 183 | opentelemetry-exporter-otlp-proto-http | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 184 | opentelemetry-instrumentation | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 185 | opentelemetry-instrumentation-aio-pika | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 186 | opentelemetry-instrumentation-aiohttp-client | 0.48b0                    |                           |                           |
| 187 | opentelemetry-instrumentation-aiohttp-server | 0.48b0                    |                           |                           |
| 188 | opentelemetry-instrumentation-aiopg | 0.48b0                    |                           |                           |
| 189 | opentelemetry-instrumentation-asgi | 0.47b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 |                           |                           |
| 190 | opentelemetry-instrumentation-asyncpg | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 191 | opentelemetry-instrumentation-botocore | 0.47b0, 0.51b0, 0.54b1, 0.55b1 |                           |                           |
| 192 | opentelemetry-instrumentation-celery | 0.51b0                    |                           |                           |
| 193 | opentelemetry-instrumentation-dbapi | 0.48b0                    |                           |                           |
| 194 | opentelemetry-instrumentation-fastapi | 0.47b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 |                           |                           |
| 195 | opentelemetry-instrumentation-httpx | 0.47b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 |                           |                           |
| 196 | opentelemetry-instrumentation-logging | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 197 | opentelemetry-instrumentation-redis | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 198 | opentelemetry-instrumentation-requests | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 199 | opentelemetry-propagator-aws-xray | 1.0.1, 1.0.2              |                           |                           |
| 200 | opentelemetry-proto       | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 201 | opentelemetry-sdk         | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 202 | opentelemetry-semantic-conventions | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 203 | opentelemetry-util-http   | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 204 | ordered-set               | 4.1.0                     |                           |                           |
| 205 | orderly-set               | 5.2.3                     | 5.4.1                     |                           |
| 206 | orjson                    | 3.10.0, 3.10.12, 3.10.15, 3.10.16, 3.10.18 | 3.10.15                   |                           |
| 207 | osparc                    | 0.8.3                     |                           |                           |
| 208 | osparc-client             | 0.8.3                     |                           |                           |
| 209 | packaging                 | 24.0, 24.1, 24.2, 25.0    | 24.0, 24.1, 24.2, 25.0    | 24.0, 24.1, 24.2, 25.0    |
| 210 | pact-python               |                           | 2.3.1                     |                           |
| 211 | pamqp                     | 3.2.1, 3.3.0              | 3.3.0                     |                           |
| 212 | pandas                    | 2.2.1, 2.2.3              | 2.2.3                     |                           |
| 213 | parse                     | 1.20.2                    | 1.20.2                    |                           |
| 214 | partd                     | 1.4.2                     | 1.4.2                     |                           |
| 215 | passlib                   | 1.7.4                     |                           |                           |
| 216 | pathable                  |                           | 0.4.4                     |                           |
| 217 | pathspec                  |                           |                           | 0.12.1                    |
| 218 | pbr                       |                           | 6.1.1                     |                           |
| 219 | pillow                    | 10.2.0, 10.3.0, 11.2.1    | 11.1.0, 11.2.1            |                           |
| 220 | pint                      | 0.24.3, 0.24.4            | 0.24.4                    |                           |
| 221 | pip                       |                           | 25.0.1                    | 25.0.1, 25.1.1            |
| 222 | pip-tools                 |                           |                           | 7.4.1                     |
| 223 | platformdirs              | 4.3.6, 4.3.8              | 4.3.6, 4.3.8              | 4.3.6, 4.3.7, 4.3.8       |
| 224 | playwright                |                           | 1.50.0                    |                           |
| 225 | pluggy                    | 1.5.0                     | 1.5.0, 1.6.0              |                           |
| 226 | ply                       |                           | 3.11                      |                           |
| 227 | pprintpp                  |                           | 0.4.0                     |                           |
| 228 | pre-commit                |                           |                           | 4.1.0, 4.2.0              |
| 229 | priority                  |                           | 2.0.0                     |                           |
| 230 | prometheus-api-client     | 0.5.5                     |                           |                           |
| 231 | prometheus-client         | 0.14.1, 0.20.0, 0.21.0, 0.21.1, 0.22.0, 0.22.1 |                           |                           |
| 232 | prompt-toolkit            | 3.0.50, 3.0.51            | 3.0.50, 3.0.51            |                           |
| 233 | propcache                 | 0.2.0, 0.2.1, 0.3.0, 0.3.1, 0.3.2 | 0.2.0, 0.2.1, 0.3.0, 0.3.1, 0.3.2 |                           |
| 234 | protobuf                  | 4.25.4, 5.29.0, 5.29.1, 5.29.3, 5.29.4, 5.29.5 | 5.29.3                    |                           |
| 235 | pscript                   | 0.7.7                     |                           |                           |
| 236 | psutil                    | 6.0.0, 6.1.0, 6.1.1, 7.0.0 | 6.1.0, 6.1.1, 7.0.0       |                           |
| 237 | psycogreen                |                           | 1.0.2                     |                           |
| 238 | psycopg2-binary           | 2.9.6, 2.9.9, 2.9.10      | 2.9.10                    |                           |
| 239 | ptvsd                     |                           | 4.3.2                     |                           |
| 240 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 241 | py-partiql-parser         |                           | 0.6.1                     |                           |
| 242 | pyasn1                    | 0.6.1                     | 0.4.8                     |                           |
| 243 | pycountry                 | 23.12.11                  |                           |                           |
| 244 | pycparser                 | 2.21, 2.22                | 2.22                      |                           |
| 245 | pycryptodome              | 3.21.0, 3.22.0, 3.23.0    | 3.21.0                    |                           |
| 246 | pydantic                  | 2.10.2, 2.10.3, 2.10.6, 2.11.0, 2.11.4, 2.11.7 | 2.10.2, 2.10.3, 2.10.6, 2.11.4, 2.11.5, 2.11.7 |                           |
| 247 | pydantic-core             | 2.27.1, 2.27.2, 2.33.0, 2.33.2 | 2.27.1, 2.27.2, 2.33.2    |                           |
| 248 | pydantic-extra-types      | 2.9.0, 2.10.0, 2.10.2, 2.10.3, 2.10.4, 2.10.5 | 2.10.2                    |                           |
| 249 | pydantic-settings         | 2.5.2, 2.6.1, 2.7.0       | 2.7.0, 2.9.1              |                           |
| 250 | pyee                      |                           | 12.1.1                    |                           |
| 251 | pyftpdlib                 |                           | 2.0.1                     |                           |
| 252 | pygments                  | 2.15.1, 2.17.2, 2.18.0, 2.19.1, 2.19.2 | 2.15.1, 2.19.1, 2.19.2    | 2.19.1                    |
| 253 | pyinstrument              | 4.6.1, 4.6.2, 5.0.0, 5.0.1, 5.0.2 | 5.0.0, 5.0.1              |                           |
| 254 | pyjwt                     | 2.4.0, 2.9.0              |                           |                           |
| 255 | pylint                    |                           |                           | 3.3.4, 3.3.5, 3.3.6, 3.3.7 |
| 256 | pyopenssl                 |                           | 25.1.0                    |                           |
| 257 | pyparsing                 | 3.1.2                     | 3.1.2, 3.2.1, 3.2.3       |                           |
| 258 | pyproject-hooks           |                           |                           | 1.2.0                     |
| 259 | pyrsistent                | 0.18.1, 0.20.0            | 0.18.1, 0.20.0            |                           |
| 260 | pytest                    | 8.3.5                     | 8.3.5, 8.4.1              |                           |
| 261 | pytest-aiohttp            |                           | 1.1.0                     |                           |
| 262 | pytest-asyncio            |                           | 0.26.0, 1.0.0             |                           |
| 263 | pytest-base-url           |                           | 2.1.0                     |                           |
| 264 | pytest-benchmark          |                           | 5.1.0                     |                           |
| 265 | pytest-celery             |                           | 1.1.3, 1.2.0              |                           |
| 266 | pytest-cov                |                           | 6.0.0, 6.1.1, 6.2.1       |                           |
| 267 | pytest-docker             |                           | 3.2.0, 3.2.1              |                           |
| 268 | pytest-docker-tools       |                           | 3.1.3, 3.1.9              |                           |
| 269 | pytest-html               |                           | 4.1.1                     |                           |
| 270 | pytest-icdiff             |                           | 0.9                       |                           |
| 271 | pytest-instafail          |                           | 0.5.0                     |                           |
| 272 | pytest-localftpserver     |                           | 1.3.2                     |                           |
| 273 | pytest-metadata           |                           | 3.1.1                     |                           |
| 274 | pytest-mock               |                           | 3.14.0, 3.14.1            |                           |
| 275 | pytest-playwright         |                           | 0.7.0                     |                           |
| 276 | pytest-runner             |                           | 6.0.1                     |                           |
| 277 | pytest-sugar              |                           | 1.0.0                     |                           |
| 278 | pytest-xdist              |                           | 3.6.1                     |                           |
| 279 | python-dateutil           | 2.8.2, 2.9.0.post0        | 2.8.2, 2.9.0.post0        |                           |
| 280 | python-dotenv             | 1.0.1, 1.1.0, 1.1.1       | 1.0.1, 1.1.0, 1.1.1       |                           |
| 281 | python-engineio           | 4.3.4, 4.10.1, 4.11.2, 4.12.1 | 4.10.1, 4.12.1            |                           |
| 282 | python-jose               | 3.3.0                     | 3.4.0                     |                           |
| 283 | python-magic              | 0.4.25, 0.4.27            |                           |                           |
| 284 | python-multipart          | 0.0.19, 0.0.20            | 0.0.20                    |                           |
| 285 | python-slugify            | 8.0.4                     | 8.0.4                     |                           |
| 286 | python-socketio           | 5.8.0, 5.11.4, 5.12.1, 5.13.0 | 5.11.4, 5.13.0            |                           |
| 287 | pytz                      | 2022.1, 2024.1, 2025.2    | 2025.1, 2025.2            |                           |
| 288 | pyyaml                    | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              |
| 289 | pyzmq                     |                           | 26.4.0                    |                           |
| 290 | redis                     | 5.2.1, 5.3.0, 6.1.0, 6.2.0 | 5.2.1, 6.1.0, 6.2.0       |                           |
| 291 | referencing               | 0.29.3, 0.35.1            | 0.8.11, 0.29.3, 0.35.1    |                           |
| 292 | regex                     | 2023.12.25                | 2023.12.25, 2024.11.6     |                           |
| 293 | repro-zipfile             | 0.4.0                     |                           |                           |
| 294 | requests                  | 2.32.2, 2.32.3, 2.32.4    | 2.32.2, 2.32.3, 2.32.4    |                           |
| 295 | requests-mock             |                           | 1.12.1                    |                           |
| 296 | responses                 |                           | 0.25.6, 0.25.7            |                           |
| 297 | respx                     |                           | 0.22.0                    |                           |
| 298 | rfc3339-validator         |                           | 0.1.4                     |                           |
| 299 | rich                      | 13.4.2, 13.7.1, 13.9.4, 14.0.0 | 13.4.2, 13.9.4            | 13.9.4                    |
| 300 | rich-toolkit              | 0.12.0, 0.13.2, 0.14.6, 0.14.7 |                           |                           |
| 301 | rpds-py                   | 0.18.0, 0.21.0, 0.22.3, 0.23.1, 0.24.0, 0.25.0, 0.25.1 | 0.18.0, 0.22.3, 0.23.1, 0.25.0, 0.25.1 |                           |
| 302 | rsa                       | 4.9                       | 4.9                       |                           |
| 303 | ruff                      |                           |                           | 0.9.9, 0.9.10, 0.11.2, 0.11.10, 0.11.11, 0.12.1 |
| 304 | s3fs                      | 2025.3.2                  |                           |                           |
| 305 | s3transfer                | 0.11.3, 0.12.0, 0.13.0    | 0.11.3, 0.12.0, 0.13.0    |                           |
| 306 | sarif-om                  |                           | 1.0.4                     |                           |
| 307 | setproctitle              | 1.3.3                     |                           |                           |
| 308 | setuptools                | 69.1.1, 74.0.0, 75.6.0    | 69.1.1, 74.0.0, 75.6.0, 75.8.2, 80.7.1, 80.9.0 | 69.1.1, 74.0.0, 75.6.0, 75.8.2, 76.0.0, 78.1.0, 80.7.1, 80.9.0 |
| 309 | sh                        | 2.0.6, 2.2.1, 2.2.2       |                           |                           |
| 310 | shellingham               | 1.5.4                     | 1.5.4                     | 1.5.4                     |
| 311 | shortuuid                 | 1.0.13                    |                           |                           |
| 312 | simple-websocket          | 1.1.0                     | 1.1.0                     |                           |
| 313 | six                       | 1.16.0, 1.17.0            | 1.16.0, 1.17.0            |                           |
| 314 | sniffio                   | 1.3.1                     | 1.3.1                     |                           |
| 315 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 316 | sqlalchemy                | 1.4.47, 1.4.52, 1.4.54    | 1.4.47, 1.4.52, 1.4.54    |                           |
| 317 | sqlalchemy2-stubs         |                           | 0.0.2a38                  |                           |
| 318 | sshpubkeys                |                           | 3.3.1                     |                           |
| 319 | starlette                 | 0.41.0, 0.41.2, 0.41.3, 0.45.3, 0.46.0, 0.46.1, 0.46.2 | 0.41.3, 0.46.0, 0.46.2    |                           |
| 320 | stream-zip                | 0.0.83                    | 0.0.83                    |                           |
| 321 | swagger-ui-py             | 23.9.23                   |                           |                           |
| 322 | sympy                     |                           | 1.13.3, 1.14.0            |                           |
| 323 | tblib                     | 3.1.0                     | 3.1.0                     |                           |
| 324 | tenacity                  | 8.5.0, 9.0.0, 9.1.2       | 8.5.0, 9.0.0, 9.1.2       |                           |
| 325 | termcolor                 |                           | 2.5.0, 3.1.0              |                           |
| 326 | text-unidecode            | 1.3                       | 1.3                       |                           |
| 327 | tomlkit                   |                           |                           | 0.13.2, 0.13.3            |
| 328 | toolz                     | 0.12.0, 0.12.1, 1.0.0     | 1.0.0                     |                           |
| 329 | tornado                   | 6.5                       | 6.5                       |                           |
| 330 | tqdm                      | 4.64.0, 4.66.2, 4.67.1    | 4.67.1                    |                           |
| 331 | twilio                    | 7.12.0                    |                           |                           |
| 332 | typer                     | 0.12.3, 0.13.1, 0.15.1, 0.15.2, 0.15.4, 0.16.0 | 0.12.3, 0.15.2            | 0.15.2                    |
| 333 | types-aioboto3            |                           | 14.1.0, 14.3.0            |                           |
| 334 | types-aiobotocore         | 2.19.0, 2.21.1, 2.22.0, 2.23.0 | 2.21.0, 2.21.1, 2.22.0    |                           |
| 335 | types-aiobotocore-ec2     | 2.19.0, 2.21.0, 2.22.0, 2.23.0 | 2.22.0                    |                           |
| 336 | types-aiobotocore-iam     |                           | 2.22.0                    |                           |
| 337 | types-aiobotocore-s3      | 2.19.0.post1, 2.21.0, 2.22.0, 2.23.0 | 2.21.0, 2.21.1, 2.22.0    |                           |
| 338 | types-aiobotocore-ssm     | 2.19.0, 2.21.0, 2.22.0, 2.23.0 | 2.22.0                    |                           |
| 339 | types-aiofiles            |                           | 24.1.0.20241221, 24.1.0.20250516 |                           |
| 340 | types-awscrt              | 0.20.5, 0.23.10, 0.27.2, 0.27.4 | 0.23.10, 0.27.2           |                           |
| 341 | types-boto3               |                           | 1.37.4, 1.38.2            |                           |
| 342 | types-cachetools          |                           |                           | 5.5.0.20240820            |
| 343 | types-docker              |                           | 7.1.0.20241229            |                           |
| 344 | types-jsonschema          |                           | 4.23.0.20241208           |                           |
| 345 | types-networkx            |                           | 3.4.2.20250515            |                           |
| 346 | types-openpyxl            |                           | 3.1.5.20241225            |                           |
| 347 | types-passlib             |                           | 1.7.7.20241221            |                           |
| 348 | types-psutil              |                           | 7.0.0.20250218            |                           |
| 349 | types-psycopg2            |                           | 2.9.21.20250121, 2.9.21.20250318, 2.9.21.20250516 |                           |
| 350 | types-pyasn1              |                           | 0.6.0.20250208            |                           |
| 351 | types-python-dateutil     | 2.9.0.20240316, 2.9.0.20241003, 2.9.0.20241206, 2.9.0.20250516 | 2.9.0.20241206            |                           |
| 352 | types-python-jose         |                           | 3.4.0.20250224            |                           |
| 353 | types-pyyaml              |                           | 6.0.12.20241230, 6.0.12.20250516 |                           |
| 354 | types-requests            |                           | 2.32.0.20250301           |                           |
| 355 | types-s3transfer          |                           | 0.11.3, 0.12.0            |                           |
| 356 | types-tqdm                |                           | 4.67.0.20250301           |                           |
| 357 | typing-extensions         | 4.12.2, 4.13.0, 4.13.2, 4.14.0 | 4.12.2, 4.13.0, 4.13.2, 4.14.0 | 4.12.2, 4.13.0, 4.13.2, 4.14.0 |
| 358 | typing-inspection         | 0.4.0, 0.4.1              | 0.4.0, 0.4.1              |                           |
| 359 | tzdata                    | 2024.1, 2025.2            | 2024.1, 2025.1, 2025.2    |                           |
| 360 | tzlocal                   | 5.2                       |                           |                           |
| 361 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 362 | ujson                     | 5.10.0                    |                           |                           |
| 363 | urllib3                   | 2.2.3, 2.3.0, 2.4.0, 2.5.0 | 2.2.3, 2.3.0, 2.4.0, 2.5.0 |                           |
| 364 | uvicorn                   | 0.34.2, 0.35.0            | 0.34.2                    |                           |
| 365 | uvloop                    | 0.21.0                    | 0.21.0                    |                           |
| 366 | vbuild                    | 0.8.2                     |                           |                           |
| 367 | vine                      | 5.1.0                     | 5.1.0                     |                           |
| 368 | virtualenv                |                           |                           | 20.29.2, 20.29.3, 20.31.2 |
| 369 | watchdog                  | 6.0.0                     |                           | 6.0.0                     |
| 370 | watchfiles                | 0.21.0, 1.0.0, 1.0.4, 1.0.5, 1.1.0 | 1.0.4                     |                           |
| 371 | wcwidth                   | 0.2.13                    | 0.2.13                    |                           |
| 372 | websocket-client          |                           | 1.8.0                     |                           |
| 373 | websockets                | 12.0, 14.1, 14.2, 15.0.1  | 15.0                      |                           |
| 374 | werkzeug                  | 2.1.2                     | 2.1.2, 3.1.3              |                           |
| 375 | wheel                     |                           |                           | 0.45.1                    |
| 376 | wrapt                     | 1.16.0, 1.17.0, 1.17.2    | 1.16.0, 1.17.0, 1.17.2    |                           |
| 377 | wsproto                   | 1.2.0                     | 1.2.0                     |                           |
| 378 | xmltodict                 |                           | 0.14.2                    |                           |
| 379 | xyzservices               | 2025.4.0                  | 2025.4.0                  |                           |
| 380 | yarl                      | 1.18.0, 1.18.3, 1.20.0, 1.20.1 | 1.18.0, 1.18.3, 1.20.0, 1.20.1 |                           |
| 381 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 382 | zipp                      | 3.20.1, 3.21.0, 3.23.0    | 3.21.0                    |                           |
| 383 | zope-event                |                           | 5.0                       |                           |
| 384 | zope-interface            |                           | 7.2                       |                           |

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
