### PR TITLE
🐛 Fixed encoding unpicklable errors

### DIFF
--- a/packages/service-library/src/servicelib/long_running_tasks/errors.py
+++ b/packages/service-library/src/servicelib/long_running_tasks/errors.py
@@ -34,6 +34,12 @@ class TaskExceptionError(BaseLongRunningError):
     )
 
 
+class TaskRaisedUnserializableError(BaseLongRunningError):
+    msg_template: str = (
+        "Task {task_id} finished with an unserializable exception: '{exception}'\n{traceback}"
+    )
+
+
 class TaskClientTimeoutError(BaseLongRunningError):
     msg_template: str = (
         "Timed out after {timeout} seconds while awaiting '{task_id}' to complete"

--- a/packages/service-library/tests/long_running_tasks/test_long_running_tasks_task.py
+++ b/packages/service-library/tests/long_running_tasks/test_long_running_tasks_task.py
@@ -25,6 +25,7 @@ from servicelib.long_running_tasks.errors import (
     TaskNotCompletedError,
     TaskNotFoundError,
     TaskNotRegisteredError,
+    TaskRaisedUnserializableError,
 )
 from servicelib.long_running_tasks.models import (
     LRTNamespace,
@@ -37,7 +38,7 @@ from servicelib.long_running_tasks.task import TaskRegistry
 from servicelib.rabbitmq._client_rpc import RabbitMQRPCClient
 from settings_library.rabbit import RabbitSettings
 from settings_library.redis import RedisSettings
-from tenacity import TryAgain
+from tenacity import TryAgain, retry, stop_after_attempt
 from tenacity.asyncio import AsyncRetrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
@@ -77,19 +78,30 @@ async def a_background_task(
 
 
 async def fast_background_task(progress: TaskProgress) -> int:
-    """this task does nothing and returns a constant"""
     return 42
 
 
 async def failing_background_task(progress: TaskProgress):
-    """this task does nothing and returns a constant"""
     msg = "failing asap"
     raise _TetingError(msg)
+
+
+async def failing_unpicklable_background_task(progress: TaskProgress):
+    @retry(
+        stop=stop_after_attempt(2),
+        reraise=False,
+    )
+    async def _innter_fail() -> None:
+        msg = "always fails with retry"
+        raise _TetingError(msg)
+
+    await _innter_fail()
 
 
 TaskRegistry.register(a_background_task)
 TaskRegistry.register(fast_background_task)
 TaskRegistry.register(failing_background_task)
+TaskRegistry.register(failing_unpicklable_background_task)
 
 
 @pytest.fixture
@@ -382,6 +394,33 @@ async def test_get_result_finished_with_error(
     assert result.str_error is not None  # nosec
     error = loads(result.str_error)
     with pytest.raises(_TetingError, match="failing asap"):
+        raise error
+
+
+async def test_get_result_finished_with_unpicklable_error(
+    long_running_manager: BaseLongRunningManager, empty_context: TaskContext
+):
+    task_id = await lrt_api.start_task(
+        long_running_manager.rpc_client,
+        long_running_manager.lrt_namespace,
+        failing_unpicklable_background_task.__name__,
+        task_context=empty_context,
+    )
+    # wait for result
+    async for attempt in AsyncRetrying(**_RETRY_PARAMS):
+        with attempt:
+            assert (
+                await long_running_manager.tasks_manager.get_task_status(
+                    task_id, with_task_context=empty_context
+                )
+            ).done
+
+    result = await long_running_manager.tasks_manager.get_task_result(
+        task_id, with_task_context=empty_context
+    )
+    assert result.str_error is not None  # nosec
+    error = loads(result.str_error)
+    with pytest.raises(TaskRaisedUnserializableError, match="cannot pickle"):
         raise error
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

As seen below, while serializing an error, it can occur that objects which are not picklable are being encoded. This caused the task to never report finishing.


```
"2025-08-26T10:05:02.511Z","05bc1a2c3929","/dy-sidecar_716e9bb6-b76e-45c6-ae91-157a8655f62e.1.jk9z3e5n0dcpfk6gvzyqdfxlp","log_level=ERROR | log_timestamp=2025-08-26 10:05:02,507 | log_source=servicelib.long_running_tasks.task:_tasks_monitor(334) | log_uid=None | log_oec=None | log_trace_id=0 | log_span_id=0 | log_msg=Execution of task_id='simcore-service-dynamic-sidecar-1756202368_f3488846-5fac-460a-8724-2ac29716bcaa.functools.task_create_service_containers.unique' finished with unexpected error, only the following allowed_errors=() are permitted.
{
  ""exception_type"": ""<class 'tenacity.RetryError'>"",
  ""exception_string"": ""RetryError[<Future at 0x719c3e19f250 state=finished returned CommandResult>]"",
  ""exception_causes"": """",
  ""error_code"": null,
  ""context"": {
    ""task_id"": ""simcore-service-dynamic-sidecar-1756202368_f3488846-5fac-460a-8724-2ac29716bcaa.functools.task_create_service_containers.unique"",
    ""task_data"": {
      ""registered_task_name"": ""task_create_service_containers"",
      ""task_id"": ""simcore-service-dynamic-sidecar-1756202368_f3488846-5fac-460a-8724-2ac29716bcaa.functools.task_create_service_containers.unique"",
      ""task_progress"": {
        ""task_id"": ""simcore-service-dynamic-sidecar-1756202368_f3488846-5fac-460a-8724-2ac29716bcaa.functools.task_create_service_containers.unique"",
        ""message"": ""finished"",
        ""percent"": 1.0
      },
      ""task_context"": {},
      ""fire_and_forget"": false,
      ""started"": ""2025-08-26T09:59:55.739460+00:00"",
      ""last_status_check"": ""2025-08-26T10:05:02.280391+00:00"",
      ""is_done"": false,
      ""result_field"": null
    },
    ""namespace"": ""simcore-service-dynamic-sidecar-1756202368_f3488846-5fac-460a-8724-2ac29716bcaa""
  },
  ""tip"": null
}
Traceback (most recent call last):
  File ""/home/scu/.venv/lib/python3.11/site-packages/servicelib/long_running_tasks/task.py"", line 321, in _tasks_monitor
    result_field = ResultField(str_result=dumps(task.result()))
                                                ^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/servicelib/long_running_tasks/task.py"", line 544, in _task_with_progress
    return await handler(progress, **task_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/simcore_service_dynamic_sidecar/modules/long_running_tasks.py"", line 205, in task_create_service_containers
    compose_start_result = await _retry_docker_compose_start(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/tenacity/asyncio/__init__.py"", line 189, in async_wrapped
    return await copy(fn, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/tenacity/asyncio/__init__.py"", line 111, in __call__
    do = await self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/tenacity/asyncio/__init__.py"", line 153, in iter
    result = await action(retry_state)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/tenacity/_utils.py"", line 99, in inner
    return call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/tenacity/__init__.py"", line 419, in exc_check
    raise retry_exc from fut.exception()
tenacity.RetryError: RetryError[<Future at 0x719c3e19f250 state=finished returned CommandResult>]",
"2025-08-26T10:05:02.513Z","05bc1a2c3929","/dy-sidecar_716e9bb6-b76e-45c6-ae91-157a8655f62e.1.jk9z3e5n0dcpfk6gvzyqdfxlp","log_level=ERROR | log_timestamp=2025-08-26 10:05:02,510 | log_source=servicelib.background_task:log_catch(575) | log_uid=None | log_oec=None | log_trace_id=0 | log_span_id=0 | log_msg=Unhandled exception:
Traceback (most recent call last):
  File ""/home/scu/.venv/lib/python3.11/site-packages/servicelib/long_running_tasks/task.py"", line 321, in _tasks_monitor
    result_field = ResultField(str_result=dumps(task.result()))
                                                ^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/servicelib/long_running_tasks/task.py"", line 544, in _task_with_progress
    return await handler(progress, **task_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/simcore_service_dynamic_sidecar/modules/long_running_tasks.py"", line 205, in task_create_service_containers
    compose_start_result = await _retry_docker_compose_start(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/tenacity/asyncio/__init__.py"", line 189, in async_wrapped
    return await copy(fn, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/tenacity/asyncio/__init__.py"", line 111, in __call__
    do = await self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/tenacity/asyncio/__init__.py"", line 153, in iter
    result = await action(retry_state)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/tenacity/_utils.py"", line 99, in inner
    return call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/tenacity/__init__.py"", line 419, in exc_check
    raise retry_exc from fut.exception()
tenacity.RetryError: RetryError[<Future at 0x719c3e19f250 state=finished returned CommandResult>]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ""/home/scu/.venv/lib/python3.11/site-packages/servicelib/logging_utils.py"", line 570, in log_catch
    yield
  File ""/home/scu/.venv/lib/python3.11/site-packages/servicelib/background_task.py"", line 88, in _wrapper
    await async_fun(*args, **kwargs)
  File ""/home/scu/.venv/lib/python3.11/site-packages/servicelib/background_task.py"", line 113, in _
    await task(**kwargs)
  File ""/home/scu/.venv/lib/python3.11/site-packages/servicelib/long_running_tasks/task.py"", line 348, in _tasks_monitor
    result_field = ResultField(str_error=dumps(e))
                                         ^^^^^^^^
  File ""/home/scu/.venv/lib/python3.11/site-packages/servicelib/long_running_tasks/_serialization.py"", line 55, in dumps
    return base64.b85encode(pickle.dumps(to_serialize)).decode(""utf-8"")
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot pickle '_thread.RLock' object",
```


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
