### PR TITLE
🐛 Serialize Pydantic type when sent as Celery task arg

### DIFF
--- a/services/web/server/src/simcore_service_webserver/celery/_task_manager.py
+++ b/services/web/server/src/simcore_service_webserver/celery/_task_manager.py
@@ -5,7 +5,8 @@ from aiohttp import web
 from celery_library.app import create_app
 from celery_library.backends.redis import RedisTaskStore
 from celery_library.task_manager import CeleryTaskManager
-from celery_library.types import register_celery_types
+from celery_library.types import register_celery_types, register_pydantic_types
+from models_library.api_schemas_storage.storage_schemas import FoldersBody
 from servicelib.celery.task_manager import TaskManager
 from servicelib.logging_utils import log_context
 from settings_library.celery import CelerySettings
@@ -15,9 +16,7 @@ from .settings import get_plugin_settings
 
 _logger = logging.getLogger(__name__)
 
-_APP_CELERY_TASK_MANAGER_KEY: Final = web.AppKey(
-    CeleryTaskManager.__name__, CeleryTaskManager
-)
+_APP_CELERY_TASK_MANAGER_KEY: Final = web.AppKey(CeleryTaskManager.__name__, CeleryTaskManager)
 
 
 async def setup_task_manager(app: web.Application):
@@ -33,6 +32,8 @@ async def setup_task_manager(app: web.Application):
             RedisTaskStore(redis_client_sdk),
         )
         register_celery_types()
+
+        register_pydantic_types(FoldersBody)
 
     yield
 

--- a/services/web/server/src/simcore_service_webserver/storage/api.py
+++ b/services/web/server/src/simcore_service_webserver/storage/api.py
@@ -16,6 +16,7 @@ from models_library.api_schemas_storage.storage_schemas import (
     FileLocation,
     FileLocationArray,
     FileMetaDataGet,
+    FoldersBody,
     PresignedLink,
 )
 from models_library.generics import Envelope
@@ -29,8 +30,7 @@ from servicelib.celery.models import ExecutionMetadata, OwnerMetadata
 from servicelib.logging_utils import log_context
 from yarl import URL
 
-from simcore_service_webserver.celery import get_task_manager
-
+from ..celery import get_task_manager
 from ..models import WebServerOwnerMetadata
 from ..projects.models import ProjectDict
 from ..projects.utils import NodesMap
@@ -113,11 +113,13 @@ async def copy_data_folders_from_project(
                     product_name=product_name,
                 ).model_dump()
             ),
-            body={
-                "source": source_project,
-                "destination": destination_project,
-                "nodes_map": nodes_map,
-            },
+            body=TypeAdapter(FoldersBody).validate_python(
+                {
+                    "source": source_project,
+                    "destination": destination_project,
+                    "nodes_map": nodes_map,
+                }
+            ),
             stop_after=datetime.timedelta(seconds=_TOTAL_TIMEOUT_TO_COPY_DATA_SECS),
             user_id=user_id,
         ):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This pull request updates the Celery task manager integration and improves type safety when copying data folders between projects. The main changes are the registration of additional Pydantic types for Celery serialization and stricter validation of the payload sent to the storage service.

**Celery task manager and type registration:**

* Registered `FoldersBody` as a Pydantic type with Celery to ensure correct (de)serialization of payloads in distributed tasks. [[1]](diffhunk://#diff-07010eb273f7596d294f280ee63331d49858d02ccbc4304d4f29ec30897edbddL8-R9) [[2]](diffhunk://#diff-07010eb273f7596d294f280ee63331d49858d02ccbc4304d4f29ec30897edbddR36-R37)
* Cleaned up and simplified the definition of the `_APP_CELERY_TASK_MANAGER_KEY`.

**Storage API improvements:**

* Updated the `copy_data_folders_from_project` function to use `TypeAdapter(FoldersBody).validate_python` for strict validation of the payload, ensuring it conforms to the expected schema before sending to the storage service.
* Added `FoldersBody` to the imports in `storage/api.py` for use in payload validation.
* Simplified the import of `get_task_manager` in `storage/api.py` for clarity.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

- No changes
