### PR TITLE
⬆️ upgrade webserver service requirements

### DIFF
--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -1,9 +1,9 @@
-aio-pika==9.1.2
+aio-pika==9.5.5
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiocache==0.11.1
+aiocache==0.12.3
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -14,11 +14,11 @@ aiodebug==2.3.0
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-aiodocker==0.21.0
+aiodocker==0.24.0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-aiofiles==0.8.0
+aiofiles==24.1.0
     # via
     #   -r requirements/../../../../packages/notifications-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
@@ -27,7 +27,7 @@ aiofiles==0.8.0
     #   -r requirements/_base.in
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.12.12
+aiohttp==3.12.13
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -70,40 +70,42 @@ aiohttp==3.12.12
     #   -r requirements/_base.in
     #   aiodocker
     #   aiohttp-jinja2
+    #   aiohttp-retry
     #   aiohttp-security
     #   aiohttp-session
-aiohttp-jinja2==1.5
+    #   twilio
+aiohttp-jinja2==1.6
     # via -r requirements/_base.in
-aiohttp-security==0.4.0
+aiohttp-retry==2.9.1
+    # via twilio
+aiohttp-security==0.5.0
     # via -r requirements/_base.in
-aiohttp-session==2.11.0
+aiohttp-session==2.12.1
     # via -r requirements/_base.in
 aiopg==1.4.0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
     #   -r requirements/_base.in
-aiormq==6.7.6
+aiormq==6.8.1
     # via aio-pika
-aiosignal==1.2.0
+aiosignal==1.3.2
     # via aiohttp
-aiosmtplib==1.1.6
+aiosmtplib==4.0.1
     # via
     #   -r requirements/../../../../packages/notifications-library/requirements/_base.in
     #   -r requirements/_base.in
-alembic==1.8.1
+alembic==1.16.2
     # via
     #   -r requirements/../../../../packages/notifications-library/requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
 annotated-types==0.7.0
     # via pydantic
-anyio==4.3.0
+anyio==4.9.0
     # via
     #   fast-depends
     #   faststream
     #   httpx
-appdirs==1.4.4
-    # via pint
 arrow==1.3.0
     # via
     #   -r requirements/../../../../packages/models-library/requirements/_base.in
@@ -115,20 +117,21 @@ arrow==1.3.0
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 async-timeout==4.0.3
     # via aiopg
-asyncpg==0.27.0
+asyncpg==0.30.0
     # via
     #   -r requirements/_base.in
     #   sqlalchemy
-attrs==21.4.0
+attrs==25.3.0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
     #   aiohttp
     #   jsonschema
-bidict==0.22.0
+    #   referencing
+bidict==0.23.1
     # via python-socketio
-captcha==0.5.0
+captcha==0.7.1
     # via -r requirements/_base.in
-certifi==2023.7.22
+certifi==2025.6.15
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -171,11 +174,11 @@ certifi==2023.7.22
     #   requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==2.0.12
+charset-normalizer==3.4.2
     # via requests
-click==8.1.3
+click==8.2.1
     # via typer
-cryptography==41.0.7
+cryptography==45.0.4
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -215,50 +218,48 @@ cryptography==41.0.7
     #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/_base.in
     #   aiohttp-session
-deepdiff==8.1.1
+deepdiff==8.5.0
     # via -r requirements/_base.in
-deprecated==1.2.14
-    # via
-    #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-    #   opentelemetry-semantic-conventions
-dnspython==2.2.1
+dnspython==2.7.0
     # via email-validator
 email-validator==2.2.0
     # via pydantic
-et-xmlfile==1.1.0
+et-xmlfile==2.0.0
     # via openpyxl
-faker==19.6.1
+exceptiongroup==1.3.0
+    # via aio-pika
+faker==37.4.0
     # via -r requirements/_base.in
 fast-depends==2.4.12
     # via faststream
-faststream==0.5.31
+faststream==0.5.43
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 flexcache==0.3
     # via pint
-flexparser==0.3.1
+flexparser==0.4
     # via pint
-frozenlist==1.4.1
+frozenlist==1.7.0
     # via
     #   -c requirements/./constraints.txt
     #   aiohttp
     #   aiosignal
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.70.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-greenlet==2.0.2
+greenlet==3.2.3
     # via sqlalchemy
-grpcio==1.66.0
+grpcio==1.73.1
     # via opentelemetry-exporter-otlp-proto-grpc
 gunicorn==23.0.0
     # via -r requirements/_base.in
-h11==0.14.0
-    # via httpcore
-httpcore==1.0.7
+h11==0.16.0
+    # via
+    #   httpcore
+    #   wsproto
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via
@@ -300,18 +301,18 @@ httpx==0.28.1
     #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-idna==3.3
+idna==3.10
     # via
     #   anyio
     #   email-validator
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.0.0
+importlib-metadata==8.7.0
     # via opentelemetry-api
 jinja-app-loader==1.0.2
     # via -r requirements/_base.in
-jinja2==3.1.2
+jinja2==3.1.6
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -352,9 +353,9 @@ jinja2==3.1.2
     #   -r requirements/../../../../packages/notifications-library/requirements/_base.in
     #   aiohttp-jinja2
     #   swagger-ui-py
-jsondiff==2.0.0
+jsondiff==2.2.1
     # via -r requirements/_base.in
-jsonschema==3.2.0
+jsonschema==4.24.0
     # via
     #   -r requirements/../../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../../packages/notifications-library/requirements/../../../packages/models-library/requirements/_base.in
@@ -362,7 +363,9 @@ jsonschema==3.2.0
     #   -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-mako==1.2.2
+jsonschema-specifications==2025.4.1
+    # via jsonschema
+mako==1.3.10
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -407,17 +410,18 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   mako
+    #   werkzeug
 mdurl==0.1.2
     # via markdown-it-py
-msgpack==1.1.0
+msgpack==1.1.1
     # via -r requirements/_base.in
-multidict==6.1.0
+multidict==6.6.2
     # via
     #   aiohttp
     #   yarl
-openpyxl==3.0.9
+openpyxl==3.1.5
     # via -r requirements/_base.in
-opentelemetry-api==1.27.0
+opentelemetry-api==1.34.1
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -435,19 +439,19 @@ opentelemetry-api==1.27.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.27.0
+opentelemetry-exporter-otlp==1.34.1
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.27.0
+opentelemetry-exporter-otlp-proto-common==1.34.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.27.0
+opentelemetry-exporter-otlp-proto-grpc==1.34.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.27.0
+opentelemetry-exporter-otlp-proto-http==1.34.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.48b0
+opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-aiohttp-client
@@ -458,50 +462,51 @@ opentelemetry-instrumentation==0.48b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.48b0
+opentelemetry-instrumentation-aio-pika==0.55b1
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-aiohttp-client==0.48b0
+opentelemetry-instrumentation-aiohttp-client==0.55b1
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-opentelemetry-instrumentation-aiohttp-server==0.48b0
+opentelemetry-instrumentation-aiohttp-server==0.55b1
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-opentelemetry-instrumentation-aiopg==0.48b0
+opentelemetry-instrumentation-aiopg==0.55b1
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
     #   -r requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.48b0
+opentelemetry-instrumentation-asyncpg==0.55b1
     # via
     #   -r requirements/../../../../packages/notifications-library/requirements/../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../../packages/postgres-database/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
-opentelemetry-instrumentation-dbapi==0.48b0
+opentelemetry-instrumentation-dbapi==0.55b1
     # via opentelemetry-instrumentation-aiopg
-opentelemetry-instrumentation-logging==0.48b0
+opentelemetry-instrumentation-logging==0.55b1
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.48b0
+opentelemetry-instrumentation-redis==0.55b1
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.48b0
+opentelemetry-instrumentation-requests==0.55b1
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.27.0
+opentelemetry-proto==1.34.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.27.0
+opentelemetry-sdk==1.34.1
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.48b0
+opentelemetry-semantic-conventions==0.55b1
     # via
+    #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
     #   opentelemetry-instrumentation-asyncpg
@@ -509,14 +514,14 @@ opentelemetry-semantic-conventions==0.48b0
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.48b0
+opentelemetry-util-http==0.55b1
     # via
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
     #   opentelemetry-instrumentation-requests
-orderly-set==5.2.3
+orderly-set==5.4.1
     # via deepdiff
-orjson==3.10.0
+orjson==3.10.18
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -579,47 +584,50 @@ orjson==3.10.0
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/_base.in
     #   deepdiff
-packaging==24.1
+packaging==25.0
     # via
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
     #   gunicorn
+    #   opentelemetry-instrumentation
     #   swagger-ui-py
-pamqp==3.2.1
+pamqp==3.3.0
     # via aiormq
 passlib==1.7.4
     # via -r requirements/_base.in
-pillow==10.3.0
+pillow==11.2.1
     # via captcha
-pint==0.24.3
+pint==0.24.4
     # via
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-prometheus-client==0.14.1
+platformdirs==4.3.8
+    # via pint
+prometheus-client==0.22.1
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-propcache==0.3.1
+propcache==0.3.2
     # via
     #   aiohttp
     #   yarl
-protobuf==4.25.4
+protobuf==5.29.5
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.0.0
+psutil==7.0.0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-psycopg2-binary==2.9.6
+psycopg2-binary==2.9.10
     # via
     #   aiopg
     #   sqlalchemy
-pycountry==23.12.11
+pycountry==24.6.1
     # via -r requirements/_base.in
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pycryptodome==3.21.0
+pycryptodome==3.23.0
     # via stream-zip
-pydantic==2.10.2
+pydantic==2.11.7
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -696,9 +704,9 @@ pydantic==2.10.2
     #   fast-depends
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.27.1
+pydantic-core==2.33.2
     # via pydantic
-pydantic-extra-types==2.9.0
+pydantic-extra-types==2.10.5
     # via
     #   -r requirements/../../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
@@ -723,7 +731,7 @@ pydantic-extra-types==2.9.0
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-pydantic-settings==2.5.2
+pydantic-settings==2.7.0
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -771,31 +779,25 @@ pydantic-settings==2.5.2
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
-pygments==2.15.1
+pygments==2.19.2
     # via rich
-pyinstrument==4.6.1
+pyinstrument==5.0.2
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-pyjwt==2.4.0
+pyjwt==2.10.1
     # via twilio
-pyrsistent==0.18.1
-    # via jsonschema
-python-dateutil==2.8.2
-    # via
-    #   arrow
-    #   faker
-python-dotenv==1.0.1
+python-dateutil==2.9.0.post0
+    # via arrow
+python-dotenv==1.1.1
     # via pydantic-settings
-python-engineio==4.3.4
+python-engineio==4.12.2
     # via python-socketio
-python-magic==0.4.25
+python-magic==0.4.27
     # via -r requirements/_base.in
-python-socketio==5.8.0
+python-socketio==5.13.0
     # via -r requirements/_base.in
-pytz==2022.1
-    # via twilio
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -835,8 +837,9 @@ pyyaml==6.0.1
     #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+    #   jsondiff
     #   swagger-ui-py
-redis==5.2.1
+redis==6.2.0
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -877,11 +880,51 @@ redis==5.2.1
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-requests==2.32.2
+referencing==0.35.1
+    # via
+    #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/notifications-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/notifications-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/notifications-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/notifications-library/requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/notifications-library/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/notifications-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/notifications-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/notifications-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../packages/simcore-sdk/requirements/../../../requirements/constraints.txt
+    #   -c requirements/../../../../requirements/constraints.txt
+    #   jsonschema
+    #   jsonschema-specifications
+requests==2.32.4
     # via
     #   opentelemetry-exporter-otlp-proto-http
     #   twilio
-rich==13.4.2
+rich==14.0.0
     # via
     #   -r requirements/../../../../packages/notifications-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
@@ -889,21 +932,21 @@ rich==13.4.2
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
-setproctitle==1.3.3
-    # via gunicorn
-setuptools==69.1.1
+rpds-py==0.25.1
     # via
     #   jsonschema
-    #   opentelemetry-instrumentation
+    #   referencing
+setproctitle==1.3.6
+    # via gunicorn
 shellingham==1.5.4
     # via typer
-six==1.16.0
-    # via
-    #   jsonschema
-    #   python-dateutil
+simple-websocket==1.1.0
+    # via python-engineio
+six==1.17.0
+    # via python-dateutil
 sniffio==1.3.1
     # via anyio
-sqlalchemy==1.4.47
+sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -953,24 +996,24 @@ stream-zip==0.0.83
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 swagger-ui-py==23.9.23
     # via -r requirements/_base.in
-tenacity==8.5.0
+tenacity==9.1.2
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
     #   -r requirements/_base.in
-toolz==0.12.0
+toolz==1.0.0
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-tqdm==4.64.0
+tqdm==4.67.1
     # via
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/_base.in
-twilio==7.12.0
+twilio==9.6.3
     # via -r requirements/_base.in
-typer==0.12.3
+typer==0.16.0
     # via
     #   -r requirements/../../../../packages/notifications-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
@@ -979,19 +1022,31 @@ typer==0.12.3
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/settings-library/requirements/_base.in
 types-python-dateutil==2.9.0.20250516
     # via arrow
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   aiodebug
-    #   aiodocker
+    #   alembic
+    #   anyio
+    #   exceptiongroup
     #   faststream
     #   flexcache
     #   flexparser
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   pint
     #   pydantic
     #   pydantic-core
+    #   pydantic-extra-types
     #   typer
-urllib3==2.2.3
+    #   typing-inspection
+typing-inspection==0.4.1
+    # via pydantic
+tzdata==2025.2
+    # via faker
+urllib3==2.5.0
     # via
     #   -c requirements/../../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -1032,11 +1087,10 @@ urllib3==2.2.3
     #   requests
 uvloop==0.21.0
     # via -r requirements/_base.in
-werkzeug==2.1.2
+werkzeug==3.1.3
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-wrapt==1.16.0
+wrapt==1.17.2
     # via
-    #   deprecated
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-aiohttp-client
@@ -1044,7 +1098,9 @@ wrapt==1.16.0
     #   opentelemetry-instrumentation-aiopg
     #   opentelemetry-instrumentation-dbapi
     #   opentelemetry-instrumentation-redis
-yarl==1.20.0
+wsproto==1.2.0
+    # via simple-websocket
+yarl==1.20.1
     # via
     #   -c requirements/./constraints.txt
     #   -r requirements/../../../../packages/notifications-library/requirements/../../../packages/postgres-database/requirements/_base.in
@@ -1055,5 +1111,5 @@ yarl==1.20.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.20.1
+zipp==3.23.0
     # via importlib-metadata

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -2,18 +2,18 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-aiohttp==3.12.12
+aiohttp==3.12.13
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   aioresponses
 aioresponses==0.7.8
     # via -r requirements/_test.in
-aiosignal==1.2.0
+aiosignal==1.3.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-alembic==1.8.1
+alembic==1.16.2
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
@@ -21,19 +21,19 @@ annotated-types==0.7.0
     # via
     #   -c requirements/_base.txt
     #   pydantic
-anyio==4.3.0
+anyio==4.9.0
     # via
     #   -c requirements/_base.txt
     #   httpx
     #   starlette
     #   watchfiles
-asyncpg==0.27.0
+asyncpg==0.30.0
     # via
     #   -c requirements/_base.txt
     #   asyncpg-stubs
-asyncpg-stubs==0.27.1
+asyncpg-stubs==0.30.2
     # via -r requirements/_test.in
-attrs==21.4.0
+attrs==25.3.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
@@ -41,28 +41,29 @@ attrs==21.4.0
     #   jsonschema
     #   pytest-docker
     #   referencing
-certifi==2023.7.22
+certifi==2025.6.15
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==3.4.2
     # via
     #   -c requirements/_base.txt
     #   requests
-click==8.1.3
+click==8.2.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
+    #   rich-toolkit
     #   typer
     #   uvicorn
-coverage==7.6.12
+coverage==7.9.1
     # via
     #   -r requirements/_test.in
     #   pytest-cov
-dnspython==2.2.1
+dnspython==2.7.0
     # via
     #   -c requirements/_base.txt
     #   email-validator
@@ -74,33 +75,35 @@ email-validator==2.2.0
     #   fastapi
 execnet==2.1.1
     # via pytest-xdist
-faker==19.6.1
+faker==37.4.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-fastapi==0.115.6
-    # via -r requirements/_test.in
-fastapi-cli==0.0.5
+fastapi==0.115.14
+    # via
+    #   -r requirements/_test.in
+    #   fastapi-pagination
+fastapi-cli==0.0.7
     # via fastapi
-fastapi-pagination==0.12.34
+fastapi-pagination==0.13.3
     # via -r requirements/_test.in
 flaky==3.8.1
     # via -r requirements/_test.in
-frozenlist==1.4.1
+frozenlist==1.7.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   aiosignal
-greenlet==2.0.2
+greenlet==3.2.3
     # via
     #   -c requirements/_base.txt
     #   sqlalchemy
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c requirements/_base.txt
     #   httpcore
     #   uvicorn
-httpcore==1.0.7
+httpcore==1.0.9
     # via
     #   -c requirements/_base.txt
     #   httpx
@@ -112,11 +115,11 @@ httpx==0.28.1
     #   -c requirements/_base.txt
     #   fastapi
     #   respx
-hypothesis==6.91.0
+hypothesis==6.135.17
     # via -r requirements/_test.in
 icdiff==2.0.7
     # via pytest-icdiff
-idna==3.3
+idna==3.10
     # via
     #   -c requirements/_base.txt
     #   anyio
@@ -124,22 +127,31 @@ idna==3.3
     #   httpx
     #   requests
     #   yarl
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-jinja2==3.1.2
+jinja2==3.1.6
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   fastapi
 jsonref==1.1.0
     # via -r requirements/_test.in
-jsonschema==3.2.0
+jsonschema==4.24.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   openapi-schema-validator
     #   openapi-spec-validator
-mako==1.2.2
+jsonschema-path==0.3.4
+    # via openapi-spec-validator
+jsonschema-specifications==2025.4.1
+    # via
+    #   -c requirements/_base.txt
+    #   jsonschema
+    #   openapi-schema-validator
+lazy-object-proxy==1.11.0
+    # via openapi-spec-validator
+mako==1.3.10
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -157,56 +169,58 @@ mdurl==0.1.2
     # via
     #   -c requirements/_base.txt
     #   markdown-it-py
-multidict==6.1.0
+multidict==6.6.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
-mypy==1.15.0
+mypy==1.16.1
     # via sqlalchemy
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via mypy
-openapi-schema-validator==0.2.3
+openapi-schema-validator==0.6.3
     # via openapi-spec-validator
-openapi-spec-validator==0.4.0
+openapi-spec-validator==0.7.2
     # via -r requirements/_test.in
-packaging==24.1
+packaging==25.0
     # via
     #   -c requirements/_base.txt
     #   aioresponses
     #   pytest
     #   pytest-sugar
-pluggy==1.5.0
-    # via pytest
+pathable==0.4.4
+    # via jsonschema-path
+pathspec==0.12.1
+    # via mypy
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
 pprintpp==0.4.0
     # via pytest-icdiff
-propcache==0.3.1
+propcache==0.3.2
     # via
     #   -c requirements/_base.txt
     #   aiohttp
     #   yarl
 py-cpuinfo==9.0.0
     # via pytest-benchmark
-pydantic==2.10.2
+pydantic==2.11.7
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   fastapi
     #   fastapi-pagination
-pydantic-core==2.27.1
+pydantic-core==2.33.2
     # via
     #   -c requirements/_base.txt
     #   pydantic
-pygments==2.15.1
+pygments==2.19.2
     # via
     #   -c requirements/_base.txt
+    #   pytest
     #   rich
-pyrsistent==0.18.1
-    # via
-    #   -c requirements/_base.txt
-    #   jsonschema
-    #   referencing
-pytest==8.3.5
+pytest==8.4.1
     # via
     #   -r requirements/_test.in
     #   pytest-asyncio
@@ -218,83 +232,88 @@ pytest==8.3.5
     #   pytest-mock
     #   pytest-sugar
     #   pytest-xdist
-pytest-asyncio==0.26.0
+pytest-asyncio==1.0.0
     # via -r requirements/_test.in
 pytest-benchmark==5.1.0
     # via -r requirements/_test.in
-pytest-cov==6.0.0
+pytest-cov==6.2.1
     # via -r requirements/_test.in
-pytest-docker==3.2.0
+pytest-docker==3.2.2
     # via -r requirements/_test.in
 pytest-icdiff==0.9
     # via -r requirements/_test.in
 pytest-instafail==0.5.0
     # via -r requirements/_test.in
-pytest-mock==3.14.0
+pytest-mock==3.14.1
     # via -r requirements/_test.in
 pytest-runner==6.0.1
     # via -r requirements/_test.in
 pytest-sugar==1.0.0
     # via -r requirements/_test.in
-pytest-xdist==3.6.1
+pytest-xdist==3.7.0
     # via -r requirements/_test.in
-python-dateutil==2.8.2
-    # via
-    #   -c requirements/_base.txt
-    #   faker
-python-dotenv==1.0.1
+python-dotenv==1.1.1
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   uvicorn
 python-multipart==0.0.20
     # via fastapi
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
-    #   openapi-spec-validator
+    #   jsonschema-path
     #   uvicorn
-redis==5.2.1
+redis==6.2.0
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-referencing==0.8.11
+referencing==0.35.1
     # via
     #   -c requirements/../../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   jsonschema
+    #   jsonschema-path
+    #   jsonschema-specifications
     #   types-jsonschema
-requests==2.32.2
+requests==2.32.4
     # via
     #   -c requirements/_base.txt
     #   docker
+    #   jsonschema-path
 respx==0.22.0
     # via -r requirements/_test.in
-rich==13.4.2
+rfc3339-validator==0.1.4
+    # via openapi-schema-validator
+rich==14.0.0
     # via
     #   -c requirements/_base.txt
+    #   rich-toolkit
     #   typer
-setuptools==69.1.1
+rich-toolkit==0.14.7
+    # via fastapi-cli
+rpds-py==0.25.1
     # via
     #   -c requirements/_base.txt
     #   jsonschema
-    #   openapi-spec-validator
+    #   referencing
 shellingham==1.5.4
     # via
     #   -c requirements/_base.txt
     #   typer
-six==1.16.0
+six==1.17.0
     # via
     #   -c requirements/_base.txt
-    #   jsonschema
-    #   python-dateutil
+    #   rfc3339-validator
 sniffio==1.3.1
     # via
     #   -c requirements/_base.txt
     #   anyio
 sortedcontainers==2.4.0
     # via hypothesis
-sqlalchemy==1.4.47
+sqlalchemy==1.4.54
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -302,48 +321,60 @@ sqlalchemy==1.4.47
     #   alembic
 sqlalchemy2-stubs==0.0.2a38
     # via sqlalchemy
-starlette==0.41.3
+starlette==0.46.2
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   fastapi
-tenacity==8.5.0
+tenacity==9.1.2
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-termcolor==2.5.0
+termcolor==3.1.0
     # via pytest-sugar
-typer==0.12.3
+typer==0.16.0
     # via
     #   -c requirements/_base.txt
     #   fastapi-cli
-types-aiofiles==24.1.0.20241221
+types-aiofiles==24.1.0.20250606
     # via -r requirements/_test.in
-types-jsonschema==4.23.0.20241208
+types-jsonschema==4.24.0.20250528
     # via -r requirements/_test.in
-types-openpyxl==3.1.5.20241225
+types-openpyxl==3.1.5.20250602
     # via -r requirements/_test.in
-types-passlib==1.7.7.20241221
+types-passlib==1.7.7.20250602
     # via -r requirements/_test.in
-types-pyyaml==6.0.12.20241230
+types-pyyaml==6.0.12.20250516
     # via -r requirements/_test.in
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -c requirements/_base.txt
+    #   alembic
+    #   anyio
     #   asyncpg-stubs
     #   fastapi
     #   fastapi-pagination
     #   mypy
     #   pydantic
     #   pydantic-core
+    #   rich-toolkit
     #   sqlalchemy2-stubs
     #   typer
-urllib3==2.2.3
+    #   typing-inspection
+typing-inspection==0.4.1
+    # via
+    #   -c requirements/_base.txt
+    #   pydantic
+tzdata==2025.2
+    # via
+    #   -c requirements/_base.txt
+    #   faker
+urllib3==2.5.0
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   docker
     #   requests
-uvicorn==0.34.2
+uvicorn==0.35.0
     # via
     #   fastapi
     #   fastapi-cli
@@ -351,14 +382,13 @@ uvloop==0.21.0
     # via
     #   -c requirements/_base.txt
     #   uvicorn
-watchfiles==1.0.4
+watchfiles==1.1.0
     # via uvicorn
-websockets==15.0
+websockets==15.0.1
     # via
     #   -r requirements/_test.in
     #   uvicorn
-yarl==1.20.0
+yarl==1.20.1
     # via
     #   -c requirements/_base.txt
     #   aiohttp
-    #   referencing

--- a/services/web/server/requirements/_tools.txt
+++ b/services/web/server/requirements/_tools.txt
@@ -1,4 +1,4 @@
-astroid==3.3.8
+astroid==3.3.10
     # via pylint
 black==25.1.0
     # via -r requirements/../../../../requirements/devenv.txt
@@ -8,19 +8,19 @@ bump2version==1.0.1
     # via -r requirements/../../../../requirements/devenv.txt
 cfgv==3.4.0
     # via pre-commit
-click==8.1.3
+click==8.2.1
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   pip-tools
-dill==0.3.9
+dill==0.4.0
     # via pylint
 distlib==0.3.9
     # via virtualenv
-filelock==3.17.0
+filelock==3.18.0
     # via virtualenv
-identify==2.6.8
+identify==2.6.12
     # via pre-commit
 inotify==0.2.10
     # via -r requirements/_tools.in
@@ -30,11 +30,11 @@ isort==6.0.1
     #   pylint
 mccabe==0.7.0
     # via pylint
-mypy==1.15.0
+mypy==1.16.1
     # via
     #   -c requirements/_test.txt
     #   -r requirements/../../../../requirements/devenv.txt
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via
     #   -c requirements/_test.txt
     #   black
@@ -43,54 +43,55 @@ nodeenv==1.9.1
     # via pre-commit
 nose==1.3.7
     # via inotify
-packaging==24.1
+packaging==25.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   build
 pathspec==0.12.1
-    # via black
-pip==25.0.1
+    # via
+    #   -c requirements/_test.txt
+    #   black
+    #   mypy
+pip==25.1.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements/../../../../requirements/devenv.txt
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via
+    #   -c requirements/_base.txt
     #   black
     #   pylint
     #   virtualenv
-pre-commit==4.1.0
+pre-commit==4.2.0
     # via -r requirements/../../../../requirements/devenv.txt
-pylint==3.3.4
+pylint==3.3.7
     # via -r requirements/../../../../requirements/devenv.txt
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.9.9
+ruff==0.12.1
     # via -r requirements/../../../../requirements/devenv.txt
-setuptools==69.1.1
-    # via
-    #   -c requirements/_base.txt
-    #   -c requirements/_test.txt
-    #   pip-tools
-tomlkit==0.13.2
+setuptools==80.9.0
+    # via pip-tools
+tomlkit==0.13.3
     # via pylint
-types-cachetools==5.5.0.20240820
+types-cachetools==6.0.0.20250525
     # via -r requirements/_tools.in
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
     #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==20.29.2
+virtualenv==20.31.2
     # via pre-commit
 wheel==0.45.1
     # via pip-tools


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 151
- #packages after ~ 161

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | aio-pika                  | 9.1.2           | 9.5.5      | *minor*    | 1 | web⬆️ |
|   2 | aiocache                  | 0.11.1          | 0.12.3     | *minor*    | 1 | web⬆️ |
|   3 | aiodocker                 | 0.21.0          | 0.24.0     | *minor*    | 1 | web⬆️ |
|   4 | aiofiles                  | 0.8.0           | 24.1.0     | **MAJOR**  | 1 | web⬆️ |
|   5 | aiohttp                   | 3.12.12         | 3.12.13    |            | 2 | web⬆️🧪 |
|   6 | aiohttp-jinja2            | 1.5             | 1.6        | *minor*    | 1 | web⬆️ |
|   7 | aiohttp-security          | 0.4.0           | 0.5.0      | *minor*    | 1 | web⬆️ |
|   8 | aiohttp-session           | 2.11.0          | 2.12.1     | *minor*    | 1 | web⬆️ |
|   9 | aiormq                    | 6.7.6           | 6.8.1      | *minor*    | 1 | web⬆️ |
|  10 | aiosignal                 | 1.2.0           | 1.3.2      | *minor*    | 2 | web⬆️🧪 |
|  11 | aiosmtplib                | 1.1.6           | 4.0.1      | **MAJOR**  | 1 | web⬆️ |
|  12 | alembic                   | 1.8.1           | 1.16.2     | *minor*    | 2 | web⬆️🧪 |
|  13 | anyio                     | 4.3.0           | 4.9.0      | *minor*    | 2 | web⬆️🧪 |
|  14 | appdirs                   | 1.4.4           | 🗑️ removed |  | 1 | web⬆️ |
|  15 | astroid                   | 3.3.8           | 3.3.10     |            | 1 | web🔧 |
|  16 | asyncpg                   | 0.27.0          | 0.30.0     | *minor*    | 2 | web⬆️🧪 |
|  17 | asyncpg-stubs             | 0.27.1          | 0.30.2     | *minor*    | 1 | web🧪 |
|  18 | attrs                     | 21.4.0          | 25.3.0     | **MAJOR**  | 2 | web⬆️🧪 |
|  19 | bidict                    | 0.22.0          | 0.23.1     | *minor*    | 1 | web⬆️ |
|  20 | captcha                   | 0.5.0           | 0.7.1      | *minor*    | 1 | web⬆️ |
|  21 | certifi                   | 2023.7.22       | 2025.6.15  | **MAJOR**  | 2 | web⬆️🧪 |
|  22 | charset-normalizer        | 2.0.12          | 3.4.2      | **MAJOR**  | 2 | web⬆️🧪 |
|  23 | click                     | 8.1.3           | 8.2.1      | *minor*    | 3 | web⬆️🧪🔧 |
|  24 | coverage                  | 7.6.12          | 7.9.1      | *minor*    | 1 | web🧪 |
|  25 | cryptography              | 41.0.7          | 45.0.4     | **MAJOR**  | 1 | web⬆️ |
|  26 | deepdiff                  | 8.1.1           | 8.5.0      | *minor*    | 1 | web⬆️ |
|  27 | deprecated                | 1.2.14          | 🗑️ removed |  | 1 | web⬆️ |
|  28 | dill                      | 0.3.9           | 0.4.0      | *minor*    | 1 | web🔧 |
|  29 | dnspython                 | 2.2.1           | 2.7.0      | *minor*    | 2 | web⬆️🧪 |
|  30 | et-xmlfile                | 1.1.0           | 2.0.0      | **MAJOR**  | 1 | web⬆️ |
|  31 | faker                     | 19.6.1          | 37.4.0     | **MAJOR**  | 2 | web⬆️🧪 |
|  32 | fastapi                   | 0.115.6         | 0.115.14   |            | 1 | web🧪 |
|  33 | fastapi-cli               | 0.0.5           | 0.0.7      |            | 1 | web🧪 |
|  34 | fastapi-pagination        | 0.12.34         | 0.13.3     | *minor*    | 1 | web🧪 |
|  35 | faststream                | 0.5.31          | 0.5.43     |            | 1 | web⬆️ |
|  36 | filelock                  | 3.17.0          | 3.18.0     | *minor*    | 1 | web🔧 |
|  37 | flexparser                | 0.3.1           | 0.4        | *minor*    | 1 | web⬆️ |
|  38 | frozenlist                | 1.4.1           | 1.7.0      | *minor*    | 2 | web⬆️🧪 |
|  39 | googleapis-common-protos  | 1.65.0          | 1.70.0     | *minor*    | 1 | web⬆️ |
|  40 | greenlet                  | 2.0.2           | 3.2.3      | **MAJOR**  | 2 | web⬆️🧪 |
|  41 | grpcio                    | 1.66.0          | 1.73.1     | *minor*    | 1 | web⬆️ |
|  42 | h11                       | 0.14.0          | 0.16.0     | *minor*    | 2 | web⬆️🧪 |
|  43 | httpcore                  | 1.0.7           | 1.0.9      |            | 2 | web⬆️🧪 |
|  44 | hypothesis                | 6.91.0          | 6.135.17   | *minor*    | 1 | web🧪 |
|  45 | identify                  | 2.6.8           | 2.6.12     |            | 1 | web🔧 |
|  46 | idna                      | 3.3             | 3.10       | *minor*    | 2 | web⬆️🧪 |
|  47 | importlib-metadata        | 8.0.0           | 8.7.0      | *minor*    | 1 | web⬆️ |
|  48 | iniconfig                 | 2.0.0           | 2.1.0      | *minor*    | 1 | web🧪 |
|  49 | jinja2                    | 3.1.2           | 3.1.6      |            | 2 | web⬆️🧪 |
|  50 | jsondiff                  | 2.0.0           | 2.2.1      | *minor*    | 1 | web⬆️ |
|  51 | jsonschema                | 3.2.0           | 4.24.0     | **MAJOR**  | 2 | web⬆️🧪 |
|  52 | mako                      | 1.2.2           | 1.3.10     | *minor*    | 2 | web⬆️🧪 |
|  53 | msgpack                   | 1.1.0           | 1.1.1      |            | 1 | web⬆️ |
|  54 | multidict                 | 6.1.0           | 6.6.2      | *minor*    | 2 | web⬆️🧪 |
|  55 | mypy                      | 1.15.0          | 1.16.1     | *minor*    | 2 | web🧪🔧 |
|  56 | mypy-extensions           | 1.0.0           | 1.1.0      | *minor*    | 2 | web🧪🔧 |
|  57 | openapi-schema-validator  | 0.2.3           | 0.6.3      | *minor*    | 1 | web🧪 |
|  58 | openapi-spec-validator    | 0.4.0           | 0.7.2      | *minor*    | 1 | web🧪 |
|  59 | openpyxl                  | 3.0.9           | 3.1.5      | *minor*    | 1 | web⬆️ |
|  60 | opentelemetry-api         | 1.27.0          | 1.34.1     | *minor*    | 1 | web⬆️ |
|  61 | opentelemetry-exporter-otlp | 1.27.0          | 1.34.1     | *minor*    | 1 | web⬆️ |
|  62 | opentelemetry-exporter-otlp-proto-common | 1.27.0          | 1.34.1     | *minor*    | 1 | web⬆️ |
|  63 | opentelemetry-exporter-otlp-proto-grpc | 1.27.0          | 1.34.1     | *minor*    | 1 | web⬆️ |
|  64 | opentelemetry-exporter-otlp-proto-http | 1.27.0          | 1.34.1     | *minor*    | 1 | web⬆️ |
|  65 | opentelemetry-instrumentation | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  66 | opentelemetry-instrumentation-aio-pika | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  67 | opentelemetry-instrumentation-aiohttp-client | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  68 | opentelemetry-instrumentation-aiohttp-server | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  69 | opentelemetry-instrumentation-aiopg | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  70 | opentelemetry-instrumentation-asyncpg | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  71 | opentelemetry-instrumentation-dbapi | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  72 | opentelemetry-instrumentation-logging | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  73 | opentelemetry-instrumentation-redis | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  74 | opentelemetry-instrumentation-requests | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  75 | opentelemetry-proto       | 1.27.0          | 1.34.1     | *minor*    | 1 | web⬆️ |
|  76 | opentelemetry-sdk         | 1.27.0          | 1.34.1     | *minor*    | 1 | web⬆️ |
|  77 | opentelemetry-semantic-conventions | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  78 | opentelemetry-util-http   | 0.48            | 0.55       | *minor*    | 1 | web⬆️ |
|  79 | orderly-set               | 5.2.3           | 5.4.1      | *minor*    | 1 | web⬆️ |
|  80 | orjson                    | 3.10.0          | 3.10.18    |            | 1 | web⬆️ |
|  81 | packaging                 | 24.1            | 25.0       | **MAJOR**  | 3 | web⬆️🧪🔧 |
|  82 | pamqp                     | 3.2.1           | 3.3.0      | *minor*    | 1 | web⬆️ |
|  83 | pillow                    | 10.3.0          | 11.2.1     | **MAJOR**  | 1 | web⬆️ |
|  84 | pint                      | 0.24.3          | 0.24.4     |            | 1 | web⬆️ |
|  85 | pip                       | 25.0.1          | 25.1.1     | *minor*    | 1 | web🔧 |
|  86 | platformdirs              | 4.3.6           | 4.3.8      |            | 1 | web🔧 |
|  87 | pluggy                    | 1.5.0           | 1.6.0      | *minor*    | 1 | web🧪 |
|  88 | pre-commit                | 4.1.0           | 4.2.0      | *minor*    | 1 | web🔧 |
|  89 | prometheus-client         | 0.14.1          | 0.22.1     | *minor*    | 1 | web⬆️ |
|  90 | propcache                 | 0.3.1           | 0.3.2      |            | 2 | web⬆️🧪 |
|  91 | protobuf                  | 4.25.4          | 5.29.5     | **MAJOR**  | 1 | web⬆️ |
|  92 | psutil                    | 6.0.0           | 7.0.0      | **MAJOR**  | 1 | web⬆️ |
|  93 | psycopg2-binary           | 2.9.6           | 2.9.10     |            | 1 | web⬆️ |
|  94 | pycountry                 | 23.12.11        | 24.6.1     | **MAJOR**  | 1 | web⬆️ |
|  95 | pycparser                 | 2.21            | 2.22       | *minor*    | 1 | web⬆️ |
|  96 | pycryptodome              | 3.21.0          | 3.23.0     | *minor*    | 1 | web⬆️ |
|  97 | pydantic                  | 2.10.2          | 2.11.7     | *minor*    | 2 | web⬆️🧪 |
|  98 | pydantic-core             | 2.27.1          | 2.33.2     | *minor*    | 2 | web⬆️🧪 |
|  99 | pydantic-extra-types      | 2.9.0           | 2.10.5     | *minor*    | 1 | web⬆️ |
| 100 | pydantic-settings         | 2.5.2           | 2.7.0      | *minor*    | 1 | web⬆️ |
| 101 | pygments                  | 2.15.1          | 2.19.2     | *minor*    | 2 | web⬆️🧪 |
| 102 | pyinstrument              | 4.6.1           | 5.0.2      | **MAJOR**  | 1 | web⬆️ |
| 103 | pyjwt                     | 2.4.0           | 2.10.1     | *minor*    | 1 | web⬆️ |
| 104 | pylint                    | 3.3.4           | 3.3.7      |            | 1 | web🔧 |
| 105 | pyrsistent                | 0.18.1          | 🗑️ removed |  | 2 | web⬆️🧪 |
| 106 | pytest                    | 8.3.5           | 8.4.1      | *minor*    | 1 | web🧪 |
| 107 | pytest-asyncio            | 0.26.0          | 1.0.0      | **MAJOR**  | 1 | web🧪 |
| 108 | pytest-cov                | 6.0.0           | 6.2.1      | *minor*    | 1 | web🧪 |
| 109 | pytest-docker             | 3.2.0           | 3.2.2      |            | 1 | web🧪 |
| 110 | pytest-mock               | 3.14.0          | 3.14.1     |            | 1 | web🧪 |
| 111 | pytest-xdist              | 3.6.1           | 3.7.0      | *minor*    | 1 | web🧪 |
| 112 | python-dateutil           | 2.8.2           | 2.9.0.post0 | *minor*    | 2 | web⬆️🧪 |
| 113 | python-dotenv             | 1.0.1           | 1.1.1      | *minor*    | 2 | web⬆️🧪 |
| 114 | python-engineio           | 4.3.4           | 4.12.2     | *minor*    | 1 | web⬆️ |
| 115 | python-magic              | 0.4.25          | 0.4.27     |            | 1 | web⬆️ |
| 116 | python-socketio           | 5.8.0           | 5.13.0     | *minor*    | 1 | web⬆️ |
| 117 | pytz                      | 2022.1          | 🗑️ removed |  | 1 | web⬆️ |
| 118 | pyyaml                    | 6.0.1           | 6.0.2      |            | 3 | web⬆️🧪🔧 |
| 119 | redis                     | 5.2.1           | 6.2.0      | **MAJOR**  | 2 | web⬆️🧪 |
| 120 | referencing               | 0.8.11          | 0.35.1     | *minor*    | 1 | web🧪 |
| 121 | requests                  | 2.32.2          | 2.32.4     |            | 2 | web⬆️🧪 |
| 122 | rich                      | 13.4.2          | 14.0.0     | **MAJOR**  | 2 | web⬆️🧪 |
| 123 | ruff                      | 0.9.9           | 0.12.1     | *minor*    | 1 | web🔧 |
| 124 | setproctitle              | 1.3.3           | 1.3.6      |            | 1 | web⬆️ |
| 125 | setuptools                | 69.1.1          | 80.9.0     | **MAJOR**  | 3 | web⬆️🧪🔧 |
| 126 | six                       | 1.16.0          | 1.17.0     | *minor*    | 2 | web⬆️🧪 |
| 127 | sqlalchemy                | 1.4.47          | 1.4.54     |            | 2 | web⬆️🧪 |
| 128 | starlette                 | 0.41.3          | 0.46.2     | *minor*    | 1 | web🧪 |
| 129 | tenacity                  | 8.5.0           | 9.1.2      | **MAJOR**  | 2 | web⬆️🧪 |
| 130 | termcolor                 | 2.5.0           | 3.1.0      | **MAJOR**  | 1 | web🧪 |
| 131 | tomlkit                   | 0.13.2          | 0.13.3     |            | 1 | web🔧 |
| 132 | toolz                     | 0.12.0          | 1.0.0      | **MAJOR**  | 1 | web⬆️ |
| 133 | tqdm                      | 4.64.0          | 4.67.1     | *minor*    | 1 | web⬆️ |
| 134 | twilio                    | 7.12.0          | 9.6.3      | **MAJOR**  | 1 | web⬆️ |
| 135 | typer                     | 0.12.3          | 0.16.0     | *minor*    | 2 | web⬆️🧪 |
| 136 | types-aiofiles            | 24.1.0.20241221 | 24.1.0.20250606 |            | 1 | web🧪 |
| 137 | types-cachetools          | 5.5.0.20240820  | 6.0.0.20250525 | **MAJOR**  | 1 | web🔧 |
| 138 | types-jsonschema          | 4.23.0.20241208 | 4.24.0.20250528 | *minor*    | 1 | web🧪 |
| 139 | types-openpyxl            | 3.1.5.20241225  | 3.1.5.20250602 |            | 1 | web🧪 |
| 140 | types-passlib             | 1.7.7.20241221  | 1.7.7.20250602 |            | 1 | web🧪 |
| 141 | types-pyyaml              | 6.0.12.20241230 | 6.0.12.20250516 |            | 1 | web🧪 |
| 142 | typing-extensions         | 4.12.2          | 4.14.0     | *minor*    | 3 | web⬆️🧪🔧 |
| 143 | urllib3                   | 2.2.3           | 2.5.0      | *minor*    | 2 | web⬆️🧪 |
| 144 | uvicorn                   | 0.34.2          | 0.35.0     | *minor*    | 1 | web🧪 |
| 145 | virtualenv                | 20.29.2         | 20.31.2    | *minor*    | 1 | web🔧 |
| 146 | watchfiles                | 1.0.4           | 1.1.0      | *minor*    | 1 | web🧪 |
| 147 | websockets                | 15.0            | 15.0.1     |            | 1 | web🧪 |
| 148 | werkzeug                  | 2.1.2           | 3.1.3      | **MAJOR**  | 1 | web⬆️ |
| 149 | wrapt                     | 1.16.0          | 1.17.2     | *minor*    | 1 | web⬆️ |
| 150 | yarl                      | 1.20.0          | 1.20.1     |            | 2 | web⬆️🧪 |
| 151 | zipp                      | 3.20.1          | 3.23.0     | *minor*    | 1 | web⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 107

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.4.1, 9.4.3, 9.5.1, 9.5.3, 9.5.4, 9.5.5 | 9.5.5                     |                           |
|   2 | aioboto3                  | 14.3.0                    | 14.3.0                    |                           |
|   3 | aiobotocore               | 2.22.0                    | 2.22.0                    |                           |
|   4 | aiocache                  | 0.12.2, 0.12.3            | 0.12.3                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0, 0.23.0, 0.24.0    | 0.23.0, 0.24.0            |                           |
|   7 | aiofiles                  | 23.2.1, 24.1.0            | 24.1.0                    |                           |
|   8 | aiohappyeyeballs          | 2.5.0, 2.6.1              | 2.5.0, 2.6.1              |                           |
|   9 | aiohttp                   | 3.11.18, 3.12.12, 3.12.13 | 3.12.12, 3.12.13          |                           |
|  10 | aiohttp-jinja2            | 1.6                       |                           |                           |
|  11 | aiohttp-retry             | 2.9.1                     |                           |                           |
|  12 | aiohttp-security          | 0.5.0                     |                           |                           |
|  13 | aiohttp-session           | 2.12.1                    |                           |                           |
|  14 | aioitertools              | 0.11.0, 0.12.0            | 0.12.0                    |                           |
|  15 | aiopg                     | 1.4.0                     | 1.4.0                     |                           |
|  16 | aioprocessing             | 2.0.1                     |                           |                           |
|  17 | aioresponses              |                           | 0.7.8                     |                           |
|  18 | aiormq                    | 6.8.0, 6.8.1              | 6.8.1                     |                           |
|  19 | aiosignal                 | 1.3.1, 1.3.2              | 1.3.1, 1.3.2              |                           |
|  20 | aiosmtplib                | 3.0.2, 4.0.0, 4.0.1       |                           |                           |
|  21 | alembic                   | 1.13.1, 1.13.3, 1.14.0, 1.14.1, 1.15.1, 1.15.2, 1.16.2 | 1.13.1, 1.14.0, 1.14.1, 1.15.1, 1.15.2, 1.16.2 |                           |
|  22 | amqp                      | 5.3.1                     | 5.3.1                     |                           |
|  23 | annotated-types           | 0.7.0                     | 0.7.0                     |                           |
|  24 | antlr4-python3-runtime    |                           | 4.13.2                    |                           |
|  25 | anyio                     | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0, 4.9.0 | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0, 4.9.0 |                           |
|  26 | arrow                     | 1.3.0                     | 1.3.0                     |                           |
|  27 | asgi-lifespan             | 2.1.0                     | 2.1.0                     |                           |
|  28 | asgiref                   | 3.8.1                     |                           |                           |
|  29 | astroid                   |                           |                           | 3.3.8, 3.3.9, 3.3.10      |
|  30 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  31 | async-timeout             | 4.0.3                     | 4.0.3                     |                           |
|  32 | asyncpg                   | 0.29.0, 0.30.0            | 0.30.0                    |                           |
|  33 | asyncpg-stubs             |                           | 0.30.0, 0.30.2            |                           |
|  34 | attrs                     | 23.2.0, 24.2.0, 25.1.0, 25.2.0, 25.3.0 | 23.2.0, 24.2.0, 25.1.0, 25.2.0, 25.3.0 |                           |
|  35 | aws-sam-translator        |                           | 1.55.0, 1.95.0, 1.97.0    |                           |
|  36 | aws-xray-sdk              |                           | 2.14.0                    |                           |
|  37 | bidict                    | 0.23.1                    | 0.23.1                    |                           |
|  38 | billiard                  | 4.2.1                     | 4.2.1                     |                           |
|  39 | binaryornot               | 0.4.4                     |                           |                           |
|  40 | black                     |                           |                           | 25.1.0                    |
|  41 | blinker                   |                           | 1.9.0                     |                           |
|  42 | blosc                     | 1.11.3                    |                           |                           |
|  43 | bokeh                     | 3.7.3                     | 3.7.3                     |                           |
|  44 | boto3                     | 1.37.3, 1.38.1            | 1.37.3, 1.38.1            |                           |
|  45 | boto3-stubs               |                           | 1.37.4                    |                           |
|  46 | botocore                  | 1.37.3, 1.38.1            | 1.37.3, 1.38.1            |                           |
|  47 | botocore-stubs            | 1.34.69, 1.35.43, 1.36.17, 1.37.4, 1.38.19 | 1.37.4, 1.38.19           |                           |
|  48 | brotli                    |                           | 1.1.0                     |                           |
|  49 | build                     |                           |                           | 1.2.2.post1               |
|  50 | bump2version              |                           |                           | 1.0.1                     |
|  51 | captcha                   | 0.7.1                     |                           |                           |
|  52 | celery                    | 5.5.2                     | 5.5.2                     |                           |
|  53 | certifi                   | 2024.2.2, 2024.8.30, 2025.1.31, 2025.4.26, 2025.6.15 | 2024.2.2, 2024.8.30, 2025.1.31, 2025.4.26, 2025.6.15 |                           |
|  54 | cffi                      | 1.17.1                    | 1.17.1                    |                           |
|  55 | cfgv                      |                           |                           | 3.4.0                     |
|  56 | cfn-lint                  |                           | 0.72.0, 1.27.0, 1.28.0, 1.35.1 |                           |
|  57 | change-case               |                           |                           | 0.5.2                     |
|  58 | chardet                   | 5.2.0                     |                           |                           |
|  59 | charset-normalizer        | 3.3.2, 3.4.0, 3.4.1, 3.4.2 | 3.3.2, 3.4.0, 3.4.1, 3.4.2 |                           |
|  60 | click                     | 8.1.7, 8.1.8, 8.2.1       | 8.1.7, 8.1.8, 8.2.1       | 8.1.7, 8.1.8, 8.2.1       |
|  61 | click-didyoumean          | 0.3.1                     | 0.3.1                     |                           |
|  62 | click-plugins             | 1.1.1                     | 1.1.1                     |                           |
|  63 | click-repl                | 0.3.0                     | 0.3.0                     |                           |
|  64 | cloudpickle               | 3.1.1                     | 3.1.1                     |                           |
|  65 | configargparse            |                           | 1.7.1                     |                           |
|  66 | contourpy                 | 1.2.0, 1.3.2              | 1.3.2                     |                           |
|  67 | cookiecutter              | 2.6.0                     |                           |                           |
|  68 | coverage                  |                           | 7.6.12, 7.7.1, 7.8.0, 7.9.1 |                           |
|  69 | cryptography              | 44.0.0, 44.0.2, 45.0.4    | 44.0.0, 44.0.2, 45.0.2    |                           |
|  70 | cycler                    | 0.12.1                    |                           |                           |
|  71 | dask                      | 2025.5.0                  | 2025.5.0                  |                           |
|  72 | dateparser                | 1.2.0                     |                           |                           |
|  73 | debugpy                   |                           | 1.8.12, 1.8.14            |                           |
|  74 | deepdiff                  | 8.5.0                     | 8.2.0, 8.5.0              |                           |
|  75 | deprecated                | 1.2.14, 1.2.15, 1.2.18    | 1.2.18                    |                           |
|  76 | dill                      |                           |                           | 0.3.9, 0.4.0              |
|  77 | distlib                   |                           |                           | 0.3.9                     |
|  78 | distributed               | 2025.5.0                  | 2025.5.0                  |                           |
|  79 | dnspython                 | 2.6.1, 2.7.0              | 2.7.0                     |                           |
|  80 | docker                    | 7.1.0                     | 7.1.0                     |                           |
|  81 | docutils                  | 0.21.2                    |                           |                           |
|  82 | ecdsa                     | 0.19.0                    | 0.19.0                    |                           |
|  83 | email-validator           | 2.1.1, 2.2.0              | 2.2.0                     |                           |
|  84 | et-xmlfile                | 2.0.0                     |                           |                           |
|  85 | exceptiongroup            | 1.2.2, 1.3.0              | 1.2.2, 1.3.0              |                           |
|  86 | execnet                   |                           | 2.1.1                     |                           |
|  87 | faker                     | 37.4.0                    | 36.1.1, 36.2.2, 37.0.0, 37.1.0, 37.3.0, 37.4.0 |                           |
|  88 | fakeredis                 |                           | 2.27.0, 2.29.0            |                           |
|  89 | fast-depends              | 2.4.12                    | 2.4.12                    |                           |
|  90 | fastapi                   | 0.115.12                  | 0.115.12, 0.115.14        |                           |
|  91 | fastapi-cli               | 0.0.6, 0.0.7              | 0.0.7                     |                           |
|  92 | fastapi-lifespan-manager  | 0.1.4                     | 0.1.4                     |                           |
|  93 | fastapi-pagination        | 0.12.31, 0.12.32, 0.12.34 | 0.13.3                    |                           |
|  94 | faststream                | 0.5.31, 0.5.33, 0.5.34, 0.5.35, 0.5.37, 0.5.41, 0.5.43 | 0.5.35                    |                           |
|  95 | filelock                  |                           |                           | 3.17.0, 3.18.0            |
|  96 | flaky                     |                           | 3.8.1                     |                           |
|  97 | flask                     |                           | 2.1.3, 3.1.0, 3.1.1       |                           |
|  98 | flask-cors                |                           | 5.0.1, 6.0.0              |                           |
|  99 | flask-login               |                           | 0.6.3                     |                           |
| 100 | flexcache                 | 0.3                       | 0.3                       |                           |
| 101 | flexparser                | 0.4                       | 0.4                       |                           |
| 102 | fonttools                 | 4.50.0                    |                           |                           |
| 103 | frozenlist                | 1.4.1, 1.5.0, 1.6.0, 1.7.0 | 1.4.1, 1.5.0, 1.6.0, 1.7.0 |                           |
| 104 | fsspec                    | 2025.3.2                  | 2025.3.2                  |                           |
| 105 | gevent                    |                           | 24.11.1                   |                           |
| 106 | geventhttpclient          |                           | 2.3.3                     |                           |
| 107 | googleapis-common-protos  | 1.65.0, 1.66.0, 1.68.0, 1.69.1, 1.69.2, 1.70.0 | 1.68.0                    |                           |
| 108 | graphql-core              |                           | 3.2.6                     |                           |
| 109 | greenlet                  | 3.0.3, 3.1.1, 3.2.2, 3.2.3 | 3.0.3, 3.1.1, 3.2.2, 3.2.3 |                           |
| 110 | grpcio                    | 1.66.0, 1.67.0, 1.68.0, 1.68.1, 1.70.0, 1.71.0, 1.73.1 | 1.70.0                    |                           |
| 111 | gunicorn                  | 23.0.0                    |                           |                           |
| 112 | h11                       | 0.14.0, 0.16.0            | 0.14.0, 0.16.0            |                           |
| 113 | h2                        | 4.1.0, 4.2.0              | 4.2.0                     |                           |
| 114 | hpack                     | 4.0.0, 4.1.0              | 4.1.0                     |                           |
| 115 | httmock                   | 1.4.0                     |                           |                           |
| 116 | httpcore                  | 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.9 | 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.9 |                           |
| 117 | httptools                 | 0.6.4                     | 0.6.4                     |                           |
| 118 | httpx                     | 0.27.0, 0.27.2, 0.28.1    | 0.27.0, 0.27.2, 0.28.1    |                           |
| 119 | hypercorn                 |                           | 0.17.3                    |                           |
| 120 | hyperframe                | 6.0.1, 6.1.0              | 6.1.0                     |                           |
| 121 | hypothesis                |                           | 6.129.0, 6.135.17         |                           |
| 122 | icdiff                    |                           | 2.0.7                     |                           |
| 123 | identify                  |                           |                           | 2.6.8, 2.6.9, 2.6.10, 2.6.12 |
| 124 | idna                      | 3.6, 3.10                 | 3.6, 3.10                 |                           |
| 125 | ifaddr                    | 0.2.0                     |                           |                           |
| 126 | importlib-metadata        | 8.0.0, 8.4.0, 8.5.0, 8.6.1, 8.7.0 | 8.5.0, 8.6.1              |                           |
| 127 | iniconfig                 | 2.0.0                     | 2.0.0, 2.1.0              |                           |
| 128 | inotify                   |                           |                           | 0.2.10                    |
| 129 | isort                     |                           |                           | 6.0.1                     |
| 130 | itsdangerous              | 2.2.0                     | 2.2.0                     |                           |
| 131 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 132 | jinja2                    | 3.1.5, 3.1.6              | 3.1.5, 3.1.6              | 3.1.6                     |
| 133 | jinja2-time               | 0.2.0                     |                           |                           |
| 134 | jmespath                  | 1.0.1                     | 1.0.1                     |                           |
| 135 | joserfc                   |                           | 1.0.4                     |                           |
| 136 | jschema-to-python         |                           | 1.2.3                     |                           |
| 137 | jsondiff                  | 2.2.1                     | 2.2.1                     |                           |
| 138 | jsonpatch                 |                           | 1.33                      |                           |
| 139 | jsonpath-ng               |                           | 1.7.0                     |                           |
| 140 | jsonpickle                |                           | 4.0.2                     |                           |
| 141 | jsonpointer               |                           | 3.0.0                     |                           |
| 142 | jsonref                   |                           | 1.1.0                     |                           |
| 143 | jsonschema                | 3.2.0, 4.21.1, 4.23.0, 4.24.0 | 3.2.0, 4.21.1, 4.23.0, 4.24.0 |                           |
| 144 | jsonschema-path           |                           | 0.3.4                     |                           |
| 145 | jsonschema-specifications | 2023.7.1, 2024.10.1, 2025.4.1 | 2023.7.1, 2024.10.1, 2025.4.1 |                           |
| 146 | junit-xml                 |                           | 1.9                       |                           |
| 147 | kiwisolver                | 1.4.5                     |                           |                           |
| 148 | kombu                     | 5.5.3                     | 5.5.3                     |                           |
| 149 | lazy-object-proxy         |                           | 1.10.0, 1.11.0            |                           |
| 150 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 151 | locust                    |                           | 2.37.5                    |                           |
| 152 | locust-cloud              |                           | 1.21.8                    |                           |
| 153 | locust-plugins            |                           | 4.7.0                     |                           |
| 154 | lupa                      |                           | 2.4                       |                           |
| 155 | lz4                       | 4.4.4                     |                           |                           |
| 156 | mako                      | 1.3.2, 1.3.5, 1.3.6, 1.3.7, 1.3.9, 1.3.10 | 1.3.2, 1.3.7, 1.3.9, 1.3.10 |                           |
| 157 | markdown-it-py            | 3.0.0                     | 3.0.0                     | 3.0.0                     |
| 158 | markdown2                 | 2.5.3                     |                           |                           |
| 159 | markupsafe                | 3.0.2                     | 3.0.2                     | 3.0.2                     |
| 160 | matplotlib                | 3.8.3                     |                           |                           |
| 161 | mccabe                    |                           |                           | 0.7.0                     |
| 162 | mdurl                     | 0.1.2                     | 0.1.2                     | 0.1.2                     |
| 163 | moto                      |                           | 4.0.1, 5.1.4              |                           |
| 164 | mpmath                    |                           | 1.3.0                     |                           |
| 165 | msgpack                   | 1.1.0, 1.1.1              | 1.1.0                     |                           |
| 166 | multidict                 | 6.0.5, 6.1.0, 6.2.0, 6.4.3, 6.4.4, 6.6.2 | 6.1.0, 6.4.4, 6.6.2       |                           |
| 167 | mypy                      |                           | 1.15.0, 1.16.1            | 1.15.0, 1.16.1            |
| 168 | mypy-extensions           |                           | 1.0.0, 1.1.0              | 1.0.0, 1.1.0              |
| 169 | narwhals                  | 1.40.0                    | 1.40.0                    |                           |
| 170 | nest-asyncio              | 1.6.0                     |                           |                           |
| 171 | networkx                  | 3.4.2                     | 2.8.8, 3.4.2              |                           |
| 172 | nicegui                   | 2.12.1                    |                           |                           |
| 173 | nodeenv                   |                           |                           | 1.9.1                     |
| 174 | nose                      |                           |                           | 1.3.7                     |
| 175 | numpy                     | 1.26.4, 2.2.6             | 2.2.3, 2.2.6              |                           |
| 176 | openapi-schema-validator  |                           | 0.2.3, 0.6.3              |                           |
| 177 | openapi-spec-validator    |                           | 0.4.0, 0.7.1, 0.7.2       |                           |
| 178 | openpyxl                  | 3.1.5                     |                           |                           |
| 179 | opentelemetry-api         | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 180 | opentelemetry-exporter-otlp | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 181 | opentelemetry-exporter-otlp-proto-common | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 182 | opentelemetry-exporter-otlp-proto-grpc | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 183 | opentelemetry-exporter-otlp-proto-http | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 184 | opentelemetry-instrumentation | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 185 | opentelemetry-instrumentation-aio-pika | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 186 | opentelemetry-instrumentation-aiohttp-client | 0.55b1                    |                           |                           |
| 187 | opentelemetry-instrumentation-aiohttp-server | 0.55b1                    |                           |                           |
| 188 | opentelemetry-instrumentation-aiopg | 0.55b1                    |                           |                           |
| 189 | opentelemetry-instrumentation-asgi | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1 |                           |                           |
| 190 | opentelemetry-instrumentation-asyncpg | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 191 | opentelemetry-instrumentation-botocore | 0.47b0, 0.48b0, 0.51b0, 0.54b1 |                           |                           |
| 192 | opentelemetry-instrumentation-celery | 0.51b0                    |                           |                           |
| 193 | opentelemetry-instrumentation-dbapi | 0.55b1                    |                           |                           |
| 194 | opentelemetry-instrumentation-fastapi | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1 |                           |                           |
| 195 | opentelemetry-instrumentation-httpx | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1 |                           |                           |
| 196 | opentelemetry-instrumentation-logging | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 197 | opentelemetry-instrumentation-redis | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 198 | opentelemetry-instrumentation-requests | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 199 | opentelemetry-propagator-aws-xray | 1.0.1, 1.0.2              |                           |                           |
| 200 | opentelemetry-proto       | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 201 | opentelemetry-sdk         | 1.26.0, 1.27.0, 1.28.2, 1.30.0, 1.31.0, 1.31.1, 1.33.1, 1.34.1 | 1.30.0                    |                           |
| 202 | opentelemetry-semantic-conventions | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 203 | opentelemetry-util-http   | 0.47b0, 0.48b0, 0.49b2, 0.51b0, 0.52b0, 0.52b1, 0.54b1, 0.55b1 | 0.51b0                    |                           |
| 204 | ordered-set               | 4.1.0                     |                           |                           |
| 205 | orderly-set               | 5.4.1                     | 5.3.0, 5.4.1              |                           |
| 206 | orjson                    | 3.10.0, 3.10.7, 3.10.12, 3.10.15, 3.10.16, 3.10.18 | 3.10.15                   |                           |
| 207 | osparc                    | 0.8.3                     |                           |                           |
| 208 | osparc-client             | 0.8.3                     |                           |                           |
| 209 | packaging                 | 24.0, 24.1, 24.2, 25.0    | 24.0, 24.1, 24.2, 25.0    | 24.0, 24.1, 24.2, 25.0    |
| 210 | pact-python               |                           | 2.3.1                     |                           |
| 211 | pamqp                     | 3.3.0                     | 3.3.0                     |                           |
| 212 | pandas                    | 2.2.1, 2.2.3              | 2.2.3                     |                           |
| 213 | parse                     | 1.20.2                    | 1.20.2                    |                           |
| 214 | partd                     | 1.4.2                     | 1.4.2                     |                           |
| 215 | passlib                   | 1.7.4                     |                           |                           |
| 216 | pathable                  |                           | 0.4.4                     |                           |
| 217 | pathspec                  |                           | 0.12.1                    | 0.12.1                    |
| 218 | pbr                       |                           | 6.1.1                     |                           |
| 219 | pillow                    | 10.2.0, 11.2.1            | 11.1.0, 11.2.1            |                           |
| 220 | pint                      | 0.24.4                    | 0.24.4                    |                           |
| 221 | pip                       |                           | 25.0.1                    | 25.0.1, 25.1.1            |
| 222 | pip-tools                 |                           |                           | 7.4.1                     |
| 223 | platformdirs              | 4.3.6, 4.3.8              | 4.3.6, 4.3.8              | 4.3.6, 4.3.7, 4.3.8       |
| 224 | playwright                |                           | 1.50.0                    |                           |
| 225 | pluggy                    | 1.5.0                     | 1.5.0, 1.6.0              |                           |
| 226 | ply                       |                           | 3.11                      |                           |
| 227 | pprintpp                  |                           | 0.4.0                     |                           |
| 228 | pre-commit                |                           |                           | 4.1.0, 4.2.0              |
| 229 | priority                  |                           | 2.0.0                     |                           |
| 230 | prometheus-api-client     | 0.5.5                     |                           |                           |
| 231 | prometheus-client         | 0.20.0, 0.21.0, 0.21.1, 0.22.0, 0.22.1 |                           |                           |
| 232 | prompt-toolkit            | 3.0.50, 3.0.51            | 3.0.50, 3.0.51            |                           |
| 233 | propcache                 | 0.2.0, 0.2.1, 0.3.0, 0.3.1, 0.3.2 | 0.2.0, 0.2.1, 0.3.0, 0.3.1, 0.3.2 |                           |
| 234 | protobuf                  | 4.25.4, 4.25.5, 5.29.0, 5.29.1, 5.29.3, 5.29.4, 5.29.5 | 5.29.3                    |                           |
| 235 | pscript                   | 0.7.7                     |                           |                           |
| 236 | psutil                    | 6.0.0, 6.1.0, 6.1.1, 7.0.0 | 6.1.0, 6.1.1, 7.0.0       |                           |
| 237 | psycogreen                |                           | 1.0.2                     |                           |
| 238 | psycopg2-binary           | 2.9.9, 2.9.10             | 2.9.10                    |                           |
| 239 | ptvsd                     |                           | 4.3.2                     |                           |
| 240 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 241 | py-partiql-parser         |                           | 0.6.1                     |                           |
| 242 | pyasn1                    | 0.6.1                     | 0.4.8                     |                           |
| 243 | pycountry                 | 24.6.1                    |                           |                           |
| 244 | pycparser                 | 2.22                      | 2.22                      |                           |
| 245 | pycryptodome              | 3.21.0, 3.22.0, 3.23.0    | 3.21.0                    |                           |
| 246 | pydantic                  | 2.10.2, 2.10.3, 2.10.6, 2.11.0, 2.11.4, 2.11.7 | 2.10.2, 2.10.3, 2.10.6, 2.11.4, 2.11.5, 2.11.7 |                           |
| 247 | pydantic-core             | 2.27.1, 2.27.2, 2.33.0, 2.33.2 | 2.27.1, 2.27.2, 2.33.2    |                           |
| 248 | pydantic-extra-types      | 2.9.0, 2.10.0, 2.10.2, 2.10.3, 2.10.4, 2.10.5 | 2.10.2                    |                           |
| 249 | pydantic-settings         | 2.6.1, 2.7.0              | 2.7.0, 2.9.1              |                           |
| 250 | pyee                      |                           | 12.1.1                    |                           |
| 251 | pyftpdlib                 |                           | 2.0.1                     |                           |
| 252 | pygments                  | 2.17.2, 2.18.0, 2.19.1, 2.19.2 | 2.19.1, 2.19.2            | 2.19.1                    |
| 253 | pyinstrument              | 4.6.2, 5.0.0, 5.0.1, 5.0.2 | 5.0.0, 5.0.1              |                           |
| 254 | pyjwt                     | 2.9.0, 2.10.1             |                           |                           |
| 255 | pylint                    |                           |                           | 3.3.4, 3.3.5, 3.3.6, 3.3.7 |
| 256 | pyopenssl                 |                           | 25.1.0                    |                           |
| 257 | pyparsing                 | 3.1.2                     | 3.1.2, 3.2.1, 3.2.3       |                           |
| 258 | pyproject-hooks           |                           |                           | 1.2.0                     |
| 259 | pyrsistent                | 0.20.0                    | 0.20.0                    |                           |
| 260 | pytest                    | 8.3.5                     | 8.3.5, 8.4.1              |                           |
| 261 | pytest-aiohttp            |                           | 1.1.0                     |                           |
| 262 | pytest-asyncio            |                           | 0.26.0, 1.0.0             |                           |
| 263 | pytest-base-url           |                           | 2.1.0                     |                           |
| 264 | pytest-benchmark          |                           | 5.1.0                     |                           |
| 265 | pytest-celery             |                           | 1.1.3, 1.2.0              |                           |
| 266 | pytest-cov                |                           | 6.0.0, 6.1.1, 6.2.1       |                           |
| 267 | pytest-docker             |                           | 3.2.0, 3.2.1, 3.2.2       |                           |
| 268 | pytest-docker-tools       |                           | 3.1.3, 3.1.9              |                           |
| 269 | pytest-html               |                           | 4.1.1                     |                           |
| 270 | pytest-icdiff             |                           | 0.9                       |                           |
| 271 | pytest-instafail          |                           | 0.5.0                     |                           |
| 272 | pytest-localftpserver     |                           | 1.3.2                     |                           |
| 273 | pytest-metadata           |                           | 3.1.1                     |                           |
| 274 | pytest-mock               |                           | 3.14.0, 3.14.1            |                           |
| 275 | pytest-playwright         |                           | 0.7.0                     |                           |
| 276 | pytest-runner             |                           | 6.0.1                     |                           |
| 277 | pytest-sugar              |                           | 1.0.0                     |                           |
| 278 | pytest-xdist              |                           | 3.6.1, 3.7.0              |                           |
| 279 | python-dateutil           | 2.9.0.post0               | 2.9.0.post0               |                           |
| 280 | python-dotenv             | 1.0.1, 1.1.0, 1.1.1       | 1.0.1, 1.1.0, 1.1.1       |                           |
| 281 | python-engineio           | 4.10.1, 4.11.2, 4.12.1, 4.12.2 | 4.10.1, 4.12.1            |                           |
| 282 | python-jose               | 3.3.0                     | 3.4.0                     |                           |
| 283 | python-magic              | 0.4.27                    |                           |                           |
| 284 | python-multipart          | 0.0.19, 0.0.20            | 0.0.20                    |                           |
| 285 | python-slugify            | 8.0.4                     | 8.0.4                     |                           |
| 286 | python-socketio           | 5.11.4, 5.12.1, 5.13.0    | 5.11.4, 5.13.0            |                           |
| 287 | pytz                      | 2024.1, 2025.2            | 2025.1, 2025.2            |                           |
| 288 | pyyaml                    | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              | 6.0.1, 6.0.2              |
| 289 | pyzmq                     |                           | 26.4.0                    |                           |
| 290 | redis                     | 5.2.1, 5.3.0, 6.1.0, 6.2.0 | 5.2.1, 6.1.0, 6.2.0       |                           |
| 291 | referencing               | 0.29.3, 0.35.1            | 0.29.3, 0.35.1            |                           |
| 292 | regex                     | 2023.12.25                | 2023.12.25, 2024.11.6     |                           |
| 293 | repro-zipfile             | 0.4.0                     |                           |                           |
| 294 | requests                  | 2.32.2, 2.32.3, 2.32.4    | 2.32.2, 2.32.3, 2.32.4    |                           |
| 295 | requests-mock             |                           | 1.12.1                    |                           |
| 296 | responses                 |                           | 0.25.6, 0.25.7            |                           |
| 297 | respx                     |                           | 0.22.0                    |                           |
| 298 | rfc3339-validator         |                           | 0.1.4                     |                           |
| 299 | rich                      | 13.7.1, 13.9.2, 13.9.4, 14.0.0 | 13.9.4, 14.0.0            | 13.9.4                    |
| 300 | rich-toolkit              | 0.12.0, 0.13.2, 0.14.6, 0.14.7 | 0.14.7                    |                           |
| 301 | rpds-py                   | 0.18.0, 0.20.0, 0.21.0, 0.22.3, 0.23.1, 0.24.0, 0.25.0, 0.25.1 | 0.18.0, 0.20.0, 0.22.3, 0.23.1, 0.25.0, 0.25.1 |                           |
| 302 | rsa                       | 4.9                       | 4.9                       |                           |
| 303 | ruff                      |                           |                           | 0.9.9, 0.9.10, 0.11.2, 0.11.10, 0.11.11, 0.12.1 |
| 304 | s3fs                      | 2025.3.2                  |                           |                           |
| 305 | s3transfer                | 0.11.3, 0.12.0            | 0.11.3, 0.12.0            |                           |
| 306 | sarif-om                  |                           | 1.0.4                     |                           |
| 307 | setproctitle              | 1.3.6                     |                           |                           |
| 308 | setuptools                | 74.0.0, 75.2.0, 75.6.0    | 74.0.0, 75.2.0, 75.6.0, 75.8.2, 80.7.1, 80.9.0 | 74.0.0, 75.2.0, 75.6.0, 75.8.2, 76.0.0, 78.1.0, 80.7.1, 80.9.0 |
| 309 | sh                        | 2.0.6, 2.1.0, 2.2.1, 2.2.2 |                           |                           |
| 310 | shellingham               | 1.5.4                     | 1.5.4                     | 1.5.4                     |
| 311 | shortuuid                 | 1.0.13                    |                           |                           |
| 312 | simple-websocket          | 1.1.0                     | 1.1.0                     |                           |
| 313 | six                       | 1.16.0, 1.17.0            | 1.16.0, 1.17.0            |                           |
| 314 | sniffio                   | 1.3.1                     | 1.3.1                     |                           |
| 315 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 316 | sqlalchemy                | 1.4.52, 1.4.54            | 1.4.52, 1.4.54            |                           |
| 317 | sqlalchemy2-stubs         |                           | 0.0.2a38                  |                           |
| 318 | sshpubkeys                |                           | 3.3.1                     |                           |
| 319 | starlette                 | 0.41.0, 0.41.2, 0.41.3, 0.45.3, 0.46.0, 0.46.1, 0.46.2 | 0.41.3, 0.46.0, 0.46.2    |                           |
| 320 | stream-zip                | 0.0.83                    | 0.0.83                    |                           |
| 321 | swagger-ui-py             | 23.9.23                   |                           |                           |
| 322 | sympy                     |                           | 1.13.3, 1.14.0            |                           |
| 323 | tblib                     | 3.1.0                     | 3.1.0                     |                           |
| 324 | tenacity                  | 8.5.0, 9.0.0, 9.1.2       | 9.0.0, 9.1.2              |                           |
| 325 | termcolor                 |                           | 2.5.0, 3.1.0              |                           |
| 326 | text-unidecode            | 1.3                       | 1.3                       |                           |
| 327 | tomlkit                   |                           |                           | 0.13.2, 0.13.3            |
| 328 | toolz                     | 0.12.1, 1.0.0             | 1.0.0                     |                           |
| 329 | tornado                   | 6.5                       | 6.5                       |                           |
| 330 | tqdm                      | 4.66.2, 4.66.5, 4.67.1    | 4.67.1                    |                           |
| 331 | twilio                    | 9.6.3                     |                           |                           |
| 332 | typer                     | 0.12.3, 0.12.5, 0.13.1, 0.15.1, 0.15.2, 0.15.4, 0.16.0 | 0.15.2, 0.16.0            | 0.15.2                    |
| 333 | types-aioboto3            |                           | 14.1.0, 14.3.0            |                           |
| 334 | types-aiobotocore         | 2.19.0, 2.21.1, 2.22.0    | 2.21.0, 2.21.1, 2.22.0    |                           |
| 335 | types-aiobotocore-ec2     | 2.19.0, 2.21.0, 2.22.0    | 2.22.0                    |                           |
| 336 | types-aiobotocore-iam     |                           | 2.22.0                    |                           |
| 337 | types-aiobotocore-s3      | 2.19.0, 2.19.0.post1, 2.21.0, 2.22.0 | 2.21.0, 2.21.1, 2.22.0    |                           |
| 338 | types-aiobotocore-ssm     | 2.19.0, 2.21.0, 2.22.0    | 2.22.0                    |                           |
| 339 | types-aiofiles            |                           | 24.1.0.20241221, 24.1.0.20250516, 24.1.0.20250606 |                           |
| 340 | types-awscrt              | 0.20.5, 0.22.0, 0.23.10, 0.27.2 | 0.23.10, 0.27.2           |                           |
| 341 | types-boto3               |                           | 1.37.4, 1.38.2            |                           |
| 342 | types-cachetools          |                           |                           | 6.0.0.20250525            |
| 343 | types-docker              |                           | 7.1.0.20241229            |                           |
| 344 | types-jsonschema          |                           | 4.23.0.20241208, 4.24.0.20250528 |                           |
| 345 | types-networkx            |                           | 3.4.2.20250515            |                           |
| 346 | types-openpyxl            |                           | 3.1.5.20250602            |                           |
| 347 | types-passlib             |                           | 1.7.7.20250602            |                           |
| 348 | types-psutil              |                           | 7.0.0.20250218            |                           |
| 349 | types-psycopg2            |                           | 2.9.21.20250121, 2.9.21.20250318, 2.9.21.20250516 |                           |
| 350 | types-pyasn1              |                           | 0.6.0.20250208            |                           |
| 351 | types-python-dateutil     | 2.9.0.20240316, 2.9.0.20241003, 2.9.0.20241206, 2.9.0.20250516 | 2.9.0.20241206            |                           |
| 352 | types-python-jose         |                           | 3.4.0.20250224            |                           |
| 353 | types-pyyaml              |                           | 6.0.12.20241230, 6.0.12.20250516 |                           |
| 354 | types-requests            |                           | 2.32.0.20250301           |                           |
| 355 | types-s3transfer          |                           | 0.11.3, 0.12.0            |                           |
| 356 | types-tqdm                |                           | 4.67.0.20250301           |                           |
| 357 | typing-extensions         | 4.12.2, 4.13.0, 4.13.2, 4.14.0 | 4.12.2, 4.13.0, 4.13.2, 4.14.0 | 4.12.2, 4.13.0, 4.13.2, 4.14.0 |
| 358 | typing-inspection         | 0.4.0, 0.4.1              | 0.4.0, 0.4.1              |                           |
| 359 | tzdata                    | 2024.1, 2025.2            | 2024.1, 2025.1, 2025.2    |                           |
| 360 | tzlocal                   | 5.2                       |                           |                           |
| 361 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 362 | ujson                     | 5.10.0                    |                           |                           |
| 363 | urllib3                   | 2.2.3, 2.3.0, 2.4.0, 2.5.0 | 2.2.3, 2.3.0, 2.4.0, 2.5.0 |                           |
| 364 | uvicorn                   | 0.34.2                    | 0.34.2, 0.35.0            |                           |
| 365 | uvloop                    | 0.21.0                    | 0.21.0                    |                           |
| 366 | vbuild                    | 0.8.2                     |                           |                           |
| 367 | vine                      | 5.1.0                     | 5.1.0                     |                           |
| 368 | virtualenv                |                           |                           | 20.29.2, 20.29.3, 20.31.2 |
| 369 | watchdog                  | 6.0.0                     |                           | 6.0.0                     |
| 370 | watchfiles                | 0.21.0, 1.0.0, 1.0.4, 1.0.5 | 1.1.0                     |                           |
| 371 | wcwidth                   | 0.2.13                    | 0.2.13                    |                           |
| 372 | websocket-client          |                           | 1.8.0                     |                           |
| 373 | websockets                | 12.0, 14.1, 14.2, 15.0.1  | 15.0.1                    |                           |
| 374 | werkzeug                  | 3.1.3                     | 2.1.2, 3.1.3              |                           |
| 375 | wheel                     |                           |                           | 0.45.1                    |
| 376 | wrapt                     | 1.16.0, 1.17.0, 1.17.2    | 1.16.0, 1.17.0, 1.17.2    |                           |
| 377 | wsproto                   | 1.2.0                     | 1.2.0                     |                           |
| 378 | xmltodict                 |                           | 0.14.2                    |                           |
| 379 | xyzservices               | 2025.4.0                  | 2025.4.0                  |                           |
| 380 | yarl                      | 1.18.0, 1.18.3, 1.20.0, 1.20.1 | 1.18.0, 1.18.3, 1.20.0, 1.20.1 |                           |
| 381 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 382 | zipp                      | 3.20.1, 3.20.2, 3.21.0, 3.23.0 | 3.21.0                    |                           |
| 383 | zope-event                |                           | 5.0                       |                           |
| 384 | zope-interface            |                           | 7.2                       |                           |

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
