### PR TITLE
WIP: limit requrests at the web-server level

### DIFF
--- a/services/web/server/docker/boot.sh
+++ b/services/web/server/docker/boot.sh
@@ -58,7 +58,8 @@ echo "$INFO" "GUNICORN_CMD_ARGS: $GUNICORN_CMD_ARGS"
 if [ "${SC_BOOT_MODE}" = "debug" ]; then
   # NOTE: ptvsd is programmatically enabled inside of the service
   # this way we can have reload in place as well
-  exec python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:"${WEBSERVER_REMOTE_DEBUGGING_PORT}" -m gunicorn simcore_service_webserver.cli:app_factory \
+  exec python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:"${WEBSERVER_REMOTE_DEBUGGING_PORT}" -m \
+    gunicorn simcore_service_webserver.cli:create_app_runner \
     --log-level="${SERVER_LOG_LEVEL}" \
     --bind 0.0.0.0:8080 \
     --worker-class aiohttp.GunicornUVLoopWebWorker \
@@ -71,7 +72,7 @@ if [ "${SC_BOOT_MODE}" = "debug" ]; then
 
 else
 
-  exec gunicorn simcore_service_webserver.cli:app_factory \
+  exec gunicorn simcore_service_webserver.cli:create_app_runner \
     --log-level="${SERVER_LOG_LEVEL}" \
     --bind 0.0.0.0:8080 \
     --worker-class aiohttp.GunicornUVLoopWebWorker \
@@ -79,5 +80,8 @@ else
     --name="webserver_$(hostname)_$(date +'%Y-%m-%d_%T')_$$" \
     --access-logfile='-' \
     --access-logformat='%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"' \
-    --worker-tmp-dir=/dev/shm
+    --worker-tmp-dir=/dev/shm \
+    --limit-request-line 4094 \
+    --limit-request-fields 100 \
+    --limit-request-field_size 8190
 fi

--- a/services/web/server/src/simcore_service_webserver/cli.py
+++ b/services/web/server/src/simcore_service_webserver/cli.py
@@ -83,6 +83,22 @@ async def app_factory() -> web.Application:
     return app
 
 
+_ACCESS_LOG_FMT = '%a %t "%r" %s %b [%Dus] "%{Referer}i" "%{User-Agent}i"'
+
+
+async def create_app_runner() -> web.AppRunner:
+
+    app = await app_factory()
+
+    # Rejects requests that are oversized. Fixes https://github.com/ITISFoundation/osparc-simcore/issues/7979
+    return web.AppRunner(
+        app,
+        access_log_format=_ACCESS_LOG_FMT,
+        max_line_size=4094,  # request line & single header line cap
+        max_field_size=8190,  # per-header field cap
+    )
+
+
 # CLI -------------
 
 main = typer.Typer(name="simcore-service-webserver")


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

There is a request that is causing this exception in the web-server
<img width="1079" height="430" alt="Image" src="https://github.com/user-attachments/assets/494803a5-e7a4-47b4-8d66-fec0016cc640" />

This PR will reject the request either in traefik or the guvicorn webserver but should never be logged in the webserver's service log

- [ ] limit in traefik (use config) and enable log as error
- [x] limit in guviocorn. I guess if limited in traefik this is not needed!?


## Related issue/s

- fixes https://github.com/ITISFoundation/osparc-simcore/issues/7979

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
