### PR TITLE
🎨 Increase timeout of file creation to avoid flaky testes in CI

### DIFF
--- a/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/test_jupyterlab.py
@@ -154,7 +154,8 @@ def test_jupyterlab(
                     expected_message_type="stdout", expected_message_contents="copied"
                 ),
                 timeout=_WAITING_TIME_FILE_CREATION_PER_GB_IN_TERMINAL
-                * max(int(large_file_size.to("GiB")), 1),
+                * max(int(large_file_size.to("GiB")), 1)
+                * 3,  # avoids flakyness since timeout is deterimned based on size
             ):
                 terminal.fill(
                     f"dd if=/dev/urandom of=output.txt bs={large_file_block_size} count={blocks_count} iflag=fullblock"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

Since the test is a bit flaky we bump up the timeout of file creation in the terminal to avoid it failing

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
