### PR TITLE
🐛 [Frontend] Fix: no-read default accessRights for the chatbot user

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/Group.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Group.js
@@ -28,11 +28,17 @@ qx.Class.define("osparc.data.model.Group", {
   construct: function(groupData) {
     this.base(arguments);
 
+    const defaultAccessRights = {
+      "read": false,
+      "write": false,
+      "delete": false,
+    };
+
     this.set({
       groupId: groupData.gid,
       label: groupData.label,
       description: groupData.description,
-      accessRights: groupData.accessRights,
+      accessRights: groupData.accessRights || defaultAccessRights,
       thumbnail: groupData.thumbnail,
       groupMembers: {},
     });
@@ -82,7 +88,7 @@ qx.Class.define("osparc.data.model.Group", {
     },
 
     groupType: {
-      check: ["me", "organization", "support", "productEveryone", "everyone"],
+      check: ["me", "organization", "support", "chatbot", "productEveryone", "everyone"],
       nullable: false,
       init: null,
     },

--- a/services/static-webserver/client/source/class/osparc/store/Groups.js
+++ b/services/static-webserver/client/source/class/osparc/store/Groups.js
@@ -106,16 +106,11 @@ qx.Class.define("osparc.store.Groups", {
           const productEveryoneGroup = this.__addToGroupsCache(resp["product"], "productEveryone");
           let supportGroup = null;
           if ("support" in resp && resp["support"]) {
-            resp["support"]["accessRights"] = {
-              "read": false,
-              "write": false,
-              "delete": false,
-            };
             supportGroup = this.__addToGroupsCache(resp["support"], "support");
           }
+          let chatbot = null;
           if ("chatbot" in resp && resp["chatbot"]) {
-            const chatbot = new osparc.data.model.Group(resp["chatbot"]);
-            this.setChatbot(chatbot);
+            chatbot = this.__addToGroupsCache(resp["chatbot"], "chatbot");
           }
           const groupMe = this.__addToGroupsCache(resp["me"], "me");
           const orgs = {};
@@ -131,6 +126,7 @@ qx.Class.define("osparc.store.Groups", {
           this.setEveryoneGroup(everyoneGroup);
           this.setEveryoneProductGroup(productEveryoneGroup);
           this.setSupportGroup(supportGroup);
+          this.setChatbot(chatbot);
           this.setOrganizations(orgs);
           this.setGroupMe(groupMe);
           const myAuthData = osparc.auth.Data.getInstance();


### PR DESCRIPTION
## What do these changes do?

This PR fixes the initialization of the ``chatbot`` "group" by defaulting its accessRights to no-read


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
