### PR TITLE
🐛 Fixes e2e-playwright jupyterlab-large-file test

### DIFF
--- a/tests/e2e-playwright/tests/jupyterlabs/_jupyter_cell_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/_jupyter_cell_code.py
@@ -221,7 +221,7 @@ def phase_5_listing_consistency() -> None:
 # ---------------------------------------------------------------------------
 ALL_PHASES: List[Tuple[str, int]] = [  # noqa: UP006
     (phase_1_create_small_files.__name__, 30 * _SECOND),
-    (phase_2_create_large_files.__name__, 1 * _MINUTE),
+    (phase_2_create_large_files.__name__, 7 * _MINUTE),
     (phase_3_read_back_files.__name__, 1 * _MINUTE),
     (phase_4_move_files.__name__, 1 * _MINUTE),
     (phase_5_listing_consistency.__name__, 30 * _SECOND),

--- a/tests/e2e-playwright/tests/jupyterlabs/_jupyter_cell_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/_jupyter_cell_code.py
@@ -28,13 +28,12 @@ NUM_SMALL_FILES: Final[int] = 1_000
 SMALL_FILE_MIN_BYTES: Final[int] = 1 * _KB
 SMALL_FILE_MAX_BYTES: Final[int] = 8 * _KB
 
-NUM_LARGE_FILES: Final[int] = 2
 LARGE_FILE_MAX_BYTES: Final[int] = 20 * _MB
 LARGE_FILE_MIN_BYTES: Final[int] = int(LARGE_FILE_MAX_BYTES * 0.9)
 LARGE_FILE_WRITE_CHUNK: Final[int] = 1 * _MB
 PARALLEL_WORKERS: Final[int] = 8
 
-FILES_TO_MOVE: Final[int] = int(0.1 * (NUM_SMALL_FILES + NUM_LARGE_FILES))
+FILES_TO_MOVE: Final[int] = int(0.1 * NUM_SMALL_FILES)
 
 _CHECKSUM_CHUNK_SIZE: Final[int] = 8 * _KB
 
@@ -139,18 +138,15 @@ def _create_large_file(index: int) -> Optional[str]:  # noqa: UP045
 @_finalise_phase
 def phase_2_create_large_files() -> None:
     print(
-        f"Phase 2: creating {NUM_LARGE_FILES} large files "
-        f"({LARGE_FILE_MIN_BYTES // 1024 // 1024}-{LARGE_FILE_MAX_BYTES // 1024 // 1024} MiB each) ..."
+        f"Phase 2: creating 1 large file "
+        f"({LARGE_FILE_MIN_BYTES // 1024 // 1024}-{LARGE_FILE_MAX_BYTES // 1024 // 1024} MiB) ..."
     )
     t0 = time.monotonic()
-    with ThreadPoolExecutor(max_workers=PARALLEL_WORKERS) as pool:
-        futures = {pool.submit(_create_large_file, i): i for i in range(NUM_LARGE_FILES)}
-        for fut in as_completed(futures):
-            err = fut.result()
-            if err:
-                errors.append(err)
+    err = _create_large_file(0)
+    if err:
+        errors.append(err)
     elapsed = time.monotonic() - t0
-    print(f"  ✓ {NUM_LARGE_FILES} large files created in {elapsed:.1f}s")
+    print(f"  ✓ 1 large file created in {elapsed:.1f}s")
 
 
 # ---------------------------------------------------------------------------
@@ -176,12 +172,13 @@ def phase_3_read_back_files() -> None:
 # Phase 4 - Rename / move files (copy-on-S3 stress)
 # ---------------------------------------------------------------------------
 @_finalise_phase
-def phase_4_move_files() -> None:
+def phase_4_move_small_files() -> None:
+    # NOTE: moving small files since it's faster
     print("Phase 4: renaming / moving files ...")
     t0 = time.monotonic()
-    all_files = list(BASE_DIR.rglob("*.bin"))
+    all_small_files = [p for p in BASE_DIR.rglob("*.bin") if not p.name.startswith("large_")]
     move_count = 0
-    files_to_move = secrets.SystemRandom().sample(all_files, min(len(all_files), FILES_TO_MOVE))
+    files_to_move = secrets.SystemRandom().sample(all_small_files, min(FILES_TO_MOVE, len(all_small_files)))
     for src in files_to_move:
         dst_dir = _random_nested_dir(BASE_DIR, MAX_DEPTH)
         dst_dir.mkdir(parents=True, exist_ok=True)
@@ -206,14 +203,13 @@ def phase_4_move_files() -> None:
 def phase_5_listing_consistency() -> None:
     print("Phase 5: directory listing consistency ...")
     t0 = time.monotonic()
+    expected_count = NUM_SMALL_FILES + 1
     all_files = list(BASE_DIR.rglob("*.bin"))
-    listed_files = set(all_files)
-    existing_files = {p for p in all_files if p.exists()}
-    missing = existing_files - listed_files
-    if missing:
-        errors.append(f"LISTING INCONSISTENCY: {len(missing)} files exist but not listed")
+    actual_count = len(all_files)
+    if actual_count != expected_count:
+        errors.append(f"LISTING INCONSISTENCY: expected {expected_count} files, found {actual_count}")
     elapsed = time.monotonic() - t0
-    print(f"  ✓ listing check done in {elapsed:.1f}s ({len(listed_files)} files found)")
+    print(f"  ✓ listing check done in {elapsed:.1f}s ({actual_count}/{expected_count} files found)")
 
 
 # ---------------------------------------------------------------------------
@@ -221,8 +217,8 @@ def phase_5_listing_consistency() -> None:
 # ---------------------------------------------------------------------------
 ALL_PHASES: List[Tuple[str, int]] = [  # noqa: UP006
     (phase_1_create_small_files.__name__, 30 * _SECOND),
-    (phase_2_create_large_files.__name__, 7 * _MINUTE),
-    (phase_3_read_back_files.__name__, 1 * _MINUTE),
-    (phase_4_move_files.__name__, 1 * _MINUTE),
-    (phase_5_listing_consistency.__name__, 30 * _SECOND),
+    (phase_2_create_large_files.__name__, 5 * _MINUTE),
+    (phase_3_read_back_files.__name__, 4 * _MINUTE),
+    (phase_4_move_small_files.__name__, 2 * _MINUTE),
+    (phase_5_listing_consistency.__name__, 1 * _MINUTE),
 ]

--- a/tests/e2e-playwright/tests/jupyterlabs/_jupyter_cell_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/_jupyter_cell_code.py
@@ -218,7 +218,7 @@ def phase_5_listing_consistency() -> None:
 ALL_PHASES: List[Tuple[str, int]] = [  # noqa: UP006
     (phase_1_create_small_files.__name__, 30 * _SECOND),
     (phase_2_create_large_files.__name__, 5 * _MINUTE),
-    (phase_3_read_back_files.__name__, 4 * _MINUTE),
-    (phase_4_move_small_files.__name__, 2 * _MINUTE),
+    (phase_3_read_back_files.__name__, 3 * _MINUTE),
+    (phase_4_move_small_files.__name__, 3 * _MINUTE),
     (phase_5_listing_consistency.__name__, 1 * _MINUTE),
 ]

--- a/tests/e2e-playwright/tests/jupyterlabs/_jupyter_cell_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/_jupyter_cell_code.py
@@ -136,7 +136,7 @@ def _create_large_file(index: int) -> Optional[str]:  # noqa: UP045
 
 
 @_finalise_phase
-def phase_2_create_large_files() -> None:
+def phase_2_create_large_file() -> None:
     print(
         f"Phase 2: creating 1 large file "
         f"({LARGE_FILE_MIN_BYTES // 1024 // 1024}-{LARGE_FILE_MAX_BYTES // 1024 // 1024} MiB) ..."
@@ -203,13 +203,14 @@ def phase_4_move_small_files() -> None:
 def phase_5_listing_consistency() -> None:
     print("Phase 5: directory listing consistency ...")
     t0 = time.monotonic()
-    expected_count = NUM_SMALL_FILES + 1
     all_files = list(BASE_DIR.rglob("*.bin"))
-    actual_count = len(all_files)
-    if actual_count != expected_count:
-        errors.append(f"LISTING INCONSISTENCY: expected {expected_count} files, found {actual_count}")
+    listed_files = set(all_files)
+    existing_files = {p for p in all_files if p.exists()}
+    missing = existing_files - listed_files
+    if missing:
+        errors.append(f"LISTING INCONSISTENCY: {len(missing)} files exist but not listed")
     elapsed = time.monotonic() - t0
-    print(f"  ✓ listing check done in {elapsed:.1f}s ({actual_count}/{expected_count} files found)")
+    print(f"  ✓ listing check done in {elapsed:.1f}s ({len(listed_files)} files found)")
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +218,7 @@ def phase_5_listing_consistency() -> None:
 # ---------------------------------------------------------------------------
 ALL_PHASES: List[Tuple[str, int]] = [  # noqa: UP006
     (phase_1_create_small_files.__name__, 30 * _SECOND),
-    (phase_2_create_large_files.__name__, 5 * _MINUTE),
+    (phase_2_create_large_file.__name__, 5 * _MINUTE),
     (phase_3_read_back_files.__name__, 3 * _MINUTE),
     (phase_4_move_small_files.__name__, 3 * _MINUTE),
     (phase_5_listing_consistency.__name__, 1 * _MINUTE),

--- a/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
@@ -38,16 +38,20 @@ def _expect_with_dialog_dismissal(iframe: FrameLocator, output_locator: Locator,
     total *timeout* (ms) is exhausted.
     """
     remaining = timeout
+    last_error: AssertionError | TimeoutError | None = None
     while remaining > 0:
+        wait_slice = min(_DISMISS_DIALOG_POLL_MS, remaining)
         try:
-            expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=min(_DISMISS_DIALOG_POLL_MS, remaining))
+            expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=wait_slice)
             return
-        except (AssertionError, TimeoutError):
-            remaining -= _DISMISS_DIALOG_POLL_MS
-            _dismiss_dialogs(iframe)
+        except (AssertionError, TimeoutError) as error:
+            last_error = error
+            remaining -= wait_slice
+            if remaining > 0:
+                _dismiss_dialogs(iframe)
 
-    # final attempt — raises the real error on failure
-    expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=_DISMISS_DIALOG_POLL_MS)
+    if last_error is not None:
+        raise last_error
 
 
 def _execute_cell_and_wait_for_marker(iframe: FrameLocator, code: str, phase_label: str, timeout: int) -> None:

--- a/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
@@ -19,10 +19,15 @@ _JUPYTER_CELL_CODE_PATH: Final[Path] = Path(__file__).parent / "_jupyter_cell_co
 
 def _dismiss_dialogs(iframe: FrameLocator) -> None:
     """Dismiss any JupyterLab modal dialogs (e.g. 'File Changed') that may pop up."""
+    dialog = iframe.locator(".jp-Dialog")
+    if dialog.count() == 0:
+        return
+
     for btn_name in ("Dismiss", "OK", "Overwrite", "Revert"):
-        btn = iframe.locator(f".jp-Dialog .jp-mod-accept:has-text('{btn_name}')")
-        while btn.count() > 0:
+        btn = dialog.locator(f".jp-mod-accept:has-text('{btn_name}')")
+        if btn.count() > 0:
             btn.first.click()
+            return
 
 
 def _expect_with_dialog_dismissal(iframe: FrameLocator, output_locator: Locator, timeout: int) -> None:

--- a/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
@@ -16,6 +16,14 @@ _IDLE_TIMEOUT_MS: Final[int] = 60 * SECOND
 _JUPYTER_CELL_CODE_PATH: Final[Path] = Path(__file__).parent / "_jupyter_cell_code.py"
 
 
+def _dismiss_dialogs(iframe: FrameLocator) -> None:
+    """Dismiss any JupyterLab modal dialogs (e.g. 'File Changed') that may pop up."""
+    for btn_name in ("Dismiss", "OK", "Overwrite", "Revert"):
+        btn = iframe.locator(f".jp-Dialog .jp-mod-accept:has-text('{btn_name}')")
+        while btn.count() > 0:
+            btn.first.click()
+
+
 def _execute_cell_and_wait_for_marker(iframe: FrameLocator, code: str, phase_label: str, timeout: int) -> None:
     """Fill a new cell with *code*, execute it and wait for COMPLETE_MARKER."""
     with log_context(
@@ -26,12 +34,28 @@ def _execute_cell_and_wait_for_marker(iframe: FrameLocator, code: str, phase_lab
         # count existing outputs so we can target the new cell's output by index
         output_count_before = iframe.locator(".jp-OutputArea-output").count()
 
+        _dismiss_dialogs(iframe)
+
         cell = iframe.get_by_label("files_creation.ipynb").get_by_role("textbox").last
         cell.fill(code)
         cell.press("Shift+Enter")
 
         output_locator = iframe.locator(".jp-OutputArea-output").nth(output_count_before)
-        expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=timeout)
+
+        # poll for the marker, dismissing any dialogs that appear mid-execution
+        deadline = timeout
+        poll_interval = 2 * SECOND
+        while deadline > 0:
+            _dismiss_dialogs(iframe)
+            try:
+                expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=poll_interval)
+                break
+            except (AssertionError, TimeoutError):
+                deadline -= poll_interval
+        else:
+            # final check — will raise the proper expect error on timeout
+            expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=poll_interval)
+
         expect(output_locator).not_to_contain_text(FAIL_MARKER)
 
         # scroll the notebook so the latest output is visible

--- a/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
@@ -5,14 +5,14 @@ from pathlib import Path
 from typing import Final
 
 from _jupyter_cell_code import ALL_PHASES, COMPLETE_MARKER, FAIL_MARKER
-from playwright.sync_api import FrameLocator, expect
+from playwright.sync_api import FrameLocator, Locator, expect
 from pydantic import ByteSize
 from pytest_simcore.helpers.datetime_tools import timedelta_as_minute_second_ms
 from pytest_simcore.helpers.logging_tools import log_context
 from pytest_simcore.helpers.playwright import SECOND
 
 _IDLE_TIMEOUT_MS: Final[int] = 60 * SECOND
-_DIMSMISS_DIALOG_POLL_S: Final[float] = timedelta(seconds=2).total_seconds()
+_DISMISS_DIALOG_POLL_MS: Final[int] = 2 * SECOND
 
 _JUPYTER_CELL_CODE_PATH: Final[Path] = Path(__file__).parent / "_jupyter_cell_code.py"
 
@@ -23,6 +23,26 @@ def _dismiss_dialogs(iframe: FrameLocator) -> None:
         btn = iframe.locator(f".jp-Dialog .jp-mod-accept:has-text('{btn_name}')")
         while btn.count() > 0:
             btn.first.click()
+
+
+def _expect_with_dialog_dismissal(iframe: FrameLocator, output_locator: Locator, timeout: int) -> None:
+    """Wait for *COMPLETE_MARKER* while periodically dismissing JupyterLab dialogs.
+
+    Playwright sync API is not thread-safe, so we poll on the main thread:
+    try a short ``expect`` wait, dismiss any dialogs, repeat until the
+    total *timeout* (ms) is exhausted.
+    """
+    remaining = timeout
+    while remaining > 0:
+        try:
+            expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=min(_DISMISS_DIALOG_POLL_MS, remaining))
+            return
+        except (AssertionError, TimeoutError):
+            remaining -= _DISMISS_DIALOG_POLL_MS
+            _dismiss_dialogs(iframe)
+
+    # final attempt — raises the real error on failure
+    expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=_DISMISS_DIALOG_POLL_MS)
 
 
 def _execute_cell_and_wait_for_marker(iframe: FrameLocator, code: str, phase_label: str, timeout: int) -> None:
@@ -43,18 +63,7 @@ def _execute_cell_and_wait_for_marker(iframe: FrameLocator, code: str, phase_lab
 
         output_locator = iframe.locator(".jp-OutputArea-output").nth(output_count_before)
 
-        # poll for the marker, dismissing any dialogs that appear mid-execution
-        deadline = timeout
-        while deadline > 0:
-            _dismiss_dialogs(iframe)
-            try:
-                expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=_DIMSMISS_DIALOG_POLL_S)
-                break
-            except (AssertionError, TimeoutError):
-                deadline -= _DIMSMISS_DIALOG_POLL_S
-        else:
-            # final check — will raise the proper expect error on timeout
-            expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=_DIMSMISS_DIALOG_POLL_S)
+        _expect_with_dialog_dismissal(iframe, output_locator, timeout)
 
         expect(output_locator).not_to_contain_text(FAIL_MARKER)
 

--- a/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
@@ -12,6 +12,7 @@ from pytest_simcore.helpers.logging_tools import log_context
 from pytest_simcore.helpers.playwright import SECOND
 
 _IDLE_TIMEOUT_MS: Final[int] = 60 * SECOND
+_DIMSMISS_DIALOG_POLL_S: Final[float] = timedelta(seconds=2).total_seconds()
 
 _JUPYTER_CELL_CODE_PATH: Final[Path] = Path(__file__).parent / "_jupyter_cell_code.py"
 
@@ -44,17 +45,16 @@ def _execute_cell_and_wait_for_marker(iframe: FrameLocator, code: str, phase_lab
 
         # poll for the marker, dismissing any dialogs that appear mid-execution
         deadline = timeout
-        poll_interval = 2 * SECOND
         while deadline > 0:
             _dismiss_dialogs(iframe)
             try:
-                expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=poll_interval)
+                expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=_DIMSMISS_DIALOG_POLL_S)
                 break
             except (AssertionError, TimeoutError):
-                deadline -= poll_interval
+                deadline -= _DIMSMISS_DIALOG_POLL_S
         else:
             # final check — will raise the proper expect error on timeout
-            expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=poll_interval)
+            expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=_DIMSMISS_DIALOG_POLL_S)
 
         expect(output_locator).not_to_contain_text(FAIL_MARKER)
 

--- a/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
@@ -6,6 +6,7 @@ from typing import Final
 
 from _jupyter_cell_code import ALL_PHASES, COMPLETE_MARKER, FAIL_MARKER
 from playwright.sync_api import FrameLocator, Locator, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from pydantic import ByteSize
 from pytest_simcore.helpers.datetime_tools import timedelta_as_minute_second_ms
 from pytest_simcore.helpers.logging_tools import log_context
@@ -38,13 +39,13 @@ def _expect_with_dialog_dismissal(iframe: FrameLocator, output_locator: Locator,
     total *timeout* (ms) is exhausted.
     """
     remaining = timeout
-    last_error: AssertionError | TimeoutError | None = None
+    last_error: AssertionError | PlaywrightTimeoutError | None = None
     while remaining > 0:
         wait_slice = min(_DISMISS_DIALOG_POLL_MS, remaining)
         try:
             expect(output_locator).to_contain_text(COMPLETE_MARKER, timeout=wait_slice)
             return
-        except (AssertionError, TimeoutError) as error:
+        except (AssertionError, PlaywrightTimeoutError) as error:
             last_error = error
             remaining -= wait_slice
             if remaining > 0:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=HERE-URL-TO-RAW-FILE)
-->

Adjusted the  `e2e-playwright -> jupyterlab-large-file` test. 
- When the file is bigger a pop-up with contents changed is displayed and it needs to be dismissed.
- Also refactored a bit the test.
- Adjusted timeouts (on average they are 4x the average test duration measured on AWS master)


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
