### PR TITLE
:bug: Fix 422 on PATCH nodes when sending null input values

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/Workbench.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Workbench.js
@@ -829,6 +829,19 @@ qx.Class.define("osparc.data.model.Workbench", {
             patchData[changedFieldKey] = nodeData[changedFieldKey];
           });
         }
+        // Filter null values from inputs/outputs: the convention is that
+        // unset ports are absent from the dict, not null.
+        ["inputs", "outputs"].forEach(field => {
+          if (patchData[field] && typeof patchData[field] === "object") {
+            const filtered = {};
+            for (const key in patchData[field]) {
+              if (patchData[field][key] !== null) {
+                filtered[key] = patchData[field][key];
+              }
+            }
+            patchData[field] = filtered;
+          }
+        });
         const params = {
           url: {
             "studyId": this.getStudy().getUuid(),


### PR DESCRIPTION
## What was happening

Guest users would intermittently hit a `422 Unprocessable Entity` when trying to run a computational service. The error came from `PATCH /v0/projects/{project_id}/nodes/{node_id}` — Pydantic rejected `null` values inside the `inputs` dict (e.g. `"stimulation_mode": null`).

The keyword here is *intermittent*: it only happened when the workbench hadn't fully initialized its node models yet.

## The problem

`Workbench.serialize()` has two code paths:
- **Initialized nodes** → calls `Node.serialize()` → `PropFormBase.getValues()`, which already filters out `null` values from inputs/outputs.
- **Uninitialized workbench** → returns the raw `__workbenchInitData` as-is, which can contain `null` values for unset ports.

When `patchWorkbenchDiffs()` picks up data from the uninitialized path, those `null` values leak into the PATCH payload. The backend rightfully rejects them — our convention is that unset ports are represented by *absent keys*, not `null`.

## The fix

Added a filter in `patchWorkbenchDiffs()` that strips `null` values from `inputs` and `outputs` dicts before sending the PATCH request. This makes the uninitialized path consistent with the initialized one, and keeps the backend validation strict as intended.