### PR TITLE
🎨 Only run a single function at a time in map endpoint

### DIFF
--- a/services/api-server/src/simcore_service_api_server/api/routes/functions_routes.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/functions_routes.py
@@ -474,7 +474,7 @@ async def map_function(
             for function_inputs in function_inputs_list
         ],
         reraise=False,
-        limit=10,
+        limit=1,
     )
 
     # Check if any tasks raised exceptions and raise the first one found


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- Only trigger a single celery task at a time in map endpoint.
- After running load tests it is clear, that (for now) we must run the functions sequentially in the api-server's amp endpoint. Otherwise requests start failing. 
- This will make the map endpoint slow, but should increase robustness for now. 
- Future steps might be to use celery task groups or celery task map for this. Which should again increase performance
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
