### PR TITLE
🎨 [Frontend] Transparent bgColor for readOnly fields

### DIFF
--- a/services/static-webserver/client/source/class/osparc/theme/Appearance.js
+++ b/services/static-webserver/client/source/class/osparc/theme/Appearance.js
@@ -641,11 +641,20 @@ qx.Theme.define("osparc.theme.Appearance", {
           decorator += "-invalid";
         }
 
+        let backgroundColor;
+        if (states.readonly) {
+          backgroundColor = "transparent";
+        } else if (states.disabled) {
+          backgroundColor = "input_background_disable";
+        } else {
+          backgroundColor = "input_background";
+        }
+
         return {
           decorator: decorator,
           padding: padding,
           textColor: textColor,
-          backgroundColor: states.disabled ? "input_background_disable" : "input_background"
+          backgroundColor: backgroundColor
         };
       }
     },


### PR DESCRIPTION
## What do these changes do?

This PR enhances the appearance for ``readOnly`` input fields by making their background transparent.

![ReadOnly](https://github.com/user-attachments/assets/7c33a901-1ab2-422d-aa82-a0846d13901c)

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
