### PR TITLE
🐛Computational backend: fix issue where job_id is inexistent + logs improvements

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_auto_scaling_core.py
@@ -575,8 +575,8 @@ def _try_assign_task_to_ec2_instance(
             _logger.debug(
                 "%s",
                 f"assigned task with {task_required_resources=}, {task_required_ec2_instance=} to "
-                f"{instance.ec2_instance.id=}:{instance.ec2_instance.type}, "
-                f"remaining resources:{instance.available_resources}/{instance.ec2_instance.resources}",
+                f"{instance.ec2_instance.id=}:{instance.ec2_instance.type=}, "
+                f"{instance.available_resources=}, {instance.ec2_instance.resources=}",
             )
             return True
     return False
@@ -599,8 +599,8 @@ def _try_assign_task_to_ec2_instance_type(
             _logger.debug(
                 "%s",
                 f"assigned task with {task_required_resources=}, {task_required_ec2_instance=} to "
-                f"{instance.instance_type}, "
-                f"remaining resources:{instance.available_resources}/{instance.instance_type.resources}",
+                f"{instance.instance_type=}, "
+                f"{instance.available_resources=}, {instance.instance_type.resources=}",
             )
             return True
     return False
@@ -1217,7 +1217,10 @@ async def _scale_down_unused_cluster_instances(
 ) -> Cluster:
     if any(not instance.has_assigned_tasks() for instance in cluster.active_nodes):
         # ask the provider to try to retire nodes actively
-        with log_catch(_logger, reraise=False):
+        with (
+            log_catch(_logger, reraise=False),
+            log_context(_logger, logging.INFO, "actively ask to retire unused nodes"),
+        ):
             await auto_scaling_mode.try_retire_nodes(app)
     cluster = await _deactivate_empty_nodes(app, cluster)
     return await _try_scale_down_cluster(app, cluster)

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -528,8 +528,8 @@ class DaskScheduler(BaseCompScheduler):
         ):
             log_error_context = {
                 "user_id": comp_run.user_id,
-                "project_id": comp_run.project_uuid,
-                "node_id": task.current.node_id,
+                "project_id": f"{comp_run.project_uuid}",
+                "node_id": f"{task.current.node_id}",
                 "job_id": task.current.job_id,
             }
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
@@ -42,16 +42,12 @@ class CompPipelinesRepository(BaseRepository):
             **pipeline_at_db.model_dump(mode="json", by_alias=True)
         )
         # FIXME: This is not a nice thing. this part of the information should be kept in comp_runs.
-        update_exclusion_policy = set()
-        if not dag_graph.nodes():
-            update_exclusion_policy.add("dag_adjacency_list")
         on_update_stmt = insert_stmt.on_conflict_do_update(
             index_elements=[comp_pipeline.c.project_id],
             set_=pipeline_at_db.model_dump(
                 mode="json",
                 by_alias=True,
                 exclude_unset=True,
-                exclude=update_exclusion_policy,
             ),
         )
         async with self.db_engine.begin() as conn:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
sometimes the `job_id` is None and that was not seen during latest refactoring actions.
This PR fixes this and improves logging in some specific locations.
This PR also ensure the `comp_pipeline` table is in sync when nodes are removed from the graph (revert https://github.com/ITISFoundation/osparc-simcore/pull/2702 in `comp_pipelines.py` discovered by @matusdrobuliak66 .
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
<img width="1783" height="490" alt="image" src="https://github.com/user-attachments/assets/7d27853f-8596-427e-9424-2d4cb9803d85" />


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
