### PR TITLE
🐛 [Frontend] Fix: Release date on Service Card

### DIFF
--- a/services/static-webserver/client/source/class/osparc/service/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/service/Utils.js
@@ -156,7 +156,7 @@ qx.Class.define("osparc.service.Utils", {
     DEPRECATED_AUTOUPDATABLE_INSTRUCTIONS: qx.locale.Manager.tr("Please Stop the Service and then Update it"),
     RETIRED_AUTOUPDATABLE_INSTRUCTIONS: qx.locale.Manager.tr("Please Update the Service"),
 
-    extractVersionFromHistory: function(metadata) {
+    getHistoryEntry: function(metadata) {
       if (metadata["history"]) {
         const found = metadata["history"].find(historyEntry => historyEntry["version"] === metadata["version"]);
         return found;
@@ -164,8 +164,16 @@ qx.Class.define("osparc.service.Utils", {
       return null;
     },
 
+    extractReleasedDateFromHistory: function(metadata) {
+      const historyEntry = this.getHistoryEntry(metadata);
+      if (historyEntry && historyEntry["released"]) {
+        return historyEntry["released"];
+      }
+      return null;
+    },
+
     isUpdatable: function(metadata) {
-      const historyEntry = this.extractVersionFromHistory(metadata);
+      const historyEntry = this.getHistoryEntry(metadata);
       if (historyEntry && historyEntry["compatibility"] && historyEntry["compatibility"]["canUpdateTo"]) {
         const latestCompatible = historyEntry["compatibility"]["canUpdateTo"];
         return latestCompatible && (metadata["key"] !== latestCompatible["key"] || metadata["version"] !== latestCompatible["version"]);
@@ -182,7 +190,7 @@ qx.Class.define("osparc.service.Utils", {
         // this works for service latest
         return new Date(metadata["release"]["retired"]);
       }
-      const historyEntry = this.extractVersionFromHistory(metadata);
+      const historyEntry = this.getHistoryEntry(metadata);
       if (historyEntry && "retired" in historyEntry && historyEntry["retired"]) {
         return new Date(historyEntry["retired"]);
       }

--- a/services/static-webserver/client/source/class/osparc/store/Services.js
+++ b/services/static-webserver/client/source/class/osparc/store/Services.js
@@ -66,7 +66,7 @@ qx.Class.define("osparc.store.Services", {
     getLatestCompatible: function(key, version) {
       const services = this.__servicesCached;
       if (key in services && version in services[key]) {
-        const historyEntry = osparc.service.Utils.extractVersionFromHistory(services[key][version]);
+        const historyEntry = osparc.service.Utils.getHistoryEntry(services[key][version]);
         if (historyEntry["compatibility"] && historyEntry["compatibility"]["canUpdateTo"]) {
           const canUpdateTo = historyEntry["compatibility"]["canUpdateTo"];
           return {
@@ -95,10 +95,10 @@ qx.Class.define("osparc.store.Services", {
       const services = this.__servicesCached;
       if (
         key in services &&
-        version in services[key] &&
-        "released" in services[key][version]
+        version in services[key]
       ) {
-        return services[key][version]["released"];
+        const serviceMetadata = services[key][version];
+        return osparc.service.Utils.extractReleasedDateFromHistory(serviceMetadata);
       }
       return null;
     },
@@ -243,7 +243,7 @@ qx.Class.define("osparc.store.Services", {
                       }
                       serviceLatest = osparc.utils.Utils.deepCloneObject(olderNonRetired);
                       // make service metadata latest model like
-                      serviceLatest["release"] = osparc.service.Utils.extractVersionFromHistory(olderNonRetired);
+                      serviceLatest["release"] = osparc.service.Utils.getHistoryEntry(olderNonRetired);
                       break;
                     }
                   }


### PR DESCRIPTION
## What do these changes do?

This PR fixes the release date display on Service Cards by properly extracting release dates from service metadata's history.

![ReleaseDate](https://github.com/user-attachments/assets/ecf56859-6088-4f67-9bc8-cdfe69568026)


## Related issue/s
- closes https://github.com/ITISFoundation/osparc-issues/issues/1982


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
