### PR TITLE
🐛 Fix performance issue when listing files filtering on projects

### DIFF
--- a/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
+++ b/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
@@ -94,6 +94,12 @@ def _list_filter_with_partial_file_id_stmt(
                 ),
             )
         )
+    else:
+        project_ids = user_or_project_filter.project_ids
+        if project_ids:
+            conditions.append(
+                file_meta_data.c.project_id.in_(f"{_}" for _ in project_ids)
+            )
 
     # Optional filters
     if file_id_prefix:

--- a/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
+++ b/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
@@ -96,7 +96,7 @@ def _list_filter_with_partial_file_id_stmt(
         )
     else:
         project_ids = user_or_project_filter.project_ids
-        if project_ids:
+        if len(project_ids) > 0:
             conditions.append(
                 file_meta_data.c.project_id.in_(f"{_}" for _ in project_ids)
             )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
- Fix a clause in storage when filtering on wither user_id or project_ids. 
- The bug is that when `UserOrProjectFilter.user_id == None` then the filtering on `project_id`s is not taken into account. This PR fixes that.
- Note that this fix only affects the case `user_id==None` which can only ever happen here: https://github.com/ITISFoundation/osparc-simcore/blob/master/services/storage/src/simcore_service_storage/simcore_s3_dsm.py#L363. And as can be seen from the logic there this will happen only when `project_id is not None`. In that case we need to to use the SQL index on the `project_id` column in the file_meta_data table to do the search.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- https://github.com/ITISFoundation/osparc-simcore/issues/8438#issuecomment-3355390684

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
