### PR TITLE
🐛E2E: check for NOT_STARTED state instead of UNKNOWN

### DIFF
--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -40,7 +40,7 @@ from pytest_simcore.helpers.playwright import (
 from pytest_simcore.helpers.pydantic_extension import Secret4TestsStr
 
 _PROJECT_CLOSING_TIMEOUT: Final[int] = 10 * MINUTE
-_OPENING_NEW_EMPTY_PROJECT_MAX_WAIT_TIME: Final[int] = 30 * SECOND
+_OPENING_NEW_EMPTY_PROJECT_MAX_WAIT_TIME: Final[int] = 60 * SECOND
 _OPENING_TUTORIAL_MAX_WAIT_TIME: Final[int] = 3 * MINUTE
 
 

--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -40,7 +40,7 @@ from pytest_simcore.helpers.playwright import (
 from pytest_simcore.helpers.pydantic_extension import Secret4TestsStr
 
 _PROJECT_CLOSING_TIMEOUT: Final[int] = 10 * MINUTE
-_OPENING_NEW_EMPTY_PROJECT_MAX_WAIT_TIME: Final[int] = 60 * SECOND
+_OPENING_NEW_EMPTY_PROJECT_MAX_WAIT_TIME: Final[int] = 30 * SECOND
 _OPENING_TUTORIAL_MAX_WAIT_TIME: Final[int] = 3 * MINUTE
 
 

--- a/tests/e2e-playwright/tests/tip/conftest.py
+++ b/tests/e2e-playwright/tests/tip/conftest.py
@@ -32,7 +32,12 @@ def create_tip_plan_from_dashboard(
 ) -> Callable[[str], dict[str, Any]]:
     def _(plan_name_test_id: str) -> dict[str, Any]:
         find_and_start_tip_plan_in_dashboard(plan_name_test_id)
-        expected_states = (RunningState.UNKNOWN,)
-        return create_new_project_and_delete(expected_states, False, None, None)
+        expected_states = (RunningState.NOT_STARTED,)
+        return create_new_project_and_delete(
+            expected_states,
+            False,  # noqa: FBT003
+            None,
+            None,
+        )
 
     return _


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
since https://github.com/ITISFoundation/osparc-simcore/pull/7996 the default state on open is `NOT_STARTED`

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- https://github.com/ITISFoundation/osparc-simcore/pull/7996

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
