### PR TITLE
🎨 Increase function rpc call timeouts to 30sec

### DIFF
--- a/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/webserver/functions/functions_rpc_interface.py
+++ b/packages/service-library/src/servicelib/rabbitmq/rpc_interfaces/webserver/functions/functions_rpc_interface.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Literal
+from typing import Annotated, Literal
 
 from models_library.api_schemas_webserver import WEBSERVER_RPC_NAMESPACE
 from models_library.api_schemas_webserver.functions import (
@@ -32,12 +32,14 @@ from models_library.rabbitmq_basic_types import RPCMethodName
 from models_library.rest_ordering import OrderBy
 from models_library.rest_pagination import PageMetaInfoLimitOffset
 from models_library.users import UserID
-from pydantic import TypeAdapter
+from pydantic import PositiveInt, TypeAdapter
 
 from .....logging_utils import log_decorator
 from .... import RabbitMQRPCClient
 
 _logger = logging.getLogger(__name__)
+
+_FUNCTION_RPC_TIMEOUT_SEC: Annotated[int, PositiveInt] = 30
 
 
 @log_decorator(_logger, level=logging.DEBUG)
@@ -54,6 +56,7 @@ async def register_function(
         function=function,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(RegisteredFunction).validate_python(
         result
@@ -74,6 +77,7 @@ async def get_function(
         function_id=function_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(RegisteredFunction).validate_python(result)
 
@@ -92,6 +96,7 @@ async def get_function_input_schema(
         function_id=function_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(FunctionInputSchema).validate_python(result)
 
@@ -110,6 +115,7 @@ async def get_function_output_schema(
         function_id=function_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(FunctionOutputSchema).validate_python(result)
 
@@ -128,6 +134,7 @@ async def delete_function(
         function_id=function_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     assert result is None  # nosec
     return result
@@ -158,6 +165,7 @@ async def list_functions(
             filter_by_function_class=filter_by_function_class,
             search_by_function_title=search_by_function_title,
             search_by_multi_columns=search_by_multi_columns,
+            timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
         )
     )
     return TypeAdapter(
@@ -188,6 +196,7 @@ async def list_function_jobs(
             filter_by_function_id=filter_by_function_id,
             filter_by_function_job_ids=filter_by_function_job_ids,
             filter_by_function_job_collection_id=filter_by_function_job_collection_id,
+            timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
         )
     )
     return TypeAdapter(
@@ -220,6 +229,7 @@ async def list_function_jobs_with_status(
         filter_by_function_id=filter_by_function_id,
         filter_by_function_job_ids=filter_by_function_job_ids,
         filter_by_function_job_collection_id=filter_by_function_job_collection_id,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(
         tuple[
@@ -247,6 +257,7 @@ async def list_function_job_collections(
         filters=filters,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(
         tuple[list[RegisteredFunctionJobCollection], PageMetaInfoLimitOffset]
@@ -269,6 +280,7 @@ async def update_function_title(
         title=title,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(RegisteredFunction).validate_python(result)
 
@@ -289,6 +301,7 @@ async def update_function_description(
         description=description,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(RegisteredFunction).validate_python(result)
 
@@ -309,6 +322,7 @@ async def run_function(
         inputs=inputs,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(RegisteredFunctionJob).validate_python(
         result
@@ -329,6 +343,7 @@ async def register_function_job(
         function_job=function_job,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(RegisteredFunctionJob).validate_python(
         result
@@ -351,6 +366,7 @@ async def patch_registered_function_job(
         product_name=product_name,
         function_job_uuid=function_job_uuid,
         registered_function_job_patch=registered_function_job_patch,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(RegisteredFunctionJob).validate_python(
         result
@@ -371,6 +387,7 @@ async def get_function_job(
         function_job_id=function_job_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
 
     return TypeAdapter(RegisteredFunctionJob).validate_python(result)
@@ -390,6 +407,7 @@ async def get_function_job_status(
         function_job_id=function_job_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(FunctionJobStatus).validate_python(result)
 
@@ -408,6 +426,7 @@ async def get_function_job_outputs(
         function_job_id=function_job_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(FunctionOutputs).validate_python(result)
 
@@ -430,6 +449,7 @@ async def update_function_job_status(
         user_id=user_id,
         product_name=product_name,
         check_write_permissions=check_write_permissions,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(FunctionJobStatus).validate_python(result)
 
@@ -452,6 +472,7 @@ async def update_function_job_outputs(
         user_id=user_id,
         product_name=product_name,
         check_write_permissions=check_write_permissions,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(FunctionOutputs).validate_python(result)
 
@@ -470,6 +491,7 @@ async def delete_function_job(
         function_job_id=function_job_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     assert result is None  # nosec
 
@@ -490,6 +512,7 @@ async def find_cached_function_jobs(
         inputs=inputs,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     if result is None:
         return None
@@ -510,6 +533,7 @@ async def register_function_job_collection(
         function_job_collection=function_job_collection,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(RegisteredFunctionJobCollection).validate_python(result)
 
@@ -528,6 +552,7 @@ async def get_function_job_collection(
         function_job_collection_id=function_job_collection_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(RegisteredFunctionJobCollection).validate_python(result)
 
@@ -546,6 +571,7 @@ async def delete_function_job_collection(
         function_job_collection_id=function_job_collection_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     assert result is None  # nosec
 
@@ -564,6 +590,7 @@ async def get_function_user_permissions(
         function_id=function_id,
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(FunctionUserAccessRights).validate_python(result)
 
@@ -582,6 +609,7 @@ async def get_functions_user_api_access_rights(
         ),
         user_id=user_id,
         product_name=product_name,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(FunctionUserApiAccessRights).validate_python(result)
 
@@ -614,6 +642,7 @@ async def set_group_permissions(
         read=read,
         write=write,
         execute=execute,
+        timeout_s=_FUNCTION_RPC_TIMEOUT_SEC,
     )
     return TypeAdapter(
         list[tuple[FunctionID | FunctionJobID, FunctionGroupAccessRights]]


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- Increase the function rpc timeouts to 30sec. See the issue below for the motivation for doing so.
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- closes #8439 

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
