### PR TITLE
🐛 `null` annotations can now be copied

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/utils.py
+++ b/services/web/server/src/simcore_service_webserver/projects/utils.py
@@ -94,7 +94,7 @@ def clone_project_document(
         )
 
         # exclude annotations UI info for conversations done in the source project
-        annotations = project_copy.get("ui", {}).get("annotations", {}).copy()
+        annotations = deepcopy(project_copy.get("ui", {}).get("annotations", {}))
         for ann_id, ann in annotations.items():
             if ann["type"] == "conversation":
                 project_copy["ui"]["annotations"].pop(ann_id)

--- a/services/web/server/src/simcore_service_webserver/projects/utils.py
+++ b/services/web/server/src/simcore_service_webserver/projects/utils.py
@@ -94,7 +94,7 @@ def clone_project_document(
         )
 
         # exclude annotations UI info for conversations done in the source project
-        annotations = deepcopy(project_copy.get("ui", {}).get("annotations", {}))
+        annotations = deepcopy(project_copy.get("ui", {}).get("annotations", {})) or {}
         for ann_id, ann in annotations.items():
             if ann["type"] == "conversation":
                 project_copy["ui"]["annotations"].pop(ann_id)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

`None.copy()` does not exist if the annotation field is empty. Using `deepcopy` which can deal with such edge cases

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
