### PR TITLE
♻️ [Maintenance] Refactor Payments Domain to Use asyncpg Instead of aiopg

### DIFF
--- a/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
@@ -125,8 +125,7 @@ async def update_payment_transaction_state(
             .where(payments_transactions.c.payment_id == payment_id)
             .returning(payments_transactions)
         )
-        row = result.one()
-        return row
+        return result.one()
 
 
 async def get_user_payments_transactions(

--- a/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
@@ -6,6 +6,7 @@ from typing import Final, TypeAlias
 
 import sqlalchemy as sa
 import sqlalchemy.exc
+from sqlalchemy.engine import Row
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from .models.payments_transactions import PaymentTransactionState, payments_transactions
@@ -14,7 +15,7 @@ _logger = logging.getLogger(__name__)
 
 
 PaymentID: TypeAlias = str
-PaymentTransactionRow: TypeAlias = sa.Row
+PaymentTransactionRow: TypeAlias = Row
 
 
 UNSET: Final[str] = "__UNSET__"

--- a/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
@@ -5,17 +5,16 @@ from decimal import Decimal
 from typing import Final, TypeAlias
 
 import sqlalchemy as sa
-from aiopg.sa.connection import SAConnection
-from aiopg.sa.result import ResultProxy, RowProxy
+import sqlalchemy.exc
+from sqlalchemy.ext.asyncio import AsyncConnection
 
-from . import aiopg_errors
 from .models.payments_transactions import PaymentTransactionState, payments_transactions
 
 _logger = logging.getLogger(__name__)
 
 
 PaymentID: TypeAlias = str
-PaymentTransactionRow: TypeAlias = RowProxy
+PaymentTransactionRow: TypeAlias = sa.Row
 
 
 UNSET: Final[str] = "__UNSET__"
@@ -39,7 +38,7 @@ class PaymentAlreadyAcked(PaymentFailure): ...
 
 
 async def insert_init_payment_transaction(
-    connection: SAConnection,
+    connection: AsyncConnection,
     *,
     payment_id: str,
     price_dollars: Decimal,
@@ -66,14 +65,14 @@ async def insert_init_payment_transaction(
                 initiated_at=initiated_at,
             )
         )
-    except aiopg_errors.UniqueViolation:
+    except sqlalchemy.exc.IntegrityError:
         return PaymentAlreadyExists(payment_id)
 
     return payment_id
 
 
 async def update_payment_transaction_state(
-    connection: SAConnection,
+    connection: AsyncConnection,
     *,
     payment_id: str,
     completion_state: PaymentTransactionState,
@@ -101,16 +100,15 @@ async def update_payment_transaction_state(
         optional["invoice_url"] = invoice_url
 
     async with connection.begin():
-        row = await (
-            await connection.execute(
-                sa.select(
-                    payments_transactions.c.initiated_at,
-                    payments_transactions.c.completed_at,
-                )
-                .where(payments_transactions.c.payment_id == payment_id)
-                .with_for_update()
+        result = await connection.execute(
+            sa.select(
+                payments_transactions.c.initiated_at,
+                payments_transactions.c.completed_at,
             )
-        ).fetchone()
+            .where(payments_transactions.c.payment_id == payment_id)
+            .with_for_update()
+        )
+        row = result.one_or_none()
 
         if row is None:
             return PaymentNotFound(payment_id=payment_id)
@@ -125,16 +123,14 @@ async def update_payment_transaction_state(
             payments_transactions.update()
             .values(completed_at=sa.func.now(), state=completion_state, **optional)
             .where(payments_transactions.c.payment_id == payment_id)
-            .returning(sa.literal_column("*"))
+            .returning(payments_transactions)
         )
-        row = await result.first()
-        assert row, "execute above should have caught this"  # nosec
-        assert isinstance(row, RowProxy)  # nosec
+        row = result.one()
         return row
 
 
 async def get_user_payments_transactions(
-    connection: SAConnection,
+    connection: AsyncConnection,
     *,
     user_id: int,
     offset: int | None = None,
@@ -149,7 +145,7 @@ async def get_user_payments_transactions(
 
     # NOTE: what if between these two calls there are new rows? can we get this in an atomic call?å
     stmt = (
-        payments_transactions.select()
+        sa.select(payments_transactions)
         .where(payments_transactions.c.user_id == user_id)
         .order_by(payments_transactions.c.created.desc())
     )  # newest first
@@ -162,6 +158,6 @@ async def get_user_payments_transactions(
         # InvalidRowCountInLimitClause: LIMIT must not be negative
         stmt = stmt.limit(limit)
 
-    result: ResultProxy = await connection.execute(stmt)
-    rows = await result.fetchall() or []
+    result = await connection.execute(stmt)
+    rows = result.fetchall()
     return total_number_of_items, rows

--- a/packages/postgres-database/src/simcore_postgres_database/utils_payments_autorecharge.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_payments_autorecharge.py
@@ -7,7 +7,7 @@ from simcore_postgres_database.models.payments_methods import (
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 
-class AutoRechargeStmts:
+class AutoRechargeStatements:
     @staticmethod
     def is_valid_payment_method(user_id, wallet_id, payment_method_id) -> sa.sql.Select:
         return sa.select(payments_methods.c.payment_method_id).where(

--- a/packages/postgres-database/tests/test_models_payments_transactions.py
+++ b/packages/postgres-database/tests/test_models_payments_transactions.py
@@ -3,7 +3,7 @@
 # pylint: disable=unexpected-keyword-arg
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
-# pytlin: disable=protected-access
+# pylint: disable=protected-access
 
 import decimal
 from collections.abc import Callable

--- a/packages/postgres-database/tests/test_models_payments_transactions.py
+++ b/packages/postgres-database/tests/test_models_payments_transactions.py
@@ -3,6 +3,7 @@
 # pylint: disable=unexpected-keyword-arg
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
+# pytlin: disable=protected-access
 
 import decimal
 from collections.abc import Callable
@@ -101,7 +102,7 @@ async def test_init_transaction_sets_it_as_pending(
     assert row is not None
 
     # tests that defaults are right?
-    assert dict(row._mapping.items()) == {
+    assert row._asdict() == {
         "completed_at": None,
         "state": PaymentTransactionState.PENDING,
         "state_message": None,

--- a/packages/postgres-database/tests/test_models_payments_transactions.py
+++ b/packages/postgres-database/tests/test_models_payments_transactions.py
@@ -262,4 +262,3 @@ async def test_get_user_payments_transactions_with_pagination_options(
             connection, user_id=user_id, limit=0
         )
         assert not rows
-        assert not rows

--- a/packages/postgres-database/tests/test_models_payments_transactions.py
+++ b/packages/postgres-database/tests/test_models_payments_transactions.py
@@ -24,23 +24,25 @@ from simcore_postgres_database.utils_payments import (
     insert_init_payment_transaction,
     update_payment_transaction_state,
 )
-from sqlalchemy.ext.asyncio import AsyncConnection
+from simcore_postgres_database.utils_repos import transaction_context
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 
-async def test_numerics_precission_and_scale(connection: AsyncConnection):
+async def test_numerics_precission_and_scale(asyncpg_engine: AsyncEngine):
     # https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Numeric
     # precision: This parameter specifies the total number of digits that can be stored, both before and after the decimal point.
     # scale: This parameter specifies the number of digits that can be stored to the right of the decimal point.
 
-    for order_of_magnitude in range(8):
-        expected = 10**order_of_magnitude + 0.123
-        got = await connection.scalar(
-            payments_transactions.insert()
-            .values(**random_payment_transaction(price_dollars=expected))
-            .returning(payments_transactions.c.price_dollars)
-        )
-        assert isinstance(got, decimal.Decimal)
-        assert float(got) == expected
+    async with asyncpg_engine.begin() as connection:
+        for order_of_magnitude in range(8):
+            expected = 10**order_of_magnitude + 0.123
+            got = await connection.scalar(
+                payments_transactions.insert()
+                .values(**random_payment_transaction(price_dollars=expected))
+                .returning(payments_transactions.c.price_dollars)
+            )
+            assert isinstance(got, decimal.Decimal)
+            assert float(got) == expected
 
 
 def _remove_not_required(data: dict[str, Any]) -> dict[str, Any]:
@@ -57,7 +59,7 @@ def _remove_not_required(data: dict[str, Any]) -> dict[str, Any]:
 
 
 @pytest.fixture
-def init_transaction(connection: AsyncConnection):
+def init_transaction(asyncpg_engine: AsyncEngine):
     async def _init(payment_id: str):
         # get payment_id from payment-gateway
         values = _remove_not_required(random_payment_transaction(payment_id=payment_id))
@@ -66,7 +68,8 @@ def init_transaction(connection: AsyncConnection):
         values["initiated_at"] = utcnow()
 
         # insert
-        ok = await insert_init_payment_transaction(connection, **values)
+        async with asyncpg_engine.begin() as connection:
+            ok = await insert_init_payment_transaction(connection, **values)
         assert ok
 
         return values
@@ -80,19 +83,20 @@ def payment_id() -> str:
 
 
 async def test_init_transaction_sets_it_as_pending(
-    connection: AsyncConnection, init_transaction: Callable, payment_id: str
+    asyncpg_engine: AsyncEngine, init_transaction: Callable, payment_id: str
 ):
     values = await init_transaction(payment_id)
     assert values["payment_id"] == payment_id
 
     # check init-ed but not completed!
-    result = await connection.execute(
-        sa.select(
-            payments_transactions.c.completed_at,
-            payments_transactions.c.state,
-            payments_transactions.c.state_message,
-        ).where(payments_transactions.c.payment_id == payment_id)
-    )
+    async with asyncpg_engine.connect() as connection:
+        result = await connection.execute(
+            sa.select(
+                payments_transactions.c.completed_at,
+                payments_transactions.c.state,
+                payments_transactions.c.state_message,
+            ).where(payments_transactions.c.payment_id == payment_id)
+        )
     row = result.one_or_none()
     assert row is not None
 
@@ -126,59 +130,64 @@ def invoice_url(faker: Faker, expected_state: PaymentTransactionState) -> str | 
     ],
 )
 async def test_complete_transaction(
-    connection: AsyncConnection,
+    asyncpg_engine: AsyncEngine,
     init_transaction: Callable,
     payment_id: str,
     expected_state: PaymentTransactionState,
     expected_message: str | None,
     invoice_url: str | None,
 ):
+    # init
     await init_transaction(payment_id)
 
-    payment_row = await update_payment_transaction_state(
-        connection,
-        payment_id=payment_id,
-        completion_state=expected_state,
-        state_message=expected_message,
-        invoice_url=invoice_url,
-    )
+    async with asyncpg_engine.connect() as connection:
+        # NOTE: internal function uses transaction
+        payment_row = await update_payment_transaction_state(
+            connection,
+            payment_id=payment_id,
+            completion_state=expected_state,
+            state_message=expected_message,
+            invoice_url=invoice_url,
+        )
 
-    assert isinstance(payment_row, PaymentTransactionRow)
-    assert payment_row.state_message == expected_message
-    assert payment_row.state == expected_state
-    assert payment_row.initiated_at < payment_row.completed_at
-    assert PaymentTransactionState(payment_row.state).is_completed()
+        assert isinstance(payment_row, PaymentTransactionRow)
+        assert payment_row.state_message == expected_message
+        assert payment_row.state == expected_state
+        assert payment_row.initiated_at < payment_row.completed_at
+        assert PaymentTransactionState(payment_row.state).is_completed()
 
 
 async def test_update_transaction_failures_and_exceptions(
-    connection: AsyncConnection,
+    asyncpg_engine: AsyncEngine,
     init_transaction: Callable,
     payment_id: str,
 ):
-    kwargs = {
-        "connection": connection,
-        "payment_id": payment_id,
-        "completion_state": PaymentTransactionState.SUCCESS,
-    }
 
-    ok = await update_payment_transaction_state(**kwargs)
-    assert isinstance(ok, PaymentNotFound)
-    assert not ok
+    async with asyncpg_engine.connect() as connection:
+        kwargs = {
+            "connection": connection,
+            "payment_id": payment_id,
+            "completion_state": PaymentTransactionState.SUCCESS,
+        }
 
-    # init & complete
-    await init_transaction(payment_id)
-    ok = await update_payment_transaction_state(**kwargs)
-    assert isinstance(ok, PaymentTransactionRow)
-    assert ok
+        ok = await update_payment_transaction_state(**kwargs)
+        assert isinstance(ok, PaymentNotFound)
+        assert not ok
 
-    # repeat -> fails
-    ok = await update_payment_transaction_state(**kwargs)
-    assert isinstance(ok, PaymentAlreadyAcked)
-    assert not ok
+        # init & complete
+        await init_transaction(payment_id)
+        ok = await update_payment_transaction_state(**kwargs)
+        assert isinstance(ok, PaymentTransactionRow)
+        assert ok
 
-    with pytest.raises(ValueError):
-        kwargs.update(completion_state=PaymentTransactionState.PENDING)
-        await update_payment_transaction_state(**kwargs)
+        # repeat -> fails
+        ok = await update_payment_transaction_state(**kwargs)
+        assert isinstance(ok, PaymentAlreadyAcked)
+        assert not ok
+
+        with pytest.raises(ValueError, match="cannot update state with"):  # noqa: PT012
+            kwargs.update(completion_state=PaymentTransactionState.PENDING)
+            await update_payment_transaction_state(**kwargs)
 
 
 @pytest.fixture
@@ -188,14 +197,18 @@ def user_id() -> int:
 
 @pytest.fixture
 def create_fake_user_transactions(
-    connection: AsyncConnection, user_id: int
+    asyncpg_engine: AsyncEngine, user_id: int
 ) -> Callable:
+
+    assert asyncpg_engine
+
     async def _go(expected_total=5):
         payment_ids = []
         for _ in range(expected_total):
             values = _remove_not_required(random_payment_transaction(user_id=user_id))
 
-            payment_id = await insert_init_payment_transaction(connection, **values)
+            async with transaction_context(asyncpg_engine) as connection:
+                payment_id = await insert_init_payment_transaction(connection, **values)
             assert payment_id
             payment_ids.append(payment_id)
 
@@ -205,19 +218,21 @@ def create_fake_user_transactions(
 
 
 async def test_get_user_payments_transactions(
-    connection: AsyncConnection, create_fake_user_transactions: Callable, user_id: int
+    asyncpg_engine: AsyncEngine, create_fake_user_transactions: Callable, user_id: int
 ):
     expected_payments_ids = await create_fake_user_transactions()
     expected_total = len(expected_payments_ids)
 
     # test offset and limit defaults
-    total, rows = await get_user_payments_transactions(connection, user_id=user_id)
+    async with asyncpg_engine.connect() as connection:
+        total, rows = await get_user_payments_transactions(connection, user_id=user_id)
+
     assert total == expected_total
     assert [r.payment_id for r in rows] == expected_payments_ids[::-1], "newest first"
 
 
 async def test_get_user_payments_transactions_with_pagination_options(
-    connection: AsyncConnection, create_fake_user_transactions: Callable, user_id: int
+    asyncpg_engine: AsyncEngine, create_fake_user_transactions: Callable, user_id: int
 ):
     expected_payments_ids = await create_fake_user_transactions()
     expected_total = len(expected_payments_ids)
@@ -226,23 +241,24 @@ async def test_get_user_payments_transactions_with_pagination_options(
     offset = int(expected_total / 4)
     limit = int(expected_total / 2)
 
-    total, rows = await get_user_payments_transactions(
-        connection, user_id=user_id, limit=limit, offset=offset
-    )
-    assert total == expected_total
-    assert [r.payment_id for r in rows] == expected_payments_ids[::-1][
-        offset : (offset + limit)
-    ], "newest first"
+    async with asyncpg_engine.connect() as connection:
+        total, rows = await get_user_payments_transactions(
+            connection, user_id=user_id, limit=limit, offset=offset
+        )
+        assert total == expected_total
+        assert [r.payment_id for r in rows] == expected_payments_ids[::-1][
+            offset : (offset + limit)
+        ], "newest first"
 
-    # test  offset>=expected_total?
-    total, rows = await get_user_payments_transactions(
-        connection, user_id=user_id, offset=expected_total
-    )
-    assert not rows
+        # test  offset>=expected_total?
+        total, rows = await get_user_payments_transactions(
+            connection, user_id=user_id, offset=expected_total
+        )
+        assert not rows
 
-    # test  limit==0?
-    total, rows = await get_user_payments_transactions(
-        connection, user_id=user_id, limit=0
-    )
-    assert not rows
-    assert not rows
+        # test  limit==0?
+        total, rows = await get_user_payments_transactions(
+            connection, user_id=user_id, limit=0
+        )
+        assert not rows
+        assert not rows

--- a/packages/postgres-database/tests/test_utils_payments_autorecharge.py
+++ b/packages/postgres-database/tests/test_utils_payments_autorecharge.py
@@ -4,37 +4,37 @@
 # pylint: disable=too-many-arguments
 
 import datetime
-from typing import TypeAlias
+from collections.abc import AsyncIterable
 
 import pytest
-import sqlalchemy as sa
-from aiopg.sa.connection import SAConnection
-from aiopg.sa.result import RowProxy
 from faker import Faker
 from pytest_simcore.helpers.faker_factories import random_payment_method, utcnow
+from pytest_simcore.helpers.postgres_tools import insert_and_get_row_lifespan
 from simcore_postgres_database.models.payments_methods import (
     InitPromptAckFlowState,
     payments_methods,
 )
-from simcore_postgres_database.utils_payments_autorecharge import AutoRechargeStmts
+from simcore_postgres_database.utils_payments_autorecharge import AutoRechargeStatements
+from sqlalchemy.engine.row import Row
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 
 #
 # HELPERS
 #
 
 
-async def _get_auto_recharge(connection, wallet_id) -> RowProxy | None:
+async def _get_auto_recharge(connection: AsyncConnection, wallet_id) -> Row | None:
     # has recharge trigger?
-    stmt = AutoRechargeStmts.get_wallet_autorecharge(wallet_id)
+    stmt = AutoRechargeStatements.get_wallet_autorecharge(wallet_id)
     result = await connection.execute(stmt)
-    return await result.first()
+    return result.first()
 
 
 async def _is_valid_payment_method(
-    connection, user_id, wallet_id, payment_method_id
+    connection: AsyncConnection, user_id, wallet_id, payment_method_id
 ) -> bool:
 
-    stmt = AutoRechargeStmts.is_valid_payment_method(
+    stmt = AutoRechargeStatements.is_valid_payment_method(
         user_id, wallet_id, payment_method_id
     )
     primary_payment_method_id = await connection.scalar(stmt)
@@ -42,37 +42,43 @@ async def _is_valid_payment_method(
 
 
 async def _upsert_autorecharge(
-    connection,
+    connection: AsyncConnection,
     wallet_id,
     enabled,
     primary_payment_method_id,
     top_up_amount_in_usd,
     monthly_limit_in_usd,
-) -> RowProxy:
+) -> Row:
     # using this primary payment-method, create an autorecharge
     # NOTE: requires the entire
-    stmt = AutoRechargeStmts.upsert_wallet_autorecharge(
+    stmt = AutoRechargeStatements.upsert_wallet_autorecharge(
         wallet_id=wallet_id,
         enabled=enabled,
         primary_payment_method_id=primary_payment_method_id,
         top_up_amount_in_usd=top_up_amount_in_usd,
         monthly_limit_in_usd=monthly_limit_in_usd,
     )
-    row = await (await connection.execute(stmt)).first()
-    assert row
-    return row
+    result = await connection.execute(stmt)
+    return result.one()
 
 
-async def _update_autorecharge(connection, wallet_id, **settings) -> int | None:
-    stmt = AutoRechargeStmts.update_wallet_autorecharge(wallet_id, **settings)
+async def _update_autorecharge(
+    connection: AsyncConnection, wallet_id, **settings
+) -> int | None:
+    stmt = AutoRechargeStatements.update_wallet_autorecharge(wallet_id, **settings)
     return await connection.scalar(stmt)
 
 
-PaymentMethodRow: TypeAlias = RowProxy
+class PaymentMethodRow(dict):
+    # Convert dict to Row-like object for compatibility
+    def __getattr__(self, key):
+        return self[key]
 
 
 @pytest.fixture
-async def payment_method(connection: SAConnection, faker: Faker) -> PaymentMethodRow:
+async def payment_method(
+    asyncpg_engine: AsyncEngine, faker: Faker
+) -> AsyncIterable[PaymentMethodRow]:
     payment_method_id = faker.uuid4().upper()
 
     raw_payment_method = random_payment_method(
@@ -81,57 +87,61 @@ async def payment_method(connection: SAConnection, faker: Faker) -> PaymentMetho
         completed_at=utcnow() + datetime.timedelta(seconds=1),
         state=InitPromptAckFlowState.SUCCESS,
     )
-    result = await connection.execute(
-        payments_methods.insert()
-        .values(**raw_payment_method)
-        .returning(sa.literal_column("*"))
-    )
-    row = await result.first()
-    assert row
-    assert row.payment_method_id == payment_method_id
-    wallet_id = row.wallet_id
-    user_id = row.user_id
 
-    assert await _is_valid_payment_method(
-        connection, user_id, wallet_id, payment_method_id
-    )
-    return row
+    # pylint: disable=contextmanager-generator-missing-cleanup
+    async with insert_and_get_row_lifespan(
+        asyncpg_engine,
+        table=payments_methods,
+        values=raw_payment_method,
+        pk_col=payments_methods.c.payment_method_id,
+        pk_value=payment_method_id,
+    ) as row_data:
+        wallet_id = row_data["wallet_id"]
+        user_id = row_data["user_id"]
+
+        async with asyncpg_engine.connect() as connection:
+            assert await _is_valid_payment_method(
+                connection, user_id, wallet_id, payment_method_id
+            )
+
+        yield PaymentMethodRow(row_data)
 
 
 async def test_payments_automation_workflow(
-    connection: SAConnection, payment_method: PaymentMethodRow
+    asyncpg_engine: AsyncEngine, payment_method: PaymentMethodRow
 ):
     payment_method_id = payment_method.payment_method_id
     wallet_id = payment_method.wallet_id
 
-    # get
-    auto_recharge = await _get_auto_recharge(connection, wallet_id)
-    assert auto_recharge is None
+    async with asyncpg_engine.begin() as connection:
+        # get
+        auto_recharge = await _get_auto_recharge(connection, wallet_id)
+        assert auto_recharge is None
 
-    # new
-    await _upsert_autorecharge(
-        connection,
-        wallet_id,
-        enabled=True,
-        primary_payment_method_id=payment_method_id,
-        top_up_amount_in_usd=100,
-        monthly_limit_in_usd=None,
-    )
+        # new
+        await _upsert_autorecharge(
+            connection,
+            wallet_id,
+            enabled=True,
+            primary_payment_method_id=payment_method_id,
+            top_up_amount_in_usd=100,
+            monthly_limit_in_usd=None,
+        )
 
-    auto_recharge = await _get_auto_recharge(connection, wallet_id)
-    assert auto_recharge is not None
-    assert auto_recharge.primary_payment_method_id == payment_method_id
-    assert auto_recharge.enabled is True
+        auto_recharge = await _get_auto_recharge(connection, wallet_id)
+        assert auto_recharge is not None
+        assert auto_recharge.primary_payment_method_id == payment_method_id
+        assert auto_recharge.enabled is True
 
-    # upsert: deactivate countdown
-    auto_recharge = await _upsert_autorecharge(
-        connection,
-        wallet_id,
-        enabled=True,
-        primary_payment_method_id=payment_method_id,
-        top_up_amount_in_usd=100,
-        monthly_limit_in_usd=10000,  # <----
-    )
-    assert auto_recharge.monthly_limit_in_usd == 10000
+        # upsert: deactivate countdown
+        auto_recharge = await _upsert_autorecharge(
+            connection,
+            wallet_id,
+            enabled=True,
+            primary_payment_method_id=payment_method_id,
+            top_up_amount_in_usd=100,
+            monthly_limit_in_usd=10000,  # <----
+        )
+        assert auto_recharge.monthly_limit_in_usd == 10000
 
-    await _update_autorecharge(connection, wallet_id, monthly_limit_in_usd=None)
+        await _update_autorecharge(connection, wallet_id, monthly_limit_in_usd=None)

--- a/packages/service-library/src/servicelib/aiohttp/db_asyncpg_engine.py
+++ b/packages/service-library/src/servicelib/aiohttp/db_asyncpg_engine.py
@@ -17,23 +17,22 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from ..db_asyncpg_utils import create_async_engine_and_database_ready
 from ..logging_utils import log_context
 
-APP_DB_ASYNC_ENGINE_KEY: Final[str] = f"{__name__ }.AsyncEngine"
-
+DB_ASYNC_ENGINE_APPKEY: Final = web.AppKey("DB_ASYNC_ENGINE", AsyncEngine)
 
 _logger = logging.getLogger(__name__)
 
 
 def _set_async_engine_to_app_state(app: web.Application, engine: AsyncEngine):
-    if exists := app.get(APP_DB_ASYNC_ENGINE_KEY, None):
-        msg = f"An instance of {type(exists)} already in app[{APP_DB_ASYNC_ENGINE_KEY}]={exists}"
+    if exists := app.get(DB_ASYNC_ENGINE_APPKEY, None):
+        msg = f"An instance of {type(exists)} already in app[{DB_ASYNC_ENGINE_APPKEY}]={exists}"
         raise ValueError(msg)
 
-    app[APP_DB_ASYNC_ENGINE_KEY] = engine
+    app[DB_ASYNC_ENGINE_APPKEY] = engine
     return get_async_engine(app)
 
 
 def get_async_engine(app: web.Application) -> AsyncEngine:
-    engine: AsyncEngine = app[APP_DB_ASYNC_ENGINE_KEY]
+    engine: AsyncEngine = app[DB_ASYNC_ENGINE_APPKEY]
     assert engine  # nosec
     return engine
 

--- a/services/payments/src/simcore_service_payments/db/auto_recharge_repo.py
+++ b/services/payments/src/simcore_service_payments/db/auto_recharge_repo.py
@@ -6,7 +6,7 @@ from models_library.basic_types import NonNegativeDecimal
 from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import BaseModel, ConfigDict, PositiveInt
-from simcore_postgres_database.utils_payments_autorecharge import AutoRechargeStmts
+from simcore_postgres_database.utils_payments_autorecharge import AutoRechargeStatements
 
 from .base import BaseRepository
 
@@ -33,7 +33,7 @@ class AutoRechargeRepo(BaseRepository):
         """
 
         async with self.db_engine.begin() as conn:
-            stmt = AutoRechargeStmts.get_wallet_autorecharge(wallet_id)
+            stmt = AutoRechargeStatements.get_wallet_autorecharge(wallet_id)
             result = await conn.execute(stmt)
             row = result.first()
             return PaymentsAutorechargeDB.model_validate(row) if row else None
@@ -50,7 +50,7 @@ class AutoRechargeRepo(BaseRepository):
 
         """
         async with self.db_engine.begin() as conn:
-            stmt = AutoRechargeStmts.is_valid_payment_method(
+            stmt = AutoRechargeStatements.is_valid_payment_method(
                 user_id=user_id,
                 wallet_id=new.wallet_id,
                 payment_method_id=new.primary_payment_method_id,
@@ -61,7 +61,7 @@ class AutoRechargeRepo(BaseRepository):
                     payment_method_id=new.primary_payment_method_id
                 )
 
-            stmt = AutoRechargeStmts.upsert_wallet_autorecharge(
+            stmt = AutoRechargeStatements.upsert_wallet_autorecharge(
                 wallet_id=wallet_id,
                 enabled=new.enabled,
                 primary_payment_method_id=new.primary_payment_method_id,

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_guests.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_guests.py
@@ -8,7 +8,6 @@ from models_library.projects import ProjectID
 from models_library.users import UserID, UserNameID
 from redis.asyncio import Redis
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
-from simcore_postgres_database.aiopg_errors import DatabaseError
 from simcore_postgres_database.models.users import UserRole
 
 from ..projects._projects_repository_legacy import ProjectDBAPI
@@ -162,7 +161,6 @@ async def remove_guest_user_with_all_its_resources(
         await users_service.delete_user_without_projects(app, user_id=user_id)
 
     except (
-        DatabaseError,
         asyncpg.exceptions.PostgresError,
         ProjectNotFoundError,
         UserNotFoundError,

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_core_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_core_utils.py
@@ -137,7 +137,6 @@ async def replace_current_owner(
         )
 
     except (
-        DatabaseError,
         asyncpg.exceptions.PostgresError,
         ProjectNotFoundError,
         UserNotFoundError,

--- a/services/web/server/src/simcore_service_webserver/payments/_autorecharge_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_autorecharge_api.py
@@ -11,7 +11,7 @@ from models_library.users import UserID
 from models_library.wallets import WalletID
 
 from ._autorecharge_db import (
-    PaymentsAutorechargeDB,
+    PaymentsAutorechargeGetDB,
     get_wallet_autorecharge,
     replace_wallet_autorecharge,
 )
@@ -23,7 +23,7 @@ _logger = logging.getLogger(__name__)
 
 
 def _from_db_to_api_model(
-    db_model: PaymentsAutorechargeDB, min_balance_in_credits: NonNegativeDecimal
+    db_model: PaymentsAutorechargeGetDB, min_balance_in_credits: NonNegativeDecimal
 ) -> GetWalletAutoRecharge:
     return GetWalletAutoRecharge(
         enabled=db_model.enabled,
@@ -36,8 +36,8 @@ def _from_db_to_api_model(
 
 def _from_api_to_db_model(
     wallet_id: WalletID, api_model: ReplaceWalletAutoRecharge
-) -> PaymentsAutorechargeDB:
-    return PaymentsAutorechargeDB(
+) -> PaymentsAutorechargeGetDB:
+    return PaymentsAutorechargeGetDB(
         wallet_id=wallet_id,
         enabled=api_model.enabled,
         primary_payment_method_id=api_model.payment_method_id,
@@ -64,7 +64,7 @@ async def get_wallet_payment_autorecharge(
         app, user_id=user_id, wallet_id=wallet_id, product_name=product_name
     )
     settings = get_plugin_settings(app)
-    got: PaymentsAutorechargeDB | None = await get_wallet_autorecharge(
+    got: PaymentsAutorechargeGetDB | None = await get_wallet_autorecharge(
         app, wallet_id=wallet_id
     )
     if not got:
@@ -104,7 +104,7 @@ async def replace_wallet_payment_autorecharge(
     )
 
     settings = get_plugin_settings(app)
-    got: PaymentsAutorechargeDB = await replace_wallet_autorecharge(
+    got: PaymentsAutorechargeGetDB = await replace_wallet_autorecharge(
         app,
         user_id=user_id,
         wallet_id=wallet_id,

--- a/services/web/server/src/simcore_service_webserver/payments/_autorecharge_db.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_autorecharge_db.py
@@ -18,7 +18,7 @@ _logger = logging.getLogger(__name__)
 AutoRechargeID: TypeAlias = PositiveInt
 
 
-class PaymentsAutorechargeDB(BaseModel):
+class PaymentsAutorechargeGetDB(BaseModel):
     wallet_id: WalletID
     enabled: bool
     primary_payment_method_id: PaymentMethodID
@@ -31,12 +31,12 @@ async def get_wallet_autorecharge(
     app: web.Application,
     *,
     wallet_id: WalletID,
-) -> PaymentsAutorechargeDB | None:
+) -> PaymentsAutorechargeGetDB | None:
     async with get_database_engine_legacy(app).acquire() as conn:
         stmt = AutoRechargeStmts.get_wallet_autorecharge(wallet_id)
         result = await conn.execute(stmt)
         row = await result.first()
-        return PaymentsAutorechargeDB.model_validate(row) if row else None
+        return PaymentsAutorechargeGetDB.model_validate(row) if row else None
 
 
 async def replace_wallet_autorecharge(
@@ -44,8 +44,8 @@ async def replace_wallet_autorecharge(
     *,
     user_id: UserID,
     wallet_id: WalletID,
-    new: PaymentsAutorechargeDB,
-) -> PaymentsAutorechargeDB:
+    new: PaymentsAutorechargeGetDB,
+) -> PaymentsAutorechargeGetDB:
     """
     Raises:
         InvalidPaymentMethodError: if `new` includes some invalid 'primary_payment_method_id'
@@ -73,4 +73,4 @@ async def replace_wallet_autorecharge(
         result = await conn.execute(stmt)
         row = await result.first()
         assert row  # nosec
-        return PaymentsAutorechargeDB.model_validate(row)
+        return PaymentsAutorechargeGetDB.model_validate(row)

--- a/services/web/server/src/simcore_service_webserver/payments/_autorecharge_db.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_autorecharge_db.py
@@ -7,7 +7,7 @@ from models_library.basic_types import NonNegativeDecimal
 from models_library.users import UserID
 from models_library.wallets import WalletID
 from pydantic import BaseModel, ConfigDict, PositiveInt
-from simcore_postgres_database.utils_payments_autorecharge import AutoRechargeStmts
+from simcore_postgres_database.utils_payments_autorecharge import AutoRechargeStatements
 from simcore_postgres_database.utils_repos import (
     pass_or_acquire_connection,
     transaction_context,
@@ -39,7 +39,7 @@ async def get_wallet_autorecharge(
     wallet_id: WalletID,
 ) -> PaymentsAutorechargeGetDB | None:
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
-        stmt = AutoRechargeStmts.get_wallet_autorecharge(wallet_id)
+        stmt = AutoRechargeStatements.get_wallet_autorecharge(wallet_id)
         result = await conn.execute(stmt)
         row = result.one_or_none()
         return PaymentsAutorechargeGetDB.model_validate(row) if row else None
@@ -59,7 +59,7 @@ async def replace_wallet_autorecharge(
 
     """
     async with transaction_context(get_asyncpg_engine(app), connection) as conn:
-        stmt = AutoRechargeStmts.is_valid_payment_method(
+        stmt = AutoRechargeStatements.is_valid_payment_method(
             user_id=user_id,
             wallet_id=new.wallet_id,
             payment_method_id=new.primary_payment_method_id,
@@ -70,7 +70,7 @@ async def replace_wallet_autorecharge(
                 payment_method_id=new.primary_payment_method_id
             )
 
-        stmt = AutoRechargeStmts.upsert_wallet_autorecharge(
+        stmt = AutoRechargeStatements.upsert_wallet_autorecharge(
             wallet_id=wallet_id,
             enabled=new.enabled,
             primary_payment_method_id=new.primary_payment_method_id,

--- a/services/web/server/src/simcore_service_webserver/payments/_methods_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_methods_api.py
@@ -25,7 +25,7 @@ from ..wallets.api import get_wallet_by_user
 from . import _rpc
 from ._autorecharge_db import get_wallet_autorecharge
 from ._methods_db import (
-    PaymentsMethodsDB,
+    PaymentsMethodsGetDB,
     delete_payment_method,
     get_successful_payment_method,
     insert_init_payment_method,
@@ -52,7 +52,7 @@ def _get_payment_methods_from_fake_gateway(fake: Faker):
 
 
 def _to_api_model(
-    entry: PaymentsMethodsDB, payment_method_details_from_gateway: dict[str, Any]
+    entry: PaymentsMethodsGetDB, payment_method_details_from_gateway: dict[str, Any]
 ) -> PaymentMethodGet:
     assert entry.completed_at  # nosec
 
@@ -107,12 +107,12 @@ async def _ack_creation_of_wallet_payment_method(
     payment_method_id: PaymentMethodID,
     completion_state: InitPromptAckFlowState,
     message: str | None = None,
-) -> PaymentsMethodsDB:
+) -> PaymentsMethodsGetDB:
     """Acks as completed (i.e. SUCCESSFUL, FAILED, CANCELED )"""
     assert completion_state != InitPromptAckFlowState.PENDING  # nosec
 
     # annotate
-    updated: PaymentsMethodsDB = await udpate_payment_method(
+    updated: PaymentsMethodsGetDB = await udpate_payment_method(
         app,
         payment_method_id=payment_method_id,
         state=completion_state,

--- a/services/web/server/src/simcore_service_webserver/payments/_onetime_api.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_onetime_api.py
@@ -24,7 +24,7 @@ from simcore_postgres_database.models.payments_transactions import (
 from simcore_postgres_database.utils_payments import insert_init_payment_transaction
 from yarl import URL
 
-from ..db.plugin import get_database_engine_legacy
+from ..db.plugin import get_asyncpg_engine
 from ..products import products_service
 from ..resource_usage.service import add_credits_to_wallet
 from ..users import users_service
@@ -46,7 +46,7 @@ _FAKE_PAYMENT_TRANSACTION_ID_PREFIX = "fpt"
 
 
 def _to_api_model(
-    transaction: _onetime_db.PaymentsTransactionsDB,
+    transaction: _onetime_db.PaymentsTransactionsGetDB,
 ) -> PaymentTransaction:
     data: dict[str, Any] = {
         "payment_id": transaction.payment_id,
@@ -90,7 +90,7 @@ async def _fake_init_payment(
         .with_query(id=payment_id)
     )
     # (2) Annotate INIT transaction
-    async with get_database_engine_legacy(app).acquire() as conn:
+    async with get_asyncpg_engine(app).begin() as conn:
         await insert_init_payment_transaction(
             conn,
             payment_id=payment_id,

--- a/services/web/server/src/simcore_service_webserver/payments/_onetime_db.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_onetime_db.py
@@ -20,8 +20,13 @@ from simcore_postgres_database.utils_payments import (
     get_user_payments_transactions,
     update_payment_transaction_state,
 )
+from simcore_postgres_database.utils_repos import (
+    pass_or_acquire_connection,
+    transaction_context,
+)
+from sqlalchemy.ext.asyncio import AsyncConnection
 
-from ..db.plugin import get_database_engine_legacy
+from ..db.plugin import get_asyncpg_engine
 from .errors import PaymentCompletedError, PaymentNotFoundError
 
 _logger = logging.getLogger(__name__)
@@ -30,7 +35,7 @@ _logger = logging.getLogger(__name__)
 #
 # NOTE: this will be moved to the payments service
 # NOTE: with https://sqlmodel.tiangolo.com/ we would only define this once!
-class PaymentsTransactionsDB(BaseModel):
+class PaymentsTransactionsGetDB(BaseModel):
     payment_id: PaymentID
     price_dollars: Decimal  # accepts negatives
     osparc_credits: Decimal  # accepts negatives
@@ -48,43 +53,47 @@ class PaymentsTransactionsDB(BaseModel):
 
 
 async def list_user_payment_transactions(
-    app,
+    app: web.Application,
+    connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
     offset: PositiveInt,
     limit: PositiveInt,
-) -> tuple[int, list[PaymentsTransactionsDB]]:
+) -> tuple[int, list[PaymentsTransactionsGetDB]]:
     """List payments done by a give user (any wallet)
 
     Sorted by newest-first
     """
-    async with get_database_engine_legacy(app).acquire() as conn:
+    async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
         total_number_of_items, rows = await get_user_payments_transactions(
             conn, user_id=user_id, offset=offset, limit=limit
         )
-        page = TypeAdapter(list[PaymentsTransactionsDB]).validate_python(rows)
+        page = TypeAdapter(list[PaymentsTransactionsGetDB]).validate_python(rows)
         return total_number_of_items, page
 
 
-async def get_pending_payment_transactions_ids(app: web.Application) -> list[PaymentID]:
-    async with get_database_engine_legacy(app).acquire() as conn:
+async def get_pending_payment_transactions_ids(
+    app: web.Application, connection: AsyncConnection | None = None
+) -> list[PaymentID]:
+    async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
         result = await conn.execute(
             sa.select(payments_transactions.c.payment_id)
             .where(payments_transactions.c.completed_at == None)  # noqa: E711
             .order_by(payments_transactions.c.initiated_at.asc())  # oldest first
         )
-        rows = await result.fetchall() or []
+        rows = result.fetchall()
         return [TypeAdapter(PaymentID).validate_python(row.payment_id) for row in rows]
 
 
 async def complete_payment_transaction(
     app: web.Application,
+    connection: AsyncConnection | None = None,
     *,
     payment_id: PaymentID,
     completion_state: PaymentTransactionState,
     state_message: str | None,
     invoice_url: HttpUrl | None = None,
-) -> PaymentsTransactionsDB:
+) -> PaymentsTransactionsGetDB:
     """
 
     Raises:
@@ -95,7 +104,7 @@ async def complete_payment_transaction(
     if invoice_url:
         optional_kwargs["invoice_url"] = invoice_url
 
-    async with get_database_engine_legacy(app).acquire() as conn:
+    async with transaction_context(get_asyncpg_engine(app), connection) as conn:
         row = await update_payment_transaction_state(
             conn,
             payment_id=payment_id,
@@ -111,4 +120,4 @@ async def complete_payment_transaction(
             raise PaymentCompletedError(payment_id=row.payment_id)
 
         assert row  # nosec
-        return PaymentsTransactionsDB.model_validate(row)
+        return PaymentsTransactionsGetDB.model_validate(row)

--- a/services/web/server/src/simcore_service_webserver/payments/_onetime_db.py
+++ b/services/web/server/src/simcore_service_webserver/payments/_onetime_db.py
@@ -22,7 +22,6 @@ from simcore_postgres_database.utils_payments import (
 )
 from simcore_postgres_database.utils_repos import (
     pass_or_acquire_connection,
-    transaction_context,
 )
 from sqlalchemy.ext.asyncio import AsyncConnection
 
@@ -104,7 +103,8 @@ async def complete_payment_transaction(
     if invoice_url:
         optional_kwargs["invoice_url"] = invoice_url
 
-    async with transaction_context(get_asyncpg_engine(app), connection) as conn:
+    async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
+        # NOTE: update_payment_transaction_state() uses a transaction internally, therefore we use pass_or_acquire_connection(...)
         row = await update_payment_transaction_state(
             conn,
             payment_id=payment_id,

--- a/services/web/server/src/simcore_service_webserver/projects/models.py
+++ b/services/web/server/src/simcore_service_webserver/projects/models.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, TypeAlias
 
-from aiopg.sa.result import RowProxy
 from common_library.dict_tools import remap_keys
 from models_library.api_schemas_webserver.projects import ProjectPatch
 from models_library.api_schemas_webserver.projects_ui import StudyUI
@@ -19,7 +18,6 @@ from pydantic import BaseModel, ConfigDict, HttpUrl, field_validator
 from simcore_postgres_database.models.projects import ProjectTemplateType, ProjectType
 
 ProjectDict: TypeAlias = dict[str, Any]
-ProjectProxy: TypeAlias = RowProxy
 
 
 class ProjectTypeAPI(str, Enum):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This PR migrates database access from **`aiopg`** to **`asyncpg`** in the following components:

* The `payments` domain within the `webserver`
* The `simcore_postgres_database.utils_payments` module and its associated test suite


### In detail summary (AI generated) 
This pull request refactors the payments database utility and its usage across the codebase to fully adopt SQLAlchemy's async API, removing legacy `aiopg` types and error handling. It also updates test cases and web server modules to use the new async interfaces and corrects model naming for autorecharge logic. These changes modernize the codebase, improve compatibility with SQLAlchemy, and simplify transaction handling.

**Database API modernization:**

* Replaced all usage of `aiopg.sa.connection.SAConnection` and related types with `sqlalchemy.ext.asyncio.AsyncConnection` and SQLAlchemy's async result types in `utils_payments.py`, updating function signatures and result handling accordingly. [[1]](diffhunk://#diff-2dcb3971cbc7e63702cf9af03a4b8148f460ae862926e8351720c17e770bb053L8-R18) [[2]](diffhunk://#diff-2dcb3971cbc7e63702cf9af03a4b8148f460ae862926e8351720c17e770bb053L42-R42) [[3]](diffhunk://#diff-2dcb3971cbc7e63702cf9af03a4b8148f460ae862926e8351720c17e770bb053L104-R112) [[4]](diffhunk://#diff-2dcb3971cbc7e63702cf9af03a4b8148f460ae862926e8351720c17e770bb053L128-R133) [[5]](diffhunk://#diff-2dcb3971cbc7e63702cf9af03a4b8148f460ae862926e8351720c17e770bb053L152-R148) [[6]](diffhunk://#diff-2dcb3971cbc7e63702cf9af03a4b8148f460ae862926e8351720c17e770bb053L165-R162)
* Updated error handling in payment transaction functions to catch `sqlalchemy.exc.IntegrityError` instead of custom `aiopg_errors.UniqueViolation`.

**Test suite updates:**

* Refactored all payment transaction tests to use `AsyncEngine` and async context management for database connections, replacing legacy connection types and adapting result assertions to new SQLAlchemy row objects. [[1]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2R6-L14) [[2]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2R28-R37) [[3]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2L61-R63) [[4]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2R72) [[5]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2L84-R105) [[6]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2L130-R145) [[7]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2L155-R167) [[8]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2L180-R189) [[9]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2L191-R211) [[10]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2L207-R236) [[11]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2R245) [[12]](diffhunk://#diff-499be634dc8810e44efe3218281292be351054c0efab66898163567bbe8c00a2R265)

**Web server module updates:**

* Removed references to `aiopg_errors.DatabaseError` in exception handling for guest user and project owner removal logic, relying solely on `asyncpg` and domain-specific errors. [[1]](diffhunk://#diff-095b9d11d90285b3393f3d7b2474a881535289e3eb51762f10b1f39297bf0430L11) [[2]](diffhunk://#diff-095b9d11d90285b3393f3d7b2474a881535289e3eb51762f10b1f39297bf0430L165) [[3]](diffhunk://#diff-7dfd884702436b72d87a66877feb91c283fe2f27d13eeafcac3cc5476cfdf58aL140)

**Autorecharge model and API corrections:**

* Renamed `PaymentsAutorechargeDB` to `PaymentsAutorechargeGetDB` and updated all references and API conversion functions to use the new model name, ensuring consistency between DB and API layers. [[1]](diffhunk://#diff-e89a2ae2f4433e844f11a634d5d582d0b6bf1834b714fa7052ae58c7e3951f9cL14-R14) [[2]](diffhunk://#diff-e89a2ae2f4433e844f11a634d5d582d0b6bf1834b714fa7052ae58c7e3951f9cL26-R26) [[3]](diffhunk://#diff-e89a2ae2f4433e844f11a634d5d582d0b6bf1834b714fa7052ae58c7e3951f9cL39-R40) [[4]](diffhunk://#diff-e89a2ae2f4433e844f11a634d5d582d0b6bf1834b714fa7052ae58c7e3951f9cL67-R67) [[5]](diffhunk://#diff-e89a2ae2f4433e844f11a634d5d582d0b6bf1834b714fa7052ae58c7e3951f9cL107-R107) [[6]](diffhunk://#diff-e0cb233e37868c7dab35378e9c3a547f9d03ecc9e2e8b014b5e6e7ac2b1cbedfL21-R26)
* Updated autorecharge DB module to use async engine and transaction context utilities for database operations.

These changes collectively improve code maintainability, test reliability, and compatibility with modern async database patterns.

## Related issue/s

- part of https://github.com/ITISFoundation/osparc-simcore/issues/4529

## How to test

```
cd packages/postgres-database
make install-dev
pytest -vv tests/test_models_payments_transactions.py
```

```
cd services/web/server
make install-dev
pytest -vv tests/unit/**/wallets/**/test_*.py
```

## Dev-ops
None