### PR TITLE
🐛✨ Opentelemetry instrument `asyncpg` for aiohttp servers and introduce decorator to generate opentelemtry profile span

### DIFF
--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -140,6 +140,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
@@ -160,11 +161,14 @@ opentelemetry-exporter-otlp-proto-http==1.34.1
 opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
 opentelemetry-instrumentation-aio-pika==0.55b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-asyncpg==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-botocore==0.55b1
     # via -r requirements/_base.in
@@ -189,6 +193,7 @@ opentelemetry-sdk==1.34.1
 opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests

--- a/packages/celery-library/requirements/_base.txt
+++ b/packages/celery-library/requirements/_base.txt
@@ -132,6 +132,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
@@ -150,10 +151,13 @@ opentelemetry-exporter-otlp-proto-http==1.34.1
 opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
 opentelemetry-instrumentation-aio-pika==0.55b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-asyncpg==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-logging==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
@@ -174,6 +178,7 @@ opentelemetry-sdk==1.34.1
 opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk

--- a/packages/notifications-library/requirements/_base.txt
+++ b/packages/notifications-library/requirements/_base.txt
@@ -26,8 +26,6 @@ idna==3.10
     # via
     #   email-validator
     #   yarl
-importlib-metadata==8.5.0
-    # via opentelemetry-api
 jinja2==3.1.5
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -64,19 +62,6 @@ mdurl==0.1.2
     # via markdown-it-py
 multidict==6.1.0
     # via yarl
-opentelemetry-api==1.34.1
-    # via
-    #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.55b1
-    # via opentelemetry-instrumentation-asyncpg
-opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/../../../packages/postgres-database/requirements/_base.in
-opentelemetry-semantic-conventions==0.55b1
-    # via
-    #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-asyncpg
 orjson==3.10.15
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -92,8 +77,6 @@ orjson==3.10.15
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/postgres-database/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.2
-    # via opentelemetry-instrumentation
 propcache==0.3.0
     # via yarl
 psycopg2-binary==2.9.10
@@ -187,15 +170,9 @@ types-python-dateutil==2.9.0.20241206
 typing-extensions==4.14.1
     # via
     #   alembic
-    #   opentelemetry-api
-    #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
     #   typer
-wrapt==1.17.2
-    # via opentelemetry-instrumentation
 yarl==1.18.3
     # via -r requirements/../../../packages/postgres-database/requirements/_base.in
-zipp==3.21.0
-    # via importlib-metadata

--- a/packages/notifications-library/requirements/_test.txt
+++ b/packages/notifications-library/requirements/_test.txt
@@ -54,7 +54,6 @@ mypy-extensions==1.1.0
     # via mypy
 packaging==24.2
     # via
-    #   -c requirements/_base.txt
     #   pytest
     #   pytest-sugar
 pathspec==0.12.1

--- a/packages/notifications-library/requirements/_tools.txt
+++ b/packages/notifications-library/requirements/_tools.txt
@@ -40,7 +40,6 @@ nodeenv==1.9.1
     # via pre-commit
 packaging==24.2
     # via
-    #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   build

--- a/packages/postgres-database/requirements/_base.in
+++ b/packages/postgres-database/requirements/_base.in
@@ -6,7 +6,6 @@
 --requirement ../../../packages/common-library/requirements/_base.in
 
 alembic
-opentelemetry-instrumentation-asyncpg
 pydantic
 sqlalchemy[postgresql_psycopg2binary,postgresql_asyncpg] # SEE extras in https://github.com/sqlalchemy/sqlalchemy/blob/main/setup.cfg#L43
 yarl

--- a/packages/postgres-database/requirements/_base.txt
+++ b/packages/postgres-database/requirements/_base.txt
@@ -8,8 +8,6 @@ greenlet==3.1.1
     # via sqlalchemy
 idna==3.10
     # via yarl
-importlib-metadata==8.5.0
-    # via opentelemetry-api
 mako==1.3.10
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -19,26 +17,11 @@ markupsafe==3.0.2
     # via mako
 multidict==6.1.0
     # via yarl
-opentelemetry-api==1.34.1
-    # via
-    #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-asyncpg
-    #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.55b1
-    # via opentelemetry-instrumentation-asyncpg
-opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/_base.in
-opentelemetry-semantic-conventions==0.55b1
-    # via
-    #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-asyncpg
 orjson==3.10.15
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/common-library/requirements/_base.in
-packaging==24.2
-    # via opentelemetry-instrumentation
 propcache==0.3.0
     # via yarl
 psycopg2-binary==2.9.10
@@ -63,14 +46,8 @@ sqlalchemy==1.4.54
 typing-extensions==4.14.1
     # via
     #   alembic
-    #   opentelemetry-api
-    #   opentelemetry-semantic-conventions
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
-wrapt==1.17.2
-    # via opentelemetry-instrumentation
 yarl==1.18.3
     # via -r requirements/_base.in
-zipp==3.21.0
-    # via importlib-metadata

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -24,9 +24,7 @@ mypy==1.16.1
 mypy-extensions==1.1.0
     # via mypy
 packaging==24.2
-    # via
-    #   -c requirements/_base.txt
-    #   pytest
+    # via pytest
 pathspec==0.12.1
     # via mypy
 pluggy==1.5.0

--- a/packages/postgres-database/requirements/_tools.txt
+++ b/packages/postgres-database/requirements/_tools.txt
@@ -39,7 +39,6 @@ nodeenv==1.9.1
     # via pre-commit
 packaging==24.2
     # via
-    #   -c requirements/_base.txt
     #   -c requirements/_test.txt
     #   black
     #   build

--- a/packages/service-library/requirements/_base.in
+++ b/packages/service-library/requirements/_base.in
@@ -19,6 +19,7 @@ faststream
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-instrumentation-aio-pika
+opentelemetry-instrumentation-asyncpg
 opentelemetry-instrumentation-logging
 opentelemetry-instrumentation-redis
 opentelemetry-instrumentation-requests

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -98,6 +98,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
@@ -116,10 +117,13 @@ opentelemetry-exporter-otlp-proto-http==1.34.1
 opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
 opentelemetry-instrumentation-aio-pika==0.55b1
+    # via -r requirements/_base.in
+opentelemetry-instrumentation-asyncpg==0.55b1
     # via -r requirements/_base.in
 opentelemetry-instrumentation-logging==0.55b1
     # via -r requirements/_base.in
@@ -140,6 +144,7 @@ opentelemetry-sdk==1.34.1
 opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk

--- a/packages/service-library/src/servicelib/aiohttp/tracing.py
+++ b/packages/service-library/src/servicelib/aiohttp/tracing.py
@@ -38,6 +38,13 @@ try:
 except ImportError:
     HAS_AIOPG = False
 try:
+    from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
+
+    HAS_ASYNCPG = True
+except ImportError:
+    HAS_ASYNCPG = False
+
+try:
     from opentelemetry.instrumentation.requests import RequestsInstrumentor
 
     HAS_REQUESTS = True
@@ -130,6 +137,13 @@ def _startup(
             msg="Attempting to add aio-pg opentelemetry autoinstrumentation...",
         ):
             AiopgInstrumentor().instrument()
+    if HAS_ASYNCPG:
+        with log_context(
+            _logger,
+            logging.INFO,
+            msg="Attempting to add asyncpg opentelemetry autoinstrumentation...",
+        ):
+            AsyncPGInstrumentor().instrument()
     if HAS_BOTOCORE:
         with log_context(
             _logger,
@@ -180,6 +194,11 @@ def _shutdown() -> None:
             AiopgInstrumentor().uninstrument()
         except Exception:  # pylint:disable=broad-exception-caught
             _logger.exception("Failed to uninstrument AiopgInstrumentor")
+    if HAS_ASYNCPG:
+        try:
+            AsyncPGInstrumentor().uninstrument()
+        except Exception:  # pylint:disable=broad-exception-caught
+            _logger.exception("Failed to uninstrument AsyncPGInstrumentor")
     if HAS_BOTOCORE:
         try:
             BotocoreInstrumentor().uninstrument()

--- a/packages/service-library/src/servicelib/tracing.py
+++ b/packages/service-library/src/servicelib/tracing.py
@@ -1,15 +1,21 @@
+from collections.abc import Callable, Coroutine
 from contextlib import contextmanager
 from contextvars import Token
-from typing import TypeAlias
+from functools import wraps
+from typing import Any, TypeAlias
 
+import pyinstrument
 from opentelemetry import context as otcontext
 from opentelemetry import trace
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
+from servicelib.redis._client import Final
 from settings_library.tracing import TracingSettings
 
 TracingContext: TypeAlias = otcontext.Context | None
 
-_OSPARC_TRACE_ID_HEADER = "x-osparc-trace-id"
+_TRACER_NAME: Final[str] = "servicelib.tracing"
+_PROFILE_ATTRIBUTE_NAME: Final[str] = "pyinstrument.profile"
+_OSPARC_TRACE_ID_HEADER: Final[str] = "x-osparc-trace-id"
 
 
 def _is_tracing() -> bool:
@@ -49,3 +55,38 @@ def get_trace_id_header() -> dict[str, str] | None:
         )  # Convert trace_id to 32-character hex string
         return {_OSPARC_TRACE_ID_HEADER: trace_id_hex}
     return None
+
+
+def with_profiled_span(
+    func: Callable[..., Coroutine[Any, Any, Any]],
+) -> Callable[..., Coroutine[Any, Any, Any]]:
+    """Decorator that wraps an async function in an OpenTelemetry span with pyinstrument profiling."""
+
+    @wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if not _is_tracing():
+            return await func(*args, **kwargs)
+
+        tracer = trace.get_tracer(_TRACER_NAME)
+        span_name = f"{func.__module__}.{func.__qualname__}"
+
+        with tracer.start_as_current_span(span_name) as span:
+            try:
+                profiler = pyinstrument.Profiler(async_mode="enabled")
+                profiler.start()
+
+                try:
+                    return await func(*args, **kwargs)
+                finally:
+                    profiler.stop()
+                    span.set_attribute(
+                        _PROFILE_ATTRIBUTE_NAME,
+                        profiler.output_text(unicode=True, color=False),
+                    )
+
+            except Exception as e:
+                span.record_exception(e)
+                span.set_status(trace.Status(trace.StatusCode.ERROR, str(e)))
+                raise
+
+    return wrapper

--- a/packages/service-library/src/servicelib/tracing.py
+++ b/packages/service-library/src/servicelib/tracing.py
@@ -81,7 +81,7 @@ def with_profiled_span(
                     profiler.stop()
                     span.set_attribute(
                         _PROFILE_ATTRIBUTE_NAME,
-                        profiler.output_text(unicode=True, color=False),
+                        profiler.output_text(unicode=True, color=False, show_all=True),
                     )
 
             except Exception as e:

--- a/packages/service-library/tests/aiohttp/test_tracing.py
+++ b/packages/service-library/tests/aiohttp/test_tracing.py
@@ -3,7 +3,7 @@
 # pylint: disable=unused-variable
 
 import importlib
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from functools import partial
 from typing import Any
 
@@ -55,10 +55,10 @@ def set_and_clean_settings_env_vars(
     indirect=True,
 )
 async def test_valid_tracing_settings(
+    mock_otel_collector: InMemorySpanExporter,
     aiohttp_client: Callable,
     set_and_clean_settings_env_vars: Callable,
     tracing_settings_in,
-    uninstrument_opentelemetry: Iterator[None],
 ) -> TestClient:
     app = web.Application()
     service_name = "simcore_service_webserver"
@@ -79,10 +79,10 @@ async def test_valid_tracing_settings(
     indirect=True,
 )
 async def test_invalid_tracing_settings(
+    mock_otel_collector: InMemorySpanExporter,
     aiohttp_client: Callable,
     set_and_clean_settings_env_vars: Callable,
     tracing_settings_in,
-    uninstrument_opentelemetry: Iterator[None],
 ) -> TestClient:
     with pytest.raises(ValidationError):
         TracingSettings()
@@ -128,11 +128,11 @@ def manage_package(request):
     indirect=True,
 )
 async def test_tracing_setup_package_detection(
+    mock_otel_collector: InMemorySpanExporter,
     aiohttp_client: Callable,
     set_and_clean_settings_env_vars: Callable[[], None],
     tracing_settings_in: Callable[[], dict[str, Any]],
     manage_package,
-    uninstrument_opentelemetry: Iterator[None],
 ):
     package_name = manage_package
     importlib.import_module(package_name)
@@ -169,7 +169,6 @@ async def test_trace_id_in_response_header(
     aiohttp_client: Callable,
     set_and_clean_settings_env_vars: Callable,
     tracing_settings_in,
-    uninstrument_opentelemetry: Iterator[None],
     server_response: web.Response | web.HTTPException,
 ) -> None:
     app = web.Application()

--- a/packages/service-library/tests/conftest.py
+++ b/packages/service-library/tests/conftest.py
@@ -12,8 +12,6 @@ from typing import Any
 import pytest
 import servicelib
 from faker import Faker
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from pytest_mock import MockerFixture
 from servicelib.redis import RedisClientSDK, RedisClientsManager, RedisManagerDBConfig
 from settings_library.redis import RedisDatabase, RedisSettings
@@ -107,13 +105,3 @@ async def get_redis_client_sdk(
         await _cleanup_redis_data(clients_manager)
         yield _
         await _cleanup_redis_data(clients_manager)
-
-
-@pytest.fixture
-def mock_otel_collector(mocker: MockerFixture) -> InMemorySpanExporter:
-    memory_exporter = InMemorySpanExporter()
-    span_processor = SimpleSpanProcessor(memory_exporter)
-    mocker.patch(
-        "servicelib.fastapi.tracing._create_span_processor", return_value=span_processor
-    )
-    return memory_exporter

--- a/packages/service-library/tests/fastapi/conftest.py
+++ b/packages/service-library/tests/fastapi/conftest.py
@@ -3,7 +3,7 @@
 # pylint: disable=unused-variable
 
 import socket
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncIterator, Callable
 from typing import cast
 
 import arrow
@@ -61,10 +61,10 @@ def get_unused_port() -> Callable[[], int]:
 
 
 @pytest.fixture
-def mock_otel_collector(mocker: MockerFixture) -> Iterator[InMemorySpanExporter]:
+def mock_otel_collector(mocker: MockerFixture) -> InMemorySpanExporter:
     memory_exporter = InMemorySpanExporter()
     span_processor = SimpleSpanProcessor(memory_exporter)
     mocker.patch(
         "servicelib.fastapi.tracing._create_span_processor", return_value=span_processor
     )
-    yield memory_exporter
+    return memory_exporter

--- a/packages/service-library/tests/fastapi/test_tracing.py
+++ b/packages/service-library/tests/fastapi/test_tracing.py
@@ -4,7 +4,7 @@
 import importlib
 import random
 import string
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from functools import partial
 from typing import Any
 
@@ -68,9 +68,9 @@ def set_and_clean_settings_env_vars(
 )
 async def test_valid_tracing_settings(
     mocked_app: FastAPI,
+    mock_otel_collector: InMemorySpanExporter,
     set_and_clean_settings_env_vars: Callable[[], None],
     tracing_settings_in: Callable[[], dict[str, Any]],
-    uninstrument_opentelemetry: Iterator[None],
 ):
     tracing_settings = TracingSettings()
     async for _ in get_tracing_instrumentation_lifespan(
@@ -102,9 +102,9 @@ async def test_valid_tracing_settings(
 )
 async def test_invalid_tracing_settings(
     mocked_app: FastAPI,
+    mock_otel_collector: InMemorySpanExporter,
     set_and_clean_settings_env_vars: Callable[[], None],
     tracing_settings_in: Callable[[], dict[str, Any]],
-    uninstrument_opentelemetry: Iterator[None],
 ):
     app = mocked_app
     with pytest.raises((BaseException, ValidationError, TypeError)):  # noqa: PT012
@@ -157,9 +157,9 @@ def manage_package(request):
 )
 async def test_tracing_setup_package_detection(
     mocked_app: FastAPI,
+    mock_otel_collector: InMemorySpanExporter,
     set_and_clean_settings_env_vars: Callable[[], None],
     tracing_settings_in: Callable[[], dict[str, Any]],
-    uninstrument_opentelemetry: Iterator[None],
     manage_package,
 ):
     package_name = manage_package
@@ -196,7 +196,6 @@ async def test_trace_id_in_response_header(
     mocked_app: FastAPI,
     set_and_clean_settings_env_vars: Callable,
     tracing_settings_in: Callable,
-    uninstrument_opentelemetry: Iterator[None],
     server_response: PlainTextResponse | HTTPException,
 ) -> None:
     tracing_settings = TracingSettings()

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -202,7 +202,7 @@ opentelemetry-instrumentation==0.55b1
 opentelemetry-instrumentation-aio-pika==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/../../../packages/postgres-database/requirements/_base.in
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-logging==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-redis==0.55b1

--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -184,6 +184,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
@@ -205,6 +206,7 @@ opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
@@ -214,6 +216,8 @@ opentelemetry-instrumentation-aio-pika==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-asyncpg==0.55b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1
@@ -238,6 +242,7 @@ opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -385,8 +385,8 @@ opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.55b1
     # via
-    #   -r requirements/../../../packages/postgres-database/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -312,6 +312,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
@@ -337,6 +338,7 @@ opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
@@ -349,6 +351,10 @@ opentelemetry-instrumentation-aio-pika==0.55b1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-asyncpg==0.55b1
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-botocore==0.55b1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
@@ -384,6 +390,7 @@ opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -254,7 +254,7 @@ opentelemetry-instrumentation-aio-pika==0.55b1
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/../../../packages/postgres-database/requirements/_base.in
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -310,6 +310,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
@@ -335,6 +336,7 @@ opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
@@ -347,6 +349,10 @@ opentelemetry-instrumentation-aio-pika==0.55b1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-asyncpg==0.55b1
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-botocore==0.55b1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
@@ -382,6 +388,7 @@ opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -213,6 +213,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
@@ -231,10 +232,13 @@ opentelemetry-exporter-otlp-proto-http==1.34.1
 opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
 opentelemetry-instrumentation-aio-pika==0.55b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-asyncpg==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-logging==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
@@ -255,6 +259,7 @@ opentelemetry-sdk==1.34.1
 opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -196,6 +196,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
@@ -217,6 +218,7 @@ opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
@@ -226,6 +228,8 @@ opentelemetry-instrumentation-aio-pika==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-asyncpg==0.55b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1
@@ -250,6 +254,7 @@ opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -434,8 +434,8 @@ opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.55b1
     # via
-    #   -r requirements/../../../packages/postgres-database/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1

--- a/services/director/requirements/_base.txt
+++ b/services/director/requirements/_base.txt
@@ -184,6 +184,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
@@ -205,6 +206,7 @@ opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
@@ -214,6 +216,8 @@ opentelemetry-instrumentation-aio-pika==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-asyncpg==0.55b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1
@@ -238,6 +242,7 @@ opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis

--- a/services/docker-api-proxy/requirements/_test.txt
+++ b/services/docker-api-proxy/requirements/_test.txt
@@ -135,6 +135,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
@@ -153,10 +154,13 @@ opentelemetry-exporter-otlp-proto-http==1.34.1
 opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
 opentelemetry-instrumentation-aio-pika==0.55b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-asyncpg==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-logging==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
@@ -177,6 +181,7 @@ opentelemetry-sdk==1.34.1
 opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -269,7 +269,7 @@ opentelemetry-instrumentation-aio-pika==0.55b1
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/../../../packages/postgres-database/requirements/_base.in
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -359,8 +359,8 @@ opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.55b1
     # via
-    #   -r requirements/../../../packages/postgres-database/requirements/_base.in
-    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1

--- a/services/efs-guardian/requirements/_base.txt
+++ b/services/efs-guardian/requirements/_base.txt
@@ -358,7 +358,9 @@ opentelemetry-instrumentation-aio-pika==0.55b1
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/../../../packages/postgres-database/requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-botocore==0.55b1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -199,6 +199,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
@@ -220,6 +221,7 @@ opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-logging
@@ -229,6 +231,8 @@ opentelemetry-instrumentation-aio-pika==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-asyncpg==0.55b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1
@@ -253,6 +257,7 @@ opentelemetry-semantic-conventions==0.55b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
+    #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis

--- a/services/notifications/requirements/_base.txt
+++ b/services/notifications/requirements/_base.txt
@@ -248,7 +248,7 @@ opentelemetry-instrumentation-aio-pika==0.55b1
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/../../../packages/postgres-database/requirements/_base.in
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -275,7 +275,7 @@ opentelemetry-instrumentation-aio-pika==0.55b1
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/../../../packages/postgres-database/requirements/_base.in
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
 opentelemetry-instrumentation-httpx==0.55b1

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -379,7 +379,9 @@ opentelemetry-instrumentation-aio-pika==0.55b1
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/../../../packages/postgres-database/requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-botocore==0.55b1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
 opentelemetry-instrumentation-fastapi==0.55b1

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -464,7 +464,10 @@ opentelemetry-instrumentation-aio-pika==0.55b1
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/../../../packages/postgres-database/requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-botocore==0.55b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/_base.in

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -466,9 +466,8 @@ opentelemetry-instrumentation-aiopg==0.55b1
     #   -r requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.55b1
     # via
-    #   -r requirements/../../../../packages/notifications-library/requirements/../../../packages/postgres-database/requirements/_base.in
-    #   -r requirements/../../../../packages/postgres-database/requirements/_base.in
-    #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
+    #   -r requirements/../../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-dbapi==0.55b1
     # via opentelemetry-instrumentation-aiopg
 opentelemetry-instrumentation-logging==0.55b1

--- a/tests/swarm-deploy/requirements/_test.txt
+++ b/tests/swarm-deploy/requirements/_test.txt
@@ -292,7 +292,9 @@ opentelemetry-instrumentation-aio-pika==0.55b1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.55b1
-    # via -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/postgres-database/requirements/_base.in
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-logging==0.55b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
- Ensure `asyncpg` is instrumented. Together with @pcrespov I discovered the other day that this library is not instrumented in the aiohttp case (webserver)
- Clean up tracing tests
- Add a decorator which can be used to generate opentelemetry spans for a given coroutine (e.g. a handler). That span will include a pyinstrument profile. This will make it easier to detect computational bottlenecks in the future. 

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
