### PR TITLE
🎨 Update chatbot client

### DIFF
--- a/services/web/server/src/simcore_service_webserver/chatbot/_client.py
+++ b/services/web/server/src/simcore_service_webserver/chatbot/_client.py
@@ -76,7 +76,6 @@ class ChatbotRestClient:
                 json={
                     "messages": [msg.model_dump(mode="json", exclude_none=True) for msg in messages],
                     "model": self._chatbot_settings.CHATBOT_MODEL,
-                    "metadata": {"collection_name": self._chatbot_settings.CHATBOT_COLLECTION_NAME},
                 },
                 headers={
                     "Content-Type": MIMETYPE_APPLICATION_JSON,

--- a/services/web/server/src/simcore_service_webserver/chatbot/settings.py
+++ b/services/web/server/src/simcore_service_webserver/chatbot/settings.py
@@ -15,7 +15,6 @@ class ChatbotSettings(BaseCustomSettings, MixinServiceSettings):
     CHATBOT_HOST: str
     CHATBOT_PORT: PortInt
     CHATBOT_MODEL: str = "gpt-4o-mini"
-    CHATBOT_COLLECTION_NAME: str = "sim4life_webplatform"
 
     @cached_property
     def base_url(self) -> str:

--- a/services/web/server/tests/unit/with_dbs/04/chatbot/test_chatbot_client.py
+++ b/services/web/server/tests/unit/with_dbs/04/chatbot/test_chatbot_client.py
@@ -39,7 +39,4 @@ async def test_chatbot_client(
     output = await chatbot_client.send(messages=[user_msg, developer_msg])
     assert isinstance(output, ResponseMessage)
     assert output.content == "42"
-    request_json = json.loads(mocked_chatbot_api.calls[0].request.content.decode())
-    metadata = request_json.get("metadata")
-    assert metadata
-    assert metadata.get("collection_name") == "sim4life_webplatform"
+    _ = json.loads(mocked_chatbot_api.calls[0].request.content.decode())


### PR DESCRIPTION
This pull request simplifies the chatbot client configuration by removing the use of the `CHATBOT_COLLECTION_NAME` setting and the associated `metadata` field from requests and tests. The changes help streamline the configuration and payload structure for chatbot interactions.

Configuration cleanup:

* Removed the `CHATBOT_COLLECTION_NAME` setting from the `ChatbotSettings` class in `chatbot/settings.py`, reducing unnecessary configuration options.

Payload simplification:

* Eliminated the inclusion of the `metadata` field (and its `collection_name`) from the JSON payload sent by the chatbot client in `_client.py`.

Test update:

* Updated the chatbot client test in `test_chatbot_client.py` to remove assertions related to the `metadata` field and `collection_name`, reflecting the simplified payload structure.<!-- Title Annotations:

### related PRs
- https://git.speag.com/oSparc/s4l-chatbox/-/merge_requests/63