### PR TITLE
🎨 Optimize project listing queries: replace anti-join and GROUP BY with EXISTS/NOT EXISTS

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/_projects_repository_legacy.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_repository_legacy.py
@@ -326,6 +326,7 @@ class ProjectDBAPI(BaseProjectDB):
         product_name: ProductName,
         user_id: UserID,
         workspace_query: WorkspaceQuery,
+        folder_query: FolderQuery,
         is_search_by_multi_columns: bool,
         user_groups: list[GroupID],
     ) -> sql.Select | None:
@@ -336,40 +337,105 @@ class ProjectDBAPI(BaseProjectDB):
                 WorkspaceScope.ALL,
             )
 
-            my_access_rights_subquery = (
-                sa.select(project_to_groups.c.project_uuid)
-                .where(
-                    (project_to_groups.c.read)  # Filters out entries where "read" is False
-                    & (project_to_groups.c.gid.in_(user_groups))  # Filters gid to be in user_groups
+            # Access rights check: use EXISTS instead of a GROUP BY subquery
+            # joined via INNER JOIN. EXISTS lets the planner stop at the first
+            # matching row and avoids materialising a grouped intermediate result.
+            access_rights_exists = sa.exists(
+                sa.select(sa.literal(1)).where(
+                    (project_to_groups.c.project_uuid == projects.c.uuid)
+                    & (project_to_groups.c.read)
+                    & (project_to_groups.c.gid.in_(user_groups))
                 )
-                .group_by(project_to_groups.c.project_uuid)
-            ).subquery("my_access_rights_subquery")
+            )
 
-            private_workspace_query = (
-                sa.select(
-                    *PROJECT_DB_COLS,
-                    projects.c.workbench,
-                    projects_to_folders.c.folder_id,
-                )
-                .select_from(
-                    projects.join(my_access_rights_subquery).join(
-                        projects_to_folders,
-                        (
-                            (projects_to_folders.c.project_uuid == projects.c.uuid)
-                            & (projects_to_folders.c.user_id == user_id)
-                        ),
-                        isouter=True,
+            # Folder scope determines the join strategy to projects_to_folders.
+            # Each scope has different semantics and benefits from a different
+            # SQL shape:
+            #
+            # ROOT -- show projects NOT placed in any folder by this user.
+            #   No join needed; use NOT EXISTS to check absence.
+            #   Avoids the costly LEFT JOIN ... IS NULL anti-join pattern.
+            #
+            # SPECIFIC -- show projects placed in a particular folder.
+            #   INNER JOIN on the exact (user_id, folder_id); only
+            #   matching rows survive, which is a simple equi-join.
+            #
+            # ALL -- search across all projects regardless of folder.
+            #   LEFT OUTER JOIN to retrieve folder_id when present,
+            #   but no filtering; used by full-depth search.
+            if folder_query.folder_scope == FolderScope.ROOT:
+                folder_not_exists = ~sa.exists(
+                    sa.select(sa.literal(1)).where(
+                        (projects_to_folders.c.project_uuid == projects.c.uuid)
+                        & (projects_to_folders.c.user_id == user_id)
+                        & (projects_to_folders.c.folder_id.is_not(None))
                     )
                 )
-                .where(
-                    (projects.c.workspace_id.is_(None))  # <-- Private workspace
-                    & (projects.c.product_name == product_name)
+                private_workspace_query = (
+                    sa.select(
+                        *PROJECT_DB_COLS,
+                        projects.c.workbench,
+                        sa.literal(None).label("folder_id"),
+                    )
+                    .select_from(projects)
+                    .where(
+                        (projects.c.workspace_id.is_(None))
+                        & (projects.c.product_name == product_name)
+                        & access_rights_exists
+                        & folder_not_exists
+                    )
                 )
-            )
-
-            assert (  # nosec
-                my_access_rights_subquery.description == "my_access_rights_subquery"
-            )
+            elif folder_query.folder_scope == FolderScope.SPECIFIC:
+                # Specific folder: INNER JOIN ensures only projects assigned
+                # to this exact folder survive — simple equi-join, no filter needed.
+                private_workspace_query = (
+                    sa.select(
+                        *PROJECT_DB_COLS,
+                        projects.c.workbench,
+                        projects_to_folders.c.folder_id,
+                    )
+                    .select_from(
+                        projects.join(
+                            projects_to_folders,
+                            (
+                                (projects_to_folders.c.project_uuid == projects.c.uuid)
+                                & (projects_to_folders.c.user_id == user_id)
+                                & (projects_to_folders.c.folder_id == folder_query.folder_id)
+                            ),
+                        )
+                    )
+                    .where(
+                        (projects.c.workspace_id.is_(None))
+                        & (projects.c.product_name == product_name)
+                        & access_rights_exists
+                    )
+                )
+            else:
+                assert folder_query.folder_scope == FolderScope.ALL  # nosec
+                # ALL (full-depth search): LEFT OUTER JOIN only to retrieve
+                # the folder_id column when present; no rows are filtered out.
+                private_workspace_query = (
+                    sa.select(
+                        *PROJECT_DB_COLS,
+                        projects.c.workbench,
+                        projects_to_folders.c.folder_id,
+                    )
+                    .select_from(
+                        projects.join(
+                            projects_to_folders,
+                            (
+                                (projects_to_folders.c.project_uuid == projects.c.uuid)
+                                & (projects_to_folders.c.user_id == user_id)
+                            ),
+                            isouter=True,
+                        )
+                    )
+                    .where(
+                        (projects.c.workspace_id.is_(None))
+                        & (projects.c.product_name == product_name)
+                        & access_rights_exists
+                    )
+                )
 
             if is_search_by_multi_columns:
                 private_workspace_query = private_workspace_query.join(
@@ -383,6 +449,7 @@ class ProjectDBAPI(BaseProjectDB):
         *,
         product_name: ProductName,
         workspace_query: WorkspaceQuery,
+        folder_query: FolderQuery,
         is_search_by_multi_columns: bool,
         user_groups: list[GroupID],
     ) -> sql.Select | None:
@@ -392,39 +459,79 @@ class ProjectDBAPI(BaseProjectDB):
                 WorkspaceScope.ALL,
             )
 
-            my_workspace_access_rights_subquery = (
-                sa.select(workspaces_access_rights.c.workspace_id)
-                .where(
-                    workspaces_access_rights.c.read,
-                    workspaces_access_rights.c.gid.in_(user_groups),
+            # Access rights check: use EXISTS instead of a GROUP BY subquery
+            # joined via INNER JOIN (same reasoning as in the private query).
+            workspace_access_exists = sa.exists(
+                sa.select(sa.literal(1)).where(
+                    (workspaces_access_rights.c.workspace_id == projects.c.workspace_id)
+                    & (workspaces_access_rights.c.read)
+                    & (workspaces_access_rights.c.gid.in_(user_groups))
                 )
-                .group_by(workspaces_access_rights.c.workspace_id)
-            ).subquery("my_workspace_access_rights_subquery")
+            )
 
-            shared_workspace_query = (
-                sa.select(
-                    *PROJECT_DB_COLS,
-                    projects.c.workbench,
-                    projects_to_folders.c.folder_id,
-                )
-                .select_from(
-                    projects.join(
-                        my_workspace_access_rights_subquery,
-                        projects.c.workspace_id == my_workspace_access_rights_subquery.c.workspace_id,
-                    ).join(
-                        projects_to_folders,
-                        (
-                            (projects_to_folders.c.project_uuid == projects.c.uuid)
-                            & (projects_to_folders.c.user_id.is_(None))
-                        ),
-                        isouter=True,
+            # Same folder-scope split as in the private workspace query.
+            # NOTE: shared workspaces store folder assignments with
+            # user_id IS NULL (folders are workspace-level, not per-user).
+            if folder_query.folder_scope == FolderScope.ROOT:
+                folder_not_exists = ~sa.exists(
+                    sa.select(sa.literal(1)).where(
+                        (projects_to_folders.c.project_uuid == projects.c.uuid)
+                        & (projects_to_folders.c.user_id.is_(None))
+                        & (projects_to_folders.c.folder_id.is_not(None))
                     )
                 )
-                .where(projects.c.product_name == product_name)
-            )
-            assert (  # nosec
-                my_workspace_access_rights_subquery.description == "my_workspace_access_rights_subquery"
-            )
+                shared_workspace_query = (
+                    sa.select(
+                        *PROJECT_DB_COLS,
+                        projects.c.workbench,
+                        sa.literal(None).label("folder_id"),
+                    )
+                    .select_from(projects)
+                    .where((projects.c.product_name == product_name) & workspace_access_exists & folder_not_exists)
+                )
+            elif folder_query.folder_scope == FolderScope.SPECIFIC:
+                # Specific folder: INNER JOIN ensures only projects assigned
+                # to this exact folder survive — simple equi-join, no filter needed.
+                shared_workspace_query = (
+                    sa.select(
+                        *PROJECT_DB_COLS,
+                        projects.c.workbench,
+                        projects_to_folders.c.folder_id,
+                    )
+                    .select_from(
+                        projects.join(
+                            projects_to_folders,
+                            (
+                                (projects_to_folders.c.project_uuid == projects.c.uuid)
+                                & (projects_to_folders.c.user_id.is_(None))
+                                & (projects_to_folders.c.folder_id == folder_query.folder_id)
+                            ),
+                        )
+                    )
+                    .where((projects.c.product_name == product_name) & workspace_access_exists)
+                )
+            else:
+                assert folder_query.folder_scope == FolderScope.ALL  # nosec
+                # ALL (full-depth search): LEFT OUTER JOIN only to retrieve
+                # the folder_id column when present; no rows are filtered out.
+                shared_workspace_query = (
+                    sa.select(
+                        *PROJECT_DB_COLS,
+                        projects.c.workbench,
+                        projects_to_folders.c.folder_id,
+                    )
+                    .select_from(
+                        projects.join(
+                            projects_to_folders,
+                            (
+                                (projects_to_folders.c.project_uuid == projects.c.uuid)
+                                & (projects_to_folders.c.user_id.is_(None))
+                            ),
+                            isouter=True,
+                        )
+                    )
+                    .where((projects.c.product_name == product_name) & workspace_access_exists)
+                )
 
             if workspace_query.workspace_scope == WorkspaceScope.ALL:
                 shared_workspace_query = shared_workspace_query.where(
@@ -447,7 +554,7 @@ class ProjectDBAPI(BaseProjectDB):
         return None
 
     @staticmethod
-    def _create_attributes_filters(  # pylint: disable=too-many-branches  # noqa: C901
+    def _create_attributes_filters(  # pylint: disable=too-many-branches
         *,
         filter_by_project_type: ProjectType | None,
         filter_by_template_type: ProjectTemplateType | None,
@@ -458,7 +565,6 @@ class ProjectDBAPI(BaseProjectDB):
         filter_guest_product_group_id: GroupID | None,
         search_by_multi_columns: str | None,
         search_by_project_name: str | None,
-        folder_query: FolderQuery,
     ) -> list[ColumnElement]:
         attributes_filters: list[ColumnElement] = []
 
@@ -505,13 +611,6 @@ class ProjectDBAPI(BaseProjectDB):
         if search_by_project_name is not None:
             attributes_filters.append(projects.c.name.like(f"%{search_by_project_name}%"))
 
-        if folder_query.folder_scope is not FolderScope.ALL:
-            if folder_query.folder_scope == FolderScope.SPECIFIC:
-                attributes_filters.append(projects_to_folders.c.folder_id == folder_query.folder_id)
-            else:
-                assert folder_query.folder_scope == FolderScope.ROOT  # nosec
-                attributes_filters.append(projects_to_folders.c.folder_id.is_(None))
-
         return attributes_filters
 
     async def list_projects_dicts(  # pylint: disable=too-many-arguments,too-many-statements,too-many-branches  # noqa: PLR0913
@@ -551,6 +650,7 @@ class ProjectDBAPI(BaseProjectDB):
                 product_name=product_name,
                 user_id=user_id,
                 workspace_query=workspace_query,
+                folder_query=folder_query,
                 is_search_by_multi_columns=search_by_multi_columns is not None,
                 user_groups=user_groups,
             )
@@ -561,6 +661,7 @@ class ProjectDBAPI(BaseProjectDB):
             shared_workspace_query = self._create_shared_workspace_query(
                 product_name=product_name,
                 workspace_query=workspace_query,
+                folder_query=folder_query,
                 is_search_by_multi_columns=search_by_multi_columns is not None,
                 user_groups=user_groups,
             )
@@ -579,7 +680,6 @@ class ProjectDBAPI(BaseProjectDB):
                 filter_guest_product_group_id=filter_guest_product_group_id,
                 search_by_multi_columns=search_by_multi_columns,
                 search_by_project_name=search_by_project_name,
-                folder_query=folder_query,
             )
 
             ###

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__list_with_query_params.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__list_with_query_params.py
@@ -7,7 +7,7 @@
 import json
 import random
 from collections import UserDict
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -34,6 +34,30 @@ from simcore_postgres_database.models.projects_to_folders import projects_to_fol
 from simcore_service_webserver._meta import api_version_prefix
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.projects.models import ProjectDict
+
+
+async def _create_folder_via_api(client: TestClient, name: str) -> FolderID:
+    """Create a folder using the REST API and return its ID."""
+    assert client.app
+    url = client.app.router["create_folder"].url_for()
+    resp = await client.post(f"{url}", json={"name": name})
+    data, _ = await assert_status(resp, status.HTTP_201_CREATED)
+    return FolderID(data["folderId"])
+
+
+async def _move_project_to_folder(
+    client: TestClient,
+    project_uuid: str,
+    folder_id: FolderID | None,
+):
+    """Move a project into a folder (or back to root when folder_id is None)."""
+    assert client.app
+    url = client.app.router["replace_project_folder"].url_for(
+        folder_id="null" if folder_id is None else f"{folder_id}",
+        project_id=project_uuid,
+    )
+    resp = await client.put(f"{url}")
+    await assert_status(resp, status.HTTP_204_NO_CONTENT)
 
 
 def standard_user_role() -> tuple[str, list[ParameterSet]]:
@@ -683,7 +707,6 @@ async def test_project_returns_to_root_after_folder_removal(
     tests_data_dir: Path,
     osparc_product_name: str,
     project_db_cleaner: None,
-    postgres_db: sa.engine.Engine,
 ):
     """When a project's folder assignment is removed, it should reappear in root listing."""
     assert client.app
@@ -709,30 +732,8 @@ async def test_project_returns_to_root_after_folder_removal(
     assert data["_meta"]["total"] == 1
 
     # Create folder and move project into it
-    with postgres_db.connect() as con:
-        result = con.execute(
-            folders_v2.insert()
-            .values(
-                name="Temp Folder",
-                parent_folder_id=None,
-                user_id=logged_user["id"],
-                workspace_id=None,
-                product_name="osparc",
-                created_by_gid=logged_user["primary_gid"],
-            )
-            .returning(folders_v2.c.folder_id)
-        )
-        row = result.fetchone()
-        assert row is not None
-        folder_id = row[0]
-
-        con.execute(
-            projects_to_folders.insert().values(
-                folder_id=folder_id,
-                project_uuid=prj["uuid"],
-                user_id=logged_user["id"],
-            )
-        )
+    folder_id = await _create_folder_via_api(client, "Temp Folder")
+    await _move_project_to_folder(client, prj["uuid"], folder_id)
 
     # Project should no longer be in root
     resp = await client.get(f"{url}")
@@ -740,14 +741,8 @@ async def test_project_returns_to_root_after_folder_removal(
     assert resp.status == status.HTTP_200_OK
     assert data["_meta"]["total"] == 0
 
-    # Remove the folder assignment
-    with postgres_db.connect() as con:
-        con.execute(
-            projects_to_folders.delete().where(
-                (projects_to_folders.c.project_uuid == prj["uuid"])
-                & (projects_to_folders.c.user_id == logged_user["id"])
-            )
-        )
+    # Move project back to root
+    await _move_project_to_folder(client, prj["uuid"], folder_id=None)
 
     # Project should be back in root
     resp = await client.get(f"{url}")
@@ -755,43 +750,6 @@ async def test_project_returns_to_root_after_folder_removal(
     assert resp.status == status.HTTP_200_OK
     assert data["_meta"]["total"] == 1
     assert data["data"][0]["uuid"] == prj["uuid"]
-
-    # Cleanup
-    with postgres_db.connect() as con:
-        con.execute(projects_to_folders.delete())
-        con.execute(folders_v2.delete())
-
-
-@pytest.fixture()
-def _create_folder(
-    postgres_db: sa.engine.Engine,
-    logged_user: UserInfoDict,
-) -> Iterator[Callable[[str], FolderID]]:
-    """Factory fixture: creates folders by name and cleans up after."""
-
-    def _factory(name: str) -> FolderID:
-        with postgres_db.connect() as con:
-            result = con.execute(
-                folders_v2.insert()
-                .values(
-                    name=name,
-                    parent_folder_id=None,
-                    user_id=logged_user["id"],
-                    workspace_id=None,
-                    product_name="osparc",
-                    created_by_gid=logged_user["primary_gid"],
-                )
-                .returning(folders_v2.c.folder_id)
-            )
-            row = result.fetchone()
-            assert row is not None
-            return row[0]
-
-    yield _factory
-
-    with postgres_db.connect() as con:
-        con.execute(projects_to_folders.delete())
-        con.execute(folders_v2.delete())
 
 
 @pytest.mark.parametrize(*standard_user_role())
@@ -804,8 +762,6 @@ async def test_multiple_folders_isolation(
     tests_data_dir: Path,
     osparc_product_name: str,
     project_db_cleaner: None,
-    postgres_db: sa.engine.Engine,
-    _create_folder,
 ):
     """Projects in folder A must not appear in folder B or root.
     Exercises the INNER JOIN path with multiple distinct folder_id values."""
@@ -827,27 +783,14 @@ async def test_multiple_folders_isolation(
         created_projects.append(prj)
 
     # Create two folders
-    folder_a = _create_folder("Folder A")
-    folder_b = _create_folder("Folder B")
+    folder_a = await _create_folder_via_api(client, "Folder A")
+    folder_b = await _create_folder_via_api(client, "Folder B")
 
     # Place projects 0,1 in folder A and projects 2,3 in folder B
-    with postgres_db.connect() as con:
-        for prj in created_projects[:2]:
-            con.execute(
-                projects_to_folders.insert().values(
-                    folder_id=folder_a,
-                    project_uuid=prj["uuid"],
-                    user_id=logged_user["id"],
-                )
-            )
-        for prj in created_projects[2:4]:
-            con.execute(
-                projects_to_folders.insert().values(
-                    folder_id=folder_b,
-                    project_uuid=prj["uuid"],
-                    user_id=logged_user["id"],
-                )
-            )
+    for prj in created_projects[:2]:
+        await _move_project_to_folder(client, prj["uuid"], folder_a)
+    for prj in created_projects[2:4]:
+        await _move_project_to_folder(client, prj["uuid"], folder_b)
     # Projects 4,5 remain in root
 
     base_url = client.app.router["list_projects"].url_for()
@@ -895,8 +838,6 @@ async def test_root_listing_pagination_with_folder_split(
     tests_data_dir: Path,
     osparc_product_name: str,
     project_db_cleaner: None,
-    postgres_db: sa.engine.Engine,
-    _create_folder,
 ):
     """Pagination total and pages must be correct after some projects are
     moved into a folder (NOT EXISTS path must not confuse the count)."""
@@ -918,16 +859,9 @@ async def test_root_listing_pagination_with_folder_split(
         created_projects.append(prj)
 
     # Move 4 projects into a folder
-    folder_id = _create_folder("Pagination Folder")
-    with postgres_db.connect() as con:
-        for prj in created_projects[:4]:
-            con.execute(
-                projects_to_folders.insert().values(
-                    folder_id=folder_id,
-                    project_uuid=prj["uuid"],
-                    user_id=logged_user["id"],
-                )
-            )
+    folder_id = await _create_folder_via_api(client, "Pagination Folder")
+    for prj in created_projects[:4]:
+        await _move_project_to_folder(client, prj["uuid"], folder_id)
 
     base_url = client.app.router["list_projects"].url_for()
 
@@ -965,8 +899,6 @@ async def test_search_respects_folder_scope(
     tests_data_dir: Path,
     osparc_product_name: str,
     project_db_cleaner: None,
-    postgres_db: sa.engine.Engine,
-    _create_folder,
 ):
     """A text search in root listing must not return projects that match
     the search term but are placed in a folder."""
@@ -996,15 +928,8 @@ async def test_search_respects_folder_scope(
     )
 
     # Move one into a folder
-    folder_id = _create_folder("Search Folder")
-    with postgres_db.connect() as con:
-        con.execute(
-            projects_to_folders.insert().values(
-                folder_id=folder_id,
-                project_uuid=prj_folder["uuid"],
-                user_id=logged_user["id"],
-            )
-        )
+    folder_id = await _create_folder_via_api(client, "Search Folder")
+    await _move_project_to_folder(client, prj_folder["uuid"], folder_id)
 
     base_url = client.app.router["list_projects"].url_for()
 

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__list_with_query_params.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__list_with_query_params.py
@@ -7,7 +7,7 @@
 import json
 import random
 from collections import UserDict
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -671,3 +671,355 @@ async def test_list_and_patch_projects_with_template_type(  # noqa: PLR0915
             ),
         )
         await assert_status(resp, status.HTTP_400_BAD_REQUEST)
+
+
+@pytest.mark.parametrize(*standard_user_role())
+async def test_project_returns_to_root_after_folder_removal(
+    mocked_dynamic_services_interface: dict[str, mock.MagicMock],
+    client: TestClient,
+    logged_user: UserDict,
+    expected: ExpectedResponse,
+    fake_project: ProjectDict,
+    tests_data_dir: Path,
+    osparc_product_name: str,
+    project_db_cleaner: None,
+    postgres_db: sa.engine.Engine,
+):
+    """When a project's folder assignment is removed, it should reappear in root listing."""
+    assert client.app
+
+    project_data = deepcopy(fake_project)
+    project_data["name"] = "Movable Project"
+    project_data["uuid"] = "d4d0eca3-d210-4db6-84f9-636700000001"
+    prj = await _new_project(
+        client,
+        logged_user["id"],
+        osparc_product_name,
+        tests_data_dir,
+        project_data,
+    )
+
+    base_url = client.app.router["list_projects"].url_for()
+
+    # Initially in root
+    url = base_url.with_query({"folder_id": "null"})
+    resp = await client.get(f"{url}")
+    data = await resp.json()
+    assert resp.status == status.HTTP_200_OK
+    assert data["_meta"]["total"] == 1
+
+    # Create folder and move project into it
+    with postgres_db.connect() as con:
+        result = con.execute(
+            folders_v2.insert()
+            .values(
+                name="Temp Folder",
+                parent_folder_id=None,
+                user_id=logged_user["id"],
+                workspace_id=None,
+                product_name="osparc",
+                created_by_gid=logged_user["primary_gid"],
+            )
+            .returning(folders_v2.c.folder_id)
+        )
+        row = result.fetchone()
+        assert row is not None
+        folder_id = row[0]
+
+        con.execute(
+            projects_to_folders.insert().values(
+                folder_id=folder_id,
+                project_uuid=prj["uuid"],
+                user_id=logged_user["id"],
+            )
+        )
+
+    # Project should no longer be in root
+    resp = await client.get(f"{url}")
+    data = await resp.json()
+    assert resp.status == status.HTTP_200_OK
+    assert data["_meta"]["total"] == 0
+
+    # Remove the folder assignment
+    with postgres_db.connect() as con:
+        con.execute(
+            projects_to_folders.delete().where(
+                (projects_to_folders.c.project_uuid == prj["uuid"])
+                & (projects_to_folders.c.user_id == logged_user["id"])
+            )
+        )
+
+    # Project should be back in root
+    resp = await client.get(f"{url}")
+    data = await resp.json()
+    assert resp.status == status.HTTP_200_OK
+    assert data["_meta"]["total"] == 1
+    assert data["data"][0]["uuid"] == prj["uuid"]
+
+    # Cleanup
+    with postgres_db.connect() as con:
+        con.execute(projects_to_folders.delete())
+        con.execute(folders_v2.delete())
+
+
+@pytest.fixture()
+def _create_folder(
+    postgres_db: sa.engine.Engine,
+    logged_user: UserInfoDict,
+) -> Iterator[Callable[[str], FolderID]]:
+    """Factory fixture: creates folders by name and cleans up after."""
+
+    def _factory(name: str) -> FolderID:
+        with postgres_db.connect() as con:
+            result = con.execute(
+                folders_v2.insert()
+                .values(
+                    name=name,
+                    parent_folder_id=None,
+                    user_id=logged_user["id"],
+                    workspace_id=None,
+                    product_name="osparc",
+                    created_by_gid=logged_user["primary_gid"],
+                )
+                .returning(folders_v2.c.folder_id)
+            )
+            row = result.fetchone()
+            assert row is not None
+            return row[0]
+
+    yield _factory
+
+    with postgres_db.connect() as con:
+        con.execute(projects_to_folders.delete())
+        con.execute(folders_v2.delete())
+
+
+@pytest.mark.parametrize(*standard_user_role())
+async def test_multiple_folders_isolation(
+    mocked_dynamic_services_interface: dict[str, mock.MagicMock],
+    client: TestClient,
+    logged_user: UserDict,
+    expected: ExpectedResponse,
+    fake_project: ProjectDict,
+    tests_data_dir: Path,
+    osparc_product_name: str,
+    project_db_cleaner: None,
+    postgres_db: sa.engine.Engine,
+    _create_folder,
+):
+    """Projects in folder A must not appear in folder B or root.
+    Exercises the INNER JOIN path with multiple distinct folder_id values."""
+    assert client.app
+
+    # Create 6 projects
+    created_projects = []
+    for i in range(6):
+        project_data = deepcopy(fake_project)
+        project_data["name"] = f"Project {i}"
+        project_data["uuid"] = f"d4d0eca3-d210-4db6-84f9-63670a0{i:05d}"
+        prj = await _new_project(
+            client,
+            logged_user["id"],
+            osparc_product_name,
+            tests_data_dir,
+            project_data,
+        )
+        created_projects.append(prj)
+
+    # Create two folders
+    folder_a = _create_folder("Folder A")
+    folder_b = _create_folder("Folder B")
+
+    # Place projects 0,1 in folder A and projects 2,3 in folder B
+    with postgres_db.connect() as con:
+        for prj in created_projects[:2]:
+            con.execute(
+                projects_to_folders.insert().values(
+                    folder_id=folder_a,
+                    project_uuid=prj["uuid"],
+                    user_id=logged_user["id"],
+                )
+            )
+        for prj in created_projects[2:4]:
+            con.execute(
+                projects_to_folders.insert().values(
+                    folder_id=folder_b,
+                    project_uuid=prj["uuid"],
+                    user_id=logged_user["id"],
+                )
+            )
+    # Projects 4,5 remain in root
+
+    base_url = client.app.router["list_projects"].url_for()
+
+    # Root listing: only projects 4,5
+    url = base_url.with_query({"folder_id": "null"})
+    resp = await client.get(f"{url}")
+    data = await resp.json()
+    assert resp.status == status.HTTP_200_OK
+    assert data["_meta"]["total"] == 2
+    root_uuids = {p["uuid"] for p in data["data"]}
+    assert root_uuids == {created_projects[4]["uuid"], created_projects[5]["uuid"]}
+
+    # Folder A: only projects 0,1
+    url = base_url.with_query({"folder_id": f"{folder_a}"})
+    resp = await client.get(f"{url}")
+    data = await resp.json()
+    assert resp.status == status.HTTP_200_OK
+    assert data["_meta"]["total"] == 2
+    folder_a_uuids = {p["uuid"] for p in data["data"]}
+    assert folder_a_uuids == {created_projects[0]["uuid"], created_projects[1]["uuid"]}
+
+    # Folder B: only projects 2,3
+    url = base_url.with_query({"folder_id": f"{folder_b}"})
+    resp = await client.get(f"{url}")
+    data = await resp.json()
+    assert resp.status == status.HTTP_200_OK
+    assert data["_meta"]["total"] == 2
+    folder_b_uuids = {p["uuid"] for p in data["data"]}
+    assert folder_b_uuids == {created_projects[2]["uuid"], created_projects[3]["uuid"]}
+
+    # No overlap between any of the three sets
+    assert root_uuids.isdisjoint(folder_a_uuids)
+    assert root_uuids.isdisjoint(folder_b_uuids)
+    assert folder_a_uuids.isdisjoint(folder_b_uuids)
+
+
+@pytest.mark.parametrize(*standard_user_role())
+async def test_root_listing_pagination_with_folder_split(
+    mocked_dynamic_services_interface: dict[str, mock.MagicMock],
+    client: TestClient,
+    logged_user: UserDict,
+    expected: ExpectedResponse,
+    fake_project: ProjectDict,
+    tests_data_dir: Path,
+    osparc_product_name: str,
+    project_db_cleaner: None,
+    postgres_db: sa.engine.Engine,
+    _create_folder,
+):
+    """Pagination total and pages must be correct after some projects are
+    moved into a folder (NOT EXISTS path must not confuse the count)."""
+    assert client.app
+
+    # Create 10 projects
+    created_projects = []
+    for i in range(10):
+        project_data = deepcopy(fake_project)
+        project_data["name"] = f"Paginated {i}"
+        project_data["uuid"] = f"d4d0eca3-d210-4db6-84f9-63670b1{i:05d}"
+        prj = await _new_project(
+            client,
+            logged_user["id"],
+            osparc_product_name,
+            tests_data_dir,
+            project_data,
+        )
+        created_projects.append(prj)
+
+    # Move 4 projects into a folder
+    folder_id = _create_folder("Pagination Folder")
+    with postgres_db.connect() as con:
+        for prj in created_projects[:4]:
+            con.execute(
+                projects_to_folders.insert().values(
+                    folder_id=folder_id,
+                    project_uuid=prj["uuid"],
+                    user_id=logged_user["id"],
+                )
+            )
+
+    base_url = client.app.router["list_projects"].url_for()
+
+    # Root should have 6 projects total
+    url = base_url.with_query({"folder_id": "null", "limit": "3", "offset": "0"})
+    resp = await client.get(f"{url}")
+    page1_data = await resp.json()
+    assert resp.status == status.HTTP_200_OK
+    assert page1_data["_meta"]["total"] == 6
+    assert len(page1_data["data"]) == 3
+
+    # Second page
+    url = base_url.with_query({"folder_id": "null", "limit": "3", "offset": "3"})
+    resp = await client.get(f"{url}")
+    data = await resp.json()
+    assert resp.status == status.HTTP_200_OK
+    assert data["_meta"]["total"] == 6
+    assert len(data["data"]) == 3
+
+    # Collect all UUIDs across both pages — should be exactly 6 unique root projects
+    all_root_uuids = {p["uuid"] for p in page1_data["data"]} | {p["uuid"] for p in data["data"]}
+    assert len(all_root_uuids) == 6
+    # None of the folder projects should appear
+    folder_uuids = {prj["uuid"] for prj in created_projects[:4]}
+    assert all_root_uuids.isdisjoint(folder_uuids)
+
+
+@pytest.mark.parametrize(*standard_user_role())
+async def test_search_respects_folder_scope(
+    mocked_dynamic_services_interface: dict[str, mock.MagicMock],
+    client: TestClient,
+    logged_user: UserDict,
+    expected: ExpectedResponse,
+    fake_project: ProjectDict,
+    tests_data_dir: Path,
+    osparc_product_name: str,
+    project_db_cleaner: None,
+    postgres_db: sa.engine.Engine,
+    _create_folder,
+):
+    """A text search in root listing must not return projects that match
+    the search term but are placed in a folder."""
+    assert client.app
+
+    # Create two projects with "Findme" in name
+    prj_in_root_data = deepcopy(fake_project)
+    prj_in_root_data["name"] = "Findme Root Project"
+    prj_in_root_data["uuid"] = "d4d0eca3-d210-4db6-84f9-63670c000001"
+    prj_root = await _new_project(
+        client,
+        logged_user["id"],
+        osparc_product_name,
+        tests_data_dir,
+        prj_in_root_data,
+    )
+
+    prj_in_folder_data = deepcopy(fake_project)
+    prj_in_folder_data["name"] = "Findme Folder Project"
+    prj_in_folder_data["uuid"] = "d4d0eca3-d210-4db6-84f9-63670c000002"
+    prj_folder = await _new_project(
+        client,
+        logged_user["id"],
+        osparc_product_name,
+        tests_data_dir,
+        prj_in_folder_data,
+    )
+
+    # Move one into a folder
+    folder_id = _create_folder("Search Folder")
+    with postgres_db.connect() as con:
+        con.execute(
+            projects_to_folders.insert().values(
+                folder_id=folder_id,
+                project_uuid=prj_folder["uuid"],
+                user_id=logged_user["id"],
+            )
+        )
+
+    base_url = client.app.router["list_projects"].url_for()
+
+    # Search in root: should find only the root project
+    url = base_url.with_query({"folder_id": "null", "search": "Findme"})
+    resp = await client.get(f"{url}")
+    data = await resp.json()
+    assert resp.status == status.HTTP_200_OK
+    assert data["_meta"]["total"] == 1
+    assert data["data"][0]["uuid"] == prj_root["uuid"]
+
+    # Search in folder: should find only the folder project
+    url = base_url.with_query({"folder_id": f"{folder_id}", "search": "Findme"})
+    resp = await client.get(f"{url}")
+    data = await resp.json()
+    assert resp.status == status.HTTP_200_OK
+    assert data["_meta"]["total"] == 1
+    assert data["data"][0]["uuid"] == prj_folder["uuid"]


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

Rewrites the project listing SQL queries to eliminate two performance bottlenecks:

1. Access rights: Replaced GROUP BY subquery joined via INNER JOIN with a correlated EXISTS check in WHERE. The planner can now stop at the first matching row instead of materialising a grouped intermediate result.

2. Folder filtering: Split the single LEFT JOIN ... WHERE folder_id IS NULL pattern into three scope-specific strategies:
    - ROOT: NOT EXISTS subquery (no join) — avoids the costly anti-join pattern that caused slow root listings **<-- This is what we were hitting here** https://github.com/ITISFoundation/osparc-simcore/issues/9027
    - SPECIFIC: INNER JOIN on exact [(user_id, folder_id)](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — simple equi-join
    - ALL: LEFT OUTER JOIN (no filter) — unchanged, used by full-depth search


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/9027

## How to test

All existing tests pass (55 tests across listing, folders, and workspaces suites). Added 4 new edge-case tests:
- Multiple folders isolation (projects don't leak between folders)
- Pagination correctness after folder split
- Search respects folder scope
- Round-trip: project returns to root after folder assignment removal

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
