### PR TITLE
🐛🎨Do not fail a pipeline when the clusters-keeper or the computational backend in general is not reachable for short time 🚨

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -82,6 +82,11 @@ class ComputationalBackendSettings(BaseCustomSettings):
         FileLinkType.PRESIGNED,
         description=f"Default file link type to use with computational backend on-demand clusters '{list(FileLinkType)}'",
     )
+    COMPUTATIONAL_BACKEND_MAX_WAITING_FOR_CLUSTER_TIMEOUT: datetime.timedelta = Field(
+        default=datetime.timedelta(minutes=30),
+        description="maximum time a pipeline can wait for a cluster to start"
+        "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formating).",
+    )
 
     @cached_property
     def default_cluster(self) -> BaseCluster:

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -85,7 +85,7 @@ class ComputationalBackendSettings(BaseCustomSettings):
     COMPUTATIONAL_BACKEND_MAX_WAITING_FOR_CLUSTER_TIMEOUT: datetime.timedelta = Field(
         default=datetime.timedelta(minutes=10),
         description="maximum time a pipeline can wait for a cluster to start"
-        "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formating).",
+        "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formatting).",
     )
 
     @cached_property

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -83,7 +83,7 @@ class ComputationalBackendSettings(BaseCustomSettings):
         description=f"Default file link type to use with computational backend on-demand clusters '{list(FileLinkType)}'",
     )
     COMPUTATIONAL_BACKEND_MAX_WAITING_FOR_CLUSTER_TIMEOUT: datetime.timedelta = Field(
-        default=datetime.timedelta(minutes=30),
+        default=datetime.timedelta(minutes=10),
         description="maximum time a pipeline can wait for a cluster to start"
         "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formating).",
     )

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -6,6 +6,7 @@ import datetime
 from functools import cached_property
 from typing import Annotated, cast
 
+from common_library.basic_types import DEFAULT_FACTORY
 from common_library.pydantic_validators import validate_numeric_string_as_timedelta
 from fastapi import FastAPI
 from models_library.basic_types import LogLevel, PortInt
@@ -50,43 +51,53 @@ from .dynamic_services_settings import DynamicServicesSettings
 
 
 class ComputationalBackendSettings(BaseCustomSettings):
-    COMPUTATIONAL_BACKEND_ENABLED: bool = Field(
-        default=True,
-    )
-    COMPUTATIONAL_BACKEND_SCHEDULING_CONCURRENCY: PositiveInt = Field(
-        default=50,
-        description="defines how many pipelines the application can schedule concurrently",
-    )
-    COMPUTATIONAL_BACKEND_DASK_CLIENT_ENABLED: bool = Field(
-        default=True,
-    )
-    COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL: AnyUrl = Field(
-        ...,
-        description="This is the cluster that will be used by default"
-        " when submitting computational services (typically "
-        "tcp://dask-scheduler:8786, tls://dask-scheduler:8786 for the internal cluster",
-    )
-    COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_AUTH: ClusterAuthentication = Field(
-        default=...,
-        description="this is the cluster authentication that will be used by default",
-    )
-    COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_FILE_LINK_TYPE: FileLinkType = Field(
-        FileLinkType.S3,
-        description=f"Default file link type to use with the internal cluster '{list(FileLinkType)}'",
-    )
-    COMPUTATIONAL_BACKEND_DEFAULT_FILE_LINK_TYPE: FileLinkType = Field(
-        FileLinkType.PRESIGNED,
-        description=f"Default file link type to use with computational backend '{list(FileLinkType)}'",
-    )
-    COMPUTATIONAL_BACKEND_ON_DEMAND_CLUSTERS_FILE_LINK_TYPE: FileLinkType = Field(
-        FileLinkType.PRESIGNED,
-        description=f"Default file link type to use with computational backend on-demand clusters '{list(FileLinkType)}'",
-    )
-    COMPUTATIONAL_BACKEND_MAX_WAITING_FOR_CLUSTER_TIMEOUT: datetime.timedelta = Field(
-        default=datetime.timedelta(minutes=10),
-        description="maximum time a pipeline can wait for a cluster to start"
-        "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formatting).",
-    )
+    COMPUTATIONAL_BACKEND_ENABLED: bool = True
+    COMPUTATIONAL_BACKEND_SCHEDULING_CONCURRENCY: Annotated[
+        PositiveInt,
+        Field(
+            description="defines how many pipelines the application can schedule concurrently"
+        ),
+    ] = 50
+    COMPUTATIONAL_BACKEND_DASK_CLIENT_ENABLED: bool = True
+    COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL: Annotated[
+        AnyUrl,
+        Field(
+            description="This is the cluster that will be used by default"
+            " when submitting computational services (typically "
+            "tcp://dask-scheduler:8786, tls://dask-scheduler:8786 for the internal cluster",
+        ),
+    ]
+    COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_AUTH: Annotated[
+        ClusterAuthentication,
+        Field(
+            description="this is the cluster authentication that will be used by default"
+        ),
+    ]
+    COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_FILE_LINK_TYPE: Annotated[
+        FileLinkType,
+        Field(
+            description=f"Default file link type to use with the internal cluster '{list(FileLinkType)}'"
+        ),
+    ] = FileLinkType.S3
+    COMPUTATIONAL_BACKEND_DEFAULT_FILE_LINK_TYPE: Annotated[
+        FileLinkType,
+        Field(
+            description=f"Default file link type to use with computational backend '{list(FileLinkType)}'"
+        ),
+    ] = FileLinkType.PRESIGNED
+    COMPUTATIONAL_BACKEND_ON_DEMAND_CLUSTERS_FILE_LINK_TYPE: Annotated[
+        FileLinkType,
+        Field(
+            description=f"Default file link type to use with computational backend on-demand clusters '{list(FileLinkType)}'"
+        ),
+    ] = FileLinkType.PRESIGNED
+    COMPUTATIONAL_BACKEND_MAX_WAITING_FOR_CLUSTER_TIMEOUT: Annotated[
+        datetime.timedelta,
+        Field(
+            description="maximum time a pipeline can wait for a cluster to start"
+            "(default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formatting)."
+        ),
+    ] = datetime.timedelta(minutes=10)
 
     @cached_property
     def default_cluster(self) -> BaseCluster:
@@ -116,91 +127,107 @@ class AppSettings(BaseApplicationSettings, MixinLoggingSettings):
         ),
     ] = LogLevel.INFO
 
-    DIRECTOR_V2_LOG_FORMAT_LOCAL_DEV_ENABLED: bool = Field(
-        default=False,
-        validation_alias=AliasChoices(
-            "DIRECTOR_V2_LOG_FORMAT_LOCAL_DEV_ENABLED",
-            "LOG_FORMAT_LOCAL_DEV_ENABLED",
+    DIRECTOR_V2_LOG_FORMAT_LOCAL_DEV_ENABLED: Annotated[
+        bool,
+        Field(
+            validation_alias=AliasChoices(
+                "DIRECTOR_V2_LOG_FORMAT_LOCAL_DEV_ENABLED",
+                "LOG_FORMAT_LOCAL_DEV_ENABLED",
+            ),
+            description="Enables local development log format. WARNING: make sure it is disabled if you want to have structured logs!",
         ),
-        description="Enables local development log format. WARNING: make sure it is disabled if you want to have structured logs!",
-    )
-    DIRECTOR_V2_LOG_FILTER_MAPPING: dict[LoggerName, list[MessageSubstring]] = Field(
-        default_factory=dict,
-        validation_alias=AliasChoices(
-            "DIRECTOR_V2_LOG_FILTER_MAPPING", "LOG_FILTER_MAPPING"
+    ] = False
+    DIRECTOR_V2_LOG_FILTER_MAPPING: Annotated[
+        dict[LoggerName, list[MessageSubstring]],
+        Field(
+            default_factory=dict,
+            validation_alias=AliasChoices(
+                "DIRECTOR_V2_LOG_FILTER_MAPPING", "LOG_FILTER_MAPPING"
+            ),
+            description="is a dictionary that maps specific loggers (such as 'uvicorn.access' or 'gunicorn.access') to a list of log message patterns that should be filtered out.",
         ),
-        description="is a dictionary that maps specific loggers (such as 'uvicorn.access' or 'gunicorn.access') to a list of log message patterns that should be filtered out.",
-    )
+    ] = DEFAULT_FACTORY
     DIRECTOR_V2_DEV_FEATURES_ENABLED: bool = False
 
-    DIRECTOR_V2_DEV_FEATURE_R_CLONE_MOUNTS_ENABLED: bool = Field(
-        default=False,
-        description=(
-            "Under development feature. If enabled state "
-            "is saved using rclone docker volumes."
+    DIRECTOR_V2_DEV_FEATURE_R_CLONE_MOUNTS_ENABLED: Annotated[
+        bool,
+        Field(
+            description=(
+                "Under development feature. If enabled state "
+                "is saved using rclone docker volumes."
+            )
         ),
-    )
+    ] = False
 
     # for passing self-signed certificate to spawned services
-    DIRECTOR_V2_SELF_SIGNED_SSL_SECRET_ID: str = Field(
-        default="",
-        description="ID of the docker secret containing the self-signed certificate",
-    )
-    DIRECTOR_V2_SELF_SIGNED_SSL_SECRET_NAME: str = Field(
-        default="",
-        description="Name of the docker secret containing the self-signed certificate",
-    )
-    DIRECTOR_V2_SELF_SIGNED_SSL_FILENAME: str = Field(
-        default="",
-        description="Filepath to self-signed osparc.crt file *as mounted inside the container*, empty strings disables it",
-    )
+    DIRECTOR_V2_SELF_SIGNED_SSL_SECRET_ID: Annotated[
+        str,
+        Field(
+            description="ID of the docker secret containing the self-signed certificate"
+        ),
+    ] = ""
+    DIRECTOR_V2_SELF_SIGNED_SSL_SECRET_NAME: Annotated[
+        str,
+        Field(
+            description="Name of the docker secret containing the self-signed certificate"
+        ),
+    ] = ""
+    DIRECTOR_V2_SELF_SIGNED_SSL_FILENAME: Annotated[
+        str,
+        Field(
+            description="Filepath to self-signed osparc.crt file *as mounted inside the container*, empty strings disables it"
+        ),
+    ] = ""
     DIRECTOR_V2_PROMETHEUS_INSTRUMENTATION_ENABLED: bool = True
     DIRECTOR_V2_PROFILING: bool = False
 
-    DIRECTOR_V2_REMOTE_DEBUGGING_PORT: PortInt | None = Field(default=None)
+    DIRECTOR_V2_REMOTE_DEBUGGING_PORT: PortInt | None = None
 
     # extras
-    SWARM_STACK_NAME: str = Field(default="undefined-please-check")
-    SERVICE_TRACKING_HEARTBEAT: datetime.timedelta = Field(
-        default=DEFAULT_RESOURCE_USAGE_HEARTBEAT_INTERVAL,
-        description="Service scheduler heartbeat (everytime a heartbeat is sent into RabbitMQ)"
-        " (default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formating)",
-    )
+    SWARM_STACK_NAME: str = "undefined-please-check"
+    SERVICE_TRACKING_HEARTBEAT: Annotated[
+        datetime.timedelta,
+        Field(
+            description="Service scheduler heartbeat (everytime a heartbeat is sent into RabbitMQ)"
+            " (default to seconds, or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formating)"
+        ),
+    ] = DEFAULT_RESOURCE_USAGE_HEARTBEAT_INTERVAL
 
-    SIMCORE_SERVICES_NETWORK_NAME: str | None = Field(
-        default=None,
-        description="used to find the right network name",
-    )
-    SIMCORE_SERVICES_PREFIX: str | None = Field(
-        "simcore/services",
-        description="useful when developing with an alternative registry namespace",
-    )
+    SIMCORE_SERVICES_NETWORK_NAME: Annotated[
+        str | None, Field(description="used to find the right network name")
+    ] = None
+    SIMCORE_SERVICES_PREFIX: Annotated[
+        str | None,
+        Field(
+            description="useful when developing with an alternative registry namespace"
+        ),
+    ] = "simcore/services"
 
-    DIRECTOR_V2_NODE_PORTS_400_REQUEST_TIMEOUT_ATTEMPTS: NonNegativeInt = Field(
-        default=NODE_PORTS_400_REQUEST_TIMEOUT_ATTEMPTS_DEFAULT_VALUE,
-        description="forwarded to sidecars which use nodeports",
-    )
+    DIRECTOR_V2_NODE_PORTS_400_REQUEST_TIMEOUT_ATTEMPTS: Annotated[
+        NonNegativeInt, Field(description="forwarded to sidecars which use nodeports")
+    ] = NODE_PORTS_400_REQUEST_TIMEOUT_ATTEMPTS_DEFAULT_VALUE
 
     # debug settings
-    CLIENT_REQUEST: ClientRequestSettings = Field(
-        json_schema_extra={"auto_default_from_env": True}
-    )
+    CLIENT_REQUEST: Annotated[
+        ClientRequestSettings, Field(json_schema_extra={"auto_default_from_env": True})
+    ] = DEFAULT_FACTORY
 
     # App modules settings ---------------------
     DIRECTOR_V2_STORAGE: Annotated[
         StorageSettings, Field(json_schema_extra={"auto_default_from_env": True})
     ]
-    DIRECTOR_V2_NODE_PORTS_STORAGE_AUTH: StorageAuthSettings | None = Field(
-        json_schema_extra={"auto_default_from_env": True}
-    )
+    DIRECTOR_V2_NODE_PORTS_STORAGE_AUTH: Annotated[
+        StorageAuthSettings | None,
+        Field(json_schema_extra={"auto_default_from_env": True}),
+    ] = None
 
     DIRECTOR_V2_CATALOG: Annotated[
         CatalogSettings | None, Field(json_schema_extra={"auto_default_from_env": True})
     ]
 
-    DIRECTOR_V0: DirectorV0Settings = Field(
-        json_schema_extra={"auto_default_from_env": True}
-    )
+    DIRECTOR_V0: Annotated[
+        DirectorV0Settings, Field(json_schema_extra={"auto_default_from_env": True})
+    ] = DEFAULT_FACTORY
 
     DYNAMIC_SERVICES: Annotated[
         DynamicServicesSettings,
@@ -211,35 +238,47 @@ class AppSettings(BaseApplicationSettings, MixinLoggingSettings):
         PostgresSettings, Field(json_schema_extra={"auto_default_from_env": True})
     ]
 
-    REDIS: RedisSettings = Field(json_schema_extra={"auto_default_from_env": True})
+    REDIS: Annotated[
+        RedisSettings, Field(json_schema_extra={"auto_default_from_env": True})
+    ] = DEFAULT_FACTORY
 
-    DIRECTOR_V2_RABBITMQ: RabbitSettings = Field(
-        json_schema_extra={"auto_default_from_env": True}
-    )
+    DIRECTOR_V2_RABBITMQ: Annotated[
+        RabbitSettings, Field(json_schema_extra={"auto_default_from_env": True})
+    ] = DEFAULT_FACTORY
 
-    TRAEFIK_SIMCORE_ZONE: str = Field("internal_simcore_stack")
+    TRAEFIK_SIMCORE_ZONE: str = "internal_simcore_stack"
 
-    DIRECTOR_V2_COMPUTATIONAL_BACKEND: ComputationalBackendSettings = Field(
-        json_schema_extra={"auto_default_from_env": True}
-    )
+    DIRECTOR_V2_COMPUTATIONAL_BACKEND: Annotated[
+        ComputationalBackendSettings,
+        Field(json_schema_extra={"auto_default_from_env": True}),
+    ] = DEFAULT_FACTORY
 
-    DIRECTOR_V2_DOCKER_REGISTRY: RegistrySettings = Field(
-        json_schema_extra={"auto_default_from_env": True},
-        description="settings for the private registry deployed with the platform",
-    )
-    DIRECTOR_V2_DOCKER_HUB_REGISTRY: RegistrySettings | None = Field(
-        default=None, description="public DockerHub registry settings"
-    )
+    DIRECTOR_V2_DOCKER_REGISTRY: Annotated[
+        RegistrySettings,
+        Field(
+            json_schema_extra={"auto_default_from_env": True},
+            description="settings for the private registry deployed with the platform",
+        ),
+    ] = DEFAULT_FACTORY
+    DIRECTOR_V2_DOCKER_HUB_REGISTRY: Annotated[
+        RegistrySettings | None, Field(description="public DockerHub registry settings")
+    ] = None
 
-    DIRECTOR_V2_RESOURCE_USAGE_TRACKER: ResourceUsageTrackerSettings = Field(
-        json_schema_extra={"auto_default_from_env": True},
-        description="resource usage tracker service client's plugin",
-    )
+    DIRECTOR_V2_RESOURCE_USAGE_TRACKER: Annotated[
+        ResourceUsageTrackerSettings,
+        Field(
+            json_schema_extra={"auto_default_from_env": True},
+            description="resource usage tracker service client's plugin",
+        ),
+    ] = DEFAULT_FACTORY
 
-    DIRECTOR_V2_TRACING: TracingSettings | None = Field(
-        json_schema_extra={"auto_default_from_env": True},
-        description="settings for opentelemetry tracing",
-    )
+    DIRECTOR_V2_TRACING: Annotated[
+        TracingSettings | None,
+        Field(
+            json_schema_extra={"auto_default_from_env": True},
+            description="settings for opentelemetry tracing",
+        ),
+    ] = None
 
     @field_validator("LOG_LEVEL", mode="before")
     @classmethod

--- a/services/director-v2/src/simcore_service_director_v2/models/comp_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/comp_tasks.py
@@ -276,3 +276,15 @@ class ComputationTaskForRpcDBGet(BaseModel):
     image: dict[str, Any]
     started_at: dt.datetime | None
     ended_at: dt.datetime | None
+
+    @field_validator("state", mode="before")
+    @classmethod
+    def _convert_from_state_type_enum_if_needed(cls, v):
+        if isinstance(v, str):
+            # try to convert to a StateType, if it fails the validations will continue
+            # and pydantic will try to convert it to a RunninState later on
+            with suppress(ValueError):
+                v = StateType(v)
+        if isinstance(v, StateType):
+            return RunningState(DB_TO_RUNNING_STATE[v])
+        return v

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -82,6 +82,9 @@ _MAX_WAITING_FOR_CLUSTER_TIMEOUT: Final[datetime.timedelta] = datetime.timedelta
 _MAX_WAITING_TIME_FOR_UNKNOWN_TASKS: Final[datetime.timedelta] = datetime.timedelta(
     seconds=30
 )
+_MAX_WAITING_TIME_FOR_MISSING_BACKEND: Final[datetime.timedelta] = datetime.timedelta(
+    minutes=5
+)
 
 
 def _auto_schedule_callback(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -778,7 +778,7 @@ class BaseCompScheduler(ABC):
 
         return comp_tasks
 
-    async def _schedule_tasks_to_start(  # noqa: C901
+    async def _schedule_tasks_to_start(
         self,
         user_id: UserID,
         project_id: ProjectID,

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -21,6 +21,7 @@ from typing import Final
 
 import arrow
 import networkx as nx
+from common_library.user_messages import user_message
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID, NodeIDStr
 from models_library.projects_state import RunningState
@@ -247,7 +248,9 @@ class BaseCompScheduler(ABC):
                 self.rabbitmq_client,
                 user_id=user_id,
                 project_id=project_id,
-                log=f"Pipeline run {run_result.value} for iteration {iteration} is done with {run_result.value} state",
+                log=user_message(
+                    f"Pipeline run {run_result.value} for iteration {iteration} is done with {run_result.value} state"
+                ),
                 log_level=logging.INFO,
             )
         await publish_pipeline_scheduling_state(
@@ -861,7 +864,9 @@ class BaseCompScheduler(ABC):
                 self.rabbitmq_client,
                 user_id,
                 project_id,
-                log="Unexpected error while scheduling computational tasks! TIP: contact osparc support if this does not resolve automatically.",
+                log=user_message(
+                    "Unexpected error while scheduling computational tasks! TIP: contact osparc support if this does not resolve automatically."
+                ),
                 log_level=logging.ERROR,
             )
             await CompTasksRepository.instance(
@@ -997,7 +1002,9 @@ class BaseCompScheduler(ABC):
                 )
                 for task in tasks_waiting_for_cluster:
                     task.state = RunningState.FAILED
-                msg = "Timed-out waiting for computational cluster! Please try again and/or contact Osparc support."
+                msg = user_message(
+                    "Timed-out waiting for computational cluster! Please try again and/or contact Osparc support."
+                )
                 _logger.error(msg)
                 await publish_project_log(
                     self.rabbitmq_client,

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -636,11 +636,13 @@ class BaseCompScheduler(ABC):
                     user_id, project_id, iteration
                 )
                 dag = await self._get_pipeline_dag(project_id)
-                comp_tasks = await self._get_pipeline_tasks(project_id, dag)
+
                 # 1. Update our list of tasks with data from backend (state, results)
                 await self._update_states_from_comp_backend(
                     user_id, project_id, iteration, dag, comp_run
                 )
+                # 1.bis get the updated tasks NOTE: we need to get them again as some states might have changed
+                comp_tasks = await self._get_pipeline_tasks(project_id, dag)
                 # 2. timeout if waiting for cluster has been there for more than X minutes
                 comp_tasks = await self._timeout_if_waiting_for_cluster_too_long(
                     user_id, project_id, comp_run, comp_tasks

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -249,7 +249,8 @@ class BaseCompScheduler(ABC):
                 user_id=user_id,
                 project_id=project_id,
                 log=user_message(
-                    f"Pipeline run {run_result.value} for iteration {iteration} is done with {run_result.value} state"
+                    f"Project pipeline execution for iteration {iteration} has completed with status: {run_result.value}",
+                    _version=1,
                 ),
                 log_level=logging.INFO,
             )
@@ -865,7 +866,8 @@ class BaseCompScheduler(ABC):
                 user_id,
                 project_id,
                 log=user_message(
-                    "Unexpected error while scheduling computational tasks! TIP: contact osparc support if this does not resolve automatically."
+                    "An unexpected error occurred during task scheduling. Please contact oSparc support if this issue persists.",
+                    _version=1,
                 ),
                 log_level=logging.ERROR,
             )
@@ -1003,7 +1005,8 @@ class BaseCompScheduler(ABC):
                 for task in tasks_waiting_for_cluster:
                     task.state = RunningState.FAILED
                 msg = user_message(
-                    "Timed-out waiting for computational cluster! Please try again and/or contact Osparc support."
+                    "The system has timed out while waiting for computational resources. Please try running your project again or contact oSparc support if this issue persists.",
+                    _version=1,
                 )
                 _logger.error(msg)
                 await publish_project_log(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -82,9 +82,6 @@ _MAX_WAITING_FOR_CLUSTER_TIMEOUT: Final[datetime.timedelta] = datetime.timedelta
 _MAX_WAITING_TIME_FOR_UNKNOWN_TASKS: Final[datetime.timedelta] = datetime.timedelta(
     seconds=30
 )
-_MAX_WAITING_TIME_FOR_MISSING_BACKEND: Final[datetime.timedelta] = datetime.timedelta(
-    minutes=5
-)
 
 
 def _auto_schedule_callback(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -76,7 +76,12 @@ _logger = logging.getLogger(__name__)
 
 _Previous = CompTaskAtDB
 _Current = CompTaskAtDB
-_MAX_WAITING_FOR_CLUSTER_TIMEOUT_IN_MIN: Final[int] = 10
+_MAX_WAITING_FOR_CLUSTER_TIMEOUT: Final[datetime.timedelta] = datetime.timedelta(
+    minutes=10
+)
+_MAX_WAITING_TIME_FOR_UNKNOWN_TASKS: Final[datetime.timedelta] = datetime.timedelta(
+    seconds=30
+)
 
 
 def _auto_schedule_callback(
@@ -115,11 +120,6 @@ class SortedTasks:
     completed: list[CompTaskAtDB]
     waiting: list[CompTaskAtDB]
     potentially_lost: list[CompTaskAtDB]
-
-
-_MAX_WAITING_TIME_FOR_UNKNOWN_TASKS: Final[datetime.timedelta] = datetime.timedelta(
-    seconds=30
-)
 
 
 async def _triage_changed_tasks(
@@ -920,7 +920,7 @@ class BaseCompScheduler(ABC):
 
             if (
                 arrow.utcnow().datetime - latest_modified_of_all_tasks
-            ) > datetime.timedelta(minutes=_MAX_WAITING_FOR_CLUSTER_TIMEOUT_IN_MIN):
+            ) > _MAX_WAITING_FOR_CLUSTER_TIMEOUT:
                 await CompTasksRepository.instance(
                     self.db_engine
                 ).update_project_tasks_state(

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -525,7 +525,7 @@ class CompRunsRepository(BaseRepository):
                     iteration = await _get_next_iteration(conn, user_id, project_id)
 
                 result = await conn.execute(
-                    comp_runs.insert()  # pylint: disable=no-value-for-parameter
+                    comp_runs.insert()
                     .values(
                         user_id=user_id,
                         project_uuid=f"{project_id}",

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -323,11 +323,14 @@ class CompRunsRepository(BaseRepository):
             total_count = await conn.scalar(count_query)
 
             items = [
-                ComputationRunRpcGet.model_validate(
-                    {
-                        **row,
-                        "state": DB_TO_RUNNING_STATE[row.state],
-                    }
+                ComputationRunRpcGet(
+                    project_uuid=row.project_uuid,
+                    iteration=row.iteration,
+                    state=DB_TO_RUNNING_STATE[row.state],
+                    info=row.info,
+                    submitted_at=row.submitted_at,
+                    started_at=row.started_at,
+                    ended_at=row.ended_at,
                 )
                 async for row in await conn.stream(list_query)
             ]

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -23,7 +23,7 @@ from .....core.errors import ComputationalTaskNotFoundError
 from .....models.comp_tasks import CompTaskAtDB, ComputationTaskForRpcDBGet
 from .....modules.resource_usage_tracker_client import ResourceUsageTrackerClient
 from .....utils.computations import to_node_class
-from .....utils.db import DB_TO_RUNNING_STATE, RUNNING_STATE_TO_DB
+from .....utils.db import RUNNING_STATE_TO_DB
 from ....catalog import CatalogClient
 from ...tables import NodeClass, StateType, comp_run_snapshot_tasks, comp_tasks
 from .._base import BaseRepository
@@ -130,12 +130,7 @@ class CompTasksRepository(BaseRepository):
             total_count = await conn.scalar(count_query)
 
             items = [
-                ComputationTaskForRpcDBGet.model_validate(
-                    {
-                        **row,
-                        "state": DB_TO_RUNNING_STATE[row["state"]],  # Convert the state
-                    }
-                )
+                ComputationTaskForRpcDBGet.model_validate(row, from_attributes=True)
                 async for row in await conn.stream(list_query)
             ]
             return cast(int, total_count), items

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -481,7 +481,7 @@ def check_scheduler_is_still_the_same(
         )
 
 
-def check_communication_with_scheduler_is_open(client: distributed.Client):
+def check_communication_with_scheduler_is_open(client: distributed.Client) -> None:
     if (
         client.scheduler_comm
         and client.scheduler_comm.comm is not None
@@ -490,12 +490,9 @@ def check_communication_with_scheduler_is_open(client: distributed.Client):
         raise ComputationalBackendNotConnectedError
 
 
-def check_scheduler_status(client: distributed.Client):
+def check_scheduler_status(client: distributed.Client) -> None:
     client_status = client.status
     if client_status not in "running":
-        _logger.error(
-            "The computational backend is not connected!",
-        )
         raise ComputationalBackendNotConnectedError
 
 

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/conftest.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/conftest.py
@@ -8,6 +8,7 @@
 # pylint: disable=too-many-statements
 
 
+import datetime
 from unittest import mock
 
 import pytest
@@ -69,3 +70,15 @@ def with_disabled_scheduler_publisher(mocker: MockerFixture) -> mock.Mock:
         "simcore_service_director_v2.modules.comp_scheduler._manager.request_pipeline_scheduling",
         autospec=True,
     )
+
+
+@pytest.fixture
+def with_short_max_wait_for_clusters_keeper(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+) -> datetime.timedelta:
+    short_time = datetime.timedelta(seconds=5)
+    setenvs_from_dict(
+        monkeypatch,
+        {"COMPUTATIONAL_BACKEND_MAX_WAITING_FOR_CLUSTER_TIMEOUT": f"{short_time}"},
+    )
+    return short_time

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -1272,7 +1272,7 @@ async def test_broken_pipeline_configuration_is_not_scheduled_and_aborted(
     await assert_comp_runs(
         sqlalchemy_async_engine,
         expected_total=1,
-        expected_state=RunningState.ABORTED,
+        expected_state=RunningState.FAILED,
         where_statement=(comp_runs.c.user_id == user["id"])
         & (comp_runs.c.project_uuid == f"{sleepers_project.uuid}"),
     )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR changes the behavior of the dv-2 computational scheduler:
*BEFORE*:
- if the clusters-keeper is not reachable,
- if the dask scheduler is not reachable,
- if rabbitmq is not reachable,
- --> the pipeline would be directly set to FAILED state

*AFTER*:
- --> the pipeline will be set to WAITING_FOR_CLUSTER state


1. Since when we deploy or play around the clusters-keeper restarts wildly this will prevent failing pipelines straight away which were issues detected a while ago that should not be happening (see fixed issues).
2. Also, a new constant was defined `COMPUTATIONAL_BACKEND_MAX_WAITING_FOR_CLUSTER_TIMEOUT` that could be used in case we should change that value (currently defaulted to 10 minutes).

tests driving changes: `test_scheduler_dask.py`


<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/8098
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/6817

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
