### PR TITLE
🐛 Autoscaling: adjust EC2 available resources based on dynamic-sidecar + OPS services

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_auto_scaling_core.py
@@ -90,7 +90,15 @@ _logger = logging.getLogger(__name__)
 def _adjust_instances_resources(
     non_adjusted_instances: list[EC2InstanceData], adjusted_resources_by_type: dict[InstanceTypeType, Resources]
 ) -> list[EC2InstanceData]:
-    """Adjusts the resources of the given EC2 instances based on their type."""
+    """Applies precomputed resource profiles to EC2 instances.
+
+    The ``adjusted_resources_by_type`` mapping typically already accounts for
+    OPS services, dynamic-sidecar overhead, and similar system-level
+    reservations. Each instance in ``non_adjusted_instances`` is returned
+    with its ``resources`` field replaced by the matching adjusted resources
+    for its ``type`` when available; otherwise its original ``resources``
+    are preserved.
+    """
     return [
         dataclasses.replace(i, resources=adjusted_resources_by_type.get(i.type, i.resources))
         for i in non_adjusted_instances


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
The Autoscaling service provides EC2 instances based on the platform needs.
For example in dynamic mode, when a dynamic-sidecar is pending the autoscaling analyses its resource requirements and provides an EC2 to fulfil the requirements.

Since we are now working in full autoscaling mode in the deployments (e.g. no fixed machines anymore), a few issues surfaced. One of them being:
- in osparc.io (where we had hot buffer of type g4dn.xlarge (4 CPUs, 16GB)
- starting iSeg or Raw-graph would randomly fail

The reason for this is the following:
- iSeg and Raw-graph require 3 CPUs and 16GB of RAM
- when there is no machine, the autoscaling would properly start a machine with > 4CPUs as it takes in account the OPS services and dynamic-sidecar resource requirements (~1.4CPUs, 1GB)
- when a machine is already active, these resource requirements were not computed, therefore the autoscaling would define a g4dn.xlarge as sufficient, even though it is not.

This PR fixes this and might need to be hotfixed.

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/8747

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
