### PR TITLE
🐛 Fixed race condition in rclone mount health detection

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_manager.py
@@ -213,7 +213,7 @@ class RCloneMountManager:
                     with log_context(
                         _logger,
                         logging.WARNING,
-                        f"Restoring mount for path='{mount.local_mount_path}'",
+                        f"restoring mount for path='{mount.local_mount_path}'",
                     ):
                         await mount.stop_mount(skip_transfer_wait=True)
                         await mount.start_mount()
@@ -223,7 +223,7 @@ class RCloneMountManager:
                 with log_context(
                     _logger,
                     logging.WARNING,
-                    "Requesting service shutdown due to mount restoration",
+                    "requesting service shutdown due to mount restoration",
                 ):
                     # NOTE: since the mount is bind mounted, we ensure that it restarts properly
                     # then we shutdown the service since the user service will have an out of date


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

The mount health detection was being registered before the mount was started.
On machines where the mounting takes longer, would cause the mount to be detected as unhealthy and the service would be shut down.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
