### PR TITLE
🐛 [Frontend] Fix: Service's Pricing Plans

### DIFF
--- a/services/static-webserver/client/source/class/osparc/store/Services.js
+++ b/services/static-webserver/client/source/class/osparc/store/Services.js
@@ -349,10 +349,15 @@ qx.Class.define("osparc.store.Services", {
     },
 
     getPricingPlan: function(serviceKey, serviceVersion) {
-      const serviceUrl = osparc.data.Resources.getServiceUrl(serviceKey, serviceVersion)
+      const serviceUrl = osparc.data.Resources.getServiceUrl(serviceKey, serviceVersion);
+      const key = serviceUrl["key"];
+      const version = serviceUrl["version"];
       // check if the service is already cached
-      if (serviceUrl in this.__pricingPlansCached) {
-        return Promise.resolve(this.__pricingPlansCached[serviceUrl]);
+      if (
+        key in this.__pricingPlansCached &&
+        version in this.__pricingPlansCached[key]
+      ) {
+        return Promise.resolve(this.__pricingPlansCached[key][version]);
       }
 
       const plansParams = {
@@ -361,7 +366,10 @@ qx.Class.define("osparc.store.Services", {
       return osparc.data.Resources.fetch("services", "pricingPlans", plansParams)
         .then(pricingPlansData => {
           // store the fetched pricing plans in the cache
-          this.__pricingPlansCached[serviceUrl] = pricingPlansData;
+          if (!(key in this.__pricingPlansCached)) {
+            this.__pricingPlansCached[key] = {};
+          }
+          this.__pricingPlansCached[key][version] = pricingPlansData;
           return pricingPlansData;
         });
     },


### PR DESCRIPTION
## What do these changes do?

The frontend wasn't caching Service's Pricing Plans correctly. This PR fixes it.

Buggy:
![Buggy](https://github.com/user-attachments/assets/589d366c-3dcd-4a23-9b41-2a04303708d1)


Fixed:
![Fixed](https://github.com/user-attachments/assets/b647c23c-13d5-4926-9805-790f84eb15fa)


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
