### PR TITLE
🎨Director v0: make compatible with OCI typed images

### DIFF
--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -411,9 +411,6 @@ async def get_image_labels(
         labels: dict[str, str] = {}
         match schema_version:
             case 2:
-                await _get_image_labels_schema_v2(
-                    app, image, tag, update_cache=update_cache
-                )
                 # Image Manifest Version 2, Schema 2 -> defaults in registries v3 (https://distribution.github.io/distribution/spec/manifest-v2-2/)
                 media_type = request_result["mediaType"]
                 if media_type in (
@@ -421,7 +418,7 @@ async def get_image_labels(
                     "application/vnd.oci.image.index.v1+json",
                 ):
                     # default to x86_64 architecture
-                    _logger.warning(
+                    _logger.info(
                         "Docker image %s:%s contains multiple architectures. "
                         "Currently defaulting to first architecture",
                         image,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->
During testing with images built using the OCI standard (new standard with which is compatible): https://github.com/opencontainers/image-spec/blob/main/image-layout.md

The director-v0 needed an update to also allow fetching labels on these images.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
