### PR TITLE
🐛🚑️ Make director-v0 work with `registry:3.0.0`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -707,7 +707,7 @@ local-registry: .env ## creates a local docker registry and configure simcore to
 							--publish 5000:5000 \
 							--volume $(LOCAL_REGISTRY_VOLUME):/var/lib/registry \
 							--name $(LOCAL_REGISTRY_HOSTNAME) \
-							registry:2)
+							registry:3.0.0)
 
 	# WARNING: environment file .env is now setup to use local registry on port 5000 without any security (take care!)...
 	@echo REGISTRY_AUTH=False >> .env

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -71,10 +71,23 @@ async def _basic_auth_registry_request(
     )
 
     session = get_client_session(app)
+    # Only accept docker distribution  V1 registry protocol ,
+    # dv0 does not have v2 compatability here, but from registry>=3.0.0
+    # the v2 scheme is default...
+    # https://specs.opencontainers.org/image-spec/media-types/?v=v1.0.1
+    # https://distribution.github.io/distribution/spec/api/
     response = await session.request(
         method.lower(),
         f"{request_url}",
         auth=auth,
+        headers={
+            "Accept": ", ".join(
+                [
+                    "application/vnd.oci.image.manifest.v1+json",
+                    "application/vnd.oci.image.index.v1+json",
+                ]
+            )
+        },
         **session_kwargs,
     )
 
@@ -104,7 +117,7 @@ async def _basic_auth_registry_request(
     return (resp_data, resp_headers)
 
 
-async def _auth_registry_request(  # noqa: C901
+async def _auth_registry_request(  # noqa: C901#
     app_settings: ApplicationSettings,
     url: URL,
     method: str,

--- a/services/docker-compose-ops-registry.yml
+++ b/services/docker-compose-ops-registry.yml
@@ -4,7 +4,7 @@
 version: "3.7"
 services:
   registry:
-    image: registry:2
+    image: registry:3.0.0
     container_name: registry
     init: true
     environment:

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   registry:
-    image: registry:2
+    image: registry:3.0.0
     restart: always
     ports:
       - "5000:5000"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
Turns out that in some internal calls the dv0 relies on the docker V1 registry protocol. The `registry:3.0.0` seems to by default return v2 specs if the client to the docker registry does not specify what is acceptable. Via the usual `Accept` headers we can inform the docker registry even on version 3.0.0 that we would like to recieve only oci-image v1 data, which is compatible with the dv0 code.

#### Bonus:
Update registry to `3.0.0` everywhere

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

Tested locally (`make up-devel`)

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
