### PR TITLE
🐛 [Frontend] Fix: Support group accessRights

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/TutorialBrowser.js
@@ -130,15 +130,6 @@ qx.Class.define("osparc.dashboard.TutorialBrowser", {
       }
     },
 
-    // overridden
-    _groupByChanged: function(groupBy) {
-      this.base(arguments, groupBy);
-
-      if (this._resourceFilter) {
-        this._resourceFilter.getChildControl("tags-layout").setVisibility(groupBy === "tags" ? "visible" : "excluded");
-      }
-    },
-
     __itemClicked: function(card) {
       if (!card.getBlocked()) {
         const templateData = this.__getTemplateData(card.getUuid());

--- a/services/static-webserver/client/source/class/osparc/store/Groups.js
+++ b/services/static-webserver/client/source/class/osparc/store/Groups.js
@@ -97,6 +97,11 @@ qx.Class.define("osparc.store.Groups", {
           const groupMe = this.__addToGroupsCache(resp["me"], "me");
           const orgs = {};
           resp["organizations"].forEach(organization => {
+            if (supportGroup && supportGroup.getGroupId() === organization["gid"]) {
+              // support group was already added to the cache, but it was missing the accessRights
+              // the accessRights come from the organization, update them
+              supportGroup.setAccessRights(organization["accessRights"]);
+            }
             const org = this.__addToGroupsCache(organization, "organization");
             orgs[org.getGroupId()] = org;
           });


### PR DESCRIPTION
## What do these changes do?

This PR fixes a bug where the support group's access rights were not being properly set. The issue occurred because the support group was added to the cache before its access rights were available, and these rights were only provided later when processing organization data.

Bonus:
- Tags filter always visible in the Tutorials tab, not only when they are grouped by tags

Buggy:
![Buggy](https://github.com/user-attachments/assets/44496305-757e-49ce-b512-5386022d20ab)

Fixed:
![Fixed](https://github.com/user-attachments/assets/075c60e5-3801-48e9-88c0-e22525d6bd3e)


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
