### PR TITLE
Potential fix for code scanning alert no. 96: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/packages/models-library/src/models_library/rpc/webserver/auth/api_keys.py
+++ b/packages/models-library/src/models_library/rpc/webserver/auth/api_keys.py
@@ -16,13 +16,23 @@ _KEY_LEN: Final = 10
 _SECRET_LEN: Final = 20
 
 
+# Application-wide pepper/salt for PBKDF2 (should ideally be kept secret and configurable)
+_API_KEY_PEPPER: Final = b"models-library-api-key-pepper-CHANGE_ME"
+_API_KEY_HASH_ITERATIONS: Final = 100_000
+
 def generate_api_key_prefix(name: str) -> str:
     return _PUNCTUATION_REGEX.sub("_", name[:5])
 
 
 def generate_unique_api_key(name: str, length: int = _KEY_LEN) -> str:
     prefix = generate_api_key_prefix(name)
-    hashed = hashlib.sha256(name.encode()).hexdigest()
+    # Use PBKDF2-HMAC-SHA256 with an application-wide pepper (salt) and high iteration count
+    hashed = hashlib.pbkdf2_hmac(
+        "sha256", 
+        name.encode(), 
+        _API_KEY_PEPPER, 
+        _API_KEY_HASH_ITERATIONS,
+    ).hex()
     return f"{prefix}_{hashed[:length]}"
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/ITISFoundation/osparc-simcore/security/code-scanning/96](https://github.com/ITISFoundation/osparc-simcore/security/code-scanning/96)

To fix this issue, use a password/secret hashing function for generating API keys based on user input if they are intended as secrets or authentication tokens (i.e., if knowledge of the key grants access). Strong choices are Argon2, bcrypt, or PBKDF2. Since deterministic generation is needed (so the same name generates the same key), PBKDF2 is the most practical among these, allowing a fixed secret salt (ideally not public) to be set. If stricter determinism without secret salt is required, we may use SHA-2 (SHA-256/512), but only if the API key isn't used as a credential (which is discouraged). For best security, switch to PBKDF2 using your own application-wide salt (hardcoded or configurable, but never exposed to users).

Therefore, replace the SHA256 hashing with PBKDF2 using a strong ("pepper") salt and an appropriately high number of iterations for reasonable computational expense. Make sure to import and use `hashlib.pbkdf2_hmac`.

**Changes required:**
1. Add an application pepper/salt constant at the top of the file.
2. Replace the `hashlib.sha256(name.encode()).hexdigest()` call with a PBKDF2-HMAC using SHA256 and the constant salt, with a high `iterations` parameter.
3. Import `os` if needed for salt (or simply declare a constant).
4. Add any necessary imports (`hashlib.pbkdf2_hmac` is available from Python standard library ≥3.4).
5. Ensure the generated key part is hex-encoded and truncated same as before.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
