### PR TITLE
🎨 Adds support for extra context in conversation updates

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_webserver/conversations.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/conversations.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Annotated, Self
+from typing import Annotated, Any, Self
 
 from pydantic import Field
 
@@ -47,6 +47,7 @@ class ConversationRestGet(OutputSchema):
 
 class ConversationPatch(InputSchema):
     name: str | None = None
+    extra_context: dict[str, Any] | None = None
 
 
 ### CONVERSATION MESSAGES ---------------------------------------------------------------

--- a/packages/models-library/src/models_library/conversations.py
+++ b/packages/models-library/src/models_library/conversations.py
@@ -70,6 +70,7 @@ class ConversationMessageGetDB(BaseModel):
 
 class ConversationPatchDB(BaseModel):
     name: ConversationName | None = None
+    extra_context: dict[str, Any] | None = None
 
 
 class ConversationMessagePatchDB(BaseModel):

--- a/services/web/server/src/simcore_service_webserver/conversations/_controller/_conversations_rest.py
+++ b/services/web/server/src/simcore_service_webserver/conversations/_controller/_conversations_rest.py
@@ -163,7 +163,7 @@ async def get_conversation(request: web.Request):
     return envelope_json_response(data)
 
 
-@routes.put(
+@routes.patch(
     f"/{VTAG}/conversations/{{conversation_id}}",
     name="update_conversation",
 )
@@ -190,7 +190,9 @@ async def update_conversation(request: web.Request):
         app=request.app,
         project_id=None,  # Support conversations don't use project_id
         conversation_id=path_params.conversation_id,
-        updates=ConversationPatchDB(name=body_params.name),
+        updates=ConversationPatchDB(
+            name=body_params.name, extra_context=body_params.extra_context
+        ),
     )
 
     data = ConversationRestGet.from_domain_model(conversation)

--- a/services/web/server/src/simcore_service_webserver/products/_models.py
+++ b/services/web/server/src/simcore_service_webserver/products/_models.py
@@ -288,6 +288,7 @@ class Product(BaseModel):
                             "LOGIN_2FA_REQUIRED": False,
                         },
                         "group_id": 12345,
+                        "support_standard_group_id": 67890,
                         "is_payment_enabled": False,
                     },
                 ]

--- a/services/web/server/src/simcore_service_webserver/statics/_events.py
+++ b/services/web/server/src/simcore_service_webserver/statics/_events.py
@@ -141,6 +141,9 @@ async def create_and_cache_statics_json(app: web.Application) -> None:
             release_vtag = _get_release_notes_vtag(vtag)
             data["vcsReleaseUrl"] = template_url.format(vtag=release_vtag)
 
+        # Add support_standard_group_id
+        data["supportStandardGroupId"] = product.support_standard_group_id
+
         data_json = json_dumps(data)
         _logger.debug("Front-end statics.json: %s", data_json)
 


### PR DESCRIPTION
Enables conversations to be patched with additional contextual data, facilitates richer support flows, and exposes support group IDs in frontend statics for improved configuration and integration.

<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
