### PR TITLE
🐛 Fix bug when notifying users based on wrong access rights

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/_groups_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_groups_service.py
@@ -252,3 +252,20 @@ async def create_project_group_without_checking_permissions(
         write=write,
         delete=delete,
     )
+
+
+async def list_project_groups_by_project_without_checking_permissions(
+    app: web.Application,
+    *,
+    project_id: ProjectID,
+) -> list[ProjectGroupGet]:
+    project_groups_db: list[ProjectGroupGetDB] = (
+        await _groups_repository.list_project_groups(app=app, project_id=project_id)
+    )
+
+    project_groups_api: list[ProjectGroupGet] = [
+        ProjectGroupGet.model_validate(group.model_dump())
+        for group in project_groups_db
+    ]
+
+    return project_groups_api


### PR DESCRIPTION
Refactors group notification to use a dedicated API for fetching project group permissions, enhancing consistency and maintainability. Removes reliance on direct access to project permission structures.

<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
🐛 Fix bug when notifying users based on wrong access rights
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/8201
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
