### PR TITLE
🎨Computational backend: performance improvements step2 - autoscaling shall ask dask to retire nodes only if necessary

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_auto_scaling_core.py
@@ -1215,7 +1215,10 @@ async def _scale_down_unused_cluster_instances(
     cluster: Cluster,
     auto_scaling_mode: AutoscalingProvider,
 ) -> Cluster:
-    await auto_scaling_mode.try_retire_nodes(app)
+    if any(not instance.has_assigned_tasks() for instance in cluster.active_nodes):
+        # ask the provider to try to retire nodes actively
+        with log_catch(_logger, reraise=False):
+            await auto_scaling_mode.try_retire_nodes(app)
     cluster = await _deactivate_empty_nodes(app, cluster)
     return await _try_scale_down_cluster(app, cluster)
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- The autoscaling service is asking the dask-backend to "retire workers" if possible
- the dask-backend provides this API but it was observed that some workers do not have the time to access their jobs before being forcefully retired
- --> this creates a situation where workers are added and removed continuously
- --> this makes large computations sometimes less efficient as workers cannot take jobs since they are retired right away

This PR only will call that API when the autoscaling estimates that the current workers are not all needed to cover the jobs needs, making it less eager to remove workers.

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
