### PR TITLE
🎨 instrument storage and director httpx client (opentelemetry)

### DIFF
--- a/services/director/src/simcore_service_director/core/application.py
+++ b/services/director/src/simcore_service_director/core/application.py
@@ -50,6 +50,7 @@ def create_app(settings: ApplicationSettings) -> FastAPI:
         app,
         max_keepalive_connections=settings.DIRECTOR_REGISTRY_CLIENT_MAX_KEEPALIVE_CONNECTIONS,
         default_timeout=settings.DIRECTOR_REGISTRY_CLIENT_TIMEOUT,
+        tracing_settings=settings.DIRECTOR_TRACING,
     )
     setup_registry(app)
 

--- a/services/storage/src/simcore_service_storage/core/application.py
+++ b/services/storage/src/simcore_service_storage/core/application.py
@@ -69,7 +69,7 @@ def create_app(settings: ApplicationSettings) -> FastAPI:  # noqa: C901
 
     setup_db(app)
     setup_s3(app)
-    setup_client_session(app)
+    setup_client_session(app, tracing_settings=settings.STORAGE_TRACING)
 
     if settings.STORAGE_CELERY and not settings.STORAGE_WORKER_MODE:
         setup_rabbitmq(app)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
Instruments the httpx clients of director-v0 and storage. This enables us to add internals of the `registry` (which since major version 3 supports opentelemetry) to our tracing, allowing us to investigate e.g. slow calls to `"/v0/catalog/services/-/latest"`

Co-Authered with @bisgaard-itis , thx!

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
