### PR TITLE
🎨 [Frontend] UX: Usage in the last 24h

### DIFF
--- a/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsSummary.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsSummary.js
@@ -46,7 +46,7 @@ qx.Class.define("osparc.desktop.credits.CreditsSummary", {
     WIDTH: 350,
     TIME_RANGES: [{
       key: 1,
-      label: "Today"
+      label: "Last 24h"
     }, {
       key: 7,
       label: "Last week"

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsSummary.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/CreditsSummary.js
@@ -116,8 +116,8 @@ qx.Class.define("osparc.desktop.credits.CreditsSummary", {
             const trItem = new qx.ui.form.ListItem(tr.label, null, tr.key);
             control.add(trItem);
           });
-          // default one week
-          const found = control.getSelectables().find(trItem => trItem.getModel() === 7);
+          // default last 24h
+          const found = control.getSelectables().find(trItem => trItem.getModel() === 1);
           if (found) {
             control.setSelection([found]);
           }

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/DateFilters.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/DateFilters.js
@@ -29,16 +29,16 @@ qx.Class.define("osparc.desktop.credits.DateFilters", {
       this.__from = this.__addDateInput("From", defaultFrom);
       this.__until = this.__addDateInput("Until", defaultTo);
 
-      const lastDayBtn = new qx.ui.form.Button("Today").set({
+      const todayBtn = new qx.ui.form.Button("Today").set({
         allowStretchY: false,
         alignY: "bottom"
       });
-      lastDayBtn.addListener("execute", () => {
+      todayBtn.addListener("execute", () => {
         const today = new Date();
         this.__from.setValue(today);
         this.__until.setValue(today);
       });
-      this._add(lastDayBtn);
+      this._add(todayBtn);
 
       const lastWeekBtn = new qx.ui.form.Button("Last week").set({
         allowStretchY: false,

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/DateFilters.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/DateFilters.js
@@ -21,11 +21,28 @@ qx.Class.define("osparc.desktop.credits.DateFilters", {
   members: {
     _buildLayout() {
       this._removeAll();
-      const defaultFrom = new Date()
-      defaultFrom.setMonth(defaultFrom.getMonth() - 1)
-      // Range defaults to previous month
+
+      const defaultFrom = new Date();
+      // Range defaults to last 24h
+      defaultFrom.defaultFrom(today.getDate() - 1);
+      const defaultTo = new Date();
+
       this.__from = this.__addDateInput("From", defaultFrom);
-      this.__until = this.__addDateInput("Until");
+      this.__until = this.__addDateInput("Until", defaultTo);
+
+      const lastDayBtn = new qx.ui.form.Button("Last 24h").set({
+        allowStretchY: false,
+        alignY: "bottom"
+      });
+      lastDayBtn.addListener("execute", () => {
+        const today = new Date();
+        const last24h = new Date(today);
+        last24h.setDate(today.getDate() - 1);
+        this.__from.setValue(last24h);
+        this.__until.setValue(today);
+      });
+      this._add(lastDayBtn);
+
       const lastWeekBtn = new qx.ui.form.Button("Last week").set({
         allowStretchY: false,
         alignY: "bottom"
@@ -38,6 +55,7 @@ qx.Class.define("osparc.desktop.credits.DateFilters", {
         this.__until.setValue(today);
       });
       this._add(lastWeekBtn);
+
       const lastMonthBtn = new qx.ui.form.Button("Last month").set({
         allowStretchY: false,
         alignY: "bottom"
@@ -50,6 +68,7 @@ qx.Class.define("osparc.desktop.credits.DateFilters", {
         this.__until.setValue(today);
       });
       this._add(lastMonthBtn);
+
       const lastYearBtn = new qx.ui.form.Button("Last year").set({
         allowStretchY: false,
         alignY: "bottom"

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/DateFilters.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/DateFilters.js
@@ -22,25 +22,20 @@ qx.Class.define("osparc.desktop.credits.DateFilters", {
     _buildLayout() {
       this._removeAll();
 
+      // Range defaults: today
       const defaultFrom = new Date();
-      // Range defaults
-      // from last 24h...
-      defaultFrom.setDate(defaultFrom.getDate() - 1);
-      // .. to now
       const defaultTo = new Date();
 
       this.__from = this.__addDateInput("From", defaultFrom);
       this.__until = this.__addDateInput("Until", defaultTo);
 
-      const lastDayBtn = new qx.ui.form.Button("Last 24h").set({
+      const lastDayBtn = new qx.ui.form.Button("Today").set({
         allowStretchY: false,
         alignY: "bottom"
       });
       lastDayBtn.addListener("execute", () => {
         const today = new Date();
-        const last24h = new Date(today);
-        last24h.setDate(today.getDate() - 1);
-        this.__from.setValue(last24h);
+        this.__from.setValue(today);
         this.__until.setValue(today);
       });
       this._add(lastDayBtn);

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/DateFilters.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/DateFilters.js
@@ -24,7 +24,7 @@ qx.Class.define("osparc.desktop.credits.DateFilters", {
 
       const defaultFrom = new Date();
       // Range defaults to last 24h
-      defaultFrom.defaultFrom(today.getDate() - 1);
+      defaultFrom.defaultFrom(defaultFrom.getDate() - 1);
       const defaultTo = new Date();
 
       this.__from = this.__addDateInput("From", defaultFrom);

--- a/services/static-webserver/client/source/class/osparc/desktop/credits/DateFilters.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/credits/DateFilters.js
@@ -23,8 +23,10 @@ qx.Class.define("osparc.desktop.credits.DateFilters", {
       this._removeAll();
 
       const defaultFrom = new Date();
-      // Range defaults to last 24h
-      defaultFrom.defaultFrom(defaultFrom.getDate() - 1);
+      // Range defaults
+      // from last 24h...
+      defaultFrom.setDate(defaultFrom.getDate() - 1);
+      // .. to now
       const defaultTo = new Date();
 
       this.__from = this.__addDateInput("From", defaultFrom);

--- a/services/web/server/src/simcore_service_webserver/projects/_conversations_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_conversations_service.py
@@ -43,7 +43,7 @@ async def create_project_conversation(
         product_name=product_name,
         user_id=user_id,
         project_id=project_uuid,
-        permission="read",
+        permission="write",
     )
     return await conversations_service.create_conversation(
         app,
@@ -95,7 +95,7 @@ async def update_project_conversation(
         product_name=product_name,
         user_id=user_id,
         project_id=project_uuid,
-        permission="read",
+        permission="write",
     )
     return await conversations_service.update_conversation(
         app,
@@ -118,7 +118,7 @@ async def delete_project_conversation(
         product_name=product_name,
         user_id=user_id,
         project_id=project_uuid,
-        permission="read",
+        permission="write",
     )
     await conversations_service.delete_conversation(
         app,
@@ -170,7 +170,7 @@ async def create_project_conversation_message(
         product_name=product_name,
         user_id=user_id,
         project_id=project_uuid,
-        permission="read",
+        permission="write",
     )
     return await conversations_service.create_message(
         app,
@@ -224,7 +224,7 @@ async def update_project_conversation_message(
         product_name=product_name,
         user_id=user_id,
         project_id=project_uuid,
-        permission="read",
+        permission="write",
     )
     return await conversations_service.update_message(
         app,
@@ -249,7 +249,7 @@ async def delete_project_conversation_message(
         product_name=product_name,
         user_id=user_id,
         project_id=project_uuid,
-        permission="read",
+        permission="write",
     )
     await conversations_service.delete_message(
         app,


### PR DESCRIPTION
## What do these changes do?

- It was misleading to say ``Today`` while we meant ``Last 24h``.
- A new time range filter was added to the Usage table: ``Last 24h``, which is the default one.

![last24h](https://github.com/user-attachments/assets/1208d407-0aea-4c27-816a-d0f3267a24c3)


## Related issue/s
- closes https://github.com/ITISFoundation/private-issues/issues/226


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
