### PR TITLE
🐛 [Frontend] Fix: Open My Account in ``s4llite``

### DIFF
--- a/services/static-webserver/client/source/class/osparc/product/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/product/Utils.js
@@ -181,6 +181,7 @@ qx.Class.define("osparc.product.Utils", {
             key: "organization",
           };
         case "osparc":
+        default:
           return {
             label: qx.locale.Manager.tr("Research Group/Organization"),
             key: "organization",


### PR DESCRIPTION
## What do these changes do?

reported by @nereaiscamu

This PR fixes the "My Account" functionality for the s4llite product by updating the switch case logic in the product utilities. The change ensures that s4llite users are properly routed to the university-specific account configuration instead of falling through to the default case.

## Related issue/s
- resolves https://z43.manuscript.com/f/cases/228581/Sim4Life-Lite-My-Account-not-working


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
