### PR TITLE
🔒️ Potential fix for code scanning alert no. 95: Clear-text logging of sensitive information

### DIFF
--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
@@ -20,10 +20,7 @@ _logger = logging.getLogger(__name__)
 
 async def _prune_expired_api_keys(app: web.Application):
     if deleted := await api_keys_service.prune_expired_api_keys(app):
-        # broadcast force logout of user_id
-        for _ in deleted:
-            _logger.info("Expired API key was removed")
-
+        _logger.info("%d expired API keys were removed", len(deleted))
     else:
         _logger.info("No API keys expired")
 

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
@@ -21,8 +21,8 @@ _logger = logging.getLogger(__name__)
 async def _prune_expired_api_keys(app: web.Application):
     if deleted := await api_keys_service.prune_expired_api_keys(app):
         # broadcast force logout of user_id
-        for api_key in deleted:
-            _logger.info("API-key %s expired and was removed", f"{api_key=}")
+        for _ in deleted:
+            _logger.info("Expired API key was removed")
 
     else:
         _logger.info("No API keys expired")


### PR DESCRIPTION
Potential fix for [https://github.com/ITISFoundation/osparc-simcore/security/code-scanning/95](https://github.com/ITISFoundation/osparc-simcore/security/code-scanning/95)

To fix this problem, we should ensure that no sensitive credential data (e.g., API keys, secrets, tokens) is directly logged. Instead, log only identifying but non-sensitive information about the expired/removed API keys, such as their database IDs, associated user IDs, display names, or generic counts. Specifically, in `services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py`, line 25 currently logs the variable `api_key` in full. 

The fix involves:
- Editing line 25 to avoid logging the full API key value.
- Use available metadata if possible (such as a display name, if that's present in the list instead).
- If only API key values are available, replace the full log with a generic message (e.g., logging just the count, or obfuscating part of the key—e.g., log a truncated or masked version).
- If project context allows, logging the API key's display name or database ID is safe.

You will edit line 25 in `_tasks_api_keys.py` to something like:
  ```python
  _logger.info("Expired API key was removed")
  ```
Or, if safe and possible, log identifying metadata, e.g.:
  ```python
  _logger.info("API-key with display name '%s' expired and was removed", api_key.display_name)
  ```
But, as only the API key or name string is available, safest is to avoid logging the key string.

No imports or method definitions are required unless additional metadata needs fetching. Use only the shown code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
