### PR TITLE
🔒️ Redact Postgres connection URL from logs

### DIFF
--- a/packages/common-library/src/common_library/network.py
+++ b/packages/common-library/src/common_library/network.py
@@ -16,10 +16,7 @@ def redact_url(url: str) -> str:
     if not parsed.password:
         return url
 
-    if parsed.username:
-        new_netloc = f"{parsed.username}:***@{parsed.hostname}"
-    else:
-        new_netloc = f":***@{parsed.hostname}"
+    new_netloc = f"{parsed.username}:***@{parsed.hostname}" if parsed.username else f":***@{parsed.hostname}"
 
     if parsed.port:
         new_netloc = f"{new_netloc}:{parsed.port}"

--- a/packages/service-library/src/servicelib/fastapi/db_asyncpg_engine.py
+++ b/packages/service-library/src/servicelib/fastapi/db_asyncpg_engine.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 
+from common_library.network import redact_url
 from fastapi import FastAPI
 from settings_library.postgres import PostgresSettings
 from simcore_postgres_database.utils_aiosqlalchemy import (  # type: ignore[import-not-found] # this on is unclear
@@ -25,7 +26,7 @@ async def connect_to_db(app: FastAPI, settings: PostgresSettings, application_na
     with log_context(
         _logger,
         logging.DEBUG,
-        f"Connecting and migraging {settings.dsn_with_async_sqlalchemy}",
+        f"Connecting and migrating {redact_url(settings.dsn_with_async_sqlalchemy)}",
     ):
         engine = await create_async_engine_and_database_ready(settings, application_name)
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request focuses on improving the security and clarity of database connection logging by ensuring sensitive information in database URLs is redacted before being logged. The main changes include updating how URLs are redacted and integrating this redaction into the database connection process.

## Related issue/s
- fixes #8786


## How to test

```shell
cd packages/common-library
pytest -v --pdb tests/test_network.py
```

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

- No changes, but @YuryHrytsuk's mood improves :)