### PR TITLE
🐛 Use allowed SMTP extra header in tests

### DIFF
--- a/packages/notifications-library/tests/email/conftest.py
+++ b/packages/notifications-library/tests/email/conftest.py
@@ -27,7 +27,7 @@ def app_environment(
 def with_smtp_extra_headers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> dict[str, str]:
-    headers = {"X-Test-Header": "TestTestTest"}
+    headers = {"x-ses-tenant": "test-tenant"}
     setenvs_from_dict(monkeypatch, {"SMTP_EXTRA_HEADERS": json.dumps(headers)})
     return headers
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

This pull request makes a small update to the test setup for SMTP extra headers in the notifications library. The test now uses one allowed header (`x-ses-tenant`) instead of a placeholder.

## Related issue/s
- relates to https://github.com/ITISFoundation/osparc-ops-environments/issues/1359

## How to test
```sh
cd packages/notification-library
make tests
```

## Dev-ops

- No changes