### PR TITLE
🎨♻️Simultaneous access: emit project update event when a user closes a project or the GC closes it

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_webserver/projects_nodes.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects_nodes.py
@@ -1,9 +1,6 @@
 # mypy: disable-error-code=truthy-function
 from typing import Annotated, Any, Literal, TypeAlias
 
-from models_library.groups import GroupID
-from models_library.projects import ProjectID
-from models_library.services_history import ServiceRelease
 from pydantic import ConfigDict, Field
 
 from ..access_rights import ExecutableAccessRights
@@ -13,8 +10,11 @@ from ..projects_nodes import InputID, InputsDict, PartialNode
 from ..projects_nodes_io import NodeID
 from ..services import ServiceKey, ServicePortKey, ServiceVersion
 from ..services_enums import ServiceState
+from ..services_history import ServiceRelease
 from ..services_resources import ServiceResourcesDict
 from ._base import InputSchemaWithoutCamelCase, OutputSchema
+from .groups import GroupID
+from .projects import ProjectID
 
 assert ServiceResourcesDict  # nosec
 __all__: tuple[str, ...] = ("ServiceResourcesDict",)

--- a/packages/models-library/src/models_library/api_schemas_webserver/projects_nodes.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects_nodes.py
@@ -6,6 +6,8 @@ from pydantic import ConfigDict, Field
 from ..access_rights import ExecutableAccessRights
 from ..api_schemas_directorv2.dynamic_services import RetrieveDataOut
 from ..basic_types import PortInt
+from ..groups import GroupID
+from ..projects import ProjectID
 from ..projects_nodes import InputID, InputsDict, PartialNode
 from ..projects_nodes_io import NodeID
 from ..services import ServiceKey, ServicePortKey, ServiceVersion
@@ -13,8 +15,6 @@ from ..services_enums import ServiceState
 from ..services_history import ServiceRelease
 from ..services_resources import ServiceResourcesDict
 from ._base import InputSchemaWithoutCamelCase, OutputSchema
-from .groups import GroupID
-from .projects import ProjectID
 
 assert ServiceResourcesDict  # nosec
 __all__: tuple[str, ...] = ("ServiceResourcesDict",)

--- a/packages/models-library/src/models_library/projects_access.py
+++ b/packages/models-library/src/models_library/projects_access.py
@@ -1,18 +1,16 @@
 """
-    Ownership and access rights
+Ownership and access rights
 """
 
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field
-from pydantic.types import PositiveInt
 
 from .basic_types import IDStr
-from .users import FirstNameStr, LastNameStr
+from .users import UserID
 
 
-class GroupIDStr(IDStr):
-    ...
+class GroupIDStr(IDStr): ...
 
 
 class AccessEnum(str, Enum):
@@ -30,18 +28,15 @@ class AccessRights(BaseModel):
 
 
 class Owner(BaseModel):
-    user_id: PositiveInt = Field(..., description="Owner's user id")
-    first_name: FirstNameStr | None = Field(..., description="Owner's first name")
-    last_name: LastNameStr | None = Field(..., description="Owner's last name")
+    user_id: UserID = Field(..., description="Owner's user id")
 
     model_config = ConfigDict(
         extra="forbid",
         json_schema_extra={
             "examples": [
-                # NOTE: None and empty string are both defining an undefined value
-                {"user_id": 1, "first_name": None, "last_name": None},
-                {"user_id": 2, "first_name": "", "last_name": ""},
-                {"user_id": 3, "first_name": "John", "last_name": "Smith"},
+                {"user_id": 1},
+                {"user_id": 42},
+                {"user_id": 666},
             ]
         },
     )

--- a/packages/models-library/src/models_library/projects_access.py
+++ b/packages/models-library/src/models_library/projects_access.py
@@ -3,6 +3,7 @@ Ownership and access rights
 """
 
 from enum import Enum
+from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -20,15 +21,15 @@ class AccessEnum(str, Enum):
 
 
 class AccessRights(BaseModel):
-    read: bool = Field(..., description="has read access")
-    write: bool = Field(..., description="has write access")
-    delete: bool = Field(..., description="has deletion rights")
+    read: Annotated[bool, Field(description="has read access")]
+    write: Annotated[bool, Field(description="has write access")]
+    delete: Annotated[bool, Field(description="has deletion rights")]
 
     model_config = ConfigDict(extra="forbid")
 
 
 class Owner(BaseModel):
-    user_id: UserID = Field(..., description="Owner's user id")
+    user_id: Annotated[UserID, Field(description="Owner's user id")]
 
     model_config = ConfigDict(
         extra="forbid",

--- a/packages/models-library/src/models_library/projects_state.py
+++ b/packages/models-library/src/models_library/projects_state.py
@@ -195,8 +195,6 @@ class ProjectLocked(BaseModel):
                     "status": ProjectStatus.OPENED,
                     "owner": {
                         "user_id": 123,
-                        "first_name": "Johnny",
-                        "last_name": "Cash",
                     },
                 },
             ]

--- a/packages/pytest-simcore/src/pytest_simcore/socketio_client.py
+++ b/packages/pytest-simcore/src/pytest_simcore/socketio_client.py
@@ -106,4 +106,3 @@ async def create_socketio_connection(
                 await sio.disconnect()
                 await sio.wait()
         assert not sio.connected
-        assert not sio.sid

--- a/services/web/server/src/simcore_service_webserver/dynamic_scheduler/api.py
+++ b/services/web/server/src/simcore_service_webserver/dynamic_scheduler/api.py
@@ -24,7 +24,6 @@ from models_library.rabbitmq_messages import ProgressRabbitMessageProject, Progr
 from models_library.services import ServicePortKey
 from models_library.users import UserID
 from pydantic import NonNegativeInt
-from pydantic.types import PositiveInt
 from servicelib.progress_bar import ProgressBarData
 from servicelib.rabbitmq import RabbitMQClient, RPCServerError
 from servicelib.rabbitmq.rpc_interfaces.dynamic_scheduler import services
@@ -94,13 +93,13 @@ async def stop_dynamic_service(
 
 async def _post_progress_message(
     rabbitmq_client: RabbitMQClient,
-    user_id: PositiveInt,
-    project_id: str,
+    user_id: UserID,
+    project_id: ProjectID,
     report: ProgressReport,
 ) -> None:
     progress_message = ProgressRabbitMessageProject(
         user_id=user_id,
-        project_id=ProjectID(project_id),
+        project_id=project_id,
         progress_type=ProgressType.PROJECT_CLOSING,
         report=report,
     )
@@ -111,14 +110,14 @@ async def _post_progress_message(
 async def stop_dynamic_services_in_project(
     app: web.Application,
     *,
-    user_id: PositiveInt,
-    project_id: str,
+    user_id: UserID,
+    project_id: ProjectID,
     simcore_user_agent: str,
     save_state: bool,
 ) -> None:
     """Stops all dynamic services in the project"""
     running_dynamic_services = await list_dynamic_services(
-        app, user_id=user_id, project_id=ProjectID(project_id)
+        app, user_id=user_id, project_id=project_id
     )
 
     async with AsyncExitStack() as stack:

--- a/services/web/server/src/simcore_service_webserver/exporter/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/exporter/_handlers.py
@@ -18,7 +18,6 @@ from ..login.decorators import login_required
 from ..projects._projects_service import create_user_notification_cb
 from ..redis import get_redis_lock_manager_client_sdk
 from ..security.decorators import permission_required
-from ..users import users_service
 from ._formatter.archive import get_sds_archive_path
 from .exceptions import SDSException
 from .utils import CleanupFileResponse
@@ -51,10 +50,7 @@ async def export_project(request: web.Request):
         get_redis_lock_manager_client_sdk(request.app),
         project_uuid=project_uuid,
         status=ProjectStatus.EXPORTING,
-        owner=Owner(
-            user_id=user_id,
-            **await users_service.get_user_fullname(request.app, user_id=user_id),
-        ),
+        owner=Owner(user_id=user_id),
         notification_cb=create_user_notification_cb(
             user_id, ProjectID(f"{project_uuid}"), request.app
         ),

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
@@ -17,7 +17,6 @@ _logger = logging.getLogger(__name__)
 async def remove_disconnected_user_resources(
     registry: RedisResourceRegistry, app: web.Application
 ) -> None:
-
     # NOTE:
     # Each user session is represented in the redis registry with two keys:
     # - "alive" is a string that keeps a TTL of the user session
@@ -31,7 +30,7 @@ async def remove_disconnected_user_resources(
 
     # clean up all resources of expired keys
     for dead_session in dead_user_sessions:
-        user_id = int(dead_session["user_id"])
+        user_id = dead_session["user_id"]
 
         # (0) If key has no resources => remove from registry and continue
         resources = await registry.get_resources(dead_session)
@@ -53,10 +52,13 @@ async def remove_disconnected_user_resources(
                 # inform that the project can be closed on the backend side
                 #
                 project_id = TypeAdapter(ProjectID).validate_python(resource_value)
-                with log_catch(_logger, reraise=False), log_context(
-                    _logger,
-                    logging.INFO,
-                    "Closing project {project_id} for user {user_id=}",
+                with (
+                    log_catch(_logger, reraise=False),
+                    log_context(
+                        _logger,
+                        logging.INFO,
+                        "Closing project {project_id} for user {user_id=}",
+                    ),
                 ):
                     await _projects_service.close_project_for_user(
                         user_id=user_id,

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
@@ -49,8 +49,6 @@ async def remove_disconnected_user_resources(
             )
 
             if resource_name == "project_id":
-                # inform that the project can be closed on the backend side
-                #
                 project_id = TypeAdapter(ProjectID).validate_python(resource_value)
                 with (
                     log_catch(_logger, reraise=False),

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
@@ -7,7 +7,6 @@ from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
 from servicelib.logging_utils import log_catch, log_context
 
 from ..projects import _projects_service
-from ..redis import get_redis_lock_manager_client
 from ..resource_manager.registry import (
     RedisResourceRegistry,
 )
@@ -18,7 +17,6 @@ _logger = logging.getLogger(__name__)
 async def remove_disconnected_user_resources(
     registry: RedisResourceRegistry, app: web.Application
 ) -> None:
-    lock_manager = get_redis_lock_manager_client(app)
 
     # NOTE:
     # Each user session is represented in the redis registry with two keys:

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
@@ -30,7 +30,7 @@ async def remove_disconnected_user_resources(
 
     # clean up all resources of expired keys
     for dead_session in dead_user_sessions:
-        user_id = dead_session["user_id"]
+        user_id = dead_session.user_id
 
         # (0) If key has no resources => remove from registry and continue
         resources = await registry.get_resources(dead_session)
@@ -63,7 +63,7 @@ async def remove_disconnected_user_resources(
                     await _projects_service.close_project_for_user(
                         user_id=user_id,
                         project_uuid=project_id,
-                        client_session_id=dead_session["client_session_id"],
+                        client_session_id=dead_session.client_session_id,
                         app=app,
                         simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
                         wait_for_service_closed=True,

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
@@ -1,6 +1,8 @@
 import logging
 
 from aiohttp import web
+from models_library.projects import ProjectID
+from pydantic import TypeAdapter
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
 from servicelib.utils import logged_gather
 
@@ -84,9 +86,9 @@ async def remove_disconnected_user_resources(
                     _logger.info(
                         "Closing project '%s' of user %s", resource_value, user_id
                     )
-                    await _projects_service.try_close_project_for_user(
+                    await _projects_service.close_project_for_user(
                         user_id,
-                        f"{resource_value}",
+                        TypeAdapter(ProjectID).validate_python(f"{resource_value}"),
                         dead_session["client_session_id"],
                         app,
                         simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
@@ -4,15 +4,13 @@ from aiohttp import web
 from models_library.projects import ProjectID
 from pydantic import TypeAdapter
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
-from servicelib.utils import logged_gather
+from servicelib.logging_utils import log_catch, log_context
 
 from ..projects import _projects_service
-from ..projects.exceptions import ProjectLockError, ProjectNotFoundError
 from ..redis import get_redis_lock_manager_client
 from ..resource_manager.registry import (
     RedisResourceRegistry,
 )
-from .settings import GUEST_USER_RC_LOCK_FORMAT
 
 _logger = logging.getLogger(__name__)
 
@@ -22,15 +20,12 @@ async def remove_disconnected_user_resources(
 ) -> None:
     lock_manager = get_redis_lock_manager_client(app)
 
-    #
-    # In redis jargon, every entry is denoted as "key"
-    # - A key can contain one or more fields: name-value pairs
-    # - A key can have a limited livespan by setting the Time-to-live (TTL) which
-    #       is automatically decreasing
-    # - Every user can open multiple sessions (e.g. in different tabs and/or browser) and
-    #   each session is hierarchically represented in the redis registry with two keys:
-    #     - "alive" is a string that keeps a TLL of the user session
-    #     - "resources" is a hash toto keep project and websocket ids
+    # NOTE:
+    # Each user session is represented in the redis registry with two keys:
+    # - "alive" is a string that keeps a TTL of the user session
+    # - "resources" is a redis hash to keep project and websocket ids attached to the user session
+    # when the alive key expires, it means the user session is disconnected
+    # and the resources attached to that user session shall be closed and removed
     #
 
     _, dead_user_sessions = await registry.get_all_resource_keys()
@@ -40,38 +35,15 @@ async def remove_disconnected_user_resources(
     for dead_session in dead_user_sessions:
         user_id = int(dead_session["user_id"])
 
-        if await lock_manager.lock(
-            GUEST_USER_RC_LOCK_FORMAT.format(user_id=user_id)
-        ).locked():
-            _logger.info(
-                "Skipping garbage-collecting %s since it is still locked",
-                f"{user_id=}",
-            )
-            continue
-
         # (0) If key has no resources => remove from registry and continue
         resources = await registry.get_resources(dead_session)
         if not resources:
             await registry.remove_key(dead_session)
             continue
 
-        # (1,2) CAREFULLY releasing every resource acquired by the expired key
-        _logger.info(
-            "%s expired. Checking resources to cleanup",
-            f"{dead_session=}",
-        )
-
         for resource_name, resource_value in resources.items():
-            # Releasing a resource consists of two steps
-            #   - (1) release actual resource (e.g. stop service, close project, deallocate memory, etc)
-            #   - (2) remove resource field entry in expired key registry after (1) is completed.
-
-            # collects a list of keys for (2)
-            keys_to_update = [
-                dead_session,
-            ]
-
-            # (1) releasing acquired resources
+            # (1) releasing acquired resources (currently only projects),
+            # that means closing project for the disconnected user
             _logger.info(
                 "(1) Releasing resource %s:%s acquired by expired %s",
                 f"{resource_name=}",
@@ -82,46 +54,17 @@ async def remove_disconnected_user_resources(
             if resource_name == "project_id":
                 # inform that the project can be closed on the backend side
                 #
-                try:
-                    _logger.info(
-                        "Closing project '%s' of user %s", resource_value, user_id
-                    )
+                project_id = TypeAdapter(ProjectID).validate_python(resource_value)
+                with log_catch(_logger, reraise=False), log_context(
+                    _logger,
+                    logging.INFO,
+                    "Closing project {project_id} for user {user_id=}",
+                ):
                     await _projects_service.close_project_for_user(
-                        user_id,
-                        TypeAdapter(ProjectID).validate_python(f"{resource_value}"),
-                        dead_session["client_session_id"],
-                        app,
+                        user_id=user_id,
+                        project_uuid=project_id,
+                        client_session_id=dead_session["client_session_id"],
+                        app=app,
                         simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
                         wait_for_service_closed=True,
                     )
-
-                except (ProjectNotFoundError, ProjectLockError) as err:
-                    _logger.warning(
-                        (
-                            "Could not remove project interactive services user_id=%s "
-                            "project_uuid=%s. Check the logs above for details [%s]"
-                        ),
-                        user_id,
-                        resource_value,
-                        err,
-                    )
-
-            # (2) remove resource field in collected keys since (1) is completed
-            _logger.info(
-                "(2) Removing field for released resource %s:%s from registry keys: %s",
-                f"{resource_name=}",
-                f"{resource_value=}",
-                keys_to_update,
-            )
-            await logged_gather(
-                *[
-                    registry.remove_resource(key, resource_name)
-                    for key in keys_to_update
-                ],
-                reraise=False,
-            )
-
-            # NOTE:
-            #   - if releasing a resource (1) fails, the resource is not removed from the registry and it allows GC to try in next round
-            #   - if any task in (2) fails, GC will clean them up in next round as well
-            #   - if all resource fields are removed from a key, next GC iteration will remove the key (see (0))

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
@@ -32,7 +32,7 @@ async def remove_disconnected_user_resources(
     #     - "resources" is a hash toto keep project and websocket ids
     #
 
-    all_session_alive, all_sessions_dead = await registry.get_all_resource_keys()
+    _, all_sessions_dead = await registry.get_all_resource_keys()
     _logger.debug("potential dead keys: %s", all_sessions_dead)
 
     # clean up all resources of expired keys

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_disconnected.py
@@ -57,7 +57,7 @@ async def remove_disconnected_user_resources(
                     log_context(
                         _logger,
                         logging.INFO,
-                        "Closing project {project_id} for user {user_id=}",
+                        f"Closing project {project_id} for user {user_id=}",
                     ),
                 ):
                     await _projects_service.close_project_for_user(

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_guests.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_guests.py
@@ -240,8 +240,3 @@ async def remove_users_manually_marked_as_guests(
             app=app,
             user_id=guest_user_id,
         )
-
-        await remove_guest_user_with_all_its_resources(
-            app=app,
-            user_id=guest_user_id,
-        )

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_guests.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_guests.py
@@ -192,7 +192,7 @@ async def remove_users_manually_marked_as_guests(
     ) = await registry.get_all_resource_keys()
 
     skip_users = {
-        int(user_session["user_id"])
+        user_session.user_id
         for user_session in itertools.chain(
             all_user_session_alive, all_user_sessions_dead
         )

--- a/services/web/server/src/simcore_service_webserver/projects/_controller/projects_slot.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_controller/projects_slot.py
@@ -30,7 +30,7 @@ async def _on_user_connected(
     assert product_name  # nosec
     # check if there is a project resource
     with managed_resource(user_id, client_session_id, app) as user_session:
-        projects: list[str] = await user_session.find(PROJECT_ID_KEY)
+        projects = await user_session.find(PROJECT_ID_KEY)
     assert len(projects) <= 1, "At the moment, at most one project per session"  # nosec
 
     if projects:
@@ -63,7 +63,7 @@ async def _on_user_disconnected(
 
     # check if there is a project resource
     with managed_resource(user_id, client_session_id, app) as user_session:
-        projects: list[str] = await user_session.find(PROJECT_ID_KEY)
+        projects = await user_session.find(PROJECT_ID_KEY)
 
     assert len(projects) <= 1, "At the moment, at most one project per session"  # nosec
 

--- a/services/web/server/src/simcore_service_webserver/projects/_controller/projects_states_rest.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_controller/projects_states_rest.py
@@ -174,9 +174,9 @@ async def open_project(request: web.Request) -> web.Response:
     except DirectorV2ServiceError as exc:
         # there was an issue while accessing the director-v2/director-v0
         # ensure the project is closed again
-        await _projects_service.try_close_project_for_user(
+        await _projects_service.close_project_for_user(
             user_id=req_ctx.user_id,
-            project_uuid=f"{path_params.project_id}",
+            project_uuid=path_params.project_id,
             client_session_id=client_session_id,
             app=request.app,
             simcore_user_agent=request.headers.get(
@@ -214,9 +214,9 @@ async def close_project(request: web.Request) -> web.Response:
         user_id=req_ctx.user_id,
         include_state=False,
     )
-    await _projects_service.try_close_project_for_user(
+    await _projects_service.close_project_for_user(
         req_ctx.user_id,
-        f"{path_params.project_id}",
+        path_params.project_id,
         client_session_id,
         request.app,
         simcore_user_agent=request.headers.get(

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
@@ -38,7 +38,6 @@ from ..storage.api import (
     copy_data_folders_from_project,
     get_project_total_size_simcore_s3,
 )
-from ..users import users_service
 from ..workspaces.api import check_user_workspace_access, get_user_workspace
 from ..workspaces.errors import WorkspaceAccessForbiddenError
 from . import _folders_repository, _projects_repository, _projects_service
@@ -203,10 +202,7 @@ async def _copy_files_from_source_project(
             get_redis_lock_manager_client_sdk(app),
             project_uuid=source_project["uuid"],
             status=ProjectStatus.CLONING,
-            owner=Owner(
-                user_id=user_id,
-                **await users_service.get_user_fullname(app, user_id=user_id),
-            ),
+            owner=Owner(user_id=user_id),
             notification_cb=_projects_service.create_user_notification_cb(
                 user_id, ProjectID(f"{source_project['uuid']}"), app
             ),

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_api_delete.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_api_delete.py
@@ -18,7 +18,6 @@ from servicelib.utils import fire_and_forget_task
 from ..director_v2 import director_v2_service
 from ..storage.api import delete_data_folders_of_project
 from ..users.exceptions import UserNotFoundError
-from ..users.users_service import FullNameDict
 from . import _projects_repository
 from ._access_rights_service import check_user_project_permission
 from ._projects_repository_legacy import ProjectDBAPI
@@ -40,13 +39,12 @@ class RemoveProjectServicesCallable(Protocol):
     # NOTE: this function was tmp added here to avoid refactoring all projects_api in a single PR
     async def __call__(
         self,
-        user_id: int,
-        project_uuid: str,
+        user_id: UserID,
+        project_uuid: ProjectID,
         app: web.Application,
         simcore_user_agent: str,
         *,
         notify_users: bool = True,
-        user_name: FullNameDict | None = None,
     ) -> None: ...
 
 
@@ -109,7 +107,7 @@ async def delete_project(
         # - raises ProjectNotFoundError, UserNotFoundError, ProjectLockError
         await remove_project_dynamic_services(
             user_id=user_id,
-            project_uuid=f"{project_uuid}",
+            project_uuid=project_uuid,
             app=app,
             simcore_user_agent=simcore_user_agent,
             notify_users=False,

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -110,9 +110,9 @@ from ..redis import (
     get_redis_document_manager_client_sdk,
     get_redis_lock_manager_client_sdk,
 )
+from ..resource_manager.models import UserSession
 from ..resource_manager.user_sessions import (
     PROJECT_ID_KEY,
-    UserSessionID,
     managed_resource,
 )
 from ..resource_usage import service as rut_api
@@ -1441,7 +1441,7 @@ async def post_trigger_connected_service_retrieve(
 
 
 async def _user_has_another_active_session(
-    users_sessions_ids: list[UserSessionID], app: web.Application
+    users_sessions_ids: list[UserSession], app: web.Application
 ) -> bool:
     # NOTE if there is an active socket in use, that means the client is active
     for u in users_sessions_ids:
@@ -1452,7 +1452,7 @@ async def _user_has_another_active_session(
 
 
 async def _clean_user_disconnected_clients(
-    users_sessions_ids: list[UserSessionID], app: web.Application
+    users_sessions_ids: list[UserSession], app: web.Application
 ):
     for u in users_sessions_ids:
         with managed_resource(u.user_id, u.client_session_id, app) as user_session:

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -1620,14 +1620,15 @@ async def close_project_for_user(
                 task_suffix_name=f"remove_project_dynamic_services_{user_id=}_{project_uuid=}",
                 fire_and_forget_tasks_collection=app[APP_FIRE_AND_FORGET_TASKS_KEY],
             )
-    # notify users that project is now closed
-    project = await get_project_for_user(
-        app,
-        f"{project_uuid}",
-        user_id,
-        include_state=True,
-    )
-    await notify_project_state_update(app, project)
+    else:
+        # when the project is still opened by other users, we just notify the project state update
+        project = await get_project_for_user(
+            app,
+            f"{project_uuid}",
+            user_id,
+            include_state=True,
+        )
+        await notify_project_state_update(app, project)
 
 
 async def _get_project_share_state(

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -129,7 +129,6 @@ from ..user_preferences.user_preferences_service import (
 )
 from ..users import users_service
 from ..users.exceptions import UserDefaultWalletNotFoundError, UserNotFoundError
-from ..users.users_service import FullNameDict
 from ..wallets import api as wallets_service
 from ..wallets.errors import WalletNotEnoughCreditsError
 from ..workspaces import _workspaces_repository as workspaces_workspaces_repository
@@ -1498,10 +1497,7 @@ async def try_open_project_for_user(
             get_redis_lock_manager_client_sdk(app),
             project_uuid=project_uuid,
             status=ProjectStatus.OPENING,
-            owner=Owner(
-                user_id=user_id,
-                **await users_service.get_user_fullname(app, user_id=user_id),
-            ),
+            owner=Owner(user_id=user_id),
             notification_cb=None,
         )
         async def _open_project() -> bool:
@@ -1983,7 +1979,6 @@ async def remove_project_dynamic_services(
     simcore_user_agent: str,
     *,
     notify_users: bool = True,
-    user_name: FullNameDict | None = None,
 ) -> None:
     """
 
@@ -1997,10 +1992,6 @@ async def remove_project_dynamic_services(
         "removing project interactive services for project [%s] and user [%s]",
         project_uuid,
         user_id,
-    )
-
-    user_name_data: FullNameDict = user_name or await users_service.get_user_fullname(
-        app, user_id=user_id
     )
 
     user_role: UserRole | None = None
@@ -2020,7 +2011,7 @@ async def remove_project_dynamic_services(
         get_redis_lock_manager_client_sdk(app),
         project_uuid=project_uuid,
         status=ProjectStatus.CLOSING,
-        owner=Owner(user_id=user_id, **user_name_data),
+        owner=Owner(user_id=user_id),
         notification_cb=(
             create_user_notification_cb(user_id, ProjectID(project_uuid), app)
             if notify_users

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service_delete.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service_delete.py
@@ -48,7 +48,7 @@ async def batch_stop_services_in_project(
         ),
         _projects_service.remove_project_dynamic_services(
             user_id=user_id,
-            project_uuid=f"{project_uuid}",
+            project_uuid=project_uuid,
             app=app,
             simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
             notify_users=False,

--- a/services/web/server/src/simcore_service_webserver/resource_manager/models.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/models.py
@@ -28,7 +28,7 @@ class UserSession(BaseModel):
     def _update_json_schema_extra(schema: JsonDict) -> None:
         schema.update(
             {
-                "exampels": [
+                "examples": [
                     {
                         "user_id": 7,
                         "client_session_id": "c7fc4985-f96a-4be3-a8ed-5a43b1aa15e2",

--- a/services/web/server/src/simcore_service_webserver/resource_manager/models.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/models.py
@@ -1,0 +1,58 @@
+from typing import Final, Self, TypeAlias, TypedDict
+
+from models_library.basic_types import UUIDStr
+from models_library.users import UserID
+from pydantic import BaseModel, ConfigDict
+from pydantic.config import JsonDict
+
+ALIVE_SUFFIX: Final[str] = "alive"  # points to a string type
+RESOURCE_SUFFIX: Final[str] = "resources"  # points to a hash (like a dict) type
+RedisHashKey: TypeAlias = str
+
+
+class UserSession(BaseModel):
+    """Parts of the key used in redis for a user-session"""
+
+    user_id: UserID
+    client_session_id: str
+
+    def to_redis_hash_key(self) -> RedisHashKey:
+        return ":".join(f"{k}={v}" for k, v in self.model_dump().items())
+
+    @classmethod
+    def from_redis_hash_key(cls, hash_key: RedisHashKey) -> Self:
+        key = dict(x.split("=") for x in hash_key.split(":") if "=" in x)
+        return cls.model_validate(key)
+
+    @staticmethod
+    def _update_json_schema_extra(schema: JsonDict) -> None:
+        schema.update(
+            {
+                "exampels": [
+                    {
+                        "user_id": 7,
+                        "client_session_id": "c7fc4985-f96a-4be3-a8ed-5a43b1aa15e2",
+                    },
+                    {
+                        "user_id": 666,
+                        "client_session_id": "*",
+                    },
+                ]
+            }
+        )
+
+    model_config = ConfigDict(
+        frozen=True,
+        json_schema_extra=_update_json_schema_extra,
+    )
+
+
+class ResourcesDict(TypedDict, total=False):
+    """Field-value pairs of {user_id}:{client_session_id}:resources key"""
+
+    project_id: UUIDStr
+    socket_id: str
+
+
+AliveSessions: TypeAlias = list[UserSession]
+DeadSessions: TypeAlias = list[UserSession]

--- a/services/web/server/src/simcore_service_webserver/resource_manager/models.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/models.py
@@ -21,7 +21,7 @@ class UserSession(BaseModel):
 
     @classmethod
     def from_redis_hash_key(cls, hash_key: RedisHashKey) -> Self:
-        key = dict(x.split("=") for x in hash_key.split(":") if "=" in x)
+        key = dict(x.split("=", 1) for x in hash_key.split(":") if "=" in x)
         return cls.model_validate(key)
 
     @staticmethod

--- a/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
@@ -14,6 +14,7 @@ This key can have a timeout value. When the key times out then the key disappear
 """
 
 import logging
+from typing import TypeAlias
 
 import redis.asyncio as aioredis
 from aiohttp import web
@@ -53,6 +54,10 @@ class ResourcesDict(TypedDict, total=False):
 
     project_id: UUIDStr
     socket_id: str
+
+
+AliveSessions: TypeAlias = list[UserSessionDict]
+DeadSessions: TypeAlias = list[UserSessionDict]
 
 
 class RedisResourceRegistry:
@@ -158,9 +163,7 @@ class RedisResourceRegistry:
             f"{self._hash_key(key)}:{_ALIVE_SUFFIX}",
         )
 
-    async def get_all_resource_keys(
-        self,
-    ) -> tuple[list[UserSessionDict], list[UserSessionDict]]:
+    async def get_all_resource_keys(self) -> tuple[AliveSessions, DeadSessions]:
         alive_keys = [
             self._decode_hash_key(hash_key)
             async for hash_key in self.client.scan_iter(match=f"*:{_ALIVE_SUFFIX}")

--- a/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
@@ -39,13 +39,10 @@ _ALIVE_SUFFIX = "alive"  # points to a string type
 _RESOURCE_SUFFIX = "resources"  # points to a hash (like a dict) type
 
 
-class _UserRequired(TypedDict, total=True):
-    user_id: str | UserID
-
-
-class UserSessionDict(_UserRequired):
+class UserSessionDict(TypedDict):
     """Parts of the key used in redis for a user-session"""
 
+    user_id: UserID
     client_session_id: str
 
 

--- a/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
@@ -14,19 +14,21 @@ This key can have a timeout value. When the key times out then the key disappear
 """
 
 import logging
-from typing import TypeAlias
 
 import redis.asyncio as aioredis
 from aiohttp import web
-from models_library.basic_types import UUIDStr
-from models_library.users import UserID
 from servicelib.redis import handle_redis_returns_union_types
-from typing_extensions import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
-    TypedDict,
-)
 
 from ..redis import get_redis_resources_client
 from ._constants import APP_CLIENT_SOCKET_REGISTRY_KEY
+from .models import (
+    ALIVE_SUFFIX,
+    RESOURCE_SUFFIX,
+    AliveSessions,
+    DeadSessions,
+    ResourcesDict,
+    UserSession,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -35,26 +37,6 @@ _logger = logging.getLogger(__name__)
 #        Key: user_id=1:client_session_id=7f40353b-db02-4474-a44d-23ce6a6e428c:alive = 1
 #        Key: user_id=1:client_session_id=7f40353b-db02-4474-a44d-23ce6a6e428c:resources = {project_id: ... , socket_id: ...}
 #
-_ALIVE_SUFFIX = "alive"  # points to a string type
-_RESOURCE_SUFFIX = "resources"  # points to a hash (like a dict) type
-
-
-class UserSession(TypedDict):
-    """Parts of the key used in redis for a user-session"""
-
-    user_id: UserID
-    client_session_id: str
-
-
-class ResourcesDict(TypedDict, total=False):
-    """Field-value pairs of {user_id}:{client_session_id}:resources key"""
-
-    project_id: UUIDStr
-    socket_id: str
-
-
-AliveSessions: TypeAlias = list[UserSession]
-DeadSessions: TypeAlias = list[UserSession]
 
 
 class RedisResourceRegistry:
@@ -76,16 +58,11 @@ class RedisResourceRegistry:
         return self._app
 
     @classmethod
-    def _hash_key(cls, key: UserSession) -> str:
-        hash_key: str = ":".join(f"{k}={v}" for k, v in key.items())
-        return hash_key
-
-    @classmethod
     def _decode_hash_key(cls, hash_key: str) -> UserSession:
         tmp_key = (
-            hash_key[: -len(f":{_RESOURCE_SUFFIX}")]
-            if hash_key.endswith(f":{_RESOURCE_SUFFIX}")
-            else hash_key[: -len(f":{_ALIVE_SUFFIX}")]
+            hash_key[: -len(f":{RESOURCE_SUFFIX}")]
+            if hash_key.endswith(f":{RESOURCE_SUFFIX}")
+            else hash_key[: -len(f":{ALIVE_SUFFIX}")]
         )
         key = dict(x.split("=") for x in tmp_key.split(":"))
         return UserSession(**key)  # type: ignore
@@ -96,19 +73,19 @@ class RedisResourceRegistry:
         return client
 
     async def set_resource(self, key: UserSession, resource: tuple[str, str]) -> None:
-        hash_key = f"{self._hash_key(key)}:{_RESOURCE_SUFFIX}"
+        hash_key = f"{key.to_redis_hash_key()}:{RESOURCE_SUFFIX}"
         field, value = resource
         await handle_redis_returns_union_types(
             self.client.hset(hash_key, mapping={field: value})
         )
 
     async def get_resources(self, key: UserSession) -> ResourcesDict:
-        hash_key = f"{self._hash_key(key)}:{_RESOURCE_SUFFIX}"
+        hash_key = f"{key.to_redis_hash_key()}:{RESOURCE_SUFFIX}"
         fields = await handle_redis_returns_union_types(self.client.hgetall(hash_key))
         return ResourcesDict(**fields)
 
     async def remove_resource(self, key: UserSession, resource_name: str) -> None:
-        hash_key = f"{self._hash_key(key)}:{_RESOURCE_SUFFIX}"
+        hash_key = f"{key.to_redis_hash_key()}:{RESOURCE_SUFFIX}"
         await handle_redis_returns_union_types(
             self.client.hdel(hash_key, resource_name)
         )
@@ -116,7 +93,7 @@ class RedisResourceRegistry:
     async def find_resources(self, key: UserSession, resource_name: str) -> list[str]:
         resources: list[str] = []
         # the key might only be partialy complete
-        partial_hash_key = f"{self._hash_key(key)}:{_RESOURCE_SUFFIX}"
+        partial_hash_key = f"{key.to_redis_hash_key()}:{RESOURCE_SUFFIX}"
         async for scanned_key in self.client.scan_iter(match=partial_hash_key):
             if await handle_redis_returns_union_types(
                 self.client.hexists(scanned_key, resource_name)
@@ -135,7 +112,7 @@ class RedisResourceRegistry:
         field, value = resource
         return [
             self._decode_hash_key(hash_key)
-            async for hash_key in self.client.scan_iter(match=f"*:{_RESOURCE_SUFFIX}")
+            async for hash_key in self.client.scan_iter(match=f"*:{RESOURCE_SUFFIX}")
             if value
             == await handle_redis_returns_union_types(self.client.hget(hash_key, field))
         ]
@@ -143,27 +120,27 @@ class RedisResourceRegistry:
     async def set_key_alive(self, key: UserSession, timeout: int) -> None:
         # setting the timeout to always expire, timeout > 0
         timeout = int(max(1, timeout))
-        hash_key = f"{self._hash_key(key)}:{_ALIVE_SUFFIX}"
+        hash_key = f"{key.to_redis_hash_key()}:{ALIVE_SUFFIX}"
         await self.client.set(hash_key, 1, ex=timeout)
 
     async def is_key_alive(self, key: UserSession) -> bool:
-        hash_key = f"{self._hash_key(key)}:{_ALIVE_SUFFIX}"
+        hash_key = f"{key.to_redis_hash_key()}:{ALIVE_SUFFIX}"
         return bool(await self.client.exists(hash_key) > 0)
 
     async def remove_key(self, key: UserSession) -> None:
         await self.client.delete(
-            f"{self._hash_key(key)}:{_RESOURCE_SUFFIX}",
-            f"{self._hash_key(key)}:{_ALIVE_SUFFIX}",
+            f"{key.to_redis_hash_key()}:{RESOURCE_SUFFIX}",
+            f"{key.to_redis_hash_key()}:{ALIVE_SUFFIX}",
         )
 
     async def get_all_resource_keys(self) -> tuple[AliveSessions, DeadSessions]:
         alive_keys = [
             self._decode_hash_key(hash_key)
-            async for hash_key in self.client.scan_iter(match=f"*:{_ALIVE_SUFFIX}")
+            async for hash_key in self.client.scan_iter(match=f"*:{ALIVE_SUFFIX}")
         ]
         dead_keys = [
             self._decode_hash_key(hash_key)
-            async for hash_key in self.client.scan_iter(match=f"*:{_RESOURCE_SUFFIX}")
+            async for hash_key in self.client.scan_iter(match=f"*:{RESOURCE_SUFFIX}")
             if self._decode_hash_key(hash_key) not in alive_keys
         ]
 

--- a/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
@@ -106,9 +106,6 @@ class RedisResourceRegistry:
         return resources
 
     async def find_keys(self, resource: tuple[str, str]) -> list[UserSession]:
-        if not resource:
-            return []
-
         field, value = resource
         return [
             self._decode_hash_key(hash_key)

--- a/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
@@ -117,11 +117,11 @@ class RedisResourceRegistry:
             == await handle_redis_returns_union_types(self.client.hget(hash_key, field))
         ]
 
-    async def set_key_alive(self, key: UserSession, timeout: int) -> None:
+    async def set_key_alive(self, key: UserSession, *, expiration_time: int) -> None:
         # setting the timeout to always expire, timeout > 0
-        timeout = int(max(1, timeout))
+        expiration_time = int(max(1, expiration_time))
         hash_key = f"{key.to_redis_hash_key()}:{ALIVE_SUFFIX}"
-        await self.client.set(hash_key, 1, ex=timeout)
+        await self.client.set(hash_key, 1, ex=expiration_time)
 
     async def is_key_alive(self, key: UserSession) -> bool:
         hash_key = f"{key.to_redis_hash_key()}:{ALIVE_SUFFIX}"

--- a/services/web/server/src/simcore_service_webserver/resource_manager/user_sessions.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/user_sessions.py
@@ -14,7 +14,7 @@ from .registry import (
     RedisResourceRegistry,
     get_registry,
 )
-from .settings import ResourceManagerSettings, get_plugin_settings
+from .settings import get_plugin_settings
 
 _logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ assert PROJECT_ID_KEY in ResourcesDict.__annotations__  # nosec
 
 
 def _get_service_deletion_timeout(app: web.Application) -> int:
-    settings: ResourceManagerSettings = get_plugin_settings(app)
+    settings = get_plugin_settings(app)
     return settings.RESOURCE_MANAGER_RESOURCE_TTL_S
 
 

--- a/services/web/server/src/simcore_service_webserver/resource_manager/user_sessions.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/user_sessions.py
@@ -11,7 +11,7 @@ from servicelib.logging_utils import get_log_record_extra, log_context
 from .registry import (
     RedisResourceRegistry,
     ResourcesDict,
-    UserSessionDict,
+    UserSession,
     get_registry,
 )
 from .settings import ResourceManagerSettings, get_plugin_settings
@@ -69,8 +69,8 @@ class UserSessionResourcesRegistry:
     def _registry(self) -> RedisResourceRegistry:
         return get_registry(self.app)
 
-    def _resource_key(self) -> UserSessionDict:
-        return UserSessionDict(
+    def _resource_key(self) -> UserSession:
+        return UserSession(
             user_id=f"{self.user_id}",
             client_session_id=self.client_session_id or "*",
         )
@@ -198,7 +198,7 @@ class UserSessionResourcesRegistry:
         app: web.Application, key: str, value: str
     ) -> list[UserSessionID]:
         registry = get_registry(app)
-        registry_keys: list[UserSessionDict] = await registry.find_keys(
+        registry_keys: list[UserSession] = await registry.find_keys(
             resource=(key, value)
         )
         users_sessions_ids: list[UserSessionID] = [

--- a/services/web/server/src/simcore_service_webserver/resource_manager/user_sessions.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/user_sessions.py
@@ -203,10 +203,10 @@ class UserSessionResourcesRegistry:
 
 @contextmanager
 def managed_resource(
-    user_id: str | int, client_session_id: str | None, app: web.Application
+    user_id: UserID, client_session_id: str | None, app: web.Application
 ) -> Iterator[UserSessionResourcesRegistry]:
     try:
-        registry = UserSessionResourcesRegistry(int(user_id), client_session_id, app)
+        registry = UserSessionResourcesRegistry(user_id, client_session_id, app)
         yield registry
     except Exception:
         _logger.debug(

--- a/services/web/server/src/simcore_service_webserver/resource_manager/user_sessions.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/user_sessions.py
@@ -83,7 +83,9 @@ class UserSessionResourcesRegistry:
         # NOTE: hearthbeat is not emulated in tests, make sure that with very small GC intervals
         # the resources do not expire; this value is usually in the order of minutes
         timeout = max(3, _get_service_deletion_timeout(self.app))
-        await self._registry.set_key_alive(self._resource_key(), timeout)
+        await self._registry.set_key_alive(
+            self._resource_key(), expiration_time=timeout
+        )
 
     async def get_socket_id(self) -> str | None:
         _logger.debug(
@@ -100,7 +102,7 @@ class UserSessionResourcesRegistry:
         """When the user disconnects expire as soon as possible the alive key
         to ensure garbage collection will trigger in the next 2 cycles."""
 
-        await self._registry.set_key_alive(self._resource_key(), 1)
+        await self._registry.set_key_alive(self._resource_key(), expiration_time=1)
 
     async def remove_socket_id(self) -> None:
         _logger.debug(
@@ -112,14 +114,16 @@ class UserSessionResourcesRegistry:
 
         await self._registry.remove_resource(self._resource_key(), _SOCKET_ID_FIELDNAME)
         await self._registry.set_key_alive(
-            self._resource_key(), _get_service_deletion_timeout(self.app)
+            self._resource_key(),
+            expiration_time=_get_service_deletion_timeout(self.app),
         )
 
     async def set_heartbeat(self) -> None:
         """Extends TTL to avoid expiration of all resources under this session"""
 
         await self._registry.set_key_alive(
-            self._resource_key(), _get_service_deletion_timeout(self.app)
+            self._resource_key(),
+            expiration_time=_get_service_deletion_timeout(self.app),
         )
 
     async def find_socket_ids(self) -> list[str]:

--- a/services/web/server/src/simcore_service_webserver/socketio/_observer.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/_observer.py
@@ -1,4 +1,4 @@
-""" Observer events handlers
+"""Observer events handlers
 
 SEE servicelib.observer
 """
@@ -40,7 +40,7 @@ async def _on_user_logout(
     _logger.debug("user %s must be disconnected", user_id)
     # find the sockets related to the user
     sio: AsyncServer = get_socket_server(app)
-    with managed_resource(user_id, client_session_id, app) as user_session:
+    with managed_resource(int(user_id), client_session_id, app) as user_session:
         # start by disconnecting this client if possible
         if client_session_id:
             if socket_id := await user_session.get_socket_id():

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -360,13 +360,15 @@ class SioConnectionData(NamedTuple):
 async def connect_to_socketio(
     client: TestClient,
     user,
-    socketio_client_factory: Callable[..., Awaitable[socketio.AsyncClient]],
+    socketio_client_factory: Callable[
+        [str | None, TestClient | None], Awaitable[tuple[socketio.AsyncClient, str]]
+    ],
 ) -> SioConnectionData:
     """Connect a user to a socket.io"""
     assert client.app
     socket_registry = get_registry(client.app)
     cur_client_session_id = f"{uuid4()}"
-    sio = await socketio_client_factory(cur_client_session_id, client)
+    sio, *_ = await socketio_client_factory(cur_client_session_id, client)
     resource_key: UserSessionDict = {
         "user_id": str(user["id"]),
         "client_session_id": cur_client_session_id,
@@ -516,7 +518,9 @@ async def assert_one_owner_for_project(
 async def test_t1_while_guest_is_connected_no_resources_are_removed(
     disable_garbage_collector_task: None,
     client: TestClient,
-    create_socketio_connection: Callable,
+    create_socketio_connection: Callable[
+        [str | None, TestClient | None], Awaitable[tuple[socketio.AsyncClient, str]]
+    ],
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
@@ -547,7 +551,9 @@ async def test_t1_while_guest_is_connected_no_resources_are_removed(
 async def test_t2_cleanup_resources_after_browser_is_closed(
     disable_garbage_collector_task: None,
     client: TestClient,
-    create_socketio_connection: Callable,
+    create_socketio_connection: Callable[
+        [str | None, TestClient | None], Awaitable[tuple[socketio.AsyncClient, str]]
+    ],
     aiopg_engine: aiopg.sa.engine.Engine,
     tests_data_dir: Path,
     osparc_product_name: str,
@@ -600,7 +606,9 @@ async def test_t2_cleanup_resources_after_browser_is_closed(
 
 async def test_t3_gc_will_not_intervene_for_regular_users_and_their_resources(
     client: TestClient,
-    create_socketio_connection: Callable,
+    create_socketio_connection: Callable[
+        [str | None, TestClient | None], Awaitable[tuple[socketio.AsyncClient, str]]
+    ],
     aiopg_engine: aiopg.sa.engine.Engine,
     fake_project: dict,
     tests_data_dir: Path,

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -359,7 +359,7 @@ class SioConnectionData(NamedTuple):
 
 async def connect_to_socketio(
     client: TestClient,
-    user,
+    user: UserInfoDict,
     socketio_client_factory: Callable[
         [str | None, TestClient | None], Awaitable[tuple[socketio.AsyncClient, str]]
     ],
@@ -369,10 +369,9 @@ async def connect_to_socketio(
     socket_registry = get_registry(client.app)
     cur_client_session_id = f"{uuid4()}"
     sio, *_ = await socketio_client_factory(cur_client_session_id, client)
-    resource_key: UserSession = {
-        "user_id": str(user["id"]),
-        "client_session_id": cur_client_session_id,
-    }
+    resource_key = UserSession(
+        user_id=user["id"], client_session_id=cur_client_session_id
+    )
     sid = sio.get_sid()
     assert sid
     assert await socket_registry.find_keys(("socket_id", sid)) == [resource_key]

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -55,7 +55,7 @@ from simcore_service_webserver.projects.models import ProjectDict
 from simcore_service_webserver.projects.plugin import setup_projects
 from simcore_service_webserver.resource_manager.plugin import setup_resource_manager
 from simcore_service_webserver.resource_manager.registry import (
-    UserSessionDict,
+    UserSession,
     get_registry,
 )
 from simcore_service_webserver.rest.plugin import setup_rest
@@ -354,7 +354,7 @@ async def change_user_role(
 
 class SioConnectionData(NamedTuple):
     sio: socketio.AsyncClient
-    resource_key: UserSessionDict
+    resource_key: UserSession
 
 
 async def connect_to_socketio(
@@ -369,7 +369,7 @@ async def connect_to_socketio(
     socket_registry = get_registry(client.app)
     cur_client_session_id = f"{uuid4()}"
     sio, *_ = await socketio_client_factory(cur_client_session_id, client)
-    resource_key: UserSessionDict = {
+    resource_key: UserSession = {
         "user_id": str(user["id"]),
         "client_session_id": cur_client_session_id,
     }

--- a/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
+++ b/services/web/server/tests/integration/02/notifications/test_rabbitmq_consumers.py
@@ -208,7 +208,7 @@ async def test_log_workflow(
     rabbitmq_publisher: RabbitMQClient,
     subscribe_to_logs: bool,
     create_socketio_connection: Callable[
-        [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
+        [str | None, TestClient | None], Awaitable[tuple[socketio.AsyncClient, str]]
     ],
     # user
     sender_same_user_id: bool,
@@ -223,7 +223,7 @@ async def test_log_workflow(
     RabbitMQ (TOPIC) --> Webserver --> Redis --> webclient (socketio)
 
     """
-    socket_io_conn = await create_socketio_connection(None, client)
+    socket_io_conn, *_ = await create_socketio_connection(None, client)
 
     mock_log_handler = mocker.MagicMock()
     socket_io_conn.on(SOCKET_IO_LOG_EVENT, handler=mock_log_handler)
@@ -316,7 +316,7 @@ async def test_progress_non_computational_workflow(
     client: TestClient,
     rabbitmq_publisher: RabbitMQClient,
     create_socketio_connection: Callable[
-        [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
+        [str | None, TestClient | None], Awaitable[tuple[socketio.AsyncClient, str]]
     ],
     subscribe_to_logs: bool,
     progress_type: ProgressType,
@@ -332,7 +332,7 @@ async def test_progress_non_computational_workflow(
     RabbitMQ (TOPIC) --> Webserver -->  Redis --> webclient (socketio)
 
     """
-    socket_io_conn = await create_socketio_connection(None, client)
+    socket_io_conn, *_ = await create_socketio_connection(None, client)
 
     mock_progress_handler = mocker.MagicMock()
     socket_io_conn.on(
@@ -374,7 +374,7 @@ async def test_progress_computational_workflow(
     rabbitmq_publisher: RabbitMQClient,
     user_project: ProjectDict,
     create_socketio_connection: Callable[
-        [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
+        [str | None, TestClient | None], Awaitable[tuple[socketio.AsyncClient, str]]
     ],
     mocker: MockerFixture,
     aiopg_engine: aiopg.sa.Engine,
@@ -391,7 +391,7 @@ async def test_progress_computational_workflow(
                                         Redis --> webclient (socketio)
 
     """
-    socket_io_conn = await create_socketio_connection(None, client)
+    socket_io_conn, *_ = await create_socketio_connection(None, client)
 
     mock_progress_handler = mocker.MagicMock()
     socket_io_conn.on(SOCKET_IO_NODE_UPDATED_EVENT, handler=mock_progress_handler)
@@ -499,7 +499,7 @@ async def test_event_workflow(
     client: TestClient,
     rabbitmq_publisher: RabbitMQClient,
     create_socketio_connection: Callable[
-        [str | None, TestClient | None], Awaitable[socketio.AsyncClient]
+        [str | None, TestClient | None], Awaitable[tuple[socketio.AsyncClient, str]]
     ],
     # user
     sender_same_user_id: bool,
@@ -512,7 +512,7 @@ async def test_event_workflow(
     RabbitMQ --> Webserver --> Redis --> webclient (socketio)
 
     """
-    socket_io_conn = await create_socketio_connection(None, client)
+    socket_io_conn, *_ = await create_socketio_connection(None, client)
     mock_event_handler = mocker.MagicMock()
     socket_io_conn.on(SOCKET_IO_EVENT, handler=mock_event_handler)
 

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -21,7 +21,7 @@ from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver.garbage_collector._core_orphans import (
     remove_orphaned_services,
 )
-from simcore_service_webserver.resource_manager.registry import UserSessionDict
+from simcore_service_webserver.resource_manager.registry import UserSession
 from simcore_service_webserver.users.exceptions import UserNotFoundError
 
 MODULE_GC_CORE_ORPHANS: Final[str] = (
@@ -44,7 +44,7 @@ def mock_registry(
     user_id: UserID, project_id: ProjectID, client_session_id: str
 ) -> mock.AsyncMock:
     async def _fake_get_all_resource_keys() -> (
-        tuple[list[UserSessionDict], list[UserSessionDict]]
+        tuple[list[UserSession], list[UserSession]]
     ):
         return ([{"user_id": user_id, "client_session_id": client_session_id}], [])
 

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -36,7 +36,7 @@ def project_id(faker: Faker) -> ProjectID:
 
 @pytest.fixture
 def client_session_id(faker: Faker) -> str:
-    return faker.uuid4(cast_to=None)
+    return faker.uuid4(cast_to=str)
 
 
 @pytest.fixture

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_core.py
@@ -46,7 +46,7 @@ def mock_registry(
     async def _fake_get_all_resource_keys() -> (
         tuple[list[UserSession], list[UserSession]]
     ):
-        return ([{"user_id": user_id, "client_session_id": client_session_id}], [])
+        return ([UserSession(user_id=user_id, client_session_id=client_session_id)], [])
 
     registry = mock.AsyncMock()
     registry.get_all_resource_keys = mock.AsyncMock(

--- a/services/web/server/tests/unit/with_dbs/01/test_resource_manager_user_sessions.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_resource_manager_user_sessions.py
@@ -21,7 +21,7 @@ from simcore_service_webserver.resource_manager.registry import (
     _ALIVE_SUFFIX,
     _RESOURCE_SUFFIX,
     RedisResourceRegistry,
-    UserSessionDict,
+    UserSession,
     get_registry,
 )
 from simcore_service_webserver.resource_manager.settings import get_plugin_settings
@@ -97,7 +97,7 @@ def create_user_ids() -> Callable[..., list[int]]:
     ],
 )
 async def test_redis_registry_hashes(
-    redis_enabled_app: web.Application, key: UserSessionDict, hash_key: str
+    redis_enabled_app: web.Application, key: UserSession, hash_key: str
 ):
     # pylint: disable=protected-access
     assert RedisResourceRegistry._hash_key(key) == hash_key  # noqa: SLF001

--- a/services/web/server/tests/unit/with_dbs/01/test_resource_manager_user_sessions.py
+++ b/services/web/server/tests/unit/with_dbs/01/test_resource_manager_user_sessions.py
@@ -102,12 +102,17 @@ async def test_redis_registry_hashes(
     # pylint: disable=protected-access
     assert RedisResourceRegistry._hash_key(key) == hash_key  # noqa: SLF001
     assert (
-        RedisResourceRegistry._decode_hash_key(f"{hash_key}:{_RESOURCE_SUFFIX}")
-        == key  # noqa: SLF001
+        RedisResourceRegistry._decode_hash_key(  # noqa: SLF001
+            f"{hash_key}:{_RESOURCE_SUFFIX}"
+        )
+        == key
     )
     assert (
-        RedisResourceRegistry._decode_hash_key(f"{hash_key}:{_ALIVE_SUFFIX}") == key
-    )  # noqa: SLF001
+        RedisResourceRegistry._decode_hash_key(  # noqa: SLF001
+            f"{hash_key}:{_ALIVE_SUFFIX}"
+        )
+        == key
+    )
 
 
 async def test_redis_registry(redis_registry: RedisResourceRegistry):

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
@@ -232,6 +232,6 @@ async def test_delete_project_while_it_is_locked_raises_error(
         get_redis_lock_manager_client_sdk(client.app),
         project_uuid=project_uuid,
         status=ProjectStatus.CLOSING,
-        owner=Owner(user_id=user_id, first_name=faker.name(), last_name=faker.name()),
+        owner=Owner(user_id=user_id),
         notification_cb=None,
     )(_request_delete_project)(client, user_project, expected.conflict)

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
@@ -157,6 +157,7 @@ async def test_delete_multiple_opened_project_forbidden(
         user_id=logged_user["id"], project_id=user_project["uuid"]
     )
     # open project in tab1
+    client_session_id1 = None
     try:
         sio, client_session_id1 = await create_socketio_connection(None, client)
         assert sio

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__delete.py
@@ -179,7 +179,8 @@ async def test_delete_multiple_opened_project_forbidden(
     try:
         sio_2, client_session_id2 = await create_socketio_connection(None, client)
         assert sio_2
-        assert client_session_id2 != client_session_id1
+        if client_session_id1:
+            assert client_session_id2 != client_session_id1
     except SocketConnectionError:
         if user_role != UserRole.ANONYMOUS:
             pytest.fail("socket io connection should not fail")

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
@@ -781,6 +781,7 @@ async def test_open_project_with_small_amount_of_dynamic_services_starts_them_au
     ]
 
     # Only create socketio connection for non-anonymous users
+    client_id = ""
     if expected.ok:
         _, client_id, _ = await create_socketio_connection_with_handlers(client)
     url = client.app.router["open_project"].url_for(project_id=project["uuid"])
@@ -826,6 +827,7 @@ async def test_open_project_with_disable_service_auto_start_set_overrides_behavi
         ]
 
         # Only create socketio connection for non-anonymous users
+        client_id = ""
         if expected.ok:
             sio, client_id, *_ = await create_socketio_connection_with_handlers(client)
         url = (
@@ -883,6 +885,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_does_not_start
     ]
 
     # Only create socketio connection for non-anonymous users
+    client_id = ""
     if expected.ok:
         _, client_id, _ = await create_socketio_connection_with_handlers(client)
     url = client.app.router["open_project"].url_for(project_id=project["uuid"])
@@ -938,6 +941,7 @@ async def test_open_project_with_large_amount_of_dynamic_services_starts_them_if
     ]
 
     # Only create socketio connection for non-anonymous users
+    client_id = ""
     if expected.ok:
         _, client_id, _ = await create_socketio_connection_with_handlers(client)
     url = client.app.router["open_project"].url_for(project_id=project["uuid"])
@@ -971,6 +975,7 @@ async def test_open_project_with_deprecated_services_ok_but_does_not_start_dynam
         datetime.now(UTC) - timedelta(days=1)
     ).isoformat()
     # Only create socketio connection for non-anonymous users
+    client_id = ""
     if expected.ok:
         _, client_id, _ = await create_socketio_connection_with_handlers(client)
     url = client.app.router["open_project"].url_for(project_id=user_project["uuid"])
@@ -1026,6 +1031,7 @@ async def test_open_project_more_than_limitation_of_max_studies_open_per_user(
     mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # Only create socketio connection for non-anonymous users
+    client_id_1 = ""
     if user_role != UserRole.ANONYMOUS:
         _, client_id_1, _ = await create_socketio_connection_with_handlers(client)
     await _open_project(
@@ -1036,6 +1042,7 @@ async def test_open_project_more_than_limitation_of_max_studies_open_per_user(
     )
 
     # Only create socketio connection for non-anonymous users
+    client_id_2 = ""
     if user_role != UserRole.ANONYMOUS:
         _, client_id_2, _ = await create_socketio_connection_with_handlers(client)
     await _open_project(

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
@@ -496,6 +496,7 @@ async def test_open_project(
     assert client.app
 
     # Only create socketio connection for non-anonymous users
+    client_id = None
     if expected != status.HTTP_401_UNAUTHORIZED:
         _, client_id, _ = await create_socketio_connection_with_handlers(client)
 
@@ -737,8 +738,9 @@ async def test_open_template_project_for_edition_with_missing_write_rights(
     )
 
     # Only create socketio connection for non-anonymous users
+    client_id = None
     if expected != status.HTTP_401_UNAUTHORIZED:
-        _, client_id_, _ = await create_socketio_connection_with_handlers(client)
+        _, client_id, _ = await create_socketio_connection_with_handlers(client)
     url = client.app.router["open_project"].url_for(project_id=template_project["uuid"])
     resp = await client.post(f"{url}", json=client_id)
     await assert_status(resp, expected)
@@ -1524,7 +1526,7 @@ async def test_open_shared_project_multiple_users(
             [opened_project_state]
             * 1,  # NOTE: only one call per user since they are part of the everyone group
         )
-        for user_j, client_j, _, sio_j, sio_j_handlers in other_users:
+        for _user_j, client_j, _, _sio_j, sio_j_handlers in other_users:
             # check already opened  by other users which should also notify
             await _assert_project_state_updated(
                 sio_j_handlers[SOCKET_IO_PROJECT_UPDATED_EVENT],
@@ -1595,7 +1597,7 @@ async def test_open_shared_project_multiple_users(
         [opened_project_state] * 2,
     )
     # check all the other users
-    for user_i, client_i, _, sio_i, sio_i_handlers in other_users:
+    for _user_i, client_i, _, _sio_i, sio_i_handlers in other_users:
         await _assert_project_state_updated(
             sio_i_handlers[SOCKET_IO_PROJECT_UPDATED_EVENT],
             shared_project,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
@@ -266,7 +266,7 @@ async def _assert_project_state_updated(
         async def _received_project_update_event() -> None:
             assert handler.call_count == len(
                 expected_project_state_updates
-            ), f"got only {handler.call_count}/{len(expected_project_state_updates)} expected calls"
+            ), f"received {handler.call_count} of {len(expected_project_state_updates)} expected calls"
             if expected_project_state_updates:
                 calls = [
                     call(
@@ -1702,8 +1702,10 @@ async def test_open_shared_project_2_users_locked_remove_once_rtc_collaboration_
         )
 
     # we should receive an event that the project lock state changed
-    # NOTE: there are a total of 2x3 calls since we are part of the primary group and the all group and user 2 is part of the all group
-    # first CLOSING, then CLOSED (so 2 calls for user1 and 1 call for user2)
+    # NOTE: user 1 is part of the primary group owning the project, and the all group
+    # there will be an event when the project is CLOSING, then another once the services are removed and the project is CLOSED
+    # user 2 is only part of the all group, therefore only receives 1 event
+
     await _assert_project_state_updated(
         sio1_handlers[SOCKET_IO_PROJECT_UPDATED_EVENT],
         shared_project,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_states_handlers.py
@@ -657,6 +657,7 @@ async def test_open_template_project_for_edition(
     )
 
     # Only create socketio connection for non-anonymous users
+    client_id = None
     if expected != status.HTTP_401_UNAUTHORIZED:
         _, client_id, _ = await create_socketio_connection_with_handlers(client)
     url = client.app.router["open_project"].url_for(project_id=template_project["uuid"])
@@ -1158,6 +1159,7 @@ async def test_get_active_project(
     mocked_notifications_plugin: dict[str, mock.Mock],
 ):
     # login with socket using client session id
+    client_id1 = ""
     try:
         sio, client_id1 = await create_socketio_connection(None, client)
         assert sio.sid
@@ -1203,6 +1205,7 @@ async def test_get_active_project(
         mocked_notifications_plugin["subscribe"].assert_not_called()
 
     # login with socket using client session id2
+    client_id2 = ""
     try:
         sio, client_id2 = await create_socketio_connection(None, client)
         assert sio.sid

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def fast_service_deletion_delay() -> int:
+    """
+    Returns the delay in seconds for fast service deletion.
+    This is used to speed up tests that involve service deletion.
+    """
+    return 1
+
+
+@pytest.fixture
+def app_environment(
+    fast_service_deletion_delay: int,
+    monkeypatch: pytest.MonkeyPatch,
+    app_environment: EnvVarsDict,
+) -> EnvVarsDict:
+    # NOTE: undos some app_environment settings
+    monkeypatch.delenv("WEBSERVER_GARBAGE_COLLECTOR", raising=False)
+    app_environment.pop("WEBSERVER_GARBAGE_COLLECTOR", None)
+
+    return app_environment | setenvs_from_dict(
+        monkeypatch,
+        {
+            "WEBSERVER_COMPUTATION": "1",
+            "WEBSERVER_NOTIFICATIONS": "1",
+            # sets TTL of a resource after logout
+            "RESOURCE_MANAGER_RESOURCE_TTL_S": f"{fast_service_deletion_delay}",
+            "GARBAGE_COLLECTOR_INTERVAL_S": "30",
+        },
+    )

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/conftest.py
@@ -1,4 +1,36 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable
+
 import pytest
+import sqlalchemy as sa
+from aiohttp.test_utils import TestClient
+from models_library.projects import ProjectID
+from pytest_simcore.helpers.assert_checks import assert_status
+from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from redis.asyncio import Redis
+from servicelib.aiohttp import status
+from servicelib.aiohttp.application import create_safe_application
+from servicelib.aiohttp.application_setup import is_setup_completed
+from simcore_service_webserver.application_settings import setup_settings
+from simcore_service_webserver.db.plugin import setup_db
+from simcore_service_webserver.director_v2.plugin import setup_director_v2
+from simcore_service_webserver.login.plugin import setup_login
+from simcore_service_webserver.notifications.plugin import setup_notifications
+from simcore_service_webserver.products.plugin import setup_products
+from simcore_service_webserver.projects.plugin import setup_projects
+from simcore_service_webserver.rabbitmq import setup_rabbitmq
+from simcore_service_webserver.resource_manager.plugin import setup_resource_manager
+from simcore_service_webserver.rest.plugin import setup_rest
+from simcore_service_webserver.security.plugin import setup_security
+from simcore_service_webserver.session.plugin import setup_session
+from simcore_service_webserver.socketio.plugin import setup_socketio
+from simcore_service_webserver.users.plugin import setup_users
 
 
 @pytest.fixture(scope="session")
@@ -29,4 +61,83 @@ def app_environment(
             "RESOURCE_MANAGER_RESOURCE_TTL_S": f"{fast_service_deletion_delay}",
             "GARBAGE_COLLECTOR_INTERVAL_S": "30",
         },
+    )
+
+
+@pytest.fixture
+async def client(
+    aiohttp_client: Callable,
+    app_environment: EnvVarsDict,
+    postgres_db: sa.engine.Engine,
+    mock_orphaned_services,
+    redis_client: Redis,
+    mock_dynamic_scheduler_rabbitmq: None,
+) -> TestClient:
+    app = create_safe_application()
+
+    assert "WEBSERVER_GARBAGE_COLLECTOR" not in app_environment
+
+    settings = setup_settings(app)
+    assert settings.WEBSERVER_GARBAGE_COLLECTOR is not None
+    assert settings.WEBSERVER_PROJECTS is not None
+
+    setup_db(app)
+    setup_session(app)
+    setup_security(app)
+    setup_rest(app)
+    setup_login(app)
+    setup_users(app)
+    setup_socketio(app)
+    assert setup_projects(app)
+    setup_director_v2(app)
+    assert setup_resource_manager(app)
+    setup_rabbitmq(app)
+    setup_notifications(app)
+    setup_products(app)
+
+    assert is_setup_completed("simcore_service_webserver.resource_manager", app)
+
+    # NOTE: garbage_collector is disabled and instead explicitly called using
+    # garbage_collectorgc_core.collect_garbage
+    assert not is_setup_completed("simcore_service_webserver.garbage_collector", app)
+
+    return await aiohttp_client(app)
+
+
+@pytest.fixture
+async def close_project() -> Callable[[TestClient, ProjectID, str], Awaitable[None]]:
+    """Closes a project by sending a request to the close_project endpoint."""
+
+    async def _close_project(
+        client: TestClient, project_uuid: ProjectID, client_session_id: str
+    ) -> None:
+        url = client.app.router["close_project"].url_for(project_id=f"{project_uuid}")
+        resp = await client.post(url, json=client_session_id)
+        await assert_status(resp, status.HTTP_204_NO_CONTENT)
+
+    return _close_project
+
+
+@pytest.fixture
+async def open_project(
+    close_project: Callable[[TestClient, ProjectID, str], Awaitable[None]],
+) -> AsyncIterator[Callable[[TestClient, ProjectID, str], Awaitable[None]]]:
+    _opened_projects: list[tuple[TestClient, ProjectID, str]] = []
+
+    async def _open_project(
+        client: TestClient, project_uuid: ProjectID, client_session_id: str
+    ) -> None:
+        url = client.app.router["open_project"].url_for(project_id=f"{project_uuid}")
+        resp = await client.post(url, json=client_session_id)
+        await assert_status(resp, status.HTTP_200_OK)
+        _opened_projects.append((client, project_uuid, client_session_id))
+
+    yield _open_project
+    # cleanup, if we cannot close that is because the user_role might not allow it
+    await asyncio.gather(
+        *(
+            close_project(client, project_uuid, client_session_id)
+            for client, project_uuid, client_session_id in _opened_projects
+        ),
+        return_exceptions=True,
     )

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_garbage_collector.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_garbage_collector.py
@@ -1,0 +1,482 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+from unittest import mock
+
+import pytest
+import socketio
+from aiohttp.test_utils import TestClient
+from aioresponses import aioresponses
+from common_library.users_enums import UserRole
+from fastapi.encoders import jsonable_encoder
+from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
+from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
+    DynamicServiceStop,
+)
+from pytest_mock import MockerFixture
+from pytest_simcore.helpers.assert_checks import assert_status
+from pytest_simcore.helpers.webserver_parametrizations import MockedStorageSubsystem
+from pytest_simcore.helpers.webserver_users import UserInfoDict
+from servicelib.aiohttp import status
+from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
+from simcore_service_webserver.garbage_collector import _core as gc_core
+from simcore_service_webserver.socketio.messages import SOCKET_IO_PROJECT_UPDATED_EVENT
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception_type,
+    stop_after_delay,
+    wait_fixed,
+)
+
+_TENACITY_ASSERT_RETRY = {
+    "reraise": True,
+    "retry": retry_if_exception_type(AssertionError),
+    "wait": wait_fixed(0.5),
+    "stop": stop_after_delay(30),
+}
+
+
+@pytest.mark.parametrize(
+    "user_role, expected_save_state",
+    [
+        (UserRole.GUEST, False),
+        (UserRole.USER, True),
+        (UserRole.TESTER, True),
+    ],
+)
+async def test_interactive_services_removed_after_logout(
+    fast_service_deletion_delay: int,
+    client: TestClient,
+    logged_user: dict[str, Any],
+    empty_user_project: dict[str, Any],
+    mocked_dynamic_services_interface: dict[str, mock.MagicMock],
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
+    client_session_id_factory: Callable[[], str],
+    create_socketio_connection: Callable,
+    storage_subsystem_mock: MockedStorageSubsystem,  # when guest user logs out garbage is collected
+    director_v2_service_mock: aioresponses,
+    expected_save_state: bool,
+    open_project: Callable,
+    mocked_notifications_plugin: dict[str, mock.Mock],
+):
+    assert client.app
+    user_id = logged_user["id"]
+    service = await create_dynamic_service_mock(
+        user_id=user_id, project_id=empty_user_project["uuid"]
+    )
+    # create websocket
+    client_session_id1 = client_session_id_factory()
+    sio = await create_socketio_connection(client_session_id1)
+    assert sio
+    # open project in client 1
+    await open_project(client, empty_user_project["uuid"], client_session_id1)
+    # logout
+    logout_url = client.app.router["auth_logout"].url_for()
+    r = await client.post(
+        f"{logout_url}", json={"client_session_id": client_session_id1}
+    )
+    assert r.url.path == logout_url.path
+    await assert_status(r, status.HTTP_200_OK)
+
+    # check result perfomed by background task
+    await asyncio.sleep(fast_service_deletion_delay + 1)
+    await gc_core.collect_garbage(client.app)
+
+    # assert dynamic service is removed *this is done in a fire/forget way so give a bit of leeway
+    async for attempt in AsyncRetrying(**_TENACITY_ASSERT_RETRY):
+        with attempt:
+            print(
+                f"--> Waiting for stop_dynamic_service with: {service.node_uuid}, {expected_save_state=}",
+            )
+            mocked_dynamic_services_interface[
+                "dynamic_scheduler.api.stop_dynamic_service"
+            ].assert_awaited_with(
+                app=client.app,
+                dynamic_service_stop=DynamicServiceStop(
+                    user_id=user_id,
+                    project_id=service.project_id,
+                    node_id=service.node_uuid,
+                    simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                    save_state=expected_save_state,
+                ),
+                progress=mock.ANY,
+            )
+
+
+@pytest.mark.parametrize(
+    "user_role, expected_save_state",
+    [
+        (UserRole.GUEST, False),
+        (UserRole.USER, True),
+        (UserRole.TESTER, True),
+    ],
+)
+async def test_interactive_services_remain_after_websocket_reconnection_from_2_tabs(
+    fast_service_deletion_delay: int,
+    director_v2_service_mock: aioresponses,
+    client: TestClient,
+    logged_user: UserInfoDict,
+    empty_user_project,
+    mocked_dynamic_services_interface,
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
+    create_socketio_connection: Callable,
+    client_session_id_factory: Callable[[], str],
+    storage_subsystem_mock,  # when guest user logs out garbage is collected
+    expected_save_state: bool,
+    mocker: MockerFixture,
+    open_project: Callable,
+    mocked_notifications_plugin: dict[str, mock.Mock],
+):
+    assert client.app
+    user_id = logged_user["id"]
+    service = await create_dynamic_service_mock(
+        user_id=user_id, project_id=empty_user_project["uuid"]
+    )
+    # create first websocket
+    client_session_id1 = client_session_id_factory()
+    sio = await create_socketio_connection(client_session_id1)
+    # open project in client 1
+    await open_project(client, empty_user_project["uuid"], client_session_id1)
+
+    # create second websocket
+    client_session_id2 = client_session_id_factory()
+    sio2 = await create_socketio_connection(client_session_id2)
+    assert sio.sid != sio2.sid
+    socket_project_state_update_mock_callable = mocker.Mock()
+    sio2.on(
+        SOCKET_IO_PROJECT_UPDATED_EVENT,
+        handler=socket_project_state_update_mock_callable,
+    )
+    # disconnect first websocket
+    # NOTE: since the service deletion delay is set to 1 second for the test, we should not sleep as long here, or the user will be deleted
+    # We have no mock-up for the heatbeat...
+    await sio.disconnect()
+    assert not sio.sid
+    async for attempt in AsyncRetrying(
+        **(_TENACITY_ASSERT_RETRY | {"wait": wait_fixed(0.1)})
+    ):
+        with attempt:
+            socket_project_state_update_mock_callable.assert_called_with(
+                jsonable_encoder(
+                    {
+                        "project_uuid": empty_user_project["uuid"],
+                        "data": {
+                            "shareState": {
+                                "locked": False,
+                                "currentUserGroupids": [logged_user["primary_gid"]],
+                                "status": "OPENED",
+                            },
+                            "state": {"value": "NOT_STARTED"},
+                        },
+                    }
+                )
+            )
+    # open project in second client
+    await open_project(client, empty_user_project["uuid"], client_session_id2)
+    # ensure sufficient time is wasted here
+    await asyncio.sleep(fast_service_deletion_delay + 1)
+    await gc_core.collect_garbage(client.app)
+
+    # assert dynamic service is still around
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_not_called()
+    # disconnect second websocket
+    await sio2.disconnect()
+    assert not sio2.sid
+    # assert dynamic service is still around for now
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_not_called()
+    # reconnect websocket
+    sio2 = await create_socketio_connection(client_session_id2)
+    # it should still be there even after waiting for auto deletion from garbage collector
+    await asyncio.sleep(fast_service_deletion_delay + 1)
+    await gc_core.collect_garbage(client.app)
+
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_not_called()
+    # now really disconnect
+    await sio2.disconnect()
+    await sio2.wait()
+    assert not sio2.sid
+    # run the garbage collector
+    # event after waiting some time
+    await asyncio.sleep(fast_service_deletion_delay + 1)
+    await gc_core.collect_garbage(client.app)
+
+    await asyncio.sleep(0)
+    # assert dynamic service is gone
+    calls = [
+        mock.call(
+            app=client.app,
+            dynamic_service_stop=DynamicServiceStop(
+                user_id=user_id,
+                project_id=service.project_id,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=expected_save_state,
+                node_id=service.node_uuid,
+            ),
+            progress=mock.ANY,
+        )
+    ]
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_has_calls(calls)
+
+
+@pytest.mark.parametrize(
+    "user_role, expected_save_state",
+    [
+        (UserRole.GUEST, False),
+        (UserRole.USER, True),
+        (UserRole.TESTER, True),
+    ],
+)
+async def test_interactive_services_removed_per_project(
+    fast_service_deletion_delay: int,
+    director_v2_service_mock: aioresponses,
+    client,
+    logged_user,
+    empty_user_project,
+    empty_user_project2,
+    mocked_dynamic_services_interface,
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
+    mocked_notification_system,
+    create_socketio_connection: Callable,
+    client_session_id_factory: Callable[[], str],
+    storage_subsystem_mock,  # when guest user logs out garbage is collected
+    expected_save_state: bool,
+    open_project: Callable,
+    mocked_notifications_plugin: dict[str, mock.Mock],
+):
+    user_id = logged_user["id"]
+    # create server with delay set to DELAY
+    service1 = await create_dynamic_service_mock(
+        user_id=user_id, project_id=empty_user_project["uuid"]
+    )
+    service2 = await create_dynamic_service_mock(
+        user_id=user_id, project_id=empty_user_project2["uuid"]
+    )
+    service3 = await create_dynamic_service_mock(
+        user_id=user_id, project_id=empty_user_project2["uuid"]
+    )
+    # create websocket1 from tab1
+    client_session_id1 = client_session_id_factory()
+    sio1 = await create_socketio_connection(client_session_id1)
+    await open_project(client, empty_user_project["uuid"], client_session_id1)
+    # create websocket2 from tab2
+    client_session_id2 = client_session_id_factory()
+    sio2 = await create_socketio_connection(client_session_id2)
+    await open_project(client, empty_user_project2["uuid"], client_session_id2)
+    # disconnect websocket1
+    await sio1.disconnect()
+    assert not sio1.sid
+    # assert dynamic service is still around
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_not_called()
+    # wait the defined delay
+    await asyncio.sleep(fast_service_deletion_delay + 1)
+    await gc_core.collect_garbage(client.app)
+    # assert dynamic service 1 is removed
+    calls = [
+        mock.call(
+            app=client.app,
+            dynamic_service_stop=DynamicServiceStop(
+                user_id=user_id,
+                project_id=service1.project_id,
+                node_id=service1.node_uuid,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=expected_save_state,
+            ),
+            progress=mock.ANY,
+        )
+    ]
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_has_calls(calls)
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].reset_mock()
+
+    # disconnect websocket2
+    await sio2.disconnect()
+    assert not sio2.sid
+    # assert dynamic services are still around
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_not_called()
+    # wait the defined delay
+    await asyncio.sleep(fast_service_deletion_delay + 1)
+    await gc_core.collect_garbage(client.app)
+    # assert dynamic service 2,3 is removed
+    calls = [
+        mock.call(
+            app=client.server.app,
+            dynamic_service_stop=DynamicServiceStop(
+                user_id=user_id,
+                project_id=service2.project_id,
+                node_id=service2.node_uuid,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=expected_save_state,
+            ),
+            progress=mock.ANY,
+        ),
+        mock.call(
+            app=client.server.app,
+            dynamic_service_stop=DynamicServiceStop(
+                user_id=user_id,
+                project_id=service3.project_id,
+                node_id=service3.node_uuid,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=expected_save_state,
+            ),
+            progress=mock.ANY,
+        ),
+    ]
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_has_calls(calls)
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].reset_mock()
+
+
+@pytest.mark.xfail(
+    reason="it is currently not permitted to open the same project from 2 different tabs"
+)
+@pytest.mark.parametrize(
+    "user_role, expected_save_state",
+    [
+        # (UserRole.ANONYMOUS),
+        # (UserRole.GUEST),
+        (UserRole.USER, True),
+        (UserRole.TESTER, True),
+    ],
+)
+async def test_services_remain_after_closing_one_out_of_two_tabs(
+    fast_service_deletion_delay: int,
+    director_v2_service_mock: aioresponses,
+    client,
+    logged_user,
+    empty_user_project,
+    empty_user_project2,
+    mocked_dynamic_services_interface,
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
+    create_socketio_connection: Callable,
+    client_session_id_factory: Callable[[], str],
+    expected_save_state: bool,
+    open_project: Callable,
+):
+    # create server with delay set to DELAY
+    service = await create_dynamic_service_mock(
+        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
+    )
+    # open project in tab1
+    client_session_id1 = client_session_id_factory()
+    sio1 = await create_socketio_connection(client_session_id1)
+    assert sio1
+    await open_project(client, empty_user_project["uuid"], client_session_id1)
+    # open project in tab2
+    client_session_id2 = client_session_id_factory()
+    sio2 = await create_socketio_connection(client_session_id2)
+    assert sio2
+    await open_project(client, empty_user_project["uuid"], client_session_id2)
+    # close project in tab1
+    await close_project(client, empty_user_project["uuid"], client_session_id1)
+    # wait the defined delay
+    await asyncio.sleep(fast_service_deletion_delay + 1)
+    await gc_core.collect_garbage(client.app)
+    # assert dynamic service is still around
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_not_called()
+    # close project in tab2
+    await close_project(client, empty_user_project["uuid"], client_session_id2)
+    # wait the defined delay
+    await asyncio.sleep(fast_service_deletion_delay + 1)
+    await gc_core.collect_garbage(client.app)
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_has_calls(
+        [mock.call(client.server.app, service.node_uuid, expected_save_state)]
+    )
+
+
+@pytest.mark.parametrize(
+    "user_role, expect_call, expected_save_state",
+    [
+        (UserRole.USER, False, True),
+        (UserRole.TESTER, False, True),
+        (UserRole.GUEST, True, False),
+    ],
+)
+async def test_websocket_disconnected_remove_or_maintain_files_based_on_role(
+    director_v2_service_mock: aioresponses,
+    client,
+    logged_user,
+    empty_user_project,
+    mocked_dynamic_services_interface,
+    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
+    client_session_id_factory: Callable[[], str],
+    create_socketio_connection: Callable,
+    # asyncpg_storage_system_mock,
+    storage_subsystem_mock,  # when guest user logs out garbage is collected
+    expect_call: bool,
+    expected_save_state: bool,
+    open_project: Callable,
+    mocked_notifications_plugin: dict[str, mock.Mock],
+):
+    user_id = logged_user["id"]
+    service = await create_dynamic_service_mock(
+        user_id=user_id, project_id=empty_user_project["uuid"]
+    )
+    # create websocket
+    client_session_id1 = client_session_id_factory()
+    sio: socketio.AsyncClient = await create_socketio_connection(client_session_id1)
+    assert sio
+    # open project in client 1
+    await open_project(client, empty_user_project["uuid"], client_session_id1)
+    # logout
+    logout_url = client.app.router["auth_logout"].url_for()
+    r = await client.post(logout_url, json={"client_session_id": client_session_id1})
+    assert r.url.path == logout_url.path
+    await assert_status(r, status.HTTP_200_OK)
+
+    # ensure sufficient time is wasted here
+    await asyncio.sleep(SERVICE_DELETION_DELAY + 1)
+    await gc_core.collect_garbage(client.app)
+
+    # assert dynamic service is removed
+    calls = [
+        mock.call(
+            app=client.server.app,
+            dynamic_service_stop=DynamicServiceStop(
+                user_id=user_id,
+                project_id=service.project_id,
+                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
+                save_state=expected_save_state,
+                node_id=service.node_uuid,
+            ),
+            progress=mock.ANY,
+        )
+    ]
+    mocked_dynamic_services_interface[
+        "dynamic_scheduler.api.stop_dynamic_service"
+    ].assert_has_calls(calls)
+
+    # this call is done async, so wait a bit here to ensure it is correctly done
+    async for attempt in AsyncRetrying(**_TENACITY_ASSERT_RETRY):
+        with attempt:
+            if expect_call:
+                # make sure `delete_project` is called
+                storage_subsystem_mock[1].assert_called_once()
+                # make sure `delete_user` is called
+                # asyncpg_storage_system_mock.assert_called_once()
+            else:
+                # make sure `delete_project` not called
+                storage_subsystem_mock[1].assert_not_called()
+                # make sure `delete_user` not called
+                # asyncpg_storage_system_mock.assert_not_called()

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py
@@ -21,7 +21,7 @@ from servicelib.aiohttp import status
 from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver.resource_manager.registry import (
     RedisResourceRegistry,
-    UserSessionDict,
+    UserSession,
     get_registry,
 )
 from tenacity.asyncio import AsyncRetrying
@@ -98,7 +98,7 @@ async def test_websocket_resource_management(
 ):
     sio, cur_client_session_id = await create_socketio_connection(None, client)
     sid = sio.get_sid()
-    resource_key = UserSessionDict(
+    resource_key = UserSession(
         user_id=f"{logged_user['id']}", client_session_id=cur_client_session_id
     )
 
@@ -143,13 +143,13 @@ async def test_websocket_multiple_connections(
     ],
 ):
     NUMBER_OF_SOCKETS = 5
-    resource_keys: list[UserSessionDict] = []
+    resource_keys: list[UserSession] = []
 
     # connect multiple clients
     clients = []
     for socket_count in range(1, NUMBER_OF_SOCKETS + 1):
         sio, cur_client_session_id = await create_socketio_connection(None, client)
-        resource_key = UserSessionDict(
+        resource_key = UserSession(
             user_id=f"{logged_user['id']}", client_session_id=cur_client_session_id
         )
         assert await socket_registry.find_keys(("socket_id", sio.get_sid())) == [

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py
@@ -938,7 +938,6 @@ async def test_regression_removing_unexisting_user(
         user_id=user_id,
         project_uuid=empty_user_project["uuid"],
         app=client.app,
-        user_name={"first_name": "my name is", "last_name": "pytest"},
         simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
     )
     # since the call to delete is happening as fire and forget task, let's wait until it is done

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py
@@ -99,7 +99,7 @@ async def test_websocket_resource_management(
     sio, cur_client_session_id = await create_socketio_connection(None, client)
     sid = sio.get_sid()
     resource_key = UserSession(
-        user_id=f"{logged_user['id']}", client_session_id=cur_client_session_id
+        user_id=logged_user["id"], client_session_id=cur_client_session_id
     )
 
     assert await socket_registry.find_keys(("socket_id", sio.get_sid())) == [
@@ -150,7 +150,7 @@ async def test_websocket_multiple_connections(
     for socket_count in range(1, NUMBER_OF_SOCKETS + 1):
         sio, cur_client_session_id = await create_socketio_connection(None, client)
         resource_key = UserSession(
-            user_id=f"{logged_user['id']}", client_session_id=cur_client_session_id
+            user_id=logged_user["id"], client_session_id=cur_client_session_id
         )
         assert await socket_registry.find_keys(("socket_id", sio.get_sid())) == [
             resource_key
@@ -161,7 +161,7 @@ async def test_websocket_multiple_connections(
         assert (
             len(
                 await socket_registry.find_resources(
-                    {"user_id": str(logged_user["id"]), "client_session_id": "*"},
+                    UserSession(user_id=logged_user["id"], client_session_id="*"),
                     "socket_id",
                 )
             )

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager.py
@@ -11,7 +11,6 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 from typing import Any
 from unittest import mock
-from unittest.mock import call
 
 import pytest
 import socketio
@@ -19,18 +18,10 @@ import socketio.exceptions
 import sqlalchemy as sa
 from aiohttp.test_utils import TestClient
 from aioresponses import aioresponses
-from models_library.api_schemas_directorv2.dynamic_services import DynamicServiceGet
-from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
-    DynamicServiceStop,
-)
-from models_library.utils.fastapi_encoders import jsonable_encoder
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
-from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from pytest_simcore.helpers.webserver_parametrizations import MockedStorageSubsystem
 from pytest_simcore.helpers.webserver_projects import NewProject
-from pytest_simcore.helpers.webserver_users import UserInfoDict
 from redis.asyncio import Redis
 from servicelib.aiohttp import status
 from servicelib.aiohttp.application import create_safe_application
@@ -40,7 +31,6 @@ from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver.application_settings import setup_settings
 from simcore_service_webserver.db.plugin import setup_db
 from simcore_service_webserver.director_v2.plugin import setup_director_v2
-from simcore_service_webserver.garbage_collector import _core as gc_core
 from simcore_service_webserver.login.plugin import setup_login
 from simcore_service_webserver.notifications.plugin import setup_notifications
 from simcore_service_webserver.products.plugin import setup_products
@@ -59,7 +49,6 @@ from simcore_service_webserver.resource_manager.registry import (
 from simcore_service_webserver.rest.plugin import setup_rest
 from simcore_service_webserver.security.plugin import setup_security
 from simcore_service_webserver.session.plugin import setup_session
-from simcore_service_webserver.socketio.messages import SOCKET_IO_PROJECT_UPDATED_EVENT
 from simcore_service_webserver.socketio.plugin import setup_socketio
 from simcore_service_webserver.users.exceptions import UserNotFoundError
 from simcore_service_webserver.users.plugin import setup_users
@@ -69,8 +58,6 @@ from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
 from yarl import URL
-
-SERVICE_DELETION_DELAY = 1
 
 
 async def close_project(client, project_uuid: str, client_session_id: str) -> None:
@@ -97,27 +84,6 @@ async def open_project() -> AsyncIterator[Callable[..., Awaitable[None]]]:
             for client, project_uuid, client_session_id in _opened_projects
         ),
         return_exceptions=True,
-    )
-
-
-@pytest.fixture
-def app_environment(
-    monkeypatch: pytest.MonkeyPatch,
-    app_environment: EnvVarsDict,
-) -> EnvVarsDict:
-    # NOTE: undos some app_environment settings
-    monkeypatch.delenv("WEBSERVER_GARBAGE_COLLECTOR", raising=False)
-    app_environment.pop("WEBSERVER_GARBAGE_COLLECTOR", None)
-
-    return app_environment | setenvs_from_dict(
-        monkeypatch,
-        {
-            "WEBSERVER_COMPUTATION": "1",
-            "WEBSERVER_NOTIFICATIONS": "1",
-            # sets TTL of a resource after logout
-            "RESOURCE_MANAGER_RESOURCE_TTL_S": f"{SERVICE_DELETION_DELAY}",
-            "GARBAGE_COLLECTOR_INTERVAL_S": "30",
-        },
     )
 
 
@@ -450,194 +416,6 @@ async def test_websocket_disconnected_after_logout(
             assert not sio3.sid
 
 
-@pytest.mark.parametrize(
-    "user_role, expected_save_state",
-    [
-        (UserRole.GUEST, False),
-        (UserRole.USER, True),
-        (UserRole.TESTER, True),
-    ],
-)
-async def test_interactive_services_removed_after_logout(
-    client: TestClient,
-    logged_user: dict[str, Any],
-    empty_user_project: dict[str, Any],
-    mocked_dynamic_services_interface: dict[str, mock.MagicMock],
-    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
-    client_session_id_factory: Callable[[], str],
-    create_socketio_connection: Callable,
-    storage_subsystem_mock: MockedStorageSubsystem,  # when guest user logs out garbage is collected
-    director_v2_service_mock: aioresponses,
-    expected_save_state: bool,
-    open_project: Callable,
-    mocked_notifications_plugin: dict[str, mock.Mock],
-):
-    assert client.app
-    user_id = logged_user["id"]
-    service = await create_dynamic_service_mock(
-        user_id=user_id, project_id=empty_user_project["uuid"]
-    )
-    # create websocket
-    client_session_id1 = client_session_id_factory()
-    sio = await create_socketio_connection(client_session_id1)
-    assert sio
-    # open project in client 1
-    await open_project(client, empty_user_project["uuid"], client_session_id1)
-    # logout
-    logout_url = client.app.router["auth_logout"].url_for()
-    r = await client.post(
-        f"{logout_url}", json={"client_session_id": client_session_id1}
-    )
-    assert r.url.path == logout_url.path
-    await assert_status(r, status.HTTP_200_OK)
-
-    # check result perfomed by background task
-    await asyncio.sleep(SERVICE_DELETION_DELAY + 1)
-    await gc_core.collect_garbage(client.app)
-
-    # assert dynamic service is removed *this is done in a fire/forget way so give a bit of leeway
-    async for attempt in AsyncRetrying(**_TENACITY_ASSERT_RETRY):
-        with attempt:
-            print(
-                f"--> Waiting for stop_dynamic_service with: {service.node_uuid}, {expected_save_state=}",
-            )
-            mocked_dynamic_services_interface[
-                "dynamic_scheduler.api.stop_dynamic_service"
-            ].assert_awaited_with(
-                app=client.app,
-                dynamic_service_stop=DynamicServiceStop(
-                    user_id=user_id,
-                    project_id=service.project_id,
-                    node_id=service.node_uuid,
-                    simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                    save_state=expected_save_state,
-                ),
-                progress=mock.ANY,
-            )
-
-
-@pytest.mark.parametrize(
-    "user_role, expected_save_state",
-    [
-        (UserRole.GUEST, False),
-        (UserRole.USER, True),
-        (UserRole.TESTER, True),
-    ],
-)
-async def test_interactive_services_remain_after_websocket_reconnection_from_2_tabs(
-    director_v2_service_mock: aioresponses,
-    client: TestClient,
-    logged_user: UserInfoDict,
-    empty_user_project,
-    mocked_dynamic_services_interface,
-    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
-    create_socketio_connection: Callable,
-    client_session_id_factory: Callable[[], str],
-    storage_subsystem_mock,  # when guest user logs out garbage is collected
-    expected_save_state: bool,
-    mocker: MockerFixture,
-    open_project: Callable,
-    mocked_notifications_plugin: dict[str, mock.Mock],
-):
-    assert client.app
-    user_id = logged_user["id"]
-    service = await create_dynamic_service_mock(
-        user_id=user_id, project_id=empty_user_project["uuid"]
-    )
-    # create first websocket
-    client_session_id1 = client_session_id_factory()
-    sio = await create_socketio_connection(client_session_id1)
-    # open project in client 1
-    await open_project(client, empty_user_project["uuid"], client_session_id1)
-
-    # create second websocket
-    client_session_id2 = client_session_id_factory()
-    sio2 = await create_socketio_connection(client_session_id2)
-    assert sio.sid != sio2.sid
-    socket_project_state_update_mock_callable = mocker.Mock()
-    sio2.on(
-        SOCKET_IO_PROJECT_UPDATED_EVENT,
-        handler=socket_project_state_update_mock_callable,
-    )
-    # disconnect first websocket
-    # NOTE: since the service deletion delay is set to 1 second for the test, we should not sleep as long here, or the user will be deleted
-    # We have no mock-up for the heatbeat...
-    await sio.disconnect()
-    assert not sio.sid
-    async for attempt in AsyncRetrying(
-        **(_TENACITY_ASSERT_RETRY | {"wait": wait_fixed(0.1)})
-    ):
-        with attempt:
-            socket_project_state_update_mock_callable.assert_called_with(
-                jsonable_encoder(
-                    {
-                        "project_uuid": empty_user_project["uuid"],
-                        "data": {
-                            "shareState": {
-                                "locked": False,
-                                "currentUserGroupids": [logged_user["primary_gid"]],
-                                "status": "OPENED",
-                            },
-                            "state": {"value": "NOT_STARTED"},
-                        },
-                    }
-                )
-            )
-    # open project in second client
-    await open_project(client, empty_user_project["uuid"], client_session_id2)
-    # ensure sufficient time is wasted here
-    await asyncio.sleep(SERVICE_DELETION_DELAY + 1)
-    await gc_core.collect_garbage(client.app)
-
-    # assert dynamic service is still around
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_not_called()
-    # disconnect second websocket
-    await sio2.disconnect()
-    assert not sio2.sid
-    # assert dynamic service is still around for now
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_not_called()
-    # reconnect websocket
-    sio2 = await create_socketio_connection(client_session_id2)
-    # it should still be there even after waiting for auto deletion from garbage collector
-    await asyncio.sleep(SERVICE_DELETION_DELAY + 1)
-    await gc_core.collect_garbage(client.app)
-
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_not_called()
-    # now really disconnect
-    await sio2.disconnect()
-    await sio2.wait()
-    assert not sio2.sid
-    # run the garbage collector
-    # event after waiting some time
-    await asyncio.sleep(SERVICE_DELETION_DELAY + 1)
-    await gc_core.collect_garbage(client.app)
-
-    await asyncio.sleep(0)
-    # assert dynamic service is gone
-    calls = [
-        call(
-            app=client.app,
-            dynamic_service_stop=DynamicServiceStop(
-                user_id=user_id,
-                project_id=service.project_id,
-                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                save_state=expected_save_state,
-                node_id=service.node_uuid,
-            ),
-            progress=mock.ANY,
-        )
-    ]
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_has_calls(calls)
-
-
 @pytest.fixture
 async def mocked_notification_system(mocker):
     mocks = {}
@@ -648,260 +426,6 @@ async def mocked_notification_system(mocker):
     mocked_notification_system.return_value.set_result("")
     mocks["mocked_notification_system"] = mocked_notification_system
     return mocks
-
-
-@pytest.mark.parametrize(
-    "user_role, expected_save_state",
-    [
-        (UserRole.GUEST, False),
-        (UserRole.USER, True),
-        (UserRole.TESTER, True),
-    ],
-)
-async def test_interactive_services_removed_per_project(
-    director_v2_service_mock: aioresponses,
-    client,
-    logged_user,
-    empty_user_project,
-    empty_user_project2,
-    mocked_dynamic_services_interface,
-    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
-    mocked_notification_system,
-    create_socketio_connection: Callable,
-    client_session_id_factory: Callable[[], str],
-    storage_subsystem_mock,  # when guest user logs out garbage is collected
-    expected_save_state: bool,
-    open_project: Callable,
-    mocked_notifications_plugin: dict[str, mock.Mock],
-):
-    user_id = logged_user["id"]
-    # create server with delay set to DELAY
-    service1 = await create_dynamic_service_mock(
-        user_id=user_id, project_id=empty_user_project["uuid"]
-    )
-    service2 = await create_dynamic_service_mock(
-        user_id=user_id, project_id=empty_user_project2["uuid"]
-    )
-    service3 = await create_dynamic_service_mock(
-        user_id=user_id, project_id=empty_user_project2["uuid"]
-    )
-    # create websocket1 from tab1
-    client_session_id1 = client_session_id_factory()
-    sio1 = await create_socketio_connection(client_session_id1)
-    await open_project(client, empty_user_project["uuid"], client_session_id1)
-    # create websocket2 from tab2
-    client_session_id2 = client_session_id_factory()
-    sio2 = await create_socketio_connection(client_session_id2)
-    await open_project(client, empty_user_project2["uuid"], client_session_id2)
-    # disconnect websocket1
-    await sio1.disconnect()
-    assert not sio1.sid
-    # assert dynamic service is still around
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_not_called()
-    # wait the defined delay
-    await asyncio.sleep(SERVICE_DELETION_DELAY + 1)
-    await gc_core.collect_garbage(client.app)
-    # assert dynamic service 1 is removed
-    calls = [
-        call(
-            app=client.app,
-            dynamic_service_stop=DynamicServiceStop(
-                user_id=user_id,
-                project_id=service1.project_id,
-                node_id=service1.node_uuid,
-                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                save_state=expected_save_state,
-            ),
-            progress=mock.ANY,
-        )
-    ]
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_has_calls(calls)
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].reset_mock()
-
-    # disconnect websocket2
-    await sio2.disconnect()
-    assert not sio2.sid
-    # assert dynamic services are still around
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_not_called()
-    # wait the defined delay
-    await asyncio.sleep(SERVICE_DELETION_DELAY + 1)
-    await gc_core.collect_garbage(client.app)
-    # assert dynamic service 2,3 is removed
-    calls = [
-        call(
-            app=client.server.app,
-            dynamic_service_stop=DynamicServiceStop(
-                user_id=user_id,
-                project_id=service2.project_id,
-                node_id=service2.node_uuid,
-                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                save_state=expected_save_state,
-            ),
-            progress=mock.ANY,
-        ),
-        call(
-            app=client.server.app,
-            dynamic_service_stop=DynamicServiceStop(
-                user_id=user_id,
-                project_id=service3.project_id,
-                node_id=service3.node_uuid,
-                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                save_state=expected_save_state,
-            ),
-            progress=mock.ANY,
-        ),
-    ]
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_has_calls(calls)
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].reset_mock()
-
-
-@pytest.mark.xfail(
-    reason="it is currently not permitted to open the same project from 2 different tabs"
-)
-@pytest.mark.parametrize(
-    "user_role, expected_save_state",
-    [
-        # (UserRole.ANONYMOUS),
-        # (UserRole.GUEST),
-        (UserRole.USER, True),
-        (UserRole.TESTER, True),
-    ],
-)
-async def test_services_remain_after_closing_one_out_of_two_tabs(
-    director_v2_service_mock: aioresponses,
-    client,
-    logged_user,
-    empty_user_project,
-    empty_user_project2,
-    mocked_dynamic_services_interface,
-    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
-    create_socketio_connection: Callable,
-    client_session_id_factory: Callable[[], str],
-    expected_save_state: bool,
-    open_project: Callable,
-):
-    # create server with delay set to DELAY
-    service = await create_dynamic_service_mock(
-        user_id=logged_user["id"], project_id=empty_user_project["uuid"]
-    )
-    # open project in tab1
-    client_session_id1 = client_session_id_factory()
-    sio1 = await create_socketio_connection(client_session_id1)
-    assert sio1
-    await open_project(client, empty_user_project["uuid"], client_session_id1)
-    # open project in tab2
-    client_session_id2 = client_session_id_factory()
-    sio2 = await create_socketio_connection(client_session_id2)
-    assert sio2
-    await open_project(client, empty_user_project["uuid"], client_session_id2)
-    # close project in tab1
-    await close_project(client, empty_user_project["uuid"], client_session_id1)
-    # wait the defined delay
-    await asyncio.sleep(SERVICE_DELETION_DELAY + 1)
-    await gc_core.collect_garbage(client.app)
-    # assert dynamic service is still around
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_not_called()
-    # close project in tab2
-    await close_project(client, empty_user_project["uuid"], client_session_id2)
-    # wait the defined delay
-    await asyncio.sleep(SERVICE_DELETION_DELAY + 1)
-    await gc_core.collect_garbage(client.app)
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_has_calls(
-        [call(client.server.app, service.node_uuid, expected_save_state)]
-    )
-
-
-@pytest.mark.parametrize(
-    "user_role, expect_call, expected_save_state",
-    [
-        (UserRole.USER, False, True),
-        (UserRole.TESTER, False, True),
-        (UserRole.GUEST, True, False),
-    ],
-)
-async def test_websocket_disconnected_remove_or_maintain_files_based_on_role(
-    director_v2_service_mock: aioresponses,
-    client,
-    logged_user,
-    empty_user_project,
-    mocked_dynamic_services_interface,
-    create_dynamic_service_mock: Callable[..., Awaitable[DynamicServiceGet]],
-    client_session_id_factory: Callable[[], str],
-    create_socketio_connection: Callable,
-    # asyncpg_storage_system_mock,
-    storage_subsystem_mock,  # when guest user logs out garbage is collected
-    expect_call: bool,
-    expected_save_state: bool,
-    open_project: Callable,
-    mocked_notifications_plugin: dict[str, mock.Mock],
-):
-    user_id = logged_user["id"]
-    service = await create_dynamic_service_mock(
-        user_id=user_id, project_id=empty_user_project["uuid"]
-    )
-    # create websocket
-    client_session_id1 = client_session_id_factory()
-    sio: socketio.AsyncClient = await create_socketio_connection(client_session_id1)
-    assert sio
-    # open project in client 1
-    await open_project(client, empty_user_project["uuid"], client_session_id1)
-    # logout
-    logout_url = client.app.router["auth_logout"].url_for()
-    r = await client.post(logout_url, json={"client_session_id": client_session_id1})
-    assert r.url.path == logout_url.path
-    await assert_status(r, status.HTTP_200_OK)
-
-    # ensure sufficient time is wasted here
-    await asyncio.sleep(SERVICE_DELETION_DELAY + 1)
-    await gc_core.collect_garbage(client.app)
-
-    # assert dynamic service is removed
-    calls = [
-        call(
-            app=client.server.app,
-            dynamic_service_stop=DynamicServiceStop(
-                user_id=user_id,
-                project_id=service.project_id,
-                simcore_user_agent=UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE,
-                save_state=expected_save_state,
-                node_id=service.node_uuid,
-            ),
-            progress=mock.ANY,
-        )
-    ]
-    mocked_dynamic_services_interface[
-        "dynamic_scheduler.api.stop_dynamic_service"
-    ].assert_has_calls(calls)
-
-    # this call is done async, so wait a bit here to ensure it is correctly done
-    async for attempt in AsyncRetrying(**_TENACITY_ASSERT_RETRY):
-        with attempt:
-            if expect_call:
-                # make sure `delete_project` is called
-                storage_subsystem_mock[1].assert_called_once()
-                # make sure `delete_user` is called
-                # asyncpg_storage_system_mock.assert_called_once()
-            else:
-                # make sure `delete_project` not called
-                storage_subsystem_mock[1].assert_not_called()
-                # make sure `delete_user` not called
-                # asyncpg_storage_system_mock.assert_not_called()
 
 
 @pytest.mark.parametrize("user_role", [UserRole.USER, UserRole.TESTER, UserRole.GUEST])

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
@@ -275,7 +275,7 @@ async def test_users_sessions_resources_registry(
                 user_session_key = UserSession(
                     user_id=user_id, client_session_id=client_session_id
                 )
-                assert rt.resource_key() == user_session_key  # noqa: SLF001
+                assert rt.resource_key == user_session_key
 
                 # set the socket id and check it is rightfully there
                 await rt.set_socket_id(socket_id)

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
@@ -183,10 +183,12 @@ async def test_redis_registry(
     STILL_ALIVE_KEY_TIMEOUT = DEAD_KEY_TIMEOUT + 1
 
     # create a key which will be alive when testing
-    await redis_registry.set_key_alive(user_session, STILL_ALIVE_KEY_TIMEOUT)
+    await redis_registry.set_key_alive(
+        user_session, expiration_time=STILL_ALIVE_KEY_TIMEOUT
+    )
     assert await redis_registry.is_key_alive(user_session) is True
     # create soon to be dead key
-    await redis_registry.set_key_alive(user_session2, DEAD_KEY_TIMEOUT)
+    await redis_registry.set_key_alive(user_session2, expiration_time=DEAD_KEY_TIMEOUT)
     alive_keys, dead_keys = await redis_registry.get_all_resource_keys()
     assert not dead_keys
     assert all(x in alive_keys for x in [user_session, user_session2])
@@ -225,8 +227,8 @@ async def test_redis_registry_key_will_always_expire(
         await redis_registry.set_resource(first_key, resource)
         await redis_registry.set_resource(second_key, resource)
 
-    await redis_registry.set_key_alive(first_key, 0)
-    await redis_registry.set_key_alive(second_key, -3000)
+    await redis_registry.set_key_alive(first_key, expiration_time=0)
+    await redis_registry.set_key_alive(second_key, expiration_time=-3000)
 
     async for attempt in AsyncRetrying(
         wait=wait_fixed(0.1),

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
@@ -149,6 +149,7 @@ async def test_redis_registry(
     }
     assert not await redis_registry.get_resources(invalid_user_session)
     # find them
+    assert await redis_registry.find_keys([]) == []
     for res in resources:
         assert await redis_registry.find_resources(user_session, res[0]) == [res[1]]
         assert not await redis_registry.find_resources(invalid_user_session, res[0])

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
@@ -84,7 +84,10 @@ def redis_registry(redis_enabled_app: web.Application) -> RedisResourceRegistry:
 @pytest.fixture
 def create_user_ids(faker: Faker) -> Callable[[int], list[UserID]]:
     def _do(number: int) -> list[UserID]:
-        return list({faker.pyint(min_value=1) for _ in range(number)})
+        unique_ids = set()
+        while len(unique_ids) < number:
+            unique_ids.add(faker.pyint(min_value=1))
+        return list(unique_ids)
 
     return _do
 

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
@@ -275,7 +275,7 @@ async def test_users_sessions_resources_registry(
                 user_session_key = UserSession(
                     user_id=user_id, client_session_id=client_session_id
                 )
-                assert rt._resource_key() == user_session_key  # noqa: SLF001
+                assert rt.resource_key() == user_session_key  # noqa: SLF001
 
                 # set the socket id and check it is rightfully there
                 await rt.set_socket_id(socket_id)

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
@@ -149,7 +149,6 @@ async def test_redis_registry(
     }
     assert not await redis_registry.get_resources(invalid_user_session)
     # find them
-    assert await redis_registry.find_keys([]) == []
     for res in resources:
         assert await redis_registry.find_resources(user_session, res[0]) == [res[1]]
         assert not await redis_registry.find_resources(invalid_user_session, res[0])

--- a/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
+++ b/services/web/server/tests/unit/with_dbs/04/garbage_collector/test_resource_manager_user_sessions.py
@@ -12,21 +12,24 @@ import pytest
 import redis.asyncio as aioredis
 from aiohttp import web
 from faker import Faker
+from models_library.users import UserID
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from servicelib.aiohttp.application import create_safe_application
 from servicelib.aiohttp.application_setup import is_setup_completed
 from simcore_service_webserver.application_settings import setup_settings
+from simcore_service_webserver.resource_manager.models import (
+    ALIVE_SUFFIX,
+    RESOURCE_SUFFIX,
+    RedisHashKey,
+    UserSession,
+)
 from simcore_service_webserver.resource_manager.plugin import setup_resource_manager
 from simcore_service_webserver.resource_manager.registry import (
-    _ALIVE_SUFFIX,
-    _RESOURCE_SUFFIX,
     RedisResourceRegistry,
-    UserSession,
     get_registry,
 )
 from simcore_service_webserver.resource_manager.settings import get_plugin_settings
 from simcore_service_webserver.resource_manager.user_sessions import (
-    UserSessionID,
     managed_resource,
 )
 from tenacity import AsyncRetrying, stop_after_delay, wait_fixed
@@ -79,123 +82,143 @@ def redis_registry(redis_enabled_app: web.Application) -> RedisResourceRegistry:
 
 
 @pytest.fixture
-def create_user_ids() -> Callable[..., list[int]]:
-    def _do(number: int) -> list[int]:
-        return list(range(number))
+def create_user_ids(faker: Faker) -> Callable[[int], list[UserID]]:
+    def _do(number: int) -> list[UserID]:
+        return list({faker.pyint(min_value=1) for _ in range(number)})
 
     return _do
 
 
 @pytest.mark.parametrize(
-    "key, hash_key",
+    "user_session, key",
     [
-        ({"some_key": "some_value"}, "some_key=some_value"),
         (
-            {"some_key": "some_value", "another_key": "another_value"},
-            "some_key=some_value:another_key=another_value",
+            UserSession(user_id=456, client_session_id="some_value"),
+            "user_id=456:client_session_id=some_value",
+        ),
+        (
+            UserSession(user_id=123, client_session_id="*"),
+            "user_id=123:client_session_id=*",
         ),
     ],
 )
 async def test_redis_registry_hashes(
-    redis_enabled_app: web.Application, key: UserSession, hash_key: str
+    redis_enabled_app: web.Application, user_session: UserSession, key: RedisHashKey
 ):
-    # pylint: disable=protected-access
-    assert RedisResourceRegistry._hash_key(key) == hash_key  # noqa: SLF001
-    assert (
-        RedisResourceRegistry._decode_hash_key(  # noqa: SLF001
-            f"{hash_key}:{_RESOURCE_SUFFIX}"
-        )
-        == key
-    )
-    assert (
-        RedisResourceRegistry._decode_hash_key(  # noqa: SLF001
-            f"{hash_key}:{_ALIVE_SUFFIX}"
-        )
-        == key
-    )
+    assert user_session.to_redis_hash_key() == key
+    assert UserSession.from_redis_hash_key(key) == user_session
+    assert UserSession.from_redis_hash_key(f"{key}:{RESOURCE_SUFFIX}") == user_session
+    assert UserSession.from_redis_hash_key(f"{key}:{RESOURCE_SUFFIX}") == user_session
+    assert UserSession.from_redis_hash_key(f"{key}:{ALIVE_SUFFIX}") == user_session
 
 
-async def test_redis_registry(redis_registry: RedisResourceRegistry):
-    random_value = randint(1, 10)  # noqa: S311
-    key = {f"key_{x}": f"value_{x}" for x in range(random_value)}
-    second_key = {f"sec_key_{x}": f"sec_value_{x}" for x in range(random_value)}
-    invalid_key = {"invalid_key": "invalid_value"}
+@pytest.fixture
+def create_user_session(faker: Faker) -> Callable[[], UserSession]:
+    def _() -> UserSession:
+        return UserSession(
+            user_id=faker.pyint(),
+            client_session_id=faker.uuid4(),
+        )
+
+    return _
+
+
+async def test_redis_registry(
+    redis_registry: RedisResourceRegistry,
+    create_user_session: Callable[[], UserSession],
+):
+    user_session = create_user_session()
+    user_session2 = create_user_session()
+
+    invalid_user_session = create_user_session()
     NUM_RESOURCES = 7
     resources = [(f"res_key{x}", f"res_value{x}") for x in range(NUM_RESOURCES)]
     invalid_resource = ("invalid_res_key", "invalid_res_value")
 
     # create resources
     for res in resources:
-        await redis_registry.set_resource(key, res)
-        assert len(await redis_registry.get_resources(key)) == resources.index(res) + 1
+        await redis_registry.set_resource(user_session, res)
+        assert (
+            len(await redis_registry.get_resources(user_session))
+            == resources.index(res) + 1
+        )
 
     # get them
-    assert await redis_registry.get_resources(key) == {x[0]: x[1] for x in resources}
-    assert not await redis_registry.get_resources(invalid_key)
+    assert await redis_registry.get_resources(user_session) == {
+        x[0]: x[1] for x in resources
+    }
+    assert not await redis_registry.get_resources(invalid_user_session)
     # find them
     for res in resources:
-        assert await redis_registry.find_resources(key, res[0]) == [res[1]]
-        assert not await redis_registry.find_resources(invalid_key, res[0])
-        assert not await redis_registry.find_resources(key, invalid_resource[0])
-        assert await redis_registry.find_keys(res) == [key]
+        assert await redis_registry.find_resources(user_session, res[0]) == [res[1]]
+        assert not await redis_registry.find_resources(invalid_user_session, res[0])
+        assert not await redis_registry.find_resources(
+            user_session, invalid_resource[0]
+        )
+        assert await redis_registry.find_keys(res) == [user_session]
         assert not await redis_registry.find_keys(invalid_resource)
     # add second key
     for res in resources:
-        await redis_registry.set_resource(second_key, res)
+        await redis_registry.set_resource(user_session2, res)
         assert (
-            len(await redis_registry.get_resources(second_key))
+            len(await redis_registry.get_resources(user_session2))
             == resources.index(res) + 1
         )
     # find them
     for res in resources:
-        assert await redis_registry.find_resources(key, res[0]) == [res[1]]
-        assert not await redis_registry.find_resources(invalid_key, res[0])
-        assert not await redis_registry.find_resources(key, invalid_resource[0])
-        assert not await redis_registry.find_resources(second_key, invalid_resource[0])
+        assert await redis_registry.find_resources(user_session, res[0]) == [res[1]]
+        assert not await redis_registry.find_resources(invalid_user_session, res[0])
+        assert not await redis_registry.find_resources(
+            user_session, invalid_resource[0]
+        )
+        assert not await redis_registry.find_resources(
+            user_session2, invalid_resource[0]
+        )
         found_keys = await redis_registry.find_keys(res)
-        assert all(x in found_keys for x in [key, second_key])
-        assert all(x in [key, second_key] for x in found_keys)
+        assert all(x in found_keys for x in [user_session, user_session2])
+        assert all(x in [user_session, user_session2] for x in found_keys)
         assert not await redis_registry.find_keys(invalid_resource)
 
     DEAD_KEY_TIMEOUT = 1
     STILL_ALIVE_KEY_TIMEOUT = DEAD_KEY_TIMEOUT + 1
 
     # create a key which will be alive when testing
-    await redis_registry.set_key_alive(key, STILL_ALIVE_KEY_TIMEOUT)
-    assert await redis_registry.is_key_alive(key) is True
+    await redis_registry.set_key_alive(user_session, STILL_ALIVE_KEY_TIMEOUT)
+    assert await redis_registry.is_key_alive(user_session) is True
     # create soon to be dead key
-    await redis_registry.set_key_alive(second_key, DEAD_KEY_TIMEOUT)
+    await redis_registry.set_key_alive(user_session2, DEAD_KEY_TIMEOUT)
     alive_keys, dead_keys = await redis_registry.get_all_resource_keys()
     assert not dead_keys
-    assert all(x in alive_keys for x in [key, second_key])
-    assert all(x in [key, second_key] for x in alive_keys)
+    assert all(x in alive_keys for x in [user_session, user_session2])
+    assert all(x in [user_session, user_session2] for x in alive_keys)
 
     await asyncio.sleep(DEAD_KEY_TIMEOUT)
 
-    assert await redis_registry.is_key_alive(second_key) is False
+    assert await redis_registry.is_key_alive(user_session2) is False
     alive_keys, dead_keys = await redis_registry.get_all_resource_keys()
-    assert alive_keys == [key]
-    assert dead_keys == [second_key]
+    assert alive_keys == [user_session]
+    assert dead_keys == [user_session2]
 
     # clean up
-    await redis_registry.remove_key(key)
-    assert await redis_registry.is_key_alive(key) is False
+    await redis_registry.remove_key(user_session)
+    assert await redis_registry.is_key_alive(user_session) is False
     for res in resources:
-        assert await redis_registry.find_keys(res) == [second_key]
-        await redis_registry.remove_resource(second_key, res[0])
-        assert len(await redis_registry.get_resources(second_key)) == len(resources) - (
-            resources.index(res) + 1
-        )
+        assert await redis_registry.find_keys(res) == [user_session2]
+        await redis_registry.remove_resource(user_session2, res[0])
+        assert len(await redis_registry.get_resources(user_session2)) == len(
+            resources
+        ) - (resources.index(res) + 1)
 
 
 async def test_redis_registry_key_will_always_expire(
     redis_registry: RedisResourceRegistry,
+    create_user_session: Callable[[], UserSession],
 ):
     def get_random_int():
         return randint(1, 10)  # noqa: S311
 
-    first_key = {f"key_{x}": f"value_{x}" for x in range(get_random_int())}
-    second_key = {f"sec_key_{x}": f"sec_value_{x}" for x in range(get_random_int())}
+    first_key = create_user_session()
+    second_key = create_user_session()
 
     resources = [(f"res_key{x}", f"res_value{x}") for x in range(get_random_int())]
     for resource in resources:
@@ -225,7 +248,7 @@ async def test_redis_registry_key_will_always_expire(
 async def test_users_sessions_resources_registry(
     redis_enabled_app: web.Application,
     redis_registry: RedisResourceRegistry,
-    create_user_ids: Callable,
+    create_user_ids: Callable[[int], list[UserID]],
 ):
     # create some user ids and socket ids
     NUM_USER_IDS = 5
@@ -246,10 +269,9 @@ async def test_users_sessions_resources_registry(
             tabs[socket_id] = client_session_id
 
             with managed_resource(user_id, client_session_id, redis_enabled_app) as rt:
-                user_session_key = {
-                    "user_id": f"{user_id}",
-                    "client_session_id": client_session_id,
-                }
+                user_session_key = UserSession(
+                    user_id=user_id, client_session_id=client_session_id
+                )
                 assert rt._resource_key() == user_session_key  # noqa: SLF001
 
                 # set the socket id and check it is rightfully there
@@ -273,18 +295,12 @@ async def test_users_sessions_resources_registry(
 
                 # resource key shall be filled
                 assert await rt.find(res_key) == [res_value]
-                list_of_same_resource_users: list[UserSessionID] = (
-                    await rt.find_users_of_resource(
-                        redis_enabled_app, res_key, res_value
-                    )
+                list_of_same_resource_users = await rt.find_users_of_resource(
+                    redis_enabled_app, res_key, res_value
                 )
-                assert list_user_ids[: (list_user_ids.index(user_id) + 1)] == sorted(
-                    {
-                        user_session.user_id
-                        for user_session in list_of_same_resource_users
-                    }
-                )
-
+                assert set(list_user_ids[: (list_user_ids.index(user_id) + 1)]) == {
+                    user_session.user_id for user_session in list_of_same_resource_users
+                }
     # remove sockets (<=> disconnecting user sessions)
     for user_id in list_user_ids:
         user = f"user id {user_id}"

--- a/tests/e2e-playwright/tests/sleepers/test_sleepers.py
+++ b/tests/e2e-playwright/tests/sleepers/test_sleepers.py
@@ -170,6 +170,7 @@ def test_sleepers(
             RunningState.WAITING_FOR_CLUSTER,
             RunningState.WAITING_FOR_RESOURCES,
             RunningState.STARTED,
+            RunningState.SUCCESS,
         ),
         timeout_ms=_WAITING_FOR_PIPELINE_TO_CHANGE_STATE,
     )
@@ -182,6 +183,7 @@ def test_sleepers(
         expected_states=(
             RunningState.WAITING_FOR_RESOURCES,
             RunningState.STARTED,
+            RunningState.SUCCESS,
         ),
         timeout_ms=_WAITING_FOR_CLUSTER_MAX_WAITING_TIME,
     )
@@ -191,7 +193,10 @@ def test_sleepers(
         current_state,
         websocket=log_in_and_out,
         if_in_states=(RunningState.WAITING_FOR_RESOURCES,),
-        expected_states=(RunningState.STARTED,),
+        expected_states=(
+            RunningState.STARTED,
+            RunningState.SUCCESS,
+        ),
         timeout_ms=_WAITING_FOR_STARTED_MAX_WAITING_TIME,
     )
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- ensures a projectUpdateEvent is emitted on project close
- refactors the garbage-collector to also use the same code for closing projects instead of doing its own stuff
- sorry: a bit more refactoring
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/8151

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
