### PR TITLE
🎨Director-v0: Pass headers on /manifests call to let the registry know we accept all manifest versions

### DIFF
--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -94,7 +94,9 @@ async def _basic_auth_registry_request(
         raise ServiceNotAvailableError(service_name=path)
 
     elif response.status_code >= status.HTTP_400_BAD_REQUEST:
-        raise RegistryConnectionError(msg=str(response))
+        raise RegistryConnectionError(
+            msg=f"{response}: {response.text} for {request_url}"
+        )
 
     else:
         # registry that does not need an auth
@@ -165,7 +167,9 @@ async def _auth_registry_request(  # noqa: C901
         if resp_wbasic.status_code == status.HTTP_404_NOT_FOUND:
             raise ServiceNotAvailableError(service_name=f"{url}")
         if resp_wbasic.status_code >= status.HTTP_400_BAD_REQUEST:
-            raise RegistryConnectionError(msg=f"{resp_wbasic}")
+            raise RegistryConnectionError(
+                msg=f"{resp_wbasic}: {resp_wbasic.text} for {url}"
+            )
         resp_data = await resp_wbasic.json(content_type=None)
         resp_headers = resp_wbasic.headers
         return (resp_data, resp_headers)
@@ -199,7 +203,22 @@ async def registry_request(
     if use_cache and (cached_response := await cache.get(cache_key)):
         assert isinstance(cached_response, tuple)  # nosec
         return cast(tuple[dict, Mapping], cached_response)
-
+    # Add proper Accept headers for manifest requests for accepting both v1 and v2
+    if "manifests/" in path and method.upper() == "GET":
+        headers = session_kwargs.get("headers", {})
+        headers.update(
+            {
+                "Accept": ", ".join(
+                    [
+                        "application/vnd.docker.distribution.manifest.v2+json",
+                        "application/vnd.docker.distribution.manifest.list.v2+json",
+                        "application/vnd.docker.distribution.manifest.v1+prettyjws",
+                        "application/json",
+                    ]
+                )
+            }
+        )
+        session_kwargs["headers"] = headers
     app_settings = get_application_settings(app)
     try:
         response, response_headers = await _retried_request(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
https://github.com/ITISFoundation/osparc-simcore/pull/8240 was missing the addition of headers when calling /manifests endpoints. this materialized when accessing from local development stack to master.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
