### PR TITLE
🎨 Run each job creation as a single task in `api-worker`

### DIFF
--- a/services/api-server/src/simcore_service_api_server/_service_function_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/_service_function_jobs.py
@@ -466,27 +466,6 @@ class FunctionJobService:
             function_class=function.function_class,
         )
 
-    async def map_function(
-        self,
-        *,
-        function: RegisteredFunction,
-        pre_registered_function_job_data_list: list[PreRegisteredFunctionJobData],
-        job_links: JobLinks,
-        pricing_spec: JobPricingSpecification | None,
-        x_simcore_parent_project_uuid: ProjectID | None,
-        x_simcore_parent_node_id: NodeID | None,
-    ) -> None:
-
-        for data in pre_registered_function_job_data_list:
-            await self.run_function(
-                function=function,
-                pre_registered_function_job_data=data,
-                pricing_spec=pricing_spec,
-                job_links=job_links,
-                x_simcore_parent_project_uuid=x_simcore_parent_project_uuid,
-                x_simcore_parent_node_id=x_simcore_parent_node_id,
-            )
-
     async def function_job_outputs(
         self,
         *,

--- a/services/api-server/src/simcore_service_api_server/_service_function_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/_service_function_jobs.py
@@ -405,7 +405,6 @@ class FunctionJobService:
     async def run_function(
         self,
         *,
-        job_creation_task_id: TaskID | None,
         function: RegisteredFunction,
         pre_registered_function_job_data: PreRegisteredFunctionJobData,
         pricing_spec: JobPricingSpecification | None,
@@ -434,7 +433,7 @@ class FunctionJobService:
                 product_name=self.product_name,
                 function_job_id=pre_registered_function_job_data.function_job_id,
                 function_class=FunctionClass.PROJECT,
-                job_creation_task_id=job_creation_task_id,
+                job_creation_task_id=None,
                 project_job_id=study_job.id,
             )
 
@@ -459,7 +458,7 @@ class FunctionJobService:
                 product_name=self.product_name,
                 function_job_id=pre_registered_function_job_data.function_job_id,
                 function_class=FunctionClass.SOLVER,
-                job_creation_task_id=job_creation_task_id,
+                job_creation_task_id=None,
                 solver_job_id=solver_job.id,
             )
 
@@ -470,7 +469,6 @@ class FunctionJobService:
     async def map_function(
         self,
         *,
-        job_creation_task_id: TaskID | None,
         function: RegisteredFunction,
         pre_registered_function_job_data_list: list[PreRegisteredFunctionJobData],
         job_links: JobLinks,
@@ -481,7 +479,6 @@ class FunctionJobService:
 
         for data in pre_registered_function_job_data_list:
             await self.run_function(
-                job_creation_task_id=job_creation_task_id,
                 function=function,
                 pre_registered_function_job_data=data,
                 pricing_spec=pricing_spec,

--- a/services/api-server/src/simcore_service_api_server/celery_worker/worker_tasks/functions_tasks.py
+++ b/services/api-server/src/simcore_service_api_server/celery_worker/worker_tasks/functions_tasks.py
@@ -127,31 +127,3 @@ async def run_function(
         x_simcore_parent_project_uuid=x_simcore_parent_project_uuid,
         x_simcore_parent_node_id=x_simcore_parent_node_id,
     )
-
-
-async def function_map(
-    task: Task,
-    task_id: TaskID,
-    *,
-    user_identity: Identity,
-    function: RegisteredFunction,
-    pre_registered_function_job_data_list: list[PreRegisteredFunctionJobData],
-    job_links: JobLinks,
-    pricing_spec: JobPricingSpecification | None,
-    x_simcore_parent_project_uuid: ProjectID | None,
-    x_simcore_parent_node_id: NodeID | None,
-) -> None:
-    assert task_id  # nosec
-    app = get_app_server(task.app).app
-    function_job_service = await _assemble_function_job_service(
-        app=app, user_identity=user_identity
-    )
-
-    return await function_job_service.map_function(
-        function=function,
-        pre_registered_function_job_data_list=pre_registered_function_job_data_list,
-        pricing_spec=pricing_spec,
-        job_links=job_links,
-        x_simcore_parent_project_uuid=x_simcore_parent_project_uuid,
-        x_simcore_parent_node_id=x_simcore_parent_node_id,
-    )

--- a/services/api-server/src/simcore_service_api_server/celery_worker/worker_tasks/functions_tasks.py
+++ b/services/api-server/src/simcore_service_api_server/celery_worker/worker_tasks/functions_tasks.py
@@ -120,7 +120,6 @@ async def run_function(
     )
 
     return await function_job_service.run_function(
-        job_creation_task_id=task_id,
         function=function,
         pre_registered_function_job_data=pre_registered_function_job_data,
         pricing_spec=pricing_spec,
@@ -149,7 +148,6 @@ async def function_map(
     )
 
     return await function_job_service.map_function(
-        job_creation_task_id=task_id,
         function=function,
         pre_registered_function_job_data_list=pre_registered_function_job_data_list,
         pricing_spec=pricing_spec,

--- a/services/api-server/src/simcore_service_api_server/celery_worker/worker_tasks/tasks.py
+++ b/services/api-server/src/simcore_service_api_server/celery_worker/worker_tasks/tasks.py
@@ -18,7 +18,7 @@ from ...api.dependencies.authentication import Identity
 from ...models.api_resources import JobLinks
 from ...models.domain.functions import PreRegisteredFunctionJobData
 from ...models.schemas.jobs import JobInputs, JobPricingSpecification
-from .functions_tasks import function_map, run_function
+from .functions_tasks import run_function
 
 _logger = logging.getLogger(__name__)
 
@@ -43,4 +43,3 @@ def setup_worker_tasks(app: Celery) -> None:
 
     with log_context(_logger, logging.INFO, msg="worker task registration"):
         register_task(app, run_function)
-        register_task(app, function_map)

--- a/services/api-server/tests/unit/api_functions/celery/test_functions_celery.py
+++ b/services/api-server/tests/unit/api_functions/celery/test_functions_celery.py
@@ -670,7 +670,9 @@ async def test_map_function(
     assert response.status_code == status.HTTP_200_OK
 
     job_collection = FunctionJobCollection.model_validate(response.json())
-    assert job_collection.job_ids == _generated_function_job_ids
+    assert (
+        job_collection.job_ids == _generated_function_job_ids
+    ), "Job ID did not preserve order or were incorrectly propagated"
     celery_task_ids = {
         elm.kwargs["registered_function_job_patch"].job_creation_task_id
         for elm in patch_mock.call_args_list


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- When using the map endpoint in the api-server we now create a separate celery task for each job creation.
- Enhance tests to check that multiple celery tasks are created and job order is preserved by map endpoint
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
