### PR TITLE
🎨 [frontend] e2e: Add ``osparc-test-id`` to start sim4life edge button

### DIFF
--- a/services/static-webserver/client/source/resource/osparc/ui_config.json
+++ b/services/static-webserver/client/source/resource/osparc/ui_config.json
@@ -108,7 +108,8 @@
         "resourceType": "service",
         "expectedKey": "simcore/services/dynamic/s4l-ui-edge",
         "title": "Sim4Life-edge",
-        "newStudyLabel": "New Sim4Life-edge"
+        "newStudyLabel": "New Sim4Life-edge",
+        "idToWidget": "startS4LEdgeButton"
       }, {
         "resourceType": "service",
         "expectedKey": "simcore/services/dynamic/s4l-jupyter",


### PR DESCRIPTION
## What do these changes do?

Related to start "Measure responsiveness times in S4L", this PR adds an ``osparc-test-id`` attribute to the Sim4Life Edge button.



## Related issue/s

- related to https://z43.manuscript.com/f/cases/232815/Sim4Life-never-freezes


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
