### PR TITLE
✨ [Frontend] Plus button: Add S4L edge to default listing

### DIFF
--- a/services/static-webserver/client/source/resource/osparc/ui_config.json
+++ b/services/static-webserver/client/source/resource/osparc/ui_config.json
@@ -106,6 +106,11 @@
         "idToWidget": "startS4LButton"
       }, {
         "resourceType": "service",
+        "expectedKey": "simcore/services/dynamic/s4l-ui-edge",
+        "title": "Sim4Life-edge",
+        "newStudyLabel": "New Sim4Life-edge"
+      }, {
+        "resourceType": "service",
         "expectedKey": "simcore/services/dynamic/s4l-jupyter",
         "title": "Jupyter Lab",
         "newStudyLabel": "New S4L Jupyter Lab"
@@ -156,6 +161,11 @@
         "title": "Sim4Life",
         "newStudyLabel": "New Sim4Life",
         "idToWidget": "startS4LButton"
+      }, {
+        "resourceType": "service",
+        "expectedKey": "simcore/services/dynamic/s4l-ui-edge",
+        "title": "Sim4Life-edge",
+        "newStudyLabel": "New Sim4Life-edge"
       }, {
         "resourceType": "service",
         "expectedKey": "simcore/services/dynamic/s4l-jupyter",


### PR DESCRIPTION
## What do these changes do?

This PR adds the Sim4Life edge service to the default UI configuration listing, making it available through the "plus button" interface for creating new projects.

![S4L-edge](https://github.com/user-attachments/assets/1da23220-280e-4153-a0f3-ee4fb0875079)


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
