### PR TITLE
🐛 fix(web-server): use `X-Forwarded-Proto` header for confirmation link scheme :ambulance:

### DIFF
--- a/services/web/server/src/simcore_service_webserver/login/_confirmation_web.py
+++ b/services/web/server/src/simcore_service_webserver/login/_confirmation_web.py
@@ -2,6 +2,7 @@ import logging
 from urllib.parse import quote
 
 from aiohttp import web
+from servicelib.common_headers import X_FORWARDED_PROTO
 from yarl import URL
 
 from simcore_service_webserver.login._application_keys import (
@@ -26,7 +27,10 @@ def _url_for_confirmation(app: web.Application, code: str) -> URL:
 def make_confirmation_link(request: web.Request, code: str) -> str:
     assert code  # nosec
     link = _url_for_confirmation(request.app, code=code)
-    return f"{request.scheme}://{request.host}{link}"
+    # Custom header by traefik. See labels in docker-compose as:
+    # - traefik.http.middlewares.${SWARM_STACK_NAME_NO_HYPHEN}_sslheader.headers.customrequestheaders.X-Forwarded-Proto=http  # noqa: E501
+    scheme = request.headers.get(X_FORWARDED_PROTO, request.scheme)
+    return f"{scheme}://{request.host}{link}"
 
 
 @ensure_single_setup(__name__, logger=_logger)

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_confirmation_service.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_confirmation_service.py
@@ -54,6 +54,16 @@ async def test_confirmation_token_workflow(
     assert confirmation_link.startswith("https://example.com/auth/confirmation/")
     assert confirmation.code in confirmation_link
 
+    # Step 5: Verify X-Forwarded-Proto header is respected
+    request_behind_proxy = make_mocked_request(
+        "GET",
+        "http://example.com/auth/confirmation/{code}",
+        app=app,
+        headers={"Host": "example.com", "X-Forwarded-Proto": "https"},
+    )
+    confirmation_link_via_proxy = _confirmation_web.make_confirmation_link(request_behind_proxy, confirmation.code)
+    assert confirmation_link_via_proxy.startswith("https://example.com/auth/confirmation/")
+
 
 async def test_expired_confirmation_token(
     confirmation_service: ConfirmationService,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request updates the confirmation link generation logic to correctly respect the `X-Forwarded-Proto` header, which is important when the service is running behind a proxy (like Traefik). 

> [!IMPORTANT]
> Confirmation links were composed using the `request.scheme` and apparently they were removed in some emails.
>
> <img width="503" height="31" alt="image" src="https://github.com/user-attachments/assets/a3d49b6c-bae0-4ada-a8bb-405d85fa2c3d" />

## Related issue/s

## How to test
```sh
cd services/web/server
make install-dev
pytest -vv --pdb tests/unit/with_dbs/03/login/test_login_confirmation_service.py
```
## Dev-ops
No changes.