### PR TITLE
♻️ RabbitMQ: Make sure exclusive queues are not set as durable (⚠️ devops)

### DIFF
--- a/packages/service-library/src/servicelib/rabbitmq/_utils.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_utils.py
@@ -85,19 +85,6 @@ async def declare_queue(
         # NOTE: setting a name will ensure multiple instance will take their data here
         queue_parameters |= {"name": queue_name}
 
-    # avoids deprecated `transient_nonexcl_queues` warning in RabbitMQ
-    if (
-        queue_parameters.get("durable", False) is False
-        and queue_parameters.get("exclusive", False) is False
-    ):
-        msg = (
-            "Queue must be `durable` or `exclusive`, but not both. "
-            "This is to avoid the `transient_nonexcl_queues` warning. "
-            "NOTE: if both `durable` and `exclusive` are missing they are considered False. "
-            f"{queue_parameters=}"
-        )
-        raise ValueError(msg)
-
     # NOTE: if below line raises something similar to ``ChannelPreconditionFailed: PRECONDITION_FAILED``
     # most likely someone changed the signature of the queues (parameters etc...)
     # Safest way to deal with it:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
- ensure exclusive queues (queues that are auto-deleted when the connection to a client is closed) are not set as durable (survive broker crash/restart) as this is pointless: e.g. if the connection is closed then the queue is anyway closed due to exclusivity

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/8078

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
⚠️ the affected queues will need to be deleted prior to deploying

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
