### PR TITLE
🐛 Add `task_manager` to api-worker

### DIFF
--- a/services/api-server/src/simcore_service_api_server/core/application.py
+++ b/services/api-server/src/simcore_service_api_server/core/application.py
@@ -89,7 +89,7 @@ def create_app(settings: ApplicationSettings | None = None) -> FastAPI:
 
     setup_rabbitmq(app)
 
-    if settings.API_SERVER_CELERY and not settings.API_SERVER_WORKER_MODE:
+    if settings.API_SERVER_CELERY:
         setup_task_manager(app, settings.API_SERVER_CELERY)
 
     if app.state.settings.API_SERVER_PROMETHEUS_INSTRUMENTATION_ENABLED:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
- Since https://github.com/ITISFoundation/osparc-simcore/pull/8354 the `task_manager` is required inside the celery worker. (see here: https://github.com/ITISFoundation/osparc-simcore/blob/master/packages/celery-library/src/celery_library/task.py#L59). This PR adds the task_manager to the api-worker. 
- The latest merge request (https://github.com/ITISFoundation/osparc-simcore/pull/8352) concerning the api-worker was with this bug because the issue was introduced by merge conflicts. The unit tests which test the api-worker mock the task_manager so the issue was not detected. 
- It is not clear to me that it is advisable to have the `task_manager` dependency inside the celery-worker. Perhaps we can discuss today @giancarloromeo. But this PR adds to the api-worker anyway to make it functional for testing before the release.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
