### PR TITLE
♻️ refactor(web-server): use notification service for 2FA email code

### DIFF
--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/auth.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/auth.py
@@ -166,12 +166,13 @@ async def login(request: web.Request):
     # otherwise create email f2a
     assert user_2fa_authentication_method == TwoFactorAuthenticationMethod.EMAIL  # nosec
     await _twofa_service.send_email_code(
-        request,
+        request.app,
         user_email=user["email"],
-        support_email=product.support_email,
         code=code,
         first_name=user["first_name"] or user["name"],
-        product=product,
+        user_name=user["name"],
+        product_name=product.name,
+        host=request.host,
         user_id=user["id"],
     )
     return envelope_response(

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/twofa.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/twofa.py
@@ -97,12 +97,13 @@ async def resend_2fa_code(request: web.Request):
     else:
         assert resend_2fa_.via == "Email"  # nosec
         await _twofa_service.send_email_code(
-            request,
+            request.app,
             user_email=user["email"],
-            support_email=product.support_email,
             code=code,
             first_name=user["first_name"] or user["name"],
-            product=product,
+            user_name=user["name"],
+            product_name=product.name,
+            host=request.host,
             user_id=user["id"],
         )
 

--- a/services/web/server/src/simcore_service_webserver/login/_twofa_service.py
+++ b/services/web/server/src/simcore_service_webserver/login/_twofa_service.py
@@ -22,7 +22,7 @@ from settings_library.twilio import TwilioSettings
 from twilio.base.exceptions import TwilioException  # type: ignore[import-untyped]
 
 from ..notifications import notifications_service
-from ..notifications._models import EmailContact
+from ..notifications.models import EmailContact
 from ..redis import get_redis_validation_code_client
 from .errors import SendingVerificationEmailError, SendingVerificationSmsError
 

--- a/services/web/server/src/simcore_service_webserver/login/_twofa_service.py
+++ b/services/web/server/src/simcore_service_webserver/login/_twofa_service.py
@@ -12,6 +12,8 @@ import logging
 
 import twilio.rest  # type: ignore[import-untyped]
 from aiohttp import web
+from models_library.notifications import Channel
+from models_library.products import ProductName
 from models_library.users import UserID
 from pydantic import BaseModel, Field
 from servicelib.logging_utils import log_decorator
@@ -19,9 +21,9 @@ from servicelib.utils_secrets import generate_passcode
 from settings_library.twilio import TwilioSettings
 from twilio.base.exceptions import TwilioException  # type: ignore[import-untyped]
 
-from ..products.models import Product
+from ..notifications import notifications_service
+from ..notifications._models import EmailContact
 from ..redis import get_redis_validation_code_client
-from ._emails_service import get_template_path, send_email_from_template
 from .errors import SendingVerificationEmailError, SendingVerificationSmsError
 
 log = logging.getLogger(__name__)
@@ -147,27 +149,37 @@ class EmailError(RuntimeError):
 
 @log_decorator(log, level=logging.DEBUG)
 async def send_email_code(
-    request: web.Request,
+    app: web.Application,
+    *,
     user_email: str,
-    support_email: str,
     code: str,
     first_name: str,
-    product: Product,
+    user_name: str,
+    product_name: ProductName,
+    host: str,
     user_id: UserID | None = None,
 ):
     try:
-        email_template_path = await get_template_path(request, "new_2fa_code.jinja2")
-        await send_email_from_template(
-            request,
-            from_=support_email,
-            to=user_email,
-            template=email_template_path,
+        await notifications_service.send_message_from_template(
+            app,
+            user_id=user_id,
+            product_name=product_name,
+            channel=Channel.email,
+            group_ids=None,
+            external_contacts=[
+                EmailContact(
+                    name=first_name,
+                    email=user_email,
+                )
+            ],
+            template_name="new_code",
             context={
-                "host": request.host,
+                "user": {
+                    "first_name": first_name,
+                    "user_name": user_name,
+                },
+                "host": host,
                 "code": code,
-                "name": first_name,
-                "support_email": support_email,
-                "product": product,
             },
         )
     except Exception as exc:

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_twofa.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_twofa.py
@@ -32,6 +32,7 @@ from simcore_service_webserver.login._twofa_service import (
     delete_2fa_code,
     get_2fa_code,
     get_redis_validation_code_client,
+    notifications_service,
     send_email_code,
 )
 from simcore_service_webserver.login.constants import (
@@ -374,7 +375,7 @@ async def test_send_email_code(
     mocker: MockerFixture,
 ):
     mock_send = mocker.patch(
-        "simcore_service_webserver.login._twofa_service.notifications_service.send_message_from_template",
+        f"{notifications_service}.send_message_from_template",
         autospec=True,
     )
 

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_twofa.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_twofa.py
@@ -375,7 +375,7 @@ async def test_send_email_code(
     mocker: MockerFixture,
 ):
     mock_send = mocker.patch(
-        f"{notifications_service}.send_message_from_template",
+        f"{notifications_service.__name__}.send_message_from_template",
         autospec=True,
     )
 

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_twofa.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_twofa.py
@@ -5,13 +5,12 @@
 
 import asyncio
 import logging
-import re
 from contextlib import AsyncExitStack
 from unittest.mock import AsyncMock
 
 import pytest
 import sqlalchemy as sa
-from aiohttp.test_utils import TestClient, make_mocked_request
+from aiohttp.test_utils import TestClient
 from faker import Faker
 from models_library.authentication import TwoFactorAuthenticationMethod
 from pytest_mock import MockerFixture, MockType
@@ -40,9 +39,6 @@ from simcore_service_webserver.login.constants import (
     MSG_2FA_UNAVAILABLE,
     MSG_LOGGED_IN,
 )
-from simcore_service_webserver.products import products_web
-from simcore_service_webserver.products.errors import UnknownProductError
-from simcore_service_webserver.products.models import Product
 from simcore_service_webserver.user_preferences import user_preferences_service
 from twilio.base.exceptions import TwilioRestException
 from yarl import URL
@@ -376,47 +372,36 @@ async def test_can_register_same_phone_in_different_accounts(
 async def test_send_email_code(
     client: TestClient,
     faker: Faker,
-    capsys: pytest.CaptureFixture,
-    mocked_email_core_remove_comments: None,
+    mocker: MockerFixture,
 ):
-    request = make_mocked_request("GET", "/dummy", app=client.app)
-
-    with pytest.raises(UnknownProductError):
-        # NOTE: this is a fake request and did not go through middlewares
-        products_web.get_current_product(request)
-
-    user_email = faker.email()
-    support_email = faker.email()
-    code = generate_passcode()
-    first_name = faker.first_name()
-
-    await send_email_code(
-        request,
-        user_email=user_email,
-        support_email=support_email,
-        code=code,
-        first_name=first_name,
-        product=Product(
-            name="osparc",
-            display_name="The Foo Product",
-            host_regex=re.compile(r".+"),
-            base_url="https://osparc.io",
-            vendor={},
-            short_name="foo",
-            support_email=support_email,
-            support=None,
-            login_settings=ProductLoginSettingsDict(
-                LOGIN_2FA_REQUIRED=True,
-            ),
-            registration_email_template=None,
-        ),
+    mock_send = mocker.patch(
+        "simcore_service_webserver.login._twofa_service.notifications_service.send_message_from_template",
+        autospec=True,
     )
 
-    out, _ = capsys.readouterr()
-    parsed_context = parse_test_marks(out)
-    assert parsed_context["code"] == f"{code}"
-    assert parsed_context["name"] == first_name.capitalize()
-    assert parsed_context["support_email"] == support_email
+    user_email = faker.email()
+    code = generate_passcode()
+    first_name = faker.first_name()
+    user_name = faker.user_name()
+
+    assert client.app
+    await send_email_code(
+        client.app,
+        user_email=user_email,
+        code=code,
+        first_name=first_name,
+        user_name=user_name,
+        product_name="osparc",
+        host="osparc.io",
+    )
+
+    mock_send.assert_called_once()
+    call_kwargs = mock_send.call_args.kwargs
+    assert call_kwargs["template_name"] == "new_code"
+    assert call_kwargs["context"]["code"] == code
+    assert call_kwargs["context"]["host"] == "osparc.io"
+    assert call_kwargs["context"]["user"]["first_name"] == first_name
+    assert call_kwargs["context"]["user"]["user_name"] == user_name
 
 
 async def test_2fa_sms_failure_during_login(

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_twofa.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_twofa.py
@@ -16,7 +16,7 @@ from models_library.authentication import TwoFactorAuthenticationMethod
 from pytest_mock import MockerFixture, MockType
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
-from pytest_simcore.helpers.webserver_login import NewUser, parse_test_marks
+from pytest_simcore.helpers.webserver_login import NewUser
 from servicelib.aiohttp import status
 from servicelib.utils_secrets import generate_passcode
 from simcore_postgres_database.models.products import ProductLoginSettingsDict, products
@@ -122,12 +122,10 @@ async def test_workflow_register_and_login_with_2fa(  # noqa: PLR0915
     client: TestClient,
     mocked_notifications_service_send_message_from_template: AsyncMock,
     confirmation_repository: ConfirmationRepository,
-    capsys: pytest.CaptureFixture,
     user_email: str,
     user_password: str,
     user_phone_number: str,
     mocked_twilio_service: dict[str, MockType],
-    mocked_email_core_remove_comments: None,
     cleanup_db_tables: None,
 ):
     assert client.app
@@ -286,10 +284,11 @@ async def test_workflow_register_and_login_with_2fa(  # noqa: PLR0915
     assert data["parameters"]["message"]
     assert data["parameters"]["expiration_2fa"]
 
-    out, _ = capsys.readouterr()
-    parsed_context = parse_test_marks(out)
-    assert parsed_context["name"] == user["name"]
-    assert "support" in parsed_context["support_email"]
+    # assert email was sent via notifications service
+    email_call = mocked_notifications_service_send_message_from_template.call_args_list[-1]
+    email_context = email_call.kwargs["context"]
+    assert email_context["user"]["first_name"] == (user["first_name"] or user["name"])
+    assert email_context["user"]["user_name"] == user["name"]
 
     # login (2FA Disabled) ---------------------------------------------------------
     await user_preferences_service.set_frontend_user_preference(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

This pull request refactors the 2FA email code delivery logic to use the centralized notifications service instead of the previous custom email implementation. The changes simplify the code, improve maintainability, and update the tests to match the new approach.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- part of https://github.com/ITISFoundation/private-issues/issues/514

## How to test

```sh
cd services/web/server
make install-dev
pytest -vv --pdb tests/unit/with_dbs/03/login/test_login_twofa.py
```
<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

No changes.
