### PR TITLE
🎨E2E: add create study, create function, start mmux

### DIFF
--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -492,9 +492,6 @@ def create_new_project_and_delete(  # noqa: C901, PLR0915
         template_id: str | None,
         service_version: str | None,
     ) -> dict[str, Any]:
-        assert (
-            len(created_project_uuids) == 0
-        ), "misuse of this fixture! only 1 study can be opened at a time. Otherwise please modify the fixture"
         with log_context(
             logging.INFO, f"Open project in {product_url=} as {is_product_billable=}"
         ) as ctx:

--- a/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
+++ b/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
@@ -1,3 +1,12 @@
+# pylint: disable=logging-fstring-interpolation
+# pylint:disable=no-value-for-parameter
+# pylint:disable=protected-access
+# pylint:disable=redefined-outer-name
+# pylint:disable=too-many-arguments
+# pylint:disable=too-many-statements
+# pylint:disable=unused-argument
+# pylint:disable=unused-variable
+
 import json
 import logging
 import re
@@ -92,7 +101,7 @@ def test_response_surface_modeling(
     service_version: str | None,
     product_url: AnyUrl,
     is_service_legacy: bool,
-    create_function_from_project: Callable[..., dict[str, Any]],
+    create_function_from_project: Callable[[Page, str], dict[str, Any]],
 ):
     # 1. create the initial study with jsonifier
     with log_context(logging.INFO, "Create new study for function"):

--- a/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
+++ b/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
@@ -54,26 +54,26 @@ def test_response_surface_modeling(
         # create the probe
         page.get_by_test_id("connect_probe_btn_number_3").click()
 
-        # create the parameter
-        with page.expect_response(
-            re.compile(rf"/projects/{jsonifier_project_data['uuid']}/nodes")
-        ):
-            page.get_by_test_id("newNodeBtn").click()
-            page.get_by_placeholder("Filter").click()
-            page.get_by_placeholder("Filter").fill("number parameter")
-            page.get_by_placeholder("Filter").press("Enter")
+        # # create the parameter
+        # with page.expect_response(
+        #     re.compile(rf"/projects/{jsonifier_project_data['uuid']}/nodes")
+        # ):
+        #     page.get_by_test_id("newNodeBtn").click()
+        #     page.get_by_placeholder("Filter").click()
+        #     page.get_by_placeholder("Filter").fill("number parameter")
+        #     page.get_by_placeholder("Filter").press("Enter")
 
-        # connect the parameter
-        page.get_by_test_id("nodeTreeItem").filter(has_text="jsonifier").all()[
-            1
-        ].click()
-        page.get_by_test_id("connect_input_btn_number_1").click()
-        page.get_by_text("set existing parameter").nth(1).click()
-        page.wait_for_timeout(1000)
-        page.get_by_text("Number Parameter").click()
-        page.wait_for_timeout(5000)
+        # # connect the parameter
+        # page.get_by_test_id("nodeTreeItem").filter(has_text="jsonifier").all()[
+        #     1
+        # ].click()
         # page.get_by_test_id("connect_input_btn_number_1").click()
-        # page.get_by_text("new parameter").click()
+        # page.get_by_text("set existing parameter").nth(1).click()
+        # page.wait_for_timeout(1000)
+        # page.get_by_text("Number Parameter").click()
+        # page.wait_for_timeout(5000)
+        page.get_by_test_id("connect_input_btn_number_1").click()
+        page.get_by_text("new parameter").click()
 
         # rename the project to identify it
         page.get_by_test_id("nodesTree").first.click()

--- a/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
+++ b/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
@@ -45,18 +45,41 @@ def test_response_surface_modeling(
         ), "Expected workbench to be a dict!"
         node_ids: list[str] = list(jsonifier_project_data["workbench"])
         assert len(node_ids) == 1, "Expected 1 node in the workbench!"
-        # create the number parameter
-        page.get_by_test_id("newNodeBtn").click()
-        page.get_by_placeholder("Filter").click()
-        page.get_by_placeholder("Filter").fill("number parameter")
-        page.get_by_placeholder("Filter").press("Enter")
 
-        # connect the jsonifier to the parameter
-        page.get_by_test_id("nodeTreeItem").filter(has_text="jsonifier").click()
-        page.locator(
-            "body > div:nth-child(5) > div:nth-child(5) > div:nth-child(3) > div:nth-child(3) > div > div:nth-child(2) > div > div > div:nth-child(3) > div:nth-child(4) > div:nth-child(1) > div > div > div:nth-child(2) > div:nth-child(2) > div > div > div > div:nth-child(2) > div.qx-panelview-content > div > div:nth-child(18)"
+        # select the jsonifier, it's the second one as the study has the same name
+        page.get_by_test_id("nodeTreeItem").filter(has_text="jsonifier").all()[
+            1
+        ].click()
+
+        # create the probe
+        page.get_by_test_id("connect_probe_btn_number_3").click()
+
+        # create the parameter
+        with page.expect_response(
+            re.compile(rf"/projects/{jsonifier_project_data['uuid']}/nodes")
+        ):
+            page.get_by_test_id("newNodeBtn").click()
+            page.get_by_placeholder("Filter").click()
+            page.get_by_placeholder("Filter").fill("number parameter")
+            page.get_by_placeholder("Filter").press("Enter")
+
+        # connect the parameter
+        page.get_by_test_id("nodeTreeItem").filter(has_text="jsonifier").all()[
+            1
+        ].click()
+        page.get_by_test_id("connect_input_btn_number_1").click()
+        page.get_by_text("set existing parameter").nth(1).click()
+        page.get_by_text("set existing parameter").nth(1).filter(
+            has_text="number parameter"
         ).click()
+        page.wait_for_timeout(5000)
+        # page.get_by_test_id("connect_input_btn_number_1").click()
+        # page.get_by_text("new parameter").click()
 
+        # rename the project to identify it
+        page.get_by_test_id("nodesTree").first.click()
+        page.get_by_test_id("nodesTree").first.press("F2")
+        page.get_by_test_id("nodesTree").first.fill("RSM study")
     # 2. convert it to a function
     # 3. start a RSM with that function
 

--- a/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
+++ b/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
@@ -10,13 +10,15 @@ from pytest_simcore.helpers.playwright import (
     MINUTE,
     RobustWebSocket,
     ServiceType,
-    wait_for_service_running,
 )
 
 _WAITING_FOR_SERVICE_TO_START: Final[int] = 5 * MINUTE
+_WAITING_FOR_SERVICE_TO_APPEAR: Final[int] = 2 * MINUTE
 _DEFAULT_RESPONSE_TO_WAIT_FOR: Final[re.Pattern] = re.compile(
     r"/flask/list_function_job_collections_for_functionid"
 )
+
+_FUNCTION_NAME: Final[str] = "playwright_test_function"
 
 
 def test_response_surface_modeling(
@@ -30,31 +32,75 @@ def test_response_surface_modeling(
     product_url: AnyUrl,
     is_service_legacy: bool,
 ):
-    with (
-        log_context(
-            logging.INFO,
-            f"Waiting for {service_key} to be responsive (waiting for {_DEFAULT_RESPONSE_TO_WAIT_FOR})",
-        ),
-        page.expect_response(
-            _DEFAULT_RESPONSE_TO_WAIT_FOR, timeout=_WAITING_FOR_SERVICE_TO_START
-        ),
-    ):
-        project_data = create_project_from_service_dashboard(
-            ServiceType.DYNAMIC, service_key, None, service_version
+    # 1. create the initial study with jsonifier
+    with log_context(logging.INFO, "Create new study..."):
+        jsonifier_project_data = create_project_from_service_dashboard(
+            ServiceType.COMPUTATIONAL, "jsonifier", None, service_version
         )
-        assert "workbench" in project_data, "Expected workbench to be in project data!"
+        assert (
+            "workbench" in jsonifier_project_data
+        ), "Expected workbench to be in project data!"
         assert isinstance(
-            project_data["workbench"], dict
+            jsonifier_project_data["workbench"], dict
         ), "Expected workbench to be a dict!"
-        node_ids: list[str] = list(project_data["workbench"])
+        node_ids: list[str] = list(jsonifier_project_data["workbench"])
         assert len(node_ids) == 1, "Expected 1 node in the workbench!"
+        # create the number parameter
+        page.get_by_test_id("newNodeBtn").click()
+        page.get_by_placeholder("Filter").click()
+        page.get_by_placeholder("Filter").fill("number parameter")
+        page.get_by_placeholder("Filter").press("Enter")
 
-        wait_for_service_running(
-            page=page,
-            node_id=node_ids[0],
-            websocket=log_in_and_out,
-            timeout=_WAITING_FOR_SERVICE_TO_START,
-            press_start_button=False,
-            product_url=product_url,
-            is_service_legacy=is_service_legacy,
-        )
+        # connect the jsonifier to the parameter
+        page.get_by_test_id("nodeTreeItem").filter(has_text="jsonifier").click()
+        page.locator(
+            "body > div:nth-child(5) > div:nth-child(5) > div:nth-child(3) > div:nth-child(3) > div > div:nth-child(2) > div > div > div:nth-child(3) > div:nth-child(4) > div:nth-child(1) > div > div > div:nth-child(2) > div:nth-child(2) > div > div > div > div:nth-child(2) > div.qx-panelview-content > div > div:nth-child(18)"
+        ).click()
+
+    # 2. convert it to a function
+    # 3. start a RSM with that function
+
+    # with log_context(
+    #     logging.INFO,
+    #     f"Waiting for {service_key} to be responsive (waiting for {_DEFAULT_RESPONSE_TO_WAIT_FOR})",
+    # ):
+    #     project_data = create_project_from_service_dashboard(
+    #         ServiceType.DYNAMIC, service_key, None, service_version
+    #     )
+    #     assert "workbench" in project_data, "Expected workbench to be in project data!"
+    #     assert isinstance(project_data["workbench"], dict), (
+    #         "Expected workbench to be a dict!"
+    #     )
+    #     node_ids: list[str] = list(project_data["workbench"])
+    #     assert len(node_ids) == 1, "Expected 1 node in the workbench!"
+
+    #     wait_for_service_running(
+    #         page=page,
+    #         node_id=node_ids[0],
+    #         websocket=log_in_and_out,
+    #         timeout=_WAITING_FOR_SERVICE_TO_START,
+    #         press_start_button=False,
+    #         product_url=product_url,
+    #         is_service_legacy=is_service_legacy,
+    #     )
+
+    # service_iframe = page.frame_locator("iframe")
+    # with log_context(logging.INFO, "Waiting for the RSM to be ready..."):
+    #     service_iframe.get_by_role("grid").wait_for(
+    #         state="visible", timeout=_WAITING_FOR_SERVICE_TO_APPEAR
+    #     )
+
+    # # select the function
+    # service_iframe.get_by_role("gridcell", name=_FUNCTION_NAME).click()
+
+    # # Find the first input field (textbox) in the iframe
+    # min_input_field = service_iframe.get_by_role("textbox").nth(0)
+    # min_input_field.fill("1")
+    # max_input_field = service_iframe.get_by_role("textbox").nth(1)
+    # max_input_field.fill("10")
+
+    # # click on next
+    # service_iframe.get_by_role("button", name="Next").click()
+
+    # # then we wait a long time
+    # page.wait_for_timeout(1 * MINUTE)

--- a/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
+++ b/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
@@ -69,9 +69,8 @@ def test_response_surface_modeling(
         ].click()
         page.get_by_test_id("connect_input_btn_number_1").click()
         page.get_by_text("set existing parameter").nth(1).click()
-        page.get_by_text("set existing parameter").nth(1).filter(
-            has_text="number parameter"
-        ).click()
+        page.wait_for_timeout(1000)
+        page.get_by_text("Number Parameter").click()
         page.wait_for_timeout(5000)
         # page.get_by_test_id("connect_input_btn_number_1").click()
         # page.get_by_text("new parameter").click()


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
This PR brings:
- create a study with a Number Parameter --> Jsonifier --> Number Probe
- create a function out of it
- start mmux as a new project
- delete the projects and the function

Still needs:
- select in mmux the function
- run the function
- check for results

@alexpargon I would need some `osparc-test-id`  in the mmux frontend if possible


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/mmux_vite/issues/232

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
