### PR TITLE
🎨 [Frontend] PO Center: Approval/Deny of account requests

### DIFF
--- a/services/static-webserver/client/source/class/osparc/po/POCenter.js
+++ b/services/static-webserver/client/source/class/osparc/po/POCenter.js
@@ -27,9 +27,7 @@ qx.Class.define("osparc.po.POCenter", {
     this.addWidgetToTabs(miniProfile);
 
     this.__addActiveUsersPage();
-    if (osparc.utils.Utils.isDevelopmentPlatform()) {
-      this.__addPendingUsersPage();
-    }
+    this.__addReviewUsersPage();
     this.__addPreRegistrationPage();
     this.__addInvitationsPage();
     this.__addProductPage();
@@ -44,8 +42,8 @@ qx.Class.define("osparc.po.POCenter", {
       this.addTab(title, iconSrc, users);
     },
 
-    __addPendingUsersPage: function() {
-      const title = this.tr("Pending Users");
+    __addReviewUsersPage: function() {
+      const title = this.tr("Review Users");
       const iconSrc = "@FontAwesome5Solid/user-plus/22";
       const usersPending = new osparc.po.UsersPending();
       this.addTab(title, iconSrc, usersPending);

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -179,7 +179,7 @@ qx.Class.define("osparc.po.UsersPending", {
           row,
           column: 1,
         });
-        pendingUsersLayout.add(new qx.ui.basic.Label(pendingUser.preRegistrationCreated ? osparc.utils.Utils.formatDateAndTime(new Date(pendingUser.preRegistrationCreated)) : "-"), {
+        pendingUsersLayout.add(new qx.ui.basic.Label(pendingUser.accountRequestReviewedAt ? osparc.utils.Utils.formatDateAndTime(new Date(pendingUser.accountRequestReviewedAt)) : "-"), {
           row,
           column: 2,
         });
@@ -236,7 +236,13 @@ qx.Class.define("osparc.po.UsersPending", {
           const reviewedUsers = resps[1];
           const pendingUsersLayout = this.getChildControl("pending-users-layout");
           pendingUsersLayout.removeAll();
-          this.__addHeader();
+          const sortByDate = (a, b) => {
+            const dateA = a.accountRequestReviewedAt ? new Date(a.accountRequestReviewedAt) : new Date(0);
+            const dateB = b.accountRequestReviewedAt ? new Date(b.accountRequestReviewedAt) : new Date(0);
+            return dateB - dateA; // sort by most recent first
+          };
+          pendingUsers.sort(sortByDate);
+          reviewedUsers.sort(sortByDate);
           this.__addRows(pendingUsers.concat(reviewedUsers));
         })
         .catch(err => osparc.FlashMessenger.logError(err));

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -248,7 +248,7 @@ qx.Class.define("osparc.po.UsersPending", {
     __createApproveButton: function(email) {
       const button = new qx.ui.form.Button(qx.locale.Manager.tr("Approve"));
       button.addListener("execute", () => {
-        const form = this.createInvitationForm(false);
+        const form = this.self().createInvitationForm(false);
         const approveBtn = new osparc.ui.form.FetchButton(qx.locale.Manager.tr("Approve"));
         approveBtn.set({
           appearance: "form-button"
@@ -307,7 +307,7 @@ qx.Class.define("osparc.po.UsersPending", {
 
       let msg = `Are you sure you want to approve ${email}`;
       if (extraCreditsInUsd) {
-        msg += ` with ${extraCreditsInUsd}$ credits`;
+        msg += ` with ${extraCreditsInUsd}$ worth credits`;
       }
       if (trialAccountDays > 0) {
         msg += ` and ${trialAccountDays} days of trial`;

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -147,9 +147,12 @@ qx.Class.define("osparc.po.UsersPending", {
 
     __addRows: function(pendingUsers) {
       const pendingUsersLayout = this.getChildControl("pending-users-layout");
+      const grid = pendingUsersLayout.getLayout();
 
       let row = 1;
       pendingUsers.forEach(pendingUser => {
+        grid.setRowAlign(row, "left", "middle");
+
         pendingUsersLayout.add(new qx.ui.basic.Label(pendingUser.firstName + " " + pendingUser.lastName), {
           row,
           column: 0,

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -76,7 +76,7 @@ qx.Class.define("osparc.po.UsersPending", {
     },
 
     createInfoButton: function(infoMetadata) {
-      const infoButton = new qx.ui.form.Button(null, "@MaterialIcons/info_outline/16");
+      const infoButton = new qx.ui.form.Button(null, "@MaterialIcons/info_outline/14");
       infoButton.addListener("execute", () => {
         const container = new qx.ui.container.Scroll();
         container.add(new osparc.ui.basic.JsonTreeWidget(infoMetadata, "pendingUserInfo"));
@@ -206,7 +206,7 @@ qx.Class.define("osparc.po.UsersPending", {
         switch (pendingUser.accountRequestStatus) {
           case "PENDING": {
             statusImage.set({
-              source: "@FontAwesome5Solid/hourglass-end/16",
+              source: "@FontAwesome5Solid/hourglass-end/14",
               textColor: "warning-yellow",
             });
             const approveButton = this.__createApproveButton(pendingUser.email);
@@ -217,7 +217,7 @@ qx.Class.define("osparc.po.UsersPending", {
           }
           case "REJECTED": {
             statusImage.set({
-              source: "@FontAwesome5Solid/times/16",
+              source: "@FontAwesome5Solid/times/14",
               textColor: "danger-red",
             });
             const approveButton = this.__createApproveButton(pendingUser.email);
@@ -227,7 +227,7 @@ qx.Class.define("osparc.po.UsersPending", {
           }
           case "APPROVED": {
             statusImage.set({
-              source: "@FontAwesome5Solid/check/16",
+              source: "@FontAwesome5Solid/check/14",
               textColor: "product-color",
             });
             const resendEmailButton = this.self().createResendEmailButton(pendingUser.email);

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -143,27 +143,6 @@ qx.Class.define("osparc.po.UsersPending", {
         row: 0,
         column: 2,
       });
-
-      pendingUsersLayout.add(new qx.ui.basic.Label(this.tr("Status")).set({
-        font: "text-14"
-      }), {
-        row: 0,
-        column: 3,
-      });
-
-      pendingUsersLayout.add(new qx.ui.basic.Label(this.tr("Info")).set({
-        font: "text-14"
-      }), {
-        row: 0,
-        column: 4,
-      });
-
-      pendingUsersLayout.add(new qx.ui.basic.Label(this.tr("Action")).set({
-        font: "text-14"
-      }), {
-        row: 0,
-        column: 5,
-      });
     },
 
     __addRows: function(pendingUsers) {

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -282,15 +282,16 @@ qx.Class.define("osparc.po.UsersPending", {
           }
           case "REJECTED": {
             const approveButton = this.self().createApproveButton(pendingUser.email);
+            approveButton.setEnabled(false); // avoid changing decision for now
             buttonsLayout.add(approveButton);
             break;
           }
           case "APPROVED": {
-            /*
             const resendEmailButton = this.self().createResendEmailButton(pendingUser.email);
+            resendEmailButton.setEnabled(false);
             buttonsLayout.add(resendEmailButton);
-            */
             const rejectButton = this.self().createRejectButton(pendingUser.email);
+            rejectButton.setEnabled(false); // avoid changing decision for now
             buttonsLayout.add(rejectButton);
             break;
           }

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -297,13 +297,25 @@ qx.Class.define("osparc.po.UsersPending", {
     },
 
     __createRejectButton: function(email) {
-      const button = new osparc.ui.form.FetchButton(qx.locale.Manager.tr("Reject"));
+      const button = new osparc.ui.form.FetchButton("Reject");
       button.addListener("execute", () => {
-        button.setFetching(true);
-        this.__rejectUser(email)
-          .then(() => osparc.FlashMessenger.logAs(qx.locale.Manager.tr("User denied"), "INFO"))
-          .catch(err => osparc.FlashMessenger.logError(err))
-          .finally(() => button.setFetching(false));
+        const msg = `Are you sure you want to reject ${email}.<br>The operation cannot be reverted"`;
+        const win = new osparc.ui.window.Confirmation(msg).set({
+          caption: "Reject",
+          confirmText: "Reject",
+          confirmAction: "delete",
+        });
+        win.center();
+        win.open();
+        win.addListener("close", () => {
+          if (win.getConfirmed()) {
+            button.setFetching(true);
+            this.__rejectUser(email)
+              .then(() => osparc.FlashMessenger.logAs(qx.locale.Manager.tr("User denied"), "INFO"))
+              .catch(err => osparc.FlashMessenger.logError(err))
+              .finally(() => button.setFetching(false));
+          }
+        });
       });
       return button;
     },

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -268,20 +268,28 @@ qx.Class.define("osparc.po.UsersPending", {
             return;
           }
           if (form.validate()) {
-            const approveUser = () => {
-              approveBtn.setFetching(true);
-              this.__approveUser(email, form)
-                .then(() => {
-                  osparc.FlashMessenger.logAs(qx.locale.Manager.tr("User approved"), "INFO");
-                })
-                .catch(err => osparc.FlashMessenger.logError(err))
-                .finally(() => {
-                  approveBtn.setFetching(false);
-                  win.close();
-                });
-            };
-
-
+            const msg = this.tr("This user has no access to the project. Do you want to share it?");
+            const win = new osparc.ui.window.Confirmation(msg).set({
+              caption: this.tr("Share"),
+              confirmText: this.tr("Share"),
+              confirmAction: "create"
+            });
+            win.center();
+            win.open();
+            win.addListener("close", () => {
+              if (win.getConfirmed()) {
+                approveBtn.setFetching(true);
+                this.__approveUser(email, form)
+                  .then(() => {
+                    osparc.FlashMessenger.logAs(qx.locale.Manager.tr("User approved"), "INFO");
+                  })
+                  .catch(err => osparc.FlashMessenger.logError(err))
+                  .finally(() => {
+                    approveBtn.setFetching(false);
+                    win.close();
+                  });
+              }
+            });
           }
         });
       });

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -116,7 +116,7 @@ qx.Class.define("osparc.po.UsersPending", {
     _buildLayout: function() {
       this.getChildControl("reload-button");
       this.getChildControl("pending-users-container");
-
+      this.__addHeader();
       this.__populatePendingUsersLayout();
     },
 
@@ -251,8 +251,6 @@ qx.Class.define("osparc.po.UsersPending", {
         .then(resps => {
           const pendingUsers = resps[0];
           const reviewedUsers = resps[1];
-          const pendingUsersLayout = this.getChildControl("pending-users-layout");
-          pendingUsersLayout.removeAll();
           const sortByDate = (a, b) => {
             const dateA = a.accountRequestReviewedAt ? new Date(a.accountRequestReviewedAt) : new Date(0);
             const dateB = b.accountRequestReviewedAt ? new Date(b.accountRequestReviewedAt) : new Date(0);
@@ -267,6 +265,7 @@ qx.Class.define("osparc.po.UsersPending", {
 
     __reload: function() {
       this.getChildControl("pending-users-layout").removeAll();
+      this.__addHeader();
       this.__populatePendingUsersLayout();
     },
 

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -183,23 +183,32 @@ qx.Class.define("osparc.po.UsersPending", {
           row,
           column: 2,
         });
-        pendingUsersLayout.add(new qx.ui.basic.Label(pendingUser.accountRequestStatus.toLowerCase()), {
+        const statusImage = new qx.ui.basic.Image();
+        pendingUsersLayout.add(statusImage, {
           row,
           column: 3,
+        });
+        pendingUsersLayout.add(new qx.ui.basic.Label(pendingUser.accountRequestStatus.toLowerCase()), {
+          row,
+          column: 4,
         });
         const infoButton = this.self().createInfoButton(pendingUser);
         pendingUsersLayout.add(infoButton, {
           row,
-          column: 4,
+          column: 5,
         });
         const buttonsLayout = new qx.ui.container.Composite(new qx.ui.layout.HBox(5));
         pendingUsersLayout.add(buttonsLayout, {
           row,
-          column: 5,
+          column: 6,
         });
 
         switch (pendingUser.accountRequestStatus) {
           case "PENDING": {
+            statusImage.set({
+              source: "@FontAwesome5Solid/hourglass-end/16",
+              textColor: "warning-yellow",
+            });
             const approveButton = this.__createApproveButton(pendingUser.email);
             buttonsLayout.add(approveButton);
             const rejectButton = this.__createRejectButton(pendingUser.email);
@@ -207,12 +216,20 @@ qx.Class.define("osparc.po.UsersPending", {
             break;
           }
           case "REJECTED": {
+            statusImage.set({
+              source: "@FontAwesome5Solid/times/16",
+              textColor: "danger-red",
+            });
             const approveButton = this.__createApproveButton(pendingUser.email);
             approveButton.setEnabled(false); // avoid changing decision for now
             buttonsLayout.add(approveButton);
             break;
           }
           case "APPROVED": {
+            statusImage.set({
+              source: "@FontAwesome5Solid/check/16",
+              textColor: "product-color",
+            });
             const resendEmailButton = this.self().createResendEmailButton(pendingUser.email);
             resendEmailButton.setEnabled(false);
             buttonsLayout.add(resendEmailButton);

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -253,7 +253,7 @@ qx.Class.define("osparc.po.UsersPending", {
           row,
           column: 1,
         });
-        pendingUsersLayout.add(new qx.ui.basic.Label(pendingUser.date ? osparc.utils.Utils.formatDateAndTime(new Date(pendingUser.date)) : "-"), {
+        pendingUsersLayout.add(new qx.ui.basic.Label(pendingUser.preRegistrationCreated ? osparc.utils.Utils.formatDateAndTime(new Date(pendingUser.preRegistrationCreated)) : "-"), {
           row,
           column: 2,
         });

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -94,10 +94,7 @@ qx.Class.define("osparc.po.UsersPending", {
           control = new qx.ui.form.Button(this.tr("Reload")).set({
             allowGrowX: false,
           });
-          control.addListener("execute", () => {
-            this.getChildControl("pending-users-layout").removeAll();
-            this.__populatePendingUsersLayout();
-          });
+          control.addListener("execute", () => this.__reload());
           this._add(control);
           break;
         case "pending-users-container":
@@ -245,6 +242,11 @@ qx.Class.define("osparc.po.UsersPending", {
         .catch(err => osparc.FlashMessenger.logError(err));
     },
 
+    __reload: function() {
+      this.getChildControl("pending-users-layout").removeAll();
+      this.__populatePendingUsersLayout();
+    },
+
     __createApproveButton: function(email) {
       const button = new qx.ui.form.Button(qx.locale.Manager.tr("Approve"));
       button.addListener("execute", () => {
@@ -289,7 +291,10 @@ qx.Class.define("osparc.po.UsersPending", {
           if (win.getConfirmed()) {
             button.setFetching(true);
             this.__rejectUser(email)
-              .then(() => osparc.FlashMessenger.logAs(qx.locale.Manager.tr("User denied"), "INFO"))
+              .then(() => {
+                osparc.FlashMessenger.logAs(qx.locale.Manager.tr("User denied"), "INFO");
+                this.__reload();
+              })
               .catch(err => osparc.FlashMessenger.logError(err))
               .finally(() => button.setFetching(false));
           }
@@ -326,6 +331,7 @@ qx.Class.define("osparc.po.UsersPending", {
           this.__approveUser(email, form)
             .then(() => {
               osparc.FlashMessenger.logAs("User approved", "INFO");
+              this.__reload();
             })
             .catch(err => osparc.FlashMessenger.logError(err))
             .finally(() => {


### PR DESCRIPTION
## What do these changes do?

- [x] Remove Approve action when Rejected (avoid changing decision for now)
- [x] Remove Reject action with Approved(avoid changing decision for now)
- [x] Pop-up to confirmation for rejection/approval: e.g. (rephrase nicer)
  - [x] ``Are you sure you want to reject {email}. The operation cannot be reverted``
  - [x] ``Are you sure you want to approve {email} with 100$ credit and expired=3days. We will proceed to send an invitation email?``
- [x] Icon with colors added to different status
- [x] Show first the pending ones, then the rest. Also sort by date: newest first.
- [x] Auto-reload after action instead of only "Reload" button (force-reload)
- [x] Inconsistency between he name of the table and the content: Named PENDING but call is including all (i.e. pending and reviewed): Renamed to ``Review Users``
- [x] Date column does not show in the table. Use ``accountRequestReviewedAt``
- [x] Remove in-master-only constraint

![POCenter](https://github.com/user-attachments/assets/e06e91c8-1c84-436b-954a-0a71641e6f25)


## Related issue/s

- closes https://github.com/ITISFoundation/osparc-simcore/issues/8044


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
