### PR TITLE
🎨 dynamic service status is now propagated to the project_id and not the node_id

### DIFF
--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/notifier/_notifier.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/notifier/_notifier.py
@@ -11,7 +11,7 @@ from models_library.api_schemas_dynamic_scheduler.socketio import (
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.api_schemas_webserver.socketio import SocketIORoomStr
-from models_library.users import UserID
+from models_library.projects import ProjectID
 from servicelib.fastapi.app_state import SingletonInAppStateMixin
 from servicelib.services_utils import get_status_as_dict
 
@@ -23,20 +23,22 @@ class Notifier(SingletonInAppStateMixin):
         self._sio_manager = sio_manager
 
     async def notify_service_status(
-        self, user_id: UserID, status: NodeGet | DynamicServiceGet | NodeGetIdle
+        self, project_id: ProjectID, status: NodeGet | DynamicServiceGet | NodeGetIdle
     ) -> None:
         await self._sio_manager.emit(
             SOCKET_IO_SERVICE_STATUS_EVENT,
             data=jsonable_encoder(get_status_as_dict(status)),
-            room=SocketIORoomStr.from_user_id(user_id),
+            room=SocketIORoomStr.from_project_id(project_id),
         )
 
 
 async def notify_service_status_change(
-    app: FastAPI, user_id: UserID, status: NodeGet | DynamicServiceGet | NodeGetIdle
+    app: FastAPI,
+    project_id: ProjectID,
+    status: NodeGet | DynamicServiceGet | NodeGetIdle,
 ) -> None:
     notifier: Notifier = Notifier.get_from_app_state(app)
-    await notifier.notify_service_status(user_id=user_id, status=status)
+    await notifier.notify_service_status(project_id=project_id, status=status)
 
 
 async def lifespan(app: FastAPI) -> AsyncIterator[State]:

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/service_tracker/__init__.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/service_tracker/__init__.py
@@ -1,8 +1,8 @@
 from ._api import (
     NORMAL_RATE_POLL_INTERVAL,
     get_all_tracked_services,
+    get_project_id_for_service,
     get_tracked_service,
-    get_user_id_for_service,
     remove_tracked_service,
     set_frontend_notified_for_service,
     set_if_status_changed_for_service,
@@ -17,11 +17,11 @@ from ._setup import service_tracker_lifespan
 
 __all__: tuple[str, ...] = (
     "get_all_tracked_services",
+    "get_project_id_for_service",
     "get_tracked_service",
-    "get_user_id_for_service",
-    "service_tracker_lifespan",
     "NORMAL_RATE_POLL_INTERVAL",
     "remove_tracked_service",
+    "service_tracker_lifespan",
     "set_frontend_notified_for_service",
     "set_if_status_changed_for_service",
     "set_request_as_running",

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/service_tracker/_api.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/service_tracker/_api.py
@@ -11,12 +11,12 @@ from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
     DynamicServiceStop,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
+from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
 from models_library.services_enums import ServiceState
 from servicelib.deferred_tasks import TaskUID
 
 from ._models import (
-    ProjectID,
     SchedulerServiceState,
     TrackedServiceModel,
     UserRequestedState,

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/service_tracker/_api.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/service_tracker/_api.py
@@ -13,10 +13,14 @@ from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
 from models_library.projects_nodes_io import NodeID
 from models_library.services_enums import ServiceState
-from models_library.users import UserID
 from servicelib.deferred_tasks import TaskUID
 
-from ._models import SchedulerServiceState, TrackedServiceModel, UserRequestedState
+from ._models import (
+    ProjectID,
+    SchedulerServiceState,
+    TrackedServiceModel,
+    UserRequestedState,
+)
 from ._setup import get_tracker
 
 _logger = logging.getLogger(__name__)
@@ -242,7 +246,7 @@ async def get_all_tracked_services(app: FastAPI) -> dict[NodeID, TrackedServiceM
     return await get_tracker(app).all()
 
 
-async def get_user_id_for_service(app: FastAPI, node_id: NodeID) -> UserID | None:
-    """returns user_id for the service"""
+async def get_project_id_for_service(app: FastAPI, node_id: NodeID) -> ProjectID | None:
+    """returns project_id for the service"""
     model: TrackedServiceModel | None = await get_tracker(app).load(node_id)
-    return model.user_id if model else None
+    return model.project_id if model else None

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/status_monitor/_deferred_get_status.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/status_monitor/_deferred_get_status.py
@@ -77,7 +77,7 @@ class DeferredGetStatus(BaseDeferredHandler[NodeGet | DynamicServiceGet | NodeGe
                 await service_tracker.set_frontend_notified_for_service(app, node_id)
             else:
                 _logger.info(
-                    "Did not find a user for '%s', skipping status delivery of: %s",
-                    node_id,
+                    "Did not find a project for '%s', skipping status delivery of: %s",
+                    project_id,
                     result,
                 )

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/status_monitor/_deferred_get_status.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/status_monitor/_deferred_get_status.py
@@ -78,6 +78,6 @@ class DeferredGetStatus(BaseDeferredHandler[NodeGet | DynamicServiceGet | NodeGe
             else:
                 _logger.info(
                     "Did not find a project for '%s', skipping status delivery of: %s",
-                    project_id,
+                    node_id,
                     result,
                 )

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/status_monitor/_deferred_get_status.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/status_monitor/_deferred_get_status.py
@@ -7,8 +7,8 @@ from models_library.api_schemas_directorv2.dynamic_services_service import (
     RunningDynamicServiceDetails,
 )
 from models_library.api_schemas_webserver.projects_nodes import NodeGet, NodeGetIdle
+from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
-from models_library.users import UserID
 from servicelib.deferred_tasks import BaseDeferredHandler, TaskUID
 from servicelib.deferred_tasks._base_deferred_handler import DeferredContext
 
@@ -69,11 +69,11 @@ class DeferredGetStatus(BaseDeferredHandler[NodeGet | DynamicServiceGet | NodeGe
         if await service_tracker.should_notify_frontend_for_service(
             app, node_id, status_changed=status_changed
         ):
-            user_id: UserID | None = await service_tracker.get_user_id_for_service(
-                app, node_id
+            project_id: ProjectID | None = (
+                await service_tracker.get_project_id_for_service(app, node_id)
             )
-            if user_id:
-                await notify_service_status_change(app, user_id, result)
+            if project_id:
+                await notify_service_status_change(app, project_id, result)
                 await service_tracker.set_frontend_notified_for_service(app, node_id)
             else:
                 _logger.info(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

Notify project_id instead of node_id when the status of a node changes. Allows for multiple users to view the node's status change.


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- https://github.com/ITISFoundation/osparc-issues/issues/1647

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

- run locally, services open as usual

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
