### PR TITLE
🎨✅ [Maintenance] Add mock handler factory for LicensesRpcApi to fix pact tests

### DIFF
--- a/services/api-server/tests/unit/pact_broker/test_pact_checkout_release.py
+++ b/services/api-server/tests/unit/pact_broker/test_pact_checkout_release.py
@@ -13,6 +13,7 @@ from models_library.api_schemas_webserver.licensed_items_checkouts import (
 )
 from pact.v3 import Verifier
 from pytest_mock import MockerFixture
+from pytest_simcore.helpers.typing_mock import HandlerMockFactory
 from simcore_service_api_server._meta import API_VERSION
 from simcore_service_api_server.api.dependencies.resource_usage_tracker_rpc import (
     get_resource_usage_tracker_client,
@@ -61,21 +62,23 @@ assert EXPECTED_RELEASE.stopped_at is not None
 
 
 @pytest.fixture
-async def mock_wb_api_server_rpc(app: FastAPI, mocker: MockerFixture) -> None:
+async def mock_wb_api_server_rpc(
+    app: FastAPI,
+    mocker: MockerFixture,
+    mock_handler_in_licenses_rpc_interface: HandlerMockFactory,
+) -> None:
     from servicelib.rabbitmq.rpc_interfaces.webserver.v1 import WebServerRpcClient
 
     app.dependency_overrides[get_wb_api_rpc_client] = lambda: WbApiRpcClient(
         _rpc_client=mocker.MagicMock(spec=WebServerRpcClient),
     )
 
-    mocker.patch(
-        "simcore_service_api_server.services_rpc.wb_api_server._checkout_licensed_item_for_wallet",
-        return_value=EXPECTED_CHECKOUT,
+    mock_handler_in_licenses_rpc_interface(
+        "checkout_licensed_item_for_wallet", return_value=EXPECTED_CHECKOUT
     )
 
-    mocker.patch(
-        "simcore_service_api_server.services_rpc.wb_api_server._release_licensed_item_for_wallet",
-        return_value=EXPECTED_RELEASE,
+    mock_handler_in_licenses_rpc_interface(
+        "release_licensed_item_for_wallet", return_value=EXPECTED_RELEASE
     )
 
 

--- a/services/api-server/tests/unit/pact_broker/test_pact_licensed_items.py
+++ b/services/api-server/tests/unit/pact_broker/test_pact_licensed_items.py
@@ -13,6 +13,7 @@ from models_library.api_schemas_webserver.licensed_items import (
 )
 from pact.v3 import Verifier
 from pytest_mock import MockerFixture
+from pytest_simcore.helpers.typing_mock import HandlerMockFactory
 from simcore_service_api_server._meta import API_VERSION
 from simcore_service_api_server.api.dependencies.webserver_rpc import (
     get_wb_api_rpc_client,
@@ -137,16 +138,21 @@ class DummyRpcClient:
 
 
 @pytest.fixture
-async def mock_wb_api_server_rpc(app: FastAPI, mocker: MockerFixture) -> None:
-    from servicelib.rabbitmq.rpc_interfaces.webserver.v1 import WebServerRpcClient
+async def mock_wb_api_server_rpc(
+    app: FastAPI,
+    mocker: MockerFixture,
+    mock_handler_in_licenses_rpc_interface: HandlerMockFactory,
+) -> None:
+    from servicelib.rabbitmq.rpc_interfaces.webserver.v1 import (  # noqa: PLC0415
+        WebServerRpcClient,
+    )
 
     app.dependency_overrides[get_wb_api_rpc_client] = lambda: WbApiRpcClient(
         _rpc_client=mocker.MagicMock(spec=WebServerRpcClient),
     )
 
-    mocker.patch(
-        "simcore_service_api_server.services_rpc.wb_api_server._get_licensed_items",
-        return_value=EXPECTED_LICENSED_ITEMS_PAGE,
+    mock_handler_in_licenses_rpc_interface(
+        "get_licensed_items", return_value=EXPECTED_LICENSED_ITEMS_PAGE
     )
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

Follows up from  https://github.com/ITISFoundation/osparc-simcore/pull/8431  and fixes `pact_broker` tests

<img width="646" height="317" alt="image" src="https://github.com/user-attachments/assets/df0ad74e-add9-495d-8edf-eda71dd5b49e" />


```
=========================== short test summary info ============================
ERROR tests/unit/pact_broker/test_pact_checkout_release.py::test_provider_against_pact - AttributeError: <module 'simcore_service_api_server.services_rpc.wb_api_server' from '/home/runner/work/osparc-simcore/osparc-simcore/.venv/lib/python3.11/site-packages/simcore_service_api_server/services_rpc/wb_api_server.py'> does not have the attribute '_checkout_licensed_item_for_wallet'
ERROR tests/unit/pact_broker/test_pact_licensed_items.py::test_provider_against_pact - AttributeError: <module 'simcore_service_api_server.services_rpc.wb_api_server' from '/home/runner/work/osparc-simcore/osparc-simcore/.venv/lib/python3.11/site-packages/simcore_service_api_server/services_rpc/wb_api_server.py'> does not have the attribute '_get_licensed_items'
============================== 2 errors in 2.65s ===============================
```


- @matusdrobuliak66, I did not notice this in my PR, why not to add pact tests as **required** in the PR CIs?

## Related issue/s

- Fixes bad fixture in pact tests in https://github.com/ITISFoundation/osparc-simcore/pull/8431


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
None