### PR TITLE
🐛 [Frontend] Fix: File Picker's getOutput helper

### DIFF
--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -66,7 +66,8 @@ qx.Class.define("osparc.file.FilePicker", {
   statics: {
     getOutput: function(outputs) {
       const output = outputs.find(out => out.getPortKey() === osparc.data.model.NodePort.FP_PORT_KEY);
-      return output.getValue();
+      // output can be undefined
+      return output ? output.getValue() : null;
     },
 
     getFilenameFromPath: function(output) {
@@ -231,9 +232,7 @@ qx.Class.define("osparc.file.FilePicker", {
           });
       } else if (osparc.file.FilePicker.isOutputDownloadLink(node.getOutputs())) {
         const outFileValue = osparc.file.FilePicker.getOutput(node.getOutputs());
-        if (osparc.utils.Utils.isObject(outFileValue) && "downloadLink" in outFileValue) {
-          osparc.utils.Utils.downloadLink(outFileValue["downloadLink"], "GET", outFileValue["label"], progressCb, loadedCb);
-        }
+        osparc.utils.Utils.downloadLink(outFileValue["downloadLink"], "GET", outFileValue["label"], progressCb, loadedCb);
       }
     },
 


### PR DESCRIPTION
## What do these changes do?

This PR fixes a bug in the FilePicker's getOutput helper function where it could cause a null pointer error when the output is undefined

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
