### PR TITLE
🎨E2E: Adds missing prefix for websocket messages

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -143,6 +143,7 @@ class SocketIOEvent:
 
 
 SOCKETIO_MESSAGE_PREFIX: Final[str] = "42"
+_WEBSOCKET_MESSAGE_PREFIX: Final[str] = "📡OSPARC-WEBSOCKET: "
 
 
 @dataclass
@@ -165,20 +166,31 @@ class RobustWebSocket:
         ) as ctx:
 
             def on_framesent(payload: str | bytes) -> None:
-                ctx.logger.debug("⬇️ Frame sent: %s", payload)
+                ctx.logger.debug(
+                    "%s⬇️ Frame sent: %s", _WEBSOCKET_MESSAGE_PREFIX, payload
+                )
 
             def on_framereceived(payload: str | bytes) -> None:
-                ctx.logger.debug("⬆️ Frame received: %s", payload)
+                ctx.logger.debug(
+                    "%s⬆️ Frame received: %s", _WEBSOCKET_MESSAGE_PREFIX, payload
+                )
 
             def on_close(_: WebSocket) -> None:
                 if self.auto_reconnect:
-                    ctx.logger.warning("⚠️ WebSocket closed. Attempting to reconnect...")
+                    ctx.logger.warning(
+                        "%s⚠️ WebSocket closed. Attempting to reconnect...",
+                        _WEBSOCKET_MESSAGE_PREFIX,
+                    )
                     self._attempt_reconnect(ctx.logger)
                 else:
-                    ctx.logger.warning("⚠️ WebSocket closed.")
+                    ctx.logger.warning(
+                        "%s⚠️ WebSocket closed.", _WEBSOCKET_MESSAGE_PREFIX
+                    )
 
             def on_socketerror(error_msg: str) -> None:
-                ctx.logger.error("❌ WebSocket error: %s", error_msg)
+                ctx.logger.error(
+                    "%s❌ WebSocket error: %s", _WEBSOCKET_MESSAGE_PREFIX, error_msg
+                )
 
             # Attach core event listeners
             self.ws.on("framesent", on_framesent)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
Osparc message are shown with: `📡OSPARC-WEBSOCKET: `
S4l message are shown with: `📡S4L-WEBSOCKET: `
<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
