### PR TITLE
♻️ Refactor: migrate more `aiohttp` app keys to type-safe `web.AppKey` (follow up)

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/__init__.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/__init__.py
@@ -1,3 +1,4 @@
 from . import server
+from ._request import RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY
 
-__all__ = ("server",)
+__all__ = ("server", "RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY")

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/__init__.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/__init__.py
@@ -1,4 +1,7 @@
 from . import server
 from ._request import LONG_RUNNING_TASKS_CONTEXT_REQKEY
 
-__all__ = ("server", "LONG_RUNNING_TASKS_CONTEXT_REQKEY")
+__all__: tuple[str, ...] = (
+    "server",
+    "LONG_RUNNING_TASKS_CONTEXT_REQKEY",
+)

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/__init__.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/__init__.py
@@ -1,4 +1,4 @@
 from . import server
-from ._request import RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY
+from ._request import LONG_RUNNING_TASKS_CONTEXT_REQKEY
 
-__all__ = ("server", "RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY")
+__all__ = ("server", "LONG_RUNNING_TASKS_CONTEXT_REQKEY")

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_constants.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_constants.py
@@ -3,9 +3,7 @@ from typing import Final
 from pydantic import PositiveFloat
 
 MINUTE: Final[PositiveFloat] = 60
-APP_LONG_RUNNING_MANAGER_KEY: Final[str] = (
-    f"{__name__ }.long_running_tasks.tasks_manager"
-)
+
 RQT_LONG_RUNNING_TASKS_CONTEXT_KEY: Final[str] = (
     f"{__name__}.long_running_tasks.context"
 )

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_constants.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_constants.py
@@ -3,7 +3,3 @@ from typing import Final
 from pydantic import PositiveFloat
 
 MINUTE: Final[PositiveFloat] = 60
-
-RQT_LONG_RUNNING_TASKS_CONTEXT_KEY: Final[str] = (
-    f"{__name__}.long_running_tasks.context"
-)

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_manager.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_manager.py
@@ -14,10 +14,10 @@ class AiohttpLongRunningManager(LongRunningManager):
         return get_task_context(request)
 
 
-APP_LONG_RUNNING_MANAGER_APPKEY: Final = web.AppKey(
-    "APP_LONG_RUNNING_MANAGER", AiohttpLongRunningManager
+LONG_RUNNING_MANAGER_APPKEY: Final = web.AppKey(
+    "LONG_RUNNING_MANAGER", AiohttpLongRunningManager
 )
 
 
 def get_long_running_manager(app: web.Application) -> AiohttpLongRunningManager:
-    return app[APP_LONG_RUNNING_MANAGER_APPKEY]
+    return app[LONG_RUNNING_MANAGER_APPKEY]

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_manager.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_manager.py
@@ -1,8 +1,9 @@
+from typing import Final
+
 from aiohttp import web
 
 from ...long_running_tasks.manager import LongRunningManager
 from ...long_running_tasks.models import TaskContext
-from ._constants import APP_LONG_RUNNING_MANAGER_KEY
 from ._request import get_task_context
 
 
@@ -13,6 +14,10 @@ class AiohttpLongRunningManager(LongRunningManager):
         return get_task_context(request)
 
 
+APP_LONG_RUNNING_MANAGER_APPKEY: Final = web.AppKey(
+    "APP_LONG_RUNNING_MANAGER", AiohttpLongRunningManager
+)
+
+
 def get_long_running_manager(app: web.Application) -> AiohttpLongRunningManager:
-    output: AiohttpLongRunningManager = app[APP_LONG_RUNNING_MANAGER_KEY]
-    return output
+    return app[APP_LONG_RUNNING_MANAGER_APPKEY]

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_request.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_request.py
@@ -2,10 +2,9 @@ from typing import Any, Final
 
 from aiohttp import web
 
-RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY: Final = web.AppKey(
-    "RQT_LONG_RUNNING_TASKS_CONTEXT", dict[str, Any]
-)
+LONG_RUNNING_TASKS_CONTEXT_REQKEY: Final = f"{__name__}.LONG_RUNNING_TASKS_CONTEXT"
 
 
 def get_task_context(request: web.Request) -> dict[str, Any]:
-    return request[RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY]
+    ctx: dict[str, Any] = request[LONG_RUNNING_TASKS_CONTEXT_REQKEY]
+    return ctx

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_request.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_request.py
@@ -2,7 +2,7 @@ from typing import Any, Final
 
 from aiohttp import web
 
-LONG_RUNNING_TASKS_CONTEXT_REQKEY: Final = f"{__name__}.LONG_RUNNING_TASKS_CONTEXT"
+LONG_RUNNING_TASKS_CONTEXT_REQKEY: Final = f"{__name__}.long_running_tasks.context"
 
 
 def get_task_context(request: web.Request) -> dict[str, Any]:

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_request.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_request.py
@@ -1,10 +1,11 @@
-from typing import Any
+from typing import Any, Final
 
 from aiohttp import web
 
-from ._constants import RQT_LONG_RUNNING_TASKS_CONTEXT_KEY
+RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY: Final = web.AppKey(
+    "RQT_LONG_RUNNING_TASKS_CONTEXT", dict[str, Any]
+)
 
 
 def get_task_context(request: web.Request) -> dict[str, Any]:
-    output: dict[str, Any] = request[RQT_LONG_RUNNING_TASKS_CONTEXT_KEY]
-    return output
+    return request[RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY]

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
@@ -29,14 +29,14 @@ from ...long_running_tasks.models import (
 )
 from ..typing_extension import Handler
 from . import _routes
-from ._constants import (
-    RQT_LONG_RUNNING_TASKS_CONTEXT_KEY,
-)
 from ._error_handlers import base_long_running_error_handler
 from ._manager import (
     APP_LONG_RUNNING_MANAGER_APPKEY,
     AiohttpLongRunningManager,
     get_long_running_manager,
+)
+from ._request import (
+    RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY,
 )
 
 
@@ -47,7 +47,7 @@ def _no_ops_decorator(handler: Handler):
 def _no_task_context_decorator(handler: Handler):
     @wraps(handler)
     async def _wrap(request: web.Request):
-        request[RQT_LONG_RUNNING_TASKS_CONTEXT_KEY] = {}
+        request[RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY] = {}
         return await handler(request)
 
     return _wrap

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
@@ -36,7 +36,7 @@ from ._manager import (
     get_long_running_manager,
 )
 from ._request import (
-    RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY,
+    LONG_RUNNING_TASKS_CONTEXT_REQKEY,
 )
 
 
@@ -47,7 +47,7 @@ def _no_ops_decorator(handler: Handler):
 def _no_task_context_decorator(handler: Handler):
     @wraps(handler)
     async def _wrap(request: web.Request):
-        request[RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY] = {}
+        request[LONG_RUNNING_TASKS_CONTEXT_REQKEY] = {}
         return await handler(request)
 
     return _wrap

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
@@ -31,7 +31,7 @@ from ..typing_extension import Handler
 from . import _routes
 from ._error_handlers import base_long_running_error_handler
 from ._manager import (
-    APP_LONG_RUNNING_MANAGER_APPKEY,
+    LONG_RUNNING_MANAGER_APPKEY,
     AiohttpLongRunningManager,
     get_long_running_manager,
 )
@@ -181,7 +181,7 @@ def setup(
         app.middlewares.append(base_long_running_error_handler)
 
         # add components to state
-        app[APP_LONG_RUNNING_MANAGER_APPKEY] = long_running_manager = (
+        app[LONG_RUNNING_MANAGER_APPKEY] = long_running_manager = (
             AiohttpLongRunningManager(
                 stale_task_check_interval=stale_task_check_interval,
                 stale_task_detect_timeout=stale_task_detect_timeout,

--- a/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
+++ b/packages/service-library/src/servicelib/aiohttp/long_running_tasks/_server.py
@@ -30,11 +30,14 @@ from ...long_running_tasks.models import (
 from ..typing_extension import Handler
 from . import _routes
 from ._constants import (
-    APP_LONG_RUNNING_MANAGER_KEY,
     RQT_LONG_RUNNING_TASKS_CONTEXT_KEY,
 )
 from ._error_handlers import base_long_running_error_handler
-from ._manager import AiohttpLongRunningManager, get_long_running_manager
+from ._manager import (
+    APP_LONG_RUNNING_MANAGER_APPKEY,
+    AiohttpLongRunningManager,
+    get_long_running_manager,
+)
 
 
 def _no_ops_decorator(handler: Handler):
@@ -178,7 +181,7 @@ def setup(
         app.middlewares.append(base_long_running_error_handler)
 
         # add components to state
-        app[APP_LONG_RUNNING_MANAGER_KEY] = long_running_manager = (
+        app[APP_LONG_RUNNING_MANAGER_APPKEY] = long_running_manager = (
             AiohttpLongRunningManager(
                 stale_task_check_interval=stale_task_check_interval,
                 stale_task_detect_timeout=stale_task_detect_timeout,

--- a/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_with_task_context.py
+++ b/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_with_task_context.py
@@ -19,8 +19,8 @@ from aiohttp.test_utils import TestClient
 from pydantic import TypeAdapter, create_model
 from pytest_simcore.helpers.assert_checks import assert_status
 from servicelib.aiohttp import long_running_tasks, status
-from servicelib.aiohttp.long_running_tasks._server import (
-    RQT_LONG_RUNNING_TASKS_CONTEXT_KEY,
+from servicelib.aiohttp.long_running_tasks._request import (
+    RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY,
 )
 from servicelib.aiohttp.requests_validation import parse_request_query_parameters_as
 from servicelib.aiohttp.rest_middlewares import append_rest_middlewares
@@ -56,7 +56,7 @@ def task_context_decorator(task_context: TaskContext):
         ) -> web.StreamResponse:
             """this task context callback tries to get the user_id from the query if available"""
             query_param = parse_request_query_parameters_as(query_model, request)
-            request[RQT_LONG_RUNNING_TASKS_CONTEXT_KEY] = query_param.model_dump()
+            request[RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY] = query_param.model_dump()
             return await handler(request)
 
         return _test_task_context_decorator

--- a/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_with_task_context.py
+++ b/packages/service-library/tests/aiohttp/long_running_tasks/test_long_running_tasks_with_task_context.py
@@ -20,7 +20,7 @@ from pydantic import TypeAdapter, create_model
 from pytest_simcore.helpers.assert_checks import assert_status
 from servicelib.aiohttp import long_running_tasks, status
 from servicelib.aiohttp.long_running_tasks._request import (
-    RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY,
+    LONG_RUNNING_TASKS_CONTEXT_REQKEY,
 )
 from servicelib.aiohttp.requests_validation import parse_request_query_parameters_as
 from servicelib.aiohttp.rest_middlewares import append_rest_middlewares
@@ -56,7 +56,7 @@ def task_context_decorator(task_context: TaskContext):
         ) -> web.StreamResponse:
             """this task context callback tries to get the user_id from the query if available"""
             query_param = parse_request_query_parameters_as(query_model, request)
-            request[RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY] = query_param.model_dump()
+            request[LONG_RUNNING_TASKS_CONTEXT_REQKEY] = query_param.model_dump()
             return await handler(request)
 
         return _test_task_context_decorator

--- a/services/web/server/src/simcore_service_webserver/long_running_tasks/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/long_running_tasks/plugin.py
@@ -30,7 +30,9 @@ def webserver_request_context_decorator(handler: Handler):
     ) -> web.StreamResponse:
         """this task context callback tries to get the user_id from the query if available"""
         req_ctx = AuthenticatedRequestContext.model_validate(request)
-        request[LONG_RUNNING_TASKS_CONTEXT_REQKEY] = req_ctx.model_dump(mode="json")
+        request[LONG_RUNNING_TASKS_CONTEXT_REQKEY] = req_ctx.model_dump(
+            mode="json", by_alias=True
+        )
         return await handler(request)
 
     return _test_task_context_decorator

--- a/services/web/server/src/simcore_service_webserver/long_running_tasks/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/long_running_tasks/plugin.py
@@ -3,8 +3,8 @@ from functools import wraps
 
 from aiohttp import web
 from models_library.utils.fastapi_encoders import jsonable_encoder
-from servicelib.aiohttp.long_running_tasks._constants import (
-    RQT_LONG_RUNNING_TASKS_CONTEXT_KEY,
+from servicelib.aiohttp.long_running_tasks import (
+    RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY,
 )
 from servicelib.aiohttp.long_running_tasks.server import setup
 from servicelib.aiohttp.typing_extension import Handler
@@ -31,7 +31,7 @@ def webserver_request_context_decorator(handler: Handler):
     ) -> web.StreamResponse:
         """this task context callback tries to get the user_id from the query if available"""
         req_ctx = AuthenticatedRequestContext.model_validate(request)
-        request[RQT_LONG_RUNNING_TASKS_CONTEXT_KEY] = jsonable_encoder(req_ctx)
+        request[RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY] = jsonable_encoder(req_ctx)
         return await handler(request)
 
     return _test_task_context_decorator

--- a/services/web/server/src/simcore_service_webserver/long_running_tasks/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/long_running_tasks/plugin.py
@@ -2,9 +2,8 @@ import logging
 from functools import wraps
 
 from aiohttp import web
-from models_library.utils.fastapi_encoders import jsonable_encoder
 from servicelib.aiohttp.long_running_tasks import (
-    RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY,
+    LONG_RUNNING_TASKS_CONTEXT_REQKEY,
 )
 from servicelib.aiohttp.long_running_tasks.server import setup
 from servicelib.aiohttp.typing_extension import Handler
@@ -31,7 +30,7 @@ def webserver_request_context_decorator(handler: Handler):
     ) -> web.StreamResponse:
         """this task context callback tries to get the user_id from the query if available"""
         req_ctx = AuthenticatedRequestContext.model_validate(request)
-        request[RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY] = jsonable_encoder(req_ctx)
+        request[LONG_RUNNING_TASKS_CONTEXT_REQKEY] = req_ctx.model_dump(mode="json")
         return await handler(request)
 
     return _test_task_context_decorator

--- a/services/web/server/src/simcore_service_webserver/projects/_permalink_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_permalink_service.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Protocol, cast
+from typing import Final, Protocol, cast
 
 from aiohttp import web
 from models_library.api_schemas_webserver.permalinks import ProjectPermalink
@@ -10,7 +10,6 @@ from yarl import URL
 from .exceptions import PermalinkFactoryError, PermalinkNotAllowedError
 from .models import ProjectDict
 
-_PROJECT_PERMALINK = f"{__name__}"
 _logger = logging.getLogger(__name__)
 
 
@@ -24,15 +23,20 @@ class CreateLinkCoroutine(Protocol):
     ) -> ProjectPermalink: ...
 
 
+_PROJECT_PERMALINK_FACTORY_APPKEY: Final = web.AppKey(
+    "PROJECT_PERMALINK_FACTORY", CreateLinkCoroutine
+)
+
+
 def register_factory(app: web.Application, factory_coro: CreateLinkCoroutine):
-    if _create := app.get(_PROJECT_PERMALINK):
+    if _create := app.get(_PROJECT_PERMALINK_FACTORY_APPKEY):
         msg = f"Permalink factory can only be set once: registered {_create}"
         raise PermalinkFactoryError(msg)
-    app[_PROJECT_PERMALINK] = factory_coro
+    app[_PROJECT_PERMALINK_FACTORY_APPKEY] = factory_coro
 
 
 def _get_factory(app: web.Application) -> CreateLinkCoroutine:
-    if _create := app.get(_PROJECT_PERMALINK):
+    if _create := app.get(_PROJECT_PERMALINK_FACTORY_APPKEY):
         return cast(CreateLinkCoroutine, _create)
 
     msg = "Undefined permalink factory. Check plugin initialization."

--- a/services/web/server/src/simcore_service_webserver/projects/_permalink_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_permalink_service.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Final, Protocol, cast
+from typing import Final, Protocol
 
 from aiohttp import web
 from models_library.api_schemas_webserver.permalinks import ProjectPermalink
@@ -37,7 +37,7 @@ def register_factory(app: web.Application, factory_coro: CreateLinkCoroutine):
 
 def _get_factory(app: web.Application) -> CreateLinkCoroutine:
     if _create := app.get(_PROJECT_PERMALINK_FACTORY_APPKEY):
-        return cast(CreateLinkCoroutine, _create)
+        return _create
 
     msg = "Undefined permalink factory. Check plugin initialization."
     raise PermalinkFactoryError(msg)

--- a/services/web/server/src/simcore_service_webserver/resource_manager/_constants.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/_constants.py
@@ -1,2 +1,0 @@
-APP_CLIENT_SOCKET_REGISTRY_KEY = f"{__name__}.resource_manager.registry"
-APP_RESOURCE_MANAGER_TASKS_KEY = f"{__name__}.resource_manager.tasks.key"

--- a/services/web/server/src/simcore_service_webserver/resource_manager/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/plugin.py
@@ -14,8 +14,7 @@ from aiohttp import web
 
 from ..application_setup import ModuleCategory, app_setup_func
 from ..redis import setup_redis
-from ._constants import APP_CLIENT_SOCKET_REGISTRY_KEY, APP_RESOURCE_MANAGER_TASKS_KEY
-from .registry import RedisResourceRegistry
+from .registry import CLIENT_SOCKET_REGISTRY_APPKEY, RedisResourceRegistry
 
 _logger = logging.getLogger(__name__)
 
@@ -33,9 +32,7 @@ APP_RESOURCE_MANAGER_CLIENT_KEY: Final = web.AppKey(
 def setup_resource_manager(app: web.Application) -> bool:
     """Sets up resource manager subsystem in the application"""
 
-    app[APP_RESOURCE_MANAGER_TASKS_KEY] = []
-
     setup_redis(app)
-    app[APP_CLIENT_SOCKET_REGISTRY_KEY] = RedisResourceRegistry(app)
+    app[CLIENT_SOCKET_REGISTRY_APPKEY] = RedisResourceRegistry(app)
 
     return True

--- a/services/web/server/src/simcore_service_webserver/resource_manager/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/plugin.py
@@ -8,7 +8,6 @@ Takes care of managing user generated resources such as:
 """
 
 import logging
-from typing import Final
 
 from aiohttp import web
 
@@ -17,10 +16,6 @@ from ..redis import setup_redis
 from .registry import CLIENT_SOCKET_REGISTRY_APPKEY, RedisResourceRegistry
 
 _logger = logging.getLogger(__name__)
-
-APP_RESOURCE_MANAGER_CLIENT_KEY: Final = web.AppKey(
-    "APP_RESOURCE_MANAGER_CLIENT_KEY", object
-)
 
 
 @app_setup_func(

--- a/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
+++ b/services/web/server/src/simcore_service_webserver/resource_manager/registry.py
@@ -14,13 +14,13 @@ This key can have a timeout value. When the key times out then the key disappear
 """
 
 import logging
+from typing import Final
 
 import redis.asyncio as aioredis
 from aiohttp import web
 from servicelib.redis import handle_redis_returns_union_types
 
 from ..redis import get_redis_resources_client
-from ._constants import APP_CLIENT_SOCKET_REGISTRY_KEY
 from .models import (
     ALIVE_SUFFIX,
     RESOURCE_SUFFIX,
@@ -144,7 +144,12 @@ class RedisResourceRegistry:
         return (alive_keys, dead_keys)
 
 
+CLIENT_SOCKET_REGISTRY_APPKEY: Final = web.AppKey(
+    "CLIENT_SOCKET_REGISTRY", RedisResourceRegistry
+)
+
+
 def get_registry(app: web.Application) -> RedisResourceRegistry:
-    client: RedisResourceRegistry = app[APP_CLIENT_SOCKET_REGISTRY_KEY]
+    client = app[CLIENT_SOCKET_REGISTRY_APPKEY]
     assert isinstance(client, RedisResourceRegistry)  # nosec
     return client

--- a/services/web/server/src/simcore_service_webserver/socketio/_utils.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/_utils.py
@@ -11,7 +11,9 @@ APP_CLIENT_SOCKET_DECORATED_HANDLERS_APPKEY: Final = web.AppKey(
     "APP_CLIENT_SOCKET_DECORATED_HANDLERS", list[Callable]
 )
 APP_CLIENT_SOCKET_SERVER_APPKEY: Final = web.AppKey(
-    "APP_CLIENT_SOCKET_SERVER", AsyncServer
+    # NOTE: AsyncServer stub library is missing
+    "APP_CLIENT_SOCKET_SERVER",
+    AsyncServer,  # type: ignore[var-annotated]
 )
 
 

--- a/services/web/server/src/simcore_service_webserver/socketio/_utils.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/_utils.py
@@ -13,7 +13,7 @@ _CLIENT_SOCKET_DECORATED_HANDLERS_APPKEY: Final = web.AppKey(
 CLIENT_SOCKET_SERVER_APPKEY: Final = web.AppKey(
     # NOTE: AsyncServer stub library is missing
     "CLIENT_SOCKET_SERVER",
-    AsyncServer,  # type: ignore[var-annotated]
+    AsyncServer,
 )
 
 

--- a/services/web/server/src/simcore_service_webserver/socketio/_utils.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/_utils.py
@@ -2,15 +2,15 @@ import inspect
 from collections.abc import Awaitable, Callable
 from functools import wraps
 from types import ModuleType
-from typing import Any, Final
+from typing import Any, Final, TypeAlias
 
 from aiohttp import web
 from socketio import AsyncServer  # type: ignore[import-untyped]
 
-APP_CLIENT_SOCKET_DECORATED_HANDLERS_APPKEY: Final = web.AppKey(
+_CLIENT_SOCKET_DECORATED_HANDLERS_APPKEY: Final = web.AppKey(
     "APP_CLIENT_SOCKET_DECORATED_HANDLERS", list[Callable]
 )
-APP_CLIENT_SOCKET_SERVER_APPKEY: Final = web.AppKey(
+CLIENT_SOCKET_SERVER_APPKEY: Final = web.AppKey(
     # NOTE: AsyncServer stub library is missing
     "APP_CLIENT_SOCKET_SERVER",
     AsyncServer,  # type: ignore[var-annotated]
@@ -18,26 +18,30 @@ APP_CLIENT_SOCKET_SERVER_APPKEY: Final = web.AppKey(
 
 
 def get_socket_server(app: web.Application) -> AsyncServer:
-    return app[APP_CLIENT_SOCKET_SERVER_APPKEY]
+    return app[CLIENT_SOCKET_SERVER_APPKEY]
 
 
 # The socket ID that was assigned to the client
-SocketID = str
+SocketID: TypeAlias = str
 
 # The environ argument is a dictionary in standard WSGI format containing the request information, including HTTP headers
-EnvironDict = dict[str, Any]
+EnvironDict: TypeAlias = dict[str, Any]
 
 # Connect event
-SocketioConnectEventHandler = Callable[
+SocketioConnectEventHandler: TypeAlias = Callable[
     [SocketID, EnvironDict, web.Application], Awaitable[None]
 ]
 
 # Disconnect event
-SocketioDisconnectEventHandler = Callable[[SocketID, web.Application], Awaitable[None]]
+SocketioDisconnectEventHandler: TypeAlias = Callable[
+    [SocketID, web.Application], Awaitable[None]
+]
 
 # Event
-AnyData = Any
-SocketioEventHandler = Callable[[SocketID, AnyData, web.Application], Awaitable[None]]
+AnyData: TypeAlias = Any
+SocketioEventHandler: TypeAlias = Callable[
+    [SocketID, AnyData, web.Application], Awaitable[None]
+]
 
 _socketio_handlers_registry: list[
     (
@@ -82,7 +86,7 @@ def register_socketio_handlers(app: web.Application, module: ModuleType):
     partial_fcts = [
         _socket_io_handler(app)(func_handler) for func_handler in member_fcts
     ]
-    app[APP_CLIENT_SOCKET_DECORATED_HANDLERS_APPKEY] = partial_fcts
+    app[_CLIENT_SOCKET_DECORATED_HANDLERS_APPKEY] = partial_fcts
 
     # register the fcts
     for func in partial_fcts:

--- a/services/web/server/src/simcore_service_webserver/socketio/_utils.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/_utils.py
@@ -2,17 +2,21 @@ import inspect
 from collections.abc import Awaitable, Callable
 from functools import wraps
 from types import ModuleType
-from typing import Any
+from typing import Any, Final
 
 from aiohttp import web
 from socketio import AsyncServer  # type: ignore[import-untyped]
 
-APP_CLIENT_SOCKET_DECORATED_HANDLERS_KEY = f"{__name__}.socketio_handlers"
-APP_CLIENT_SOCKET_SERVER_KEY = f"{__name__}.socketio_socketio"
+APP_CLIENT_SOCKET_DECORATED_HANDLERS_APPKEY: Final = web.AppKey(
+    "APP_CLIENT_SOCKET_DECORATED_HANDLERS", list[Callable]
+)
+APP_CLIENT_SOCKET_SERVER_APPKEY: Final = web.AppKey(
+    "APP_CLIENT_SOCKET_SERVER", AsyncServer
+)
 
 
 def get_socket_server(app: web.Application) -> AsyncServer:
-    return app[APP_CLIENT_SOCKET_SERVER_KEY]
+    return app[APP_CLIENT_SOCKET_SERVER_APPKEY]
 
 
 # The socket ID that was assigned to the client
@@ -76,7 +80,7 @@ def register_socketio_handlers(app: web.Application, module: ModuleType):
     partial_fcts = [
         _socket_io_handler(app)(func_handler) for func_handler in member_fcts
     ]
-    app[APP_CLIENT_SOCKET_DECORATED_HANDLERS_KEY] = partial_fcts
+    app[APP_CLIENT_SOCKET_DECORATED_HANDLERS_APPKEY] = partial_fcts
 
     # register the fcts
     for func in partial_fcts:

--- a/services/web/server/src/simcore_service_webserver/socketio/_utils.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/_utils.py
@@ -8,11 +8,11 @@ from aiohttp import web
 from socketio import AsyncServer  # type: ignore[import-untyped]
 
 _CLIENT_SOCKET_DECORATED_HANDLERS_APPKEY: Final = web.AppKey(
-    "APP_CLIENT_SOCKET_DECORATED_HANDLERS", list[Callable]
+    "CLIENT_SOCKET_DECORATED_HANDLERS", list[Callable]
 )
 CLIENT_SOCKET_SERVER_APPKEY: Final = web.AppKey(
     # NOTE: AsyncServer stub library is missing
-    "APP_CLIENT_SOCKET_SERVER",
+    "CLIENT_SOCKET_SERVER",
     AsyncServer,  # type: ignore[var-annotated]
 )
 

--- a/services/web/server/src/simcore_service_webserver/socketio/server.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/server.py
@@ -10,7 +10,7 @@ from socketio import AsyncAioPikaManager, AsyncServer  # type: ignore[import-unt
 from ..rabbitmq_settings import get_plugin_settings as get_rabbitmq_settings
 from . import _handlers
 from ._utils import (
-    APP_CLIENT_SOCKET_SERVER_APPKEY,
+    CLIENT_SOCKET_SERVER_APPKEY,
     get_socket_server,
     register_socketio_handlers,
 )
@@ -30,7 +30,7 @@ async def _socketio_server_cleanup_ctx(app: web.Application) -> AsyncIterator[No
     )
     sio_server.attach(app)
 
-    app[APP_CLIENT_SOCKET_SERVER_APPKEY] = sio_server
+    app[CLIENT_SOCKET_SERVER_APPKEY] = sio_server
 
     register_socketio_handlers(app, _handlers)
 

--- a/services/web/server/src/simcore_service_webserver/socketio/server.py
+++ b/services/web/server/src/simcore_service_webserver/socketio/server.py
@@ -10,7 +10,7 @@ from socketio import AsyncAioPikaManager, AsyncServer  # type: ignore[import-unt
 from ..rabbitmq_settings import get_plugin_settings as get_rabbitmq_settings
 from . import _handlers
 from ._utils import (
-    APP_CLIENT_SOCKET_SERVER_KEY,
+    APP_CLIENT_SOCKET_SERVER_APPKEY,
     get_socket_server,
     register_socketio_handlers,
 )
@@ -30,7 +30,7 @@ async def _socketio_server_cleanup_ctx(app: web.Application) -> AsyncIterator[No
     )
     sio_server.attach(app)
 
-    app[APP_CLIENT_SOCKET_SERVER_KEY] = sio_server
+    app[APP_CLIENT_SOCKET_SERVER_APPKEY] = sio_server
 
     register_socketio_handlers(app, _handlers)
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Follows up refactoring webserver's `app` state keys from strings to `web.AppKey` (see #7734)

**Application state key refactoring:**

* Replaced string-based keys with `web.AppKey` objects in the long-running tasks module, introducing `APP_LONG_RUNNING_MANAGER_APPKEY` and `RQT_LONG_RUNNING_TASKS_CONTEXT_APPKEY` for safer access to manager and task context objects (`_manager.py`, `_request.py`, `_server.py`, `__init__.py`, tests, and plugins). [[1]](diffhunk://#diff-a52eb8db426355febdfd90a361ee6ece63d66f97b7ebd0a00b8aac871e99eaa4R1-L5) [[2]](diffhunk://#diff-a52eb8db426355febdfd90a361ee6ece63d66f97b7ebd0a00b8aac871e99eaa4R17-R23) [[3]](diffhunk://#diff-a1a9868662d09f21ea9224cd94a07cb1b351de281442f70e61450ced29036f99L1-R11) [[4]](diffhunk://#diff-7b7ff72ad4bf18c0db1d602c4e79cf83ac238f1555bd021585d0fec0cd1738faL32-R40) [[5]](diffhunk://#diff-7b7ff72ad4bf18c0db1d602c4e79cf83ac238f1555bd021585d0fec0cd1738faL47-R50) [[6]](diffhunk://#diff-7b7ff72ad4bf18c0db1d602c4e79cf83ac238f1555bd021585d0fec0cd1738faL181-R184) [[7]](diffhunk://#diff-3d63f2595186a29db7a649fff6305120959d88da8b333ff74644f17101282e02R2-R4) [[8]](diffhunk://#diff-4fde1f13862dfe7b2c55c00c0f1f57b4959f87676a2cb515a775a20e7359945fL22-R23) [[9]](diffhunk://#diff-4fde1f13862dfe7b2c55c00c0f1f57b4959f87676a2cb515a775a20e7359945fL59-R59) [[10]](diffhunk://#diff-1047acec2cbe773398fe1640775f8d9a91aeade1bf9ddc8a456cf014b396b6edL6-R7) [[11]](diffhunk://#diff-1047acec2cbe773398fe1640775f8d9a91aeade1bf9ddc8a456cf014b396b6edL34-R34)
* Removed obsolete constants and updated usages in the resource manager module, introducing `CLIENT_SOCKET_REGISTRY_APPKEY` for registry access (`_constants.py`, `plugin.py`, `registry.py`). [[1]](diffhunk://#diff-e295c44508197b7df0cf22cef388a5f647bf60d561e3acfc8feb5fa4b289c90eL1-L2) [[2]](diffhunk://#diff-93993d78c391b7a160b1cc89df0949ad0de49f957c30887f282bb14fe12bc2b8L17-R17) [[3]](diffhunk://#diff-93993d78c391b7a160b1cc89df0949ad0de49f957c30887f282bb14fe12bc2b8L36-R36) [[4]](diffhunk://#diff-44ac2fa38733e2e1d5de34714fac51144b58df013c761298e9c2c9886e583090R17-L23) [[5]](diffhunk://#diff-44ac2fa38733e2e1d5de34714fac51144b58df013c761298e9c2c9886e583090R147-R153)
* Refactored the project permalink service to use `PROJECT_PERMALINK_FACTORY_APPKEY` instead of a string key for the permalink factory coroutine (`_permalink_service.py`). [[1]](diffhunk://#diff-5f93d4561f4a539066d61e724022433dc01d1489497b59ec30de53e3c0eb6f45L3-R3) [[2]](diffhunk://#diff-5f93d4561f4a539066d61e724022433dc01d1489497b59ec30de53e3c0eb6f45L13) [[3]](diffhunk://#diff-5f93d4561f4a539066d61e724022433dc01d1489497b59ec30de53e3c0eb6f45R26-R39)
* Updated socketio utility module to use `APP_CLIENT_SOCKET_DECORATED_HANDLERS_APPKEY` and `APP_CLIENT_SOCKET_SERVER_APPKEY` for handler and server references, replacing string keys (`_utils.py`). [[1]](diffhunk://#diff-ac97f221e06f535d55412b48a61a1ccadae8ecaac0dbea04182848db0256f4d4L5-R19) [[2]](diffhunk://#diff-ac97f221e06f535d55412b48a61a1ccadae8ecaac0dbea04182848db0256f4d4L79-R83)


## Related issue/s

- resolves #7734

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
None