### PR TITLE
remove fake progress

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/NodeProgressSequence.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/NodeProgressSequence.js
@@ -343,35 +343,5 @@ qx.Class.define("osparc.data.model.NodeProgressSequence", {
 
       this.__computeOverallProgress();
     },
-
-    __startSidecarPullingFakeProgress: function() {
-      // stop any previous timer
-      this.__stopSidecarPullingFakeProgress();
-      // increase fake progress:
-      // - every second
-      // - up to 99%
-      // - by progressStep each time: fill it in about 60 seconds
-      // - make sure the backend didn't already update it
-      this.__sidecarFakeProgressTimer = setInterval(() => {
-        const progressStep = 1/60;
-        const sidecarProgress = this.getSidecarPulling();
-        if (sidecarProgress.value < 0.99) {
-          const newValue = Math.min(sidecarProgress.value + progressStep, 0.99);
-          this.setSidecarPulling({
-            progressLabel: `${(osparc.utils.Utils.safeToFixed(newValue * 100, 1))}%`,
-            value: newValue
-          });
-        } else {
-          this.__stopSidecarPullingFakeProgress();
-        }
-      }, 1000);
-    },
-
-    __stopSidecarPullingFakeProgress: function() {
-      if (this.__sidecarFakeProgressTimer) {
-        clearInterval(this.__sidecarFakeProgressTimer);
-        this.__sidecarFakeProgressTimer = null;
-      }
-    },
   }
 });


### PR DESCRIPTION
## What do these changes do?

Since the backend now provides some progress on the sidecar startup step, this PR removes the fake progress implementation for sidecar pulling in the frontend.

## Related issue/s
- deprecated after https://github.com/ITISFoundation/osparc-simcore/pull/8687


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
