### PR TITLE
🐛 [Frontend] Fix: invalidate cache after emptying trash

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -1119,7 +1119,10 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       searchBarTextField.addListener("tap", () => this.__extendSearchBar());
 
       const header = this.__header = new osparc.dashboard.StudyBrowserHeader();
-      this.__header.addListener("trashEmptied", () => this.reloadResources(), this);
+      this.__header.addListener("trashEmptied", () => {
+        this.invalidateStudies();
+        this.reloadResources();
+      }, this);
       this._addToLayout(header);
 
       this._createResourcesLayout("studiesList");


### PR DESCRIPTION
## What do these changes do?

reported by @pcrespov https://github.com/ITISFoundation/osparc-simcore/issues/8476#issuecomment-3382775717

This PR fixes a bug where the cache wasn't being invalidated after emptying the trash in the dashboard, ensuring that the UI properly reflects the updated state after trash operations.

![EmptyTrash](https://github.com/user-attachments/assets/ece2485f-784a-453e-ba31-b51eeb2d6cdd)

## Related issue/s
- closes https://github.com/ITISFoundation/osparc-simcore/issues/8476


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
