### PR TITLE
🐛Director-v2 computational scheduler: tasks specific state combination was missing and returning UNKNOWN pipeline state

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/utils/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/computations.py
@@ -65,6 +65,7 @@ _TASK_TO_PIPELINE_CONVERSIONS = {
         RunningState.PENDING,
         RunningState.NOT_STARTED,
         RunningState.WAITING_FOR_CLUSTER,
+        RunningState.WAITING_FOR_RESOURCES,
     ): RunningState.STARTED,
 }
 

--- a/services/director-v2/tests/unit/test_utils_computation.py
+++ b/services/director-v2/tests/unit/test_utils_computation.py
@@ -266,6 +266,15 @@ def fake_task(fake_task_file: Path) -> CompTaskAtDB:
             RunningState.WAITING_FOR_RESOURCES,
             id="published and waiting for resources = waiting for resources",
         ),
+        pytest.param(
+            [
+                (RunningState.SUCCESS),
+                (RunningState.WAITING_FOR_RESOURCES),
+                (RunningState.PUBLISHED),
+            ],
+            RunningState.STARTED,
+            id="success, published and waiting for resources = waiting for resources",
+        ),
     ],
 )
 def test_get_pipeline_state_from_task_states(

--- a/services/director-v2/tests/unit/test_utils_computation.py
+++ b/services/director-v2/tests/unit/test_utils_computation.py
@@ -275,6 +275,15 @@ def fake_task(fake_task_file: Path) -> CompTaskAtDB:
             RunningState.STARTED,
             id="success, published and waiting for resources = waiting for resources",
         ),
+        pytest.param(
+            [
+                (RunningState.SUCCESS),
+                (RunningState.WAITING_FOR_CLUSTER),
+                (RunningState.PUBLISHED),
+            ],
+            RunningState.STARTED,
+            id="success, published and waiting for cluster = waiting for resources",
+        ),
     ],
 )
 def test_get_pipeline_state_from_task_states(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
An issue was found while running metamodeling pipelines where a pipelines' tasks where in the following state:
<img width="370" height="189" alt="image" src="https://github.com/user-attachments/assets/9c62b6fe-3bc7-4f6c-a860-ca25ed837e70" />
the function that transforms separate computational tasks statuses in pipeline status would transform to UNKNOWN which was a missing use-case.

UNKNOWN is then saved as FAILED in the DB. Since we now access the result from outside the DV-2 this became an issue in function jobs caching.

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
