### PR TITLE
🎨 [Frontend] PO Center: don't list registered users in Review users section

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -1145,7 +1145,7 @@ qx.Class.define("osparc.data.Resources", {
           },
           getReviewedUsers: {
             method: "GET",
-            url: statics.API + "/admin/user-accounts?review_status=REVIEWED&offset={offset}&limit={limit}"
+            url: statics.API + "/admin/user-accounts?review_status=REVIEWED&offset={offset}&limit={limit}&registered={registered}"
           },
           previewApproval: {
             method: "POST",

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -314,7 +314,11 @@ qx.Class.define("osparc.po.UsersPending", {
       this.getChildControl("filter-users").exclude();
 
       const paramsPending = {};
-      const paramsReviewed = {};
+      const paramsReviewed = {
+        url: {
+          registered: "false", // only show reviewed users that are not yet registered
+        }
+      };
       Promise.all([
         osparc.data.Resources.getInstance().getAllPages("poUsers", paramsPending, "getPendingUsers"),
         osparc.data.Resources.getInstance().getAllPages("poUsers", paramsReviewed, "getReviewedUsers"),

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -128,7 +128,7 @@ qx.Class.define("osparc.po.UsersPending", {
           this.getChildControl("header-layout").add(control);
           break;
         case "intro-text":
-          control = new qx.ui.basic.Label(this.tr("List of pending users or approved/rejected, but not yet registered:")).set({
+          control = new qx.ui.basic.Label(this.tr("List of pending users or reviewed but not yet registered:")).set({
             font: "text-14",
             textColor: "text",
             allowGrowX: true


### PR DESCRIPTION
## What do these changes do?

Updates the PO Center “Users Pending” view to ensure the “Reviewed users” list excludes users who have already completed registration, aligning the frontend behavior with the new backend registered filter introduced in https://github.com/ITISFoundation/osparc-simcore/pull/9024.


## Related issue/s
- follows https://github.com/ITISFoundation/osparc-simcore/pull/9024


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
