### PR TITLE
🐛RabbitMQ client: prevent crashing consumer if channel is closed

### DIFF
--- a/packages/service-library/src/servicelib/rabbitmq/_client.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client.py
@@ -118,6 +118,8 @@ async def _on_message(
                         message_handler, max_retries_upon_error, message
                     )
     except ChannelInvalidStateError as exc:
+        # NOTE: this error can happen as can be seen in aio-pika code
+        # see https://github.com/mosquito/aio-pika/blob/master/aio_pika/robust_queue.py
         _logger.exception(
             **create_troubleshooting_log_kwargs(
                 "Cannot process message because channel is closed. Message will be requeued by RabbitMQ",

--- a/packages/service-library/src/servicelib/rabbitmq/_client.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client.py
@@ -112,7 +112,6 @@ async def _on_message(
             )
             with log_catch(_logger, reraise=False):
                 await _nack_message(message_handler, max_retries_upon_error, message)
-            raise
 
 
 @dataclass

--- a/packages/service-library/src/servicelib/rabbitmq/_client.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client.py
@@ -97,7 +97,7 @@ async def _on_message(
                     await _nack_message(
                         message_handler, max_retries_upon_error, message
                     )
-        except Exception as exc:
+        except Exception as exc:  # pylint: disable=broad-exception-caught
             _logger.exception(
                 **create_troubleshooting_log_kwargs(
                     "Unhandled exception raised in message handler or when nacking message",

--- a/packages/service-library/src/servicelib/rabbitmq/_client.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client.py
@@ -105,7 +105,7 @@ async def _on_message(
                     error_context={
                         "message_id": message.message_id,
                         "message_body": message.body,
-                        "message_handler": message_handler.__name__,
+                        "message_handler": f"{message_handler}",
                     },
                     tip="This could indicate an error in the message handler, please check the message handler code",
                 )

--- a/packages/service-library/src/servicelib/redis/_constants.py
+++ b/packages/service-library/src/servicelib/redis/_constants.py
@@ -3,6 +3,9 @@ from typing import Final
 
 from pydantic import NonNegativeInt
 
+DEFAULT_EXPECTED_LOCK_OVERALL_TIME: Final[datetime.timedelta] = datetime.timedelta(
+    seconds=30
+)
 DEFAULT_LOCK_TTL: Final[datetime.timedelta] = datetime.timedelta(seconds=10)
 DEFAULT_SOCKET_TIMEOUT: Final[datetime.timedelta] = datetime.timedelta(seconds=30)
 

--- a/packages/service-library/src/servicelib/redis/_decorators.py
+++ b/packages/service-library/src/servicelib/redis/_decorators.py
@@ -14,7 +14,7 @@ from redis.asyncio.lock import Lock
 
 from ..background_task import periodic
 from ._client import RedisClientSDK
-from ._constants import DEFAULT_LOCK_TTL
+from ._constants import DEFAULT_EXPECTED_LOCK_OVERALL_TIME, DEFAULT_LOCK_TTL
 from ._errors import CouldNotAcquireLockError, LockLostError
 from ._utils import auto_extend_lock
 
@@ -95,6 +95,7 @@ def exclusive(
             ):
                 raise CouldNotAcquireLockError(lock=lock)
 
+            lock_acquisition_time = arrow.utcnow()
             try:
                 async with asyncio.TaskGroup() as tg:
                     started_event = asyncio.Event()
@@ -157,6 +158,19 @@ def exclusive(
                             "Look for synchronous code that prevents refreshing the lock or asyncio loop overload.",
                         )
                     )
+                finally:
+                    lock_release_time = arrow.utcnow()
+                    locking_time = lock_release_time - lock_acquisition_time
+                    if locking_time > DEFAULT_EXPECTED_LOCK_OVERALL_TIME:
+                        _logger.warning(
+                            "Lock `%s'for %s was held for %s which is longer than the expected (%s). "
+                            "TIP: consider reducing the locking time by optimizing the code inside "
+                            "the critical section or increasing the default locking time",
+                            redis_lock_key,
+                            coro.__name__,
+                            locking_time,
+                            DEFAULT_EXPECTED_LOCK_OVERALL_TIME,
+                        )
 
         return _wrapper
 

--- a/packages/service-library/src/servicelib/redis/_decorators.py
+++ b/packages/service-library/src/servicelib/redis/_decorators.py
@@ -163,7 +163,7 @@ def exclusive(
                     locking_time = lock_release_time - lock_acquisition_time
                     if locking_time > DEFAULT_EXPECTED_LOCK_OVERALL_TIME:
                         _logger.warning(
-                            "Lock `%s'for %s was held for %s which is longer than the expected (%s). "
+                            "Lock `%s' for %s was held for %s which is longer than the expected (%s). "
                             "TIP: consider reducing the locking time by optimizing the code inside "
                             "the critical section or increasing the default locking time",
                             redis_lock_key,

--- a/packages/service-library/src/servicelib/redis/_semaphore_decorator.py
+++ b/packages/service-library/src/servicelib/redis/_semaphore_decorator.py
@@ -7,12 +7,14 @@ from collections.abc import AsyncIterator, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any, ParamSpec, TypeVar
 
+import arrow
 from common_library.async_tools import cancel_wait_task
 from common_library.logging.logging_errors import create_troubleshooting_log_kwargs
 
 from ..background_task import periodic
 from ._client import RedisClientSDK
 from ._constants import (
+    DEFAULT_EXPECTED_LOCK_OVERALL_TIME,
     DEFAULT_SEMAPHORE_TTL,
     DEFAULT_SOCKET_TIMEOUT,
 )
@@ -42,6 +44,7 @@ async def _managed_semaphore_execution(
     if not await semaphore.acquire():
         raise SemaphoreAcquisitionError(name=semaphore_key, capacity=semaphore.capacity)
 
+    lock_acquisition_time = arrow.utcnow()
     try:
         # NOTE: Use TaskGroup for proper exception propagation, this ensures that in case of error the context manager will be properly exited
         # and the semaphore released.
@@ -100,6 +103,18 @@ async def _managed_semaphore_execution(
                     "Look for synchronous code that prevents refreshing the semaphore or asyncio loop overload.",
                 )
             )
+        finally:
+            lock_release_time = arrow.utcnow()
+            locking_time = lock_release_time - lock_acquisition_time
+            if locking_time > DEFAULT_EXPECTED_LOCK_OVERALL_TIME:
+                _logger.warning(
+                    "Semaphore '%s' was held for %s which is longer than expected (%s). "
+                    "TIP: consider reducing the locking time by optimizing the code inside "
+                    "the critical section or increasing the default locking time",
+                    semaphore_key,
+                    locking_time,
+                    DEFAULT_EXPECTED_LOCK_OVERALL_TIME,
+                )
 
 
 def _create_semaphore(

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq.py
@@ -314,7 +314,7 @@ async def test_subscribe_always_returns_fails_stops(
 
 
 @pytest.mark.parametrize("topics", _TOPICS)
-@pytest.mark.no_cleanup_check_rabbitmq_server_has_no_errors()
+@pytest.mark.no_cleanup_check_rabbitmq_server_has_no_errors
 async def test_publish_with_no_registered_subscriber(
     on_message_spy: mock.Mock,
     create_rabbitmq_client: Callable[[str], RabbitMQClient],
@@ -476,7 +476,7 @@ async def test_rabbit_client_pub_sub_republishes_if_exception_raised(
 
 @pytest.fixture
 async def ensure_queue_deletion(
-    create_rabbitmq_client: Callable[[str], RabbitMQClient]
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
 ) -> AsyncIterator[Callable[[QueueName], None]]:
     created_queues = set()
 
@@ -723,7 +723,7 @@ async def test_rabbit_adding_topics_to_a_fanout_exchange(
     await _assert_message_received(mocked_message_parser, 0)
 
 
-@pytest.mark.no_cleanup_check_rabbitmq_server_has_no_errors()
+@pytest.mark.no_cleanup_check_rabbitmq_server_has_no_errors
 async def test_rabbit_not_using_the_same_exchange_type_raises(
     create_rabbitmq_client: Callable[[str], RabbitMQClient],
     random_exchange_name: Callable[[], str],
@@ -738,7 +738,7 @@ async def test_rabbit_not_using_the_same_exchange_type_raises(
         await client.subscribe(exchange_name, mocked_message_parser, topics=[])
 
 
-@pytest.mark.no_cleanup_check_rabbitmq_server_has_no_errors()
+@pytest.mark.no_cleanup_check_rabbitmq_server_has_no_errors
 async def test_unsubscribe_consumer(
     create_rabbitmq_client: Callable[[str], RabbitMQClient],
     random_exchange_name: Callable[[], str],

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -249,9 +249,9 @@ class DaskClient:
                 self.backend.client.publish_dataset(task_future, name=job_id)
             )
 
-            _logger.debug(
+            _logger.info(
                 "Dask task %s started [%s]",
-                f"{task_future.key=}",
+                f"{job_id=}",
                 f"{node_image.command=}",
             )
             return PublishedComputationTask(node_id=node_id, job_id=DaskJobID(job_id))


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request introduces improvements to logging and error handling in both the RabbitMQ and Redis modules.

* **Redis**: adds monitoring for lock and semaphore holding times. 
The changes aim to provide more actionable and structured logs for troubleshooting, and to help detect and warn about potential performance bottlenecks related to lock/semaphore usage. Minor test and logging adjustments are also included. It is expected to see some warnings appear when the expected time a lock is held is exceeded. Some further adjustments will be needed to silence the warnings that are unnecessary.
* **Rabbit**: use structured logs for connections/channel closing callbacks and unhandled exceptions in message handling. Also handle the ChannelClosed issue during a message similarly as in aio-pika itself.


**Lock and Semaphore Monitoring:**

* Added `DEFAULT_EXPECTED_LOCK_OVERALL_TIME` constant and logic to warn if Redis locks or semaphores are held longer than expected, helping to identify performance issues or code that holds resources too long. 

These changes improve observability, make troubleshooting easier, and help proactively detect resource contention issues.
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/8379
- relates to https://github.com/ITISFoundation/private-issues/issues/10

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
