### PR TITLE
🐛 Fixed bad merge

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/r_clone_mount_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/r_clone_mount_manager.py
@@ -146,9 +146,6 @@ class DynamicSidecarRCloneMountDelegate(DelegateInterface):
 
     async def remove_container(self, container_name: str) -> None:
         async with _get_docker_client() as client:
-            existing_container = await client.containers.get(container_name)
-            await existing_container.delete(force=True)
-
             try:
                 container = await client.containers.get(container_name)
             except DockerError as e:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

This sneaked up because of a bad merged in the code.


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
