### PR TITLE
✨ feat(login): show targeted wrong-password message for merged sim4life accounts :warning: :ambulance:

### DIFF
--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -66,8 +66,9 @@ class Vendor(TypedDict, total=False):
     company_address: str
     company_links: list[tuple[str, str]]  # list of (link_name, link_url)
     marketing_tip_fallback_products_on_wrong_password: (
-        list[str]  # list of product names to check; on wrong password, if user has an account
-        # in any of these products, suggest using credentials from the first one
+        list[str]  # list of product names to check (in order); on wrong password, if the user has an account
+        # in any of these products, suggest using the password from the first matching product
+        # (accounts were merged/unified across platforms)
     )
 
 

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -65,6 +65,9 @@ class Vendor(TypedDict, total=False):
     company_name: str
     company_address: str
     company_links: list[tuple[str, str]]  # list of (link_name, link_url)
+    marketing_login_tip_on_wrong_password: (
+        bool  # If True, show a tip on wrong password for users with accounts in other products
+    )
 
 
 class IssueTracker(TypedDict, total=True):

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -66,7 +66,8 @@ class Vendor(TypedDict, total=False):
     company_address: str
     company_links: list[tuple[str, str]]  # list of (link_name, link_url)
     marketing_login_tip_on_wrong_password: (
-        bool  # If True, show a tip on wrong password for users with accounts in other products
+        list[str]  # List of product names to check; on wrong password, if user has an account
+        # in any of these products, suggest using credentials from the first one
     )
 
 

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -65,7 +65,7 @@ class Vendor(TypedDict, total=False):
     company_name: str
     company_address: str
     company_links: list[tuple[str, str]]  # list of (link_name, link_url)
-    marketing_tip_fallback_products_on_wrong_password: (
+    marketing_fallback_products_on_wrong_password: (
         list[str]  # list of product names to check (in order); on wrong password, if the user has an account
         # in any of these products, suggest using the password from the first matching product
         # (accounts were merged/unified across platforms)

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -65,7 +65,7 @@ class Vendor(TypedDict, total=False):
     company_name: str
     company_address: str
     company_links: list[tuple[str, str]]  # list of (link_name, link_url)
-    marketing_tip_fallback_product_on_wrong_password: (
+    marketing_tip_fallback_products_on_wrong_password: (
         list[str]  # list of product names to check; on wrong password, if user has an account
         # in any of these products, suggest using credentials from the first one
     )

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -65,8 +65,8 @@ class Vendor(TypedDict, total=False):
     company_name: str
     company_address: str
     company_links: list[tuple[str, str]]  # list of (link_name, link_url)
-    marketing_login_tip_on_wrong_password: (
-        list[str]  # List of product names to check; on wrong password, if user has an account
+    marketing_tip_fallback_product_on_wrong_password: (
+        list[str]  # list of product names to check; on wrong password, if user has an account
         # in any of these products, suggest using credentials from the first one
     )
 

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -48,27 +48,32 @@ _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
 }
 
 
-async def _should_show_login_tip(app: web.Application, *, user_id: int, product_name: str) -> bool:
-    """Show a login tip when the current product has ``marketing_login_tip_on_wrong_password``
-    enabled in its vendor config AND the user also belongs to another product
-    that does NOT have the flag enabled.
+async def _should_show_login_tip(app: web.Application, *, user_id: int, product_name: str) -> str | None:
+    """Returns the suggested product display name when a login tip should be shown.
+
+    Checks if the current product has ``marketing_login_tip_on_wrong_password``
+    configured with a list of product names. If the user belongs to any of those
+    products, returns the display name of the first (preferred) product.
     """
     try:
         current_product = products_service.get_product(app, product_name=product_name)
         vendor = current_product.vendor or {}
-        if not vendor.get("marketing_login_tip_on_wrong_password", False):
-            return False
+        tip_products: list[str] = vendor.get("marketing_login_tip_on_wrong_password", [])
+        if not tip_products:
+            return None
 
-        for other_product in products_service.list_products(app):
-            if other_product.name == product_name:
+        preferred_product = products_service.get_product(app, product_name=tip_products[0])
+        preferred_display_name = preferred_product.display_name
+
+        for check_product_name in tip_products:
+            try:
+                check_product = products_service.get_product(app, product_name=check_product_name)
+            except ProductNotFoundError:
                 continue
-            other_vendor = other_product.vendor or {}
-            if other_vendor.get("marketing_login_tip_on_wrong_password", False):
-                continue
-            if other_product.group_id is not None and await groups_service.is_user_in_group(
-                app, user_id=user_id, group_id=other_product.group_id
+            if check_product.group_id is not None and await groups_service.is_user_in_group(
+                app, user_id=user_id, group_id=check_product.group_id
             ):
-                return True
+                return preferred_display_name
     except ProductNotFoundError:
         _logger.debug(
             "Product %s not found while checking login tip for user %s",
@@ -81,7 +86,7 @@ async def _should_show_login_tip(app: web.Application, *, user_id: int, product_
             user_id,
             exc_info=True,
         )
-    return False
+    return None
 
 
 async def _handle_legacy_error_response(request: web.Request, exception: Exception):
@@ -97,8 +102,9 @@ async def _handle_legacy_error_response(request: web.Request, exception: Excepti
 
     msg = MSG_WRONG_PASSWORD
     product_name = products_web.get_product_name(request)
-    if await _should_show_login_tip(request.app, user_id=exception.user_id, product_name=product_name):
-        msg = MSG_WRONG_PASSWORD_MERGED_ACCOUNTS
+    suggested_product = await _should_show_login_tip(request.app, user_id=exception.user_id, product_name=product_name)
+    if suggested_product:
+        msg = MSG_WRONG_PASSWORD_MERGED_ACCOUNTS.format(suggested_product=suggested_product)
 
     return handle_aiohttp_web_http_error(
         request=request,

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -97,9 +97,12 @@ async def _handle_legacy_error_response(request: web.Request, exception: Excepti
         exception, WrongPasswordError
     ), f"Expected WrongPasswordError, got {type(exception)}"
 
+    user_id = exception.error_context().get("user_id")
+    assert user_id is not None, "user_id must be present in error context"  # nosec
+
     msg = MSG_WRONG_PASSWORD
     product_name = products_web.get_product_name(request)
-    suggested_product = await _try_show_login_tip(request.app, user_id=exception.user_id, product_name=product_name)
+    suggested_product = await _try_show_login_tip(request.app, user_id=user_id, product_name=product_name)
     if suggested_product:
         msg = MSG_WRONG_PASSWORD_MERGED_ACCOUNTS.format(suggested_product=suggested_product)
 

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -51,14 +51,14 @@ _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
 async def _should_show_login_tip(app: web.Application, *, user_id: int, product_name: str) -> str | None:
     """Returns the suggested product display name when a login tip should be shown.
 
-    Checks if the current product has ``marketing_login_tip_on_wrong_password``
+    Checks if the current product has ``marketing_tip_fallback_product_on_wrong_password``
     configured with a list of product names. If the user belongs to any of those
     products, returns the display name of the first (preferred) product.
     """
     try:
         current_product = products_service.get_product(app, product_name=product_name)
         vendor = current_product.vendor or {}
-        tip_products: list[str] = vendor.get("marketing_login_tip_on_wrong_password", [])
+        tip_products: list[str] = vendor.get("marketing_tip_fallback_product_on_wrong_password", [])
         if not tip_products:
             return None
 

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -62,8 +62,7 @@ async def _should_show_login_tip(app: web.Application, *, user_id: int, product_
         if not tip_products:
             return None
 
-        fallback_product = products_service.get_product(app, product_name=tip_products[0])
-        fallback_display_name = fallback_product.display_name
+        fallback_display_name = products_service.get_product(app, product_name=tip_products[0]).display_name
 
         for check_product_name in tip_products:
             try:

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Final
 
 from aiohttp import web
 from common_library.user_messages import user_message
@@ -14,6 +13,7 @@ from ....exception_handling import (
 )
 from ....groups import api as groups_service
 from ....products import products_service
+from ....products.errors import ProductNotFoundError
 from ....users.exceptions import AlreadyPreRegisteredError
 from ...constants import (
     MSG_2FA_UNAVAILABLE,
@@ -27,11 +27,6 @@ from ...errors import (
 )
 
 log = logging.getLogger(__name__)
-
-# Products involved in the sim4life.io / sim4life.science database merge.
-# Users that belong to multiple of these products get a targeted
-# wrong-password message informing them about unified login.
-_MERGED_PRODUCT_NAMES: Final[set[str]] = {"s4l", "s4llite"}
 
 _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
     AlreadyPreRegisteredError: HttpErrorInfo(
@@ -53,19 +48,36 @@ _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
 }
 
 
-async def _is_user_affected_by_db_merge(app: web.Application, *, user_id: int) -> bool:
-    """Checks if user belongs to all products involved in the DB merge."""
+async def _should_show_login_tip(app: web.Application, *, user_id: int, product_name: str) -> bool:
+    """Show a login tip when the current product has ``marketing_login_tip_on_wrong_password``
+    enabled in its vendor config AND the user also belongs to another product
+    that does NOT have the flag enabled.
+    """
     try:
-        for product_name in _MERGED_PRODUCT_NAMES:
-            product = products_service.get_product(app, product_name=product_name)
-            if product.group_id is None or not await groups_service.is_user_in_group(
-                app, user_id=user_id, group_id=product.group_id
+        current_product = products_service.get_product(app, product_name=product_name)
+        vendor = current_product.vendor or {}
+        if not vendor.get("marketing_login_tip_on_wrong_password", False):
+            return False
+
+        for other_product in products_service.list_products(app):
+            if other_product.name == product_name:
+                continue
+            other_vendor = other_product.vendor or {}
+            if other_vendor.get("marketing_login_tip_on_wrong_password", False):
+                continue
+            if other_product.group_id is not None and await groups_service.is_user_in_group(
+                app, user_id=user_id, group_id=other_product.group_id
             ):
-                return False
-        return True
+                return True
+    except ProductNotFoundError:
+        log.debug(
+            "Product %s not found while checking login tip for user %s",
+            product_name,
+            user_id,
+        )
     except Exception:  # pylint: disable=broad-except
         log.warning(
-            "Failed to check merged-accounts status for user %s",
+            "Unexpected error checking login tip for user %s",
             user_id,
             exc_info=True,
         )
@@ -85,7 +97,12 @@ async def _handle_legacy_error_response(request: web.Request, exception: Excepti
 
     msg = MSG_WRONG_PASSWORD
     user_id: int | None = getattr(exception, "user_id", None)
-    if user_id is not None and await _is_user_affected_by_db_merge(request.app, user_id=user_id):
+    product_name: str | None = getattr(exception, "product_name", None)
+    if (
+        user_id is not None
+        and product_name is not None
+        and await _should_show_login_tip(request.app, user_id=user_id, product_name=product_name)
+    ):
         msg = MSG_WRONG_PASSWORD_MERGED_ACCOUNTS
 
     return handle_aiohttp_web_http_error(

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -1,3 +1,5 @@
+import logging
+
 from aiohttp import web
 from common_library.user_messages import user_message
 from servicelib.aiohttp import status
@@ -9,19 +11,33 @@ from ....exception_handling import (
     exception_handling_decorator,
     to_exceptions_handlers_map,
 )
+from ....groups import api as groups_service
+from ....products import products_service
 from ....users.exceptions import AlreadyPreRegisteredError
-from ...constants import MSG_2FA_UNAVAILABLE, MSG_WRONG_PASSWORD
+from ...constants import (
+    MSG_2FA_UNAVAILABLE,
+    MSG_WRONG_PASSWORD,
+    MSG_WRONG_PASSWORD_MERGED_ACCOUNTS,
+)
 from ...errors import (
     SendingVerificationEmailError,
     SendingVerificationSmsError,
     WrongPasswordError,
 )
 
+log = logging.getLogger(__name__)
+
+# Products involved in the sim4life.io / sim4life.science database merge.
+# Users that belong to multiple of these products get a targeted
+# wrong-password message informing them about unified login.
+_MERGED_PRODUCT_NAMES: set[str] = {"s4l", "s4llite"}
+
 _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
     AlreadyPreRegisteredError: HttpErrorInfo(
         status.HTTP_409_CONFLICT,
         user_message(
-            "An account for the email {email} has been submitted. If you haven't received any updates, please contact support.",
+            "An account for the email {email} has been submitted. "
+            "If you haven't received any updates, please contact support.",
             _version=1,
         ),
     ),
@@ -36,6 +52,25 @@ _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
 }
 
 
+async def _is_user_affected_by_db_merge(app: web.Application, *, user_id: int) -> bool:
+    """Checks if user belongs to all products involved in the DB merge."""
+    try:
+        for product_name in _MERGED_PRODUCT_NAMES:
+            product = products_service.get_product(app, product_name=product_name)
+            if product.group_id is None or not await groups_service.is_user_in_group(
+                app, user_id=user_id, group_id=product.group_id
+            ):
+                return False
+        return True
+    except Exception:  # pylint: disable=broad-except
+        log.warning(
+            "Failed to check merged-accounts status for user %s",
+            user_id,
+            exc_info=True,
+        )
+    return False
+
+
 async def _handle_legacy_error_response(request: web.Request, exception: Exception):
     """
     This handlers keeps compatibility with error responses that include deprecated
@@ -47,9 +82,14 @@ async def _handle_legacy_error_response(request: web.Request, exception: Excepti
         exception, WrongPasswordError
     ), f"Expected WrongPasswordError, got {type(exception)}"
 
+    msg = MSG_WRONG_PASSWORD
+    user_id: int | None = getattr(exception, "user_id", None)
+    if user_id is not None and await _is_user_affected_by_db_merge(request.app, user_id=user_id):
+        msg = MSG_WRONG_PASSWORD_MERGED_ACCOUNTS
+
     return handle_aiohttp_web_http_error(
         request=request,
-        exception=web.HTTPUnauthorized(text=MSG_WRONG_PASSWORD),
+        exception=web.HTTPUnauthorized(text=msg),
     )
 
 

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -79,11 +79,11 @@ async def _should_show_login_tip(app: web.Application, *, user_id: int, product_
             product_name,
             user_id,
         )
-    except Exception:  # pylint: disable=broad-except
-        _logger.warning(
-            "Unexpected error checking login tip for user %s",
+    except Exception as exc:  # pylint: disable=broad-except
+        _logger.debug(
+            "Unexpected error checking login tip for user %s: %s",
             user_id,
-            exc_info=True,
+            exc,
         )
     return None
 

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -12,7 +12,7 @@ from ....exception_handling import (
     to_exceptions_handlers_map,
 )
 from ....groups import api as groups_service
-from ....products import products_service
+from ....products import products_service, products_web
 from ....products.errors import ProductNotFoundError
 from ....users.exceptions import AlreadyPreRegisteredError
 from ...constants import (
@@ -96,13 +96,8 @@ async def _handle_legacy_error_response(request: web.Request, exception: Excepti
     ), f"Expected WrongPasswordError, got {type(exception)}"
 
     msg = MSG_WRONG_PASSWORD
-    user_id: int | None = getattr(exception, "user_id", None)
-    product_name: str | None = getattr(exception, "product_name", None)
-    if (
-        user_id is not None
-        and product_name is not None
-        and await _should_show_login_tip(request.app, user_id=user_id, product_name=product_name)
-    ):
+    product_name = products_web.get_product_name(request)
+    if await _should_show_login_tip(request.app, user_id=exception.user_id, product_name=product_name):
         msg = MSG_WRONG_PASSWORD_MERGED_ACCOUNTS
 
     return handle_aiohttp_web_http_error(

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -77,7 +77,7 @@ async def _try_show_login_fallbacks_on_wrong_password(
     except Exception as exc:  # pylint: disable=broad-except
         _logger.exception(
             **create_troubleshooting_log_kwargs(
-                "Unexpected error checking login",
+                "Unexpected error checking fallback products for wrong password",
                 error=exc,
                 error_context={
                     "user_id": user_id,

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -62,7 +62,15 @@ async def _try_show_login_tip(app: web.Application, *, user_id: int, product_nam
         if not tip_products:
             return None
 
-        fallback_display_name = products_service.get_product(app, product_name=tip_products[0]).display_name
+        try:
+            fallback_display_name = products_service.get_product(app, product_name=tip_products[0]).display_name
+        except ProductNotFoundError:
+            _logger.debug(
+                "Fallback product %s not found while checking login tip for user %s",
+                tip_products[0],
+                user_id,
+            )
+            return None
 
         for check_product_name in tip_products:
             try:

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -51,25 +51,15 @@ _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
 async def _try_show_login_tip(app: web.Application, *, user_id: int, product_name: str) -> str | None:
     """Returns the suggested product display name when a login tip should be shown.
 
-    Checks if the current product has ``marketing_tip_fallback_product_on_wrong_password``
+    Checks if the current product has ``marketing_tip_fallback_products_on_wrong_password``
     configured with a list of product names. If the user belongs to any of those
-    products, returns the display name of the first (preferred) product.
+    products, returns the display name of the matching product.
     """
     try:
         current_product = products_service.get_product(app, product_name=product_name)
         vendor = current_product.vendor or {}
-        tip_products: list[str] = vendor.get("marketing_tip_fallback_product_on_wrong_password", [])
+        tip_products: list[str] = vendor.get("marketing_tip_fallback_products_on_wrong_password", [])
         if not tip_products:
-            return None
-
-        try:
-            fallback_display_name = products_service.get_product(app, product_name=tip_products[0]).display_name
-        except ProductNotFoundError:
-            _logger.debug(
-                "Fallback product %s not found while checking login tip for user %s",
-                tip_products[0],
-                user_id,
-            )
             return None
 
         for check_product_name in tip_products:
@@ -80,7 +70,7 @@ async def _try_show_login_tip(app: web.Application, *, user_id: int, product_nam
             if check_product.group_id is not None and await groups_service.is_user_in_group(
                 app, user_id=user_id, group_id=check_product.group_id
             ):
-                return fallback_display_name
+                return check_product.display_name
     except ProductNotFoundError:
         _logger.debug(
             "Product %s not found while checking login tip for user %s",

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -48,7 +48,7 @@ _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
 }
 
 
-async def _should_show_login_tip(app: web.Application, *, user_id: int, product_name: str) -> str | None:
+async def _try_show_login_tip(app: web.Application, *, user_id: int, product_name: str) -> str | None:
     """Returns the suggested product display name when a login tip should be shown.
 
     Checks if the current product has ``marketing_tip_fallback_product_on_wrong_password``
@@ -101,7 +101,7 @@ async def _handle_legacy_error_response(request: web.Request, exception: Excepti
 
     msg = MSG_WRONG_PASSWORD
     product_name = products_web.get_product_name(request)
-    suggested_product = await _should_show_login_tip(request.app, user_id=exception.user_id, product_name=product_name)
+    suggested_product = await _try_show_login_tip(request.app, user_id=exception.user_id, product_name=product_name)
     if suggested_product:
         msg = MSG_WRONG_PASSWORD_MERGED_ACCOUNTS.format(suggested_product=suggested_product)
 

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Final
 
 from aiohttp import web
 from common_library.user_messages import user_message
@@ -30,7 +31,7 @@ log = logging.getLogger(__name__)
 # Products involved in the sim4life.io / sim4life.science database merge.
 # Users that belong to multiple of these products get a targeted
 # wrong-password message informing them about unified login.
-_MERGED_PRODUCT_NAMES: set[str] = {"s4l", "s4llite"}
+_MERGED_PRODUCT_NAMES: Final[set[str]] = {"s4l", "s4llite"}
 
 _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
     AlreadyPreRegisteredError: HttpErrorInfo(

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -26,7 +26,7 @@ from ...errors import (
     WrongPasswordError,
 )
 
-log = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
     AlreadyPreRegisteredError: HttpErrorInfo(
@@ -70,13 +70,13 @@ async def _should_show_login_tip(app: web.Application, *, user_id: int, product_
             ):
                 return True
     except ProductNotFoundError:
-        log.debug(
+        _logger.debug(
             "Product %s not found while checking login tip for user %s",
             product_name,
             user_id,
         )
     except Exception:  # pylint: disable=broad-except
-        log.warning(
+        _logger.warning(
             "Unexpected error checking login tip for user %s",
             user_id,
             exc_info=True,

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -62,8 +62,8 @@ async def _should_show_login_tip(app: web.Application, *, user_id: int, product_
         if not tip_products:
             return None
 
-        preferred_product = products_service.get_product(app, product_name=tip_products[0])
-        preferred_display_name = preferred_product.display_name
+        fallback_product = products_service.get_product(app, product_name=tip_products[0])
+        fallback_display_name = fallback_product.display_name
 
         for check_product_name in tip_products:
             try:
@@ -73,7 +73,7 @@ async def _should_show_login_tip(app: web.Application, *, user_id: int, product_
             if check_product.group_id is not None and await groups_service.is_user_in_group(
                 app, user_id=user_id, group_id=check_product.group_id
             ):
-                return preferred_display_name
+                return fallback_display_name
     except ProductNotFoundError:
         _logger.debug(
             "Product %s not found while checking login tip for user %s",

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -1,6 +1,7 @@
 import logging
 
 from aiohttp import web
+from common_library.logging.logging_errors import create_troubleshooting_log_kwargs
 from common_library.user_messages import user_message
 from servicelib.aiohttp import status
 from servicelib.aiohttp.rest_middlewares import handle_aiohttp_web_http_error
@@ -48,7 +49,9 @@ _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
 }
 
 
-async def _try_show_login_tip(app: web.Application, *, user_id: int, product_name: str) -> str | None:
+async def _try_show_login_fallbacks_on_wrong_password(
+    app: web.Application, *, user_id: int, product_name: str
+) -> str | None:
     """Returns the suggested product display name when a login tip should be shown.
 
     Checks if the current product has ``marketing_fallback_products_on_wrong_password``
@@ -71,17 +74,16 @@ async def _try_show_login_tip(app: web.Application, *, user_id: int, product_nam
                 app, user_id=user_id, group_id=check_product.group_id
             ):
                 return check_product.display_name
-    except ProductNotFoundError:
-        _logger.debug(
-            "Product %s not found while checking login tip for user %s",
-            product_name,
-            user_id,
-        )
     except Exception as exc:  # pylint: disable=broad-except
-        _logger.debug(
-            "Unexpected error checking login tip for user %s: %s",
-            user_id,
-            exc,
+        _logger.exception(
+            **create_troubleshooting_log_kwargs(
+                "Unexpected error checking login",
+                error=exc,
+                error_context={
+                    "user_id": user_id,
+                    "product_name": product_name,
+                },
+            )
         )
     return None
 
@@ -102,7 +104,9 @@ async def _handle_legacy_error_response(request: web.Request, exception: Excepti
 
     msg = MSG_WRONG_PASSWORD
     product_name = products_web.get_product_name(request)
-    suggested_product = await _try_show_login_tip(request.app, user_id=user_id, product_name=product_name)
+    suggested_product = await _try_show_login_fallbacks_on_wrong_password(
+        request.app, user_id=user_id, product_name=product_name
+    )
     if suggested_product:
         msg = MSG_WRONG_PASSWORD_MERGED_ACCOUNTS.format(suggested_product=suggested_product)
 

--- a/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/login/_controller/rest/_rest_exceptions.py
@@ -51,14 +51,14 @@ _TO_HTTP_ERROR_MAP: ExceptionToHttpErrorMap = {
 async def _try_show_login_tip(app: web.Application, *, user_id: int, product_name: str) -> str | None:
     """Returns the suggested product display name when a login tip should be shown.
 
-    Checks if the current product has ``marketing_tip_fallback_products_on_wrong_password``
+    Checks if the current product has ``marketing_fallback_products_on_wrong_password``
     configured with a list of product names. If the user belongs to any of those
     products, returns the display name of the matching product.
     """
     try:
         current_product = products_service.get_product(app, product_name=product_name)
         vendor = current_product.vendor or {}
-        tip_products: list[str] = vendor.get("marketing_tip_fallback_products_on_wrong_password", [])
+        tip_products: list[str] = vendor.get("marketing_fallback_products_on_wrong_password", [])
         if not tip_products:
             return None
 

--- a/services/web/server/src/simcore_service_webserver/login/constants.py
+++ b/services/web/server/src/simcore_service_webserver/login/constants.py
@@ -97,9 +97,9 @@ MSG_WRONG_PASSWORD: Final[str] = user_message(
 )
 MSG_WRONG_PASSWORD_MERGED_ACCOUNTS: Final[str] = user_message(
     "The password does not match the one associated with this email address."
-    " Since sim4life.io and sim4life.science have been merged,"
-    " please use your sim4life.io credentials to log in."
-    " You can also reset your password if needed.",
+    " If you have accounts on multiple platforms, please note that your login"
+    " credentials have been unified. Try using the password from your other account,"
+    " or reset your password if needed.",
     _version=1,
 )
 MSG_WEAK_PASSWORD: Final[str] = user_message(

--- a/services/web/server/src/simcore_service_webserver/login/constants.py
+++ b/services/web/server/src/simcore_service_webserver/login/constants.py
@@ -32,7 +32,8 @@ MSG_EMAIL_SENT: Final[str] = user_message("We've sent an email to {email} with f
 MSG_LOGGED_IN: Final[str] = user_message("You have successfully signed in.", _version=1)
 MSG_LOGGED_OUT: Final[str] = user_message("You have successfully signed out.", _version=1)
 MSG_OFTEN_RESET_PASSWORD: Final[str] = user_message(
-    "You've recently requested a password reset. Please check your email for the reset link or wait before requesting another one.",
+    "You've recently requested a password reset. "
+    "Please check your email for the reset link or wait before requesting another one.",
     _version=1,
 )
 MSG_PASSWORD_CHANGE_NOT_ALLOWED: Final[str] = user_message(
@@ -63,7 +64,8 @@ MSG_UNAUTHORIZED_PHONE_CONFIRMATION: Final[str] = user_message(
 )
 MSG_UNKNOWN_EMAIL: Final[str] = user_message("This email address is not registered.", _version=1)
 MSG_USER_DELETED: Final[str] = user_message(
-    "This account is scheduled for deletion. To reactivate it or for more information, please contact support: {support_email}",
+    "This account is scheduled for deletion. "
+    "To reactivate it or for more information, please contact support: {support_email}",
     _version=1,
 )
 MSG_USER_BANNED: Final[str] = user_message(
@@ -71,11 +73,13 @@ MSG_USER_BANNED: Final[str] = user_message(
     _version=1,
 )
 MSG_USER_EXPIRED: Final[str] = user_message(
-    "This account has expired and access is no longer available. Please contact support for assistance: {support_email}",
+    "This account has expired and access is no longer available. "
+    "Please contact support for assistance: {support_email}",
     _version=1,
 )
 MSG_USER_DISABLED: Final[str] = user_message(
-    "This account has been disabled and cannot be registered again. Please contact support for details: {support_email}",
+    "This account has been disabled and cannot be registered again. "
+    "Please contact support for details: {support_email}",
     _version=1,
 )
 MSG_WRONG_2FA_CODE__INVALID: Final[str] = user_message(
@@ -90,6 +94,13 @@ MSG_WRONG_CAPTCHA__INVALID: Final[str] = user_message("The CAPTCHA entered is in
 MSG_WRONG_PASSWORD: Final[str] = user_message(
     "The password does not match the one associated with this email address. Please try again.",
     _version=3,
+)
+MSG_WRONG_PASSWORD_MERGED_ACCOUNTS: Final[str] = user_message(
+    "The password does not match the one associated with this email address."
+    " Since sim4life.io and sim4life.science have been merged,"
+    " please use your sim4life.science credentials to log in."
+    " You can also reset your password if needed.",
+    _version=1,
 )
 MSG_WEAK_PASSWORD: Final[str] = user_message(
     "Your password must contain at least {LOGIN_PASSWORD_MIN_LENGTH} characters for security.",

--- a/services/web/server/src/simcore_service_webserver/login/constants.py
+++ b/services/web/server/src/simcore_service_webserver/login/constants.py
@@ -98,7 +98,7 @@ MSG_WRONG_PASSWORD: Final[str] = user_message(
 MSG_WRONG_PASSWORD_MERGED_ACCOUNTS: Final[str] = user_message(
     "The password does not match the one associated with this email address."
     " If you have accounts on multiple platforms, please note that your login"
-    " credentials have been unified. Try using the password from your other account,"
+    " credentials have been unified. Try using your {suggested_product} password,"
     " or reset your password if needed.",
     _version=1,
 )

--- a/services/web/server/src/simcore_service_webserver/login/constants.py
+++ b/services/web/server/src/simcore_service_webserver/login/constants.py
@@ -98,7 +98,7 @@ MSG_WRONG_PASSWORD: Final[str] = user_message(
 MSG_WRONG_PASSWORD_MERGED_ACCOUNTS: Final[str] = user_message(
     "The password does not match the one associated with this email address."
     " Since sim4life.io and sim4life.science have been merged,"
-    " please use your sim4life.science credentials to log in."
+    " please use your sim4life.io credentials to log in."
     " You can also reset your password if needed.",
     _version=1,
 )

--- a/services/web/server/src/simcore_service_webserver/login/constants.py
+++ b/services/web/server/src/simcore_service_webserver/login/constants.py
@@ -97,8 +97,8 @@ MSG_WRONG_PASSWORD: Final[str] = user_message(
 )
 MSG_WRONG_PASSWORD_MERGED_ACCOUNTS: Final[str] = user_message(
     "The password does not match the one associated with this email address."
-    " If you have accounts on multiple platforms, please note that your login"
-    " credentials have been unified. Try using your {suggested_product} password.",
+    " If you have accounts on multiple platforms, you now benefit from a unified login."
+    " Please try using your {suggested_product} password.",
     _version=1,
 )
 MSG_WEAK_PASSWORD: Final[str] = user_message(

--- a/services/web/server/src/simcore_service_webserver/login/constants.py
+++ b/services/web/server/src/simcore_service_webserver/login/constants.py
@@ -97,7 +97,7 @@ MSG_WRONG_PASSWORD: Final[str] = user_message(
 )
 MSG_WRONG_PASSWORD_MERGED_ACCOUNTS: Final[str] = user_message(
     "The password does not match the one associated with this email address."
-    " Your accounts across multiple platforms have been unified into a single login."
+    "TIP: Your accounts across multiple platforms have been unified into a single login."
     " Please try using the password from your {suggested_product} account.",
     _version=1,
 )

--- a/services/web/server/src/simcore_service_webserver/login/constants.py
+++ b/services/web/server/src/simcore_service_webserver/login/constants.py
@@ -97,8 +97,8 @@ MSG_WRONG_PASSWORD: Final[str] = user_message(
 )
 MSG_WRONG_PASSWORD_MERGED_ACCOUNTS: Final[str] = user_message(
     "The password does not match the one associated with this email address."
-    " If you have accounts on multiple platforms, you now benefit from a unified login."
-    " Please try using your {suggested_product} password.",
+    " Your accounts across multiple platforms have been unified into a single login."
+    " Please try using the password from your {suggested_product} account.",
     _version=1,
 )
 MSG_WEAK_PASSWORD: Final[str] = user_message(

--- a/services/web/server/src/simcore_service_webserver/login/constants.py
+++ b/services/web/server/src/simcore_service_webserver/login/constants.py
@@ -98,8 +98,7 @@ MSG_WRONG_PASSWORD: Final[str] = user_message(
 MSG_WRONG_PASSWORD_MERGED_ACCOUNTS: Final[str] = user_message(
     "The password does not match the one associated with this email address."
     " If you have accounts on multiple platforms, please note that your login"
-    " credentials have been unified. Try using your {suggested_product} password,"
-    " or reset your password if needed.",
+    " credentials have been unified. Try using your {suggested_product} password.",
     _version=1,
 )
 MSG_WEAK_PASSWORD: Final[str] = user_message(

--- a/services/web/server/src/simcore_service_webserver/login/errors.py
+++ b/services/web/server/src/simcore_service_webserver/login/errors.py
@@ -1,5 +1,3 @@
-from models_library.users import UserID
-
 from ..errors import WebServerBaseError
 
 
@@ -16,4 +14,3 @@ class SendingVerificationEmailError(LoginError):
 
 class WrongPasswordError(LoginError):
     msg_template = "Invalid password provided for user {user_id}"
-    user_id: UserID

--- a/services/web/server/src/simcore_service_webserver/login/errors.py
+++ b/services/web/server/src/simcore_service_webserver/login/errors.py
@@ -1,3 +1,5 @@
+from models_library.users import UserID
+
 from ..errors import WebServerBaseError
 
 
@@ -13,4 +15,5 @@ class SendingVerificationEmailError(LoginError):
 
 
 class WrongPasswordError(LoginError):
-    msg_template = "Invalid password provided"
+    msg_template = "Invalid password provided for user {user_id}"
+    user_id: UserID

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -5,9 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import web
+from simcore_service_webserver.groups import api as groups_service
 from simcore_service_webserver.login._controller.rest._rest_exceptions import (
     _is_user_affected_by_db_merge,
 )
+from simcore_service_webserver.products import products_service
 
 
 def _create_fake_product(*, group_id: int | None) -> MagicMock:
@@ -33,7 +35,7 @@ def mock_products(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
         return products[product_name]
 
     monkeypatch.setattr(
-        "simcore_service_webserver.login._controller.rest._rest_exceptions.products_service.get_product",
+        f"{products_service.__name__}.get_product",
         _get_product,
     )
     return products
@@ -43,7 +45,7 @@ def mock_products(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
 def mock_is_user_in_group(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     mock = AsyncMock(return_value=False)
     monkeypatch.setattr(
-        "simcore_service_webserver.login._controller.rest._rest_exceptions.groups_service.is_user_in_group",
+        f"{groups_service.__name__}.is_user_in_group",
         mock,
     )
     return mock
@@ -113,7 +115,7 @@ async def test_db_merge_check_handles_missing_product_gracefully(
         raise KeyError(product_name)
 
     monkeypatch.setattr(
-        "simcore_service_webserver.login._controller.rest._rest_exceptions.products_service.get_product",
+        f"{products_service.__name__}.get_product",
         _get_product,
     )
 
@@ -137,7 +139,7 @@ async def test_db_merge_check_skips_product_without_group_id(
         return products[product_name]
 
     monkeypatch.setattr(
-        "simcore_service_webserver.login._controller.rest._rest_exceptions.products_service.get_product",
+        f"{products_service.__name__}.get_product",
         _get_product,
     )
     mock_is_user_in_group.return_value = True

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -1,0 +1,147 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from simcore_service_webserver.login._controller.rest._rest_exceptions import (
+    _is_user_affected_by_db_merge,
+)
+
+
+def _create_fake_product(*, group_id: int | None) -> MagicMock:
+    product = MagicMock()
+    product.group_id = group_id
+    return product
+
+
+@pytest.fixture
+def mock_app() -> web.Application:
+    return web.Application()
+
+
+@pytest.fixture
+def mock_products(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
+    """Creates fake s4l and s4llite products with distinct group_ids."""
+    products = {
+        "s4l": _create_fake_product(group_id=10),
+        "s4llite": _create_fake_product(group_id=20),
+    }
+
+    def _get_product(_app: web.Application, product_name: str) -> MagicMock:
+        return products[product_name]
+
+    monkeypatch.setattr(
+        "simcore_service_webserver.login._controller.rest._rest_exceptions.products_service.get_product",
+        _get_product,
+    )
+    return products
+
+
+@pytest.fixture
+def mock_is_user_in_group(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    mock = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        "simcore_service_webserver.login._controller.rest._rest_exceptions.groups_service.is_user_in_group",
+        mock,
+    )
+    return mock
+
+
+async def test_user_in_both_merged_products_is_detected(
+    mock_app: web.Application,
+    mock_products: dict[str, MagicMock],
+    mock_is_user_in_group: AsyncMock,
+):
+    # User belongs to both s4l (group_id=10) and s4llite (group_id=20)
+    mock_is_user_in_group.return_value = True
+
+    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
+
+    assert result is True
+
+
+async def test_user_in_only_one_product_is_not_affected(
+    mock_app: web.Application,
+    mock_products: dict[str, MagicMock],
+    mock_is_user_in_group: AsyncMock,
+):
+    # User only belongs to s4l (group_id=10), not s4llite (group_id=20)
+    async def _selective_membership(_app: web.Application, *, user_id: int, group_id: int):
+        return group_id == 10  # only in s4l
+
+    mock_is_user_in_group.side_effect = _selective_membership
+
+    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
+
+    assert result is False
+
+
+async def test_user_in_no_merged_products_is_not_affected(
+    mock_app: web.Application,
+    mock_products: dict[str, MagicMock],
+    mock_is_user_in_group: AsyncMock,
+):
+    mock_is_user_in_group.return_value = False
+
+    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
+
+    assert result is False
+
+
+async def test_db_merge_check_handles_exceptions_gracefully(
+    mock_app: web.Application,
+    mock_products: dict[str, MagicMock],
+    mock_is_user_in_group: AsyncMock,
+):
+    # Simulate a DB error — should return False, not raise
+    mock_is_user_in_group.side_effect = RuntimeError("DB connection failed")
+
+    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
+
+    assert result is False
+
+
+async def test_db_merge_check_handles_missing_product_gracefully(
+    mock_app: web.Application,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_is_user_in_group: AsyncMock,
+):
+    # Product not found in app cache
+    def _get_product(_app: web.Application, product_name: str) -> MagicMock:
+        raise KeyError(product_name)
+
+    monkeypatch.setattr(
+        "simcore_service_webserver.login._controller.rest._rest_exceptions.products_service.get_product",
+        _get_product,
+    )
+
+    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
+
+    assert result is False
+
+
+async def test_db_merge_check_skips_product_without_group_id(
+    mock_app: web.Application,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_is_user_in_group: AsyncMock,
+):
+    # s4l has no group_id, s4llite has one — user is in s4llite but not enough
+    products = {
+        "s4l": _create_fake_product(group_id=None),
+        "s4llite": _create_fake_product(group_id=20),
+    }
+
+    def _get_product(_app: web.Application, product_name: str) -> MagicMock:
+        return products[product_name]
+
+    monkeypatch.setattr(
+        "simcore_service_webserver.login._controller.rest._rest_exceptions.products_service.get_product",
+        _get_product,
+    )
+    mock_is_user_in_group.return_value = True
+
+    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
+
+    assert result is False

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -43,34 +44,45 @@ def mock_is_user_in_group(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     return mock
 
 
-def _patch_products(
-    monkeypatch: pytest.MonkeyPatch,
-    all_products: list[MagicMock],
-) -> None:
-    products_by_name = {p.name: p for p in all_products}
+@pytest.fixture
+def patch_products(monkeypatch: pytest.MonkeyPatch) -> Callable[[list[MagicMock]], None]:
+    def _patch(all_products: list[MagicMock]) -> None:
+        products_by_name = {p.name: p for p in all_products}
 
-    def _get_product(_app: web.Application, product_name: str) -> MagicMock:
-        if product_name not in products_by_name:
-            raise ProductNotFoundError(product_name=product_name)
-        return products_by_name[product_name]
+        def _get_product(_app: web.Application, product_name: str) -> MagicMock:
+            if product_name not in products_by_name:
+                raise ProductNotFoundError(product_name=product_name)
+            return products_by_name[product_name]
 
-    monkeypatch.setattr(
-        f"{products_service.__name__}.get_product",
-        _get_product,
-    )
+        monkeypatch.setattr(
+            f"{products_service.__name__}.get_product",
+            _get_product,
+        )
+
+    return _patch
+
+
+@pytest.fixture
+def s4l_product() -> MagicMock:
+    return _create_fake_product(name="s4l", display_name="Sim4Life", group_id=10)
+
+
+@pytest.fixture
+def s4llite_product() -> MagicMock:
+    return _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
 
 
 @pytest.mark.acceptance_test("For https://github.com/ITISFoundation/private-issues/issues/535")
 async def test_tip_returns_preferred_product_display_name(
     mock_app: web.Application,
-    monkeypatch: pytest.MonkeyPatch,
+    patch_products: Callable,
     mock_is_user_in_group: AsyncMock,
+    s4l_product: MagicMock,
 ):
     # s4llite configured to suggest s4l; user belongs to s4l
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l", "osparc"])
-    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=10)
     osparc = _create_fake_product(name="osparc", display_name="o²S²PARC", group_id=30)
-    _patch_products(monkeypatch, [s4llite, s4l, osparc])
+    patch_products([s4llite, s4l_product, osparc])
     mock_is_user_in_group.return_value = True
 
     result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
@@ -80,13 +92,13 @@ async def test_tip_returns_preferred_product_display_name(
 
 async def test_tip_not_shown_when_no_tip_configured(
     mock_app: web.Application,
-    monkeypatch: pytest.MonkeyPatch,
+    patch_products: Callable,
     mock_is_user_in_group: AsyncMock,
+    s4llite_product: MagicMock,
 ):
     # s4l has no tip configured
     s4l = _create_fake_product(name="s4l", group_id=10)
-    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
-    _patch_products(monkeypatch, [s4l, s4llite])
+    patch_products([s4l, s4llite_product])
     mock_is_user_in_group.return_value = True
 
     result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4l")
@@ -96,14 +108,14 @@ async def test_tip_not_shown_when_no_tip_configured(
 
 async def test_tip_not_shown_when_user_not_in_listed_products(
     mock_app: web.Application,
-    monkeypatch: pytest.MonkeyPatch,
+    patch_products: Callable,
     mock_is_user_in_group: AsyncMock,
+    s4llite_product: MagicMock,
+    s4l_product: MagicMock,
 ):
     # s4llite configured to check s4l, but user is NOT in s4l
-    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
-    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=10)
-    _patch_products(monkeypatch, [s4llite, s4l])
-    mock_is_user_in_group.return_value = False
+    patch_products([s4llite_product, s4l_product])
+    # mock_is_user_in_group defaults to return_value=False
 
     result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
@@ -112,12 +124,12 @@ async def test_tip_not_shown_when_user_not_in_listed_products(
 
 async def test_tip_handles_db_error_gracefully(
     mock_app: web.Application,
-    monkeypatch: pytest.MonkeyPatch,
+    patch_products: Callable,
     mock_is_user_in_group: AsyncMock,
+    s4llite_product: MagicMock,
+    s4l_product: MagicMock,
 ):
-    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
-    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=10)
-    _patch_products(monkeypatch, [s4llite, s4l])
+    patch_products([s4llite_product, s4l_product])
     mock_is_user_in_group.side_effect = RuntimeError("DB connection failed")
 
     result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
@@ -127,10 +139,10 @@ async def test_tip_handles_db_error_gracefully(
 
 async def test_tip_handles_missing_current_product_gracefully(
     mock_app: web.Application,
-    monkeypatch: pytest.MonkeyPatch,
+    patch_products: Callable,
     mock_is_user_in_group: AsyncMock,
 ):
-    _patch_products(monkeypatch, [])  # no products configured
+    patch_products([])  # no products configured
 
     result = await _try_show_login_tip(mock_app, user_id=42, product_name="unknown")
 
@@ -139,13 +151,13 @@ async def test_tip_handles_missing_current_product_gracefully(
 
 async def test_tip_skips_listed_product_without_group_id(
     mock_app: web.Application,
-    monkeypatch: pytest.MonkeyPatch,
+    patch_products: Callable,
     mock_is_user_in_group: AsyncMock,
+    s4llite_product: MagicMock,
 ):
     # s4llite configured to check s4l, but s4l has no group_id
-    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
-    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=None)
-    _patch_products(monkeypatch, [s4llite, s4l])
+    s4l_no_group = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=None)
+    patch_products([s4llite_product, s4l_no_group])
     mock_is_user_in_group.return_value = True
 
     result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
@@ -155,13 +167,13 @@ async def test_tip_skips_listed_product_without_group_id(
 
 async def test_tip_skips_unknown_listed_product(
     mock_app: web.Application,
-    monkeypatch: pytest.MonkeyPatch,
+    patch_products: Callable,
     mock_is_user_in_group: AsyncMock,
+    s4l_product: MagicMock,
 ):
     # s4llite lists "nonexistent" and "s4l"; nonexistent is skipped, user is in s4l
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l", "nonexistent"])
-    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=10)
-    _patch_products(monkeypatch, [s4llite, s4l])
+    patch_products([s4llite, s4l_product])
     mock_is_user_in_group.return_value = True
 
     result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -7,7 +7,7 @@ import pytest
 from aiohttp import web
 from simcore_service_webserver.groups import api as groups_service
 from simcore_service_webserver.login._controller.rest._rest_exceptions import (
-    _should_show_login_tip,
+    _try_show_login_tip,
 )
 from simcore_service_webserver.products import products_service
 from simcore_service_webserver.products.errors import ProductNotFoundError
@@ -73,7 +73,7 @@ async def test_tip_returns_preferred_product_display_name(
     _patch_products(monkeypatch, [s4llite, s4l, osparc])
     mock_is_user_in_group.return_value = True
 
-    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
     assert result == "Sim4Life"
 
@@ -89,7 +89,7 @@ async def test_tip_not_shown_when_no_tip_configured(
     _patch_products(monkeypatch, [s4l, s4llite])
     mock_is_user_in_group.return_value = True
 
-    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4l")
+    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4l")
 
     assert result is None
 
@@ -105,7 +105,7 @@ async def test_tip_not_shown_when_user_not_in_listed_products(
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = False
 
-    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
     assert result is None
 
@@ -120,7 +120,7 @@ async def test_tip_handles_db_error_gracefully(
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.side_effect = RuntimeError("DB connection failed")
 
-    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
     assert result is None
 
@@ -132,7 +132,7 @@ async def test_tip_handles_missing_current_product_gracefully(
 ):
     _patch_products(monkeypatch, [])  # no products configured
 
-    result = await _should_show_login_tip(mock_app, user_id=42, product_name="unknown")
+    result = await _try_show_login_tip(mock_app, user_id=42, product_name="unknown")
 
     assert result is None
 
@@ -148,7 +148,7 @@ async def test_tip_skips_listed_product_without_group_id(
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = True
 
-    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
     assert result is None
 
@@ -164,7 +164,7 @@ async def test_tip_skips_unknown_listed_product(
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = True
 
-    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
     # preferred is s4l (first in list)
     assert result == "Sim4Life"

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -7,38 +7,25 @@ import pytest
 from aiohttp import web
 from simcore_service_webserver.groups import api as groups_service
 from simcore_service_webserver.login._controller.rest._rest_exceptions import (
-    _is_user_affected_by_db_merge,
+    _should_show_login_tip,
 )
 from simcore_service_webserver.products import products_service
+from simcore_service_webserver.products.errors import ProductNotFoundError
 
 
-def _create_fake_product(*, group_id: int | None) -> MagicMock:
+def _create_fake_product(
+    *, name: str, group_id: int | None, marketing_login_tip_on_wrong_password: bool = False
+) -> MagicMock:
     product = MagicMock()
+    product.name = name
     product.group_id = group_id
+    product.vendor = {"marketing_login_tip_on_wrong_password": True} if marketing_login_tip_on_wrong_password else {}
     return product
 
 
 @pytest.fixture
 def mock_app() -> web.Application:
     return web.Application()
-
-
-@pytest.fixture
-def mock_products(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
-    """Creates fake s4l and s4llite products with distinct group_ids."""
-    products = {
-        "s4l": _create_fake_product(group_id=10),
-        "s4llite": _create_fake_product(group_id=20),
-    }
-
-    def _get_product(_app: web.Application, product_name: str) -> MagicMock:
-        return products[product_name]
-
-    monkeypatch.setattr(
-        f"{products_service.__name__}.get_product",
-        _get_product,
-    )
-    return products
 
 
 @pytest.fixture
@@ -51,99 +38,129 @@ def mock_is_user_in_group(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     return mock
 
 
-async def test_user_in_both_merged_products_is_detected(
+def _patch_products(
+    monkeypatch: pytest.MonkeyPatch,
+    all_products: list[MagicMock],
+) -> None:
+    products_by_name = {p.name: p for p in all_products}
+
+    def _get_product(_app: web.Application, product_name: str) -> MagicMock:
+        if product_name not in products_by_name:
+            raise ProductNotFoundError(product_name=product_name)
+        return products_by_name[product_name]
+
+    monkeypatch.setattr(
+        f"{products_service.__name__}.get_product",
+        _get_product,
+    )
+    monkeypatch.setattr(
+        f"{products_service.__name__}.list_products",
+        lambda _app: all_products,
+    )
+
+
+async def test_tip_shown_when_flag_enabled_and_user_in_other_product(
     mock_app: web.Application,
-    mock_products: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
     mock_is_user_in_group: AsyncMock,
 ):
-    # User belongs to both s4l (group_id=10) and s4llite (group_id=20)
+    # s4llite has the flag, s4l does not; user is in s4l
+    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
+    s4l = _create_fake_product(name="s4l", group_id=10)
+    _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = True
 
-    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
+    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
     assert result is True
 
 
-async def test_user_in_only_one_product_is_not_affected(
-    mock_app: web.Application,
-    mock_products: dict[str, MagicMock],
-    mock_is_user_in_group: AsyncMock,
-):
-    # User only belongs to s4l (group_id=10), not s4llite (group_id=20)
-    async def _selective_membership(_app: web.Application, *, user_id: int, group_id: int):
-        return group_id == 10  # only in s4l
-
-    mock_is_user_in_group.side_effect = _selective_membership
-
-    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
-
-    assert result is False
-
-
-async def test_user_in_no_merged_products_is_not_affected(
-    mock_app: web.Application,
-    mock_products: dict[str, MagicMock],
-    mock_is_user_in_group: AsyncMock,
-):
-    mock_is_user_in_group.return_value = False
-
-    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
-
-    assert result is False
-
-
-async def test_db_merge_check_handles_exceptions_gracefully(
-    mock_app: web.Application,
-    mock_products: dict[str, MagicMock],
-    mock_is_user_in_group: AsyncMock,
-):
-    # Simulate a DB error — should return False, not raise
-    mock_is_user_in_group.side_effect = RuntimeError("DB connection failed")
-
-    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
-
-    assert result is False
-
-
-async def test_db_merge_check_handles_missing_product_gracefully(
+async def test_tip_not_shown_when_flag_disabled_on_current_product(
     mock_app: web.Application,
     monkeypatch: pytest.MonkeyPatch,
     mock_is_user_in_group: AsyncMock,
 ):
-    # Product not found in app cache
-    def _get_product(_app: web.Application, product_name: str) -> MagicMock:
-        raise KeyError(product_name)
-
-    monkeypatch.setattr(
-        f"{products_service.__name__}.get_product",
-        _get_product,
-    )
-
-    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
-
-    assert result is False
-
-
-async def test_db_merge_check_skips_product_without_group_id(
-    mock_app: web.Application,
-    monkeypatch: pytest.MonkeyPatch,
-    mock_is_user_in_group: AsyncMock,
-):
-    # s4l has no group_id, s4llite has one — user is in s4llite but not enough
-    products = {
-        "s4l": _create_fake_product(group_id=None),
-        "s4llite": _create_fake_product(group_id=20),
-    }
-
-    def _get_product(_app: web.Application, product_name: str) -> MagicMock:
-        return products[product_name]
-
-    monkeypatch.setattr(
-        f"{products_service.__name__}.get_product",
-        _get_product,
-    )
+    # s4l does NOT have the flag; even if user is in another product
+    s4l = _create_fake_product(name="s4l", group_id=10)
+    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
+    _patch_products(monkeypatch, [s4l, s4llite])
     mock_is_user_in_group.return_value = True
 
-    result = await _is_user_affected_by_db_merge(mock_app, user_id=42)
+    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4l")
+
+    assert result is False
+
+
+async def test_tip_not_shown_when_user_not_in_any_other_product(
+    mock_app: web.Application,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_is_user_in_group: AsyncMock,
+):
+    # s4llite has the flag, but user is NOT in s4l
+    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
+    s4l = _create_fake_product(name="s4l", group_id=10)
+    _patch_products(monkeypatch, [s4llite, s4l])
+    mock_is_user_in_group.return_value = False
+
+    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+
+    assert result is False
+
+
+async def test_tip_not_shown_when_other_product_also_has_flag(
+    mock_app: web.Application,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_is_user_in_group: AsyncMock,
+):
+    # Both products have the flag — user in both, but tip should NOT show
+    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
+    s4l = _create_fake_product(name="s4l", group_id=10, marketing_login_tip_on_wrong_password=True)
+    _patch_products(monkeypatch, [s4llite, s4l])
+    mock_is_user_in_group.return_value = True
+
+    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+
+    assert result is False
+
+
+async def test_tip_handles_db_error_gracefully(
+    mock_app: web.Application,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_is_user_in_group: AsyncMock,
+):
+    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
+    s4l = _create_fake_product(name="s4l", group_id=10)
+    _patch_products(monkeypatch, [s4llite, s4l])
+    mock_is_user_in_group.side_effect = RuntimeError("DB connection failed")
+
+    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+
+    assert result is False
+
+
+async def test_tip_handles_missing_product_gracefully(
+    mock_app: web.Application,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_is_user_in_group: AsyncMock,
+):
+    _patch_products(monkeypatch, [])  # no products configured
+
+    result = await _should_show_login_tip(mock_app, user_id=42, product_name="unknown")
+
+    assert result is False
+
+
+async def test_tip_skips_other_product_without_group_id(
+    mock_app: web.Application,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_is_user_in_group: AsyncMock,
+):
+    # s4llite has the flag, s4l has no group_id — can't check membership
+    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
+    s4l = _create_fake_product(name="s4l", group_id=None)
+    _patch_products(monkeypatch, [s4llite, s4l])
+    mock_is_user_in_group.return_value = True
+
+    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
     assert result is False

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -187,8 +187,29 @@ async def test_tip_skips_unknown_listed_product(
 
     result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
-    # preferred is s4l (first in list)
     assert result == "Sim4Life"
+
+
+async def test_tip_returns_matching_product_not_first(
+    mock_app: web.Application,
+    patch_products: Callable,
+    mock_is_user_in_group: AsyncMock,
+):
+    """User belongs only to the second listed product; its display name is returned."""
+    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=10)
+    osparc = _create_fake_product(name="osparc", display_name="o²S²PARC", group_id=30)
+    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l", "osparc"])
+    patch_products([s4llite, s4l, osparc])
+
+    async def _is_in_group(_app, *, user_id, group_id):
+        # user is only in osparc (group_id=30), not s4l (group_id=10)
+        return group_id == 30
+
+    mock_is_user_in_group.side_effect = _is_in_group
+
+    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+
+    assert result == "o²S²PARC"
 
 
 # ---------------------------------------------------------------------------

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -68,14 +68,14 @@ async def test_tip_returns_preferred_product_display_name(
 ):
     # s4llite configured to suggest s4l; user belongs to s4l
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l", "osparc"])
-    s4l = _create_fake_product(name="s4l", display_name="sim4life.io", group_id=10)
+    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=10)
     osparc = _create_fake_product(name="osparc", display_name="o²S²PARC", group_id=30)
     _patch_products(monkeypatch, [s4llite, s4l, osparc])
     mock_is_user_in_group.return_value = True
 
     result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
-    assert result == "sim4life.io"
+    assert result == "Sim4Life"
 
 
 async def test_tip_not_shown_when_no_tip_configured(
@@ -101,7 +101,7 @@ async def test_tip_not_shown_when_user_not_in_listed_products(
 ):
     # s4llite configured to check s4l, but user is NOT in s4l
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
-    s4l = _create_fake_product(name="s4l", display_name="sim4life.science", group_id=10)
+    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=10)
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = False
 
@@ -116,7 +116,7 @@ async def test_tip_handles_db_error_gracefully(
     mock_is_user_in_group: AsyncMock,
 ):
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
-    s4l = _create_fake_product(name="s4l", display_name="sim4life.io", group_id=10)
+    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=10)
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.side_effect = RuntimeError("DB connection failed")
 
@@ -144,7 +144,7 @@ async def test_tip_skips_listed_product_without_group_id(
 ):
     # s4llite configured to check s4l, but s4l has no group_id
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
-    s4l = _create_fake_product(name="s4l", display_name="sim4life.io", group_id=None)
+    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=None)
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = True
 
@@ -160,11 +160,11 @@ async def test_tip_skips_unknown_listed_product(
 ):
     # s4llite lists "nonexistent" and "s4l"; nonexistent is skipped, user is in s4l
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l", "nonexistent"])
-    s4l = _create_fake_product(name="s4l", display_name="sim4life.io", group_id=10)
+    s4l = _create_fake_product(name="s4l", display_name="Sim4Life", group_id=10)
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = True
 
     result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
     # preferred is s4l (first in list)
-    assert result == "sim4life.io"
+    assert result == "Sim4Life"

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -34,7 +34,7 @@ def _create_fake_product(
     product.name = name
     product.display_name = display_name or name
     product.group_id = group_id
-    product.vendor = {"marketing_tip_fallback_product_on_wrong_password": tip_products} if tip_products else {}
+    product.vendor = {"marketing_tip_fallback_products_on_wrong_password": tip_products} if tip_products else {}
     return product
 
 

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -14,12 +14,17 @@ from simcore_service_webserver.products.errors import ProductNotFoundError
 
 
 def _create_fake_product(
-    *, name: str, group_id: int | None, marketing_login_tip_on_wrong_password: bool = False
+    *,
+    name: str,
+    display_name: str = "",
+    group_id: int | None,
+    tip_products: list[str] | None = None,
 ) -> MagicMock:
     product = MagicMock()
     product.name = name
+    product.display_name = display_name or name
     product.group_id = group_id
-    product.vendor = {"marketing_login_tip_on_wrong_password": True} if marketing_login_tip_on_wrong_password else {}
+    product.vendor = {"marketing_login_tip_on_wrong_password": tip_products} if tip_products else {}
     return product
 
 
@@ -53,75 +58,56 @@ def _patch_products(
         f"{products_service.__name__}.get_product",
         _get_product,
     )
-    monkeypatch.setattr(
-        f"{products_service.__name__}.list_products",
-        lambda _app: all_products,
-    )
 
 
 @pytest.mark.acceptance_test("For https://github.com/ITISFoundation/private-issues/issues/535")
-async def test_tip_shown_when_flag_enabled_and_user_in_other_product(
+async def test_tip_returns_preferred_product_display_name(
     mock_app: web.Application,
     monkeypatch: pytest.MonkeyPatch,
     mock_is_user_in_group: AsyncMock,
 ):
-    # s4llite has the flag, s4l does not; user is in s4l
-    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
-    s4l = _create_fake_product(name="s4l", group_id=10)
-    _patch_products(monkeypatch, [s4llite, s4l])
+    # s4llite configured to suggest s4l; user belongs to s4l
+    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l", "osparc"])
+    s4l = _create_fake_product(name="s4l", display_name="sim4life.science", group_id=10)
+    osparc = _create_fake_product(name="osparc", display_name="o²S²PARC", group_id=30)
+    _patch_products(monkeypatch, [s4llite, s4l, osparc])
     mock_is_user_in_group.return_value = True
 
     result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
-    assert result is True
+    assert result == "sim4life.science"
 
 
-async def test_tip_not_shown_when_flag_disabled_on_current_product(
+async def test_tip_not_shown_when_no_tip_configured(
     mock_app: web.Application,
     monkeypatch: pytest.MonkeyPatch,
     mock_is_user_in_group: AsyncMock,
 ):
-    # s4l does NOT have the flag; even if user is in another product
+    # s4l has no tip configured
     s4l = _create_fake_product(name="s4l", group_id=10)
-    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
+    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
     _patch_products(monkeypatch, [s4l, s4llite])
     mock_is_user_in_group.return_value = True
 
     result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4l")
 
-    assert result is False
+    assert result is None
 
 
-async def test_tip_not_shown_when_user_not_in_any_other_product(
+async def test_tip_not_shown_when_user_not_in_listed_products(
     mock_app: web.Application,
     monkeypatch: pytest.MonkeyPatch,
     mock_is_user_in_group: AsyncMock,
 ):
-    # s4llite has the flag, but user is NOT in s4l
-    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
-    s4l = _create_fake_product(name="s4l", group_id=10)
+    # s4llite configured to check s4l, but user is NOT in s4l
+    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
+    s4l = _create_fake_product(name="s4l", display_name="sim4life.science", group_id=10)
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = False
 
     result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
-    assert result is False
-
-
-async def test_tip_not_shown_when_other_product_also_has_flag(
-    mock_app: web.Application,
-    monkeypatch: pytest.MonkeyPatch,
-    mock_is_user_in_group: AsyncMock,
-):
-    # Both products have the flag — user in both, but tip should NOT show
-    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
-    s4l = _create_fake_product(name="s4l", group_id=10, marketing_login_tip_on_wrong_password=True)
-    _patch_products(monkeypatch, [s4llite, s4l])
-    mock_is_user_in_group.return_value = True
-
-    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
-
-    assert result is False
+    assert result is None
 
 
 async def test_tip_handles_db_error_gracefully(
@@ -129,17 +115,17 @@ async def test_tip_handles_db_error_gracefully(
     monkeypatch: pytest.MonkeyPatch,
     mock_is_user_in_group: AsyncMock,
 ):
-    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
-    s4l = _create_fake_product(name="s4l", group_id=10)
+    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
+    s4l = _create_fake_product(name="s4l", display_name="sim4life.science", group_id=10)
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.side_effect = RuntimeError("DB connection failed")
 
     result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
-    assert result is False
+    assert result is None
 
 
-async def test_tip_handles_missing_product_gracefully(
+async def test_tip_handles_missing_current_product_gracefully(
     mock_app: web.Application,
     monkeypatch: pytest.MonkeyPatch,
     mock_is_user_in_group: AsyncMock,
@@ -148,20 +134,37 @@ async def test_tip_handles_missing_product_gracefully(
 
     result = await _should_show_login_tip(mock_app, user_id=42, product_name="unknown")
 
-    assert result is False
+    assert result is None
 
 
-async def test_tip_skips_other_product_without_group_id(
+async def test_tip_skips_listed_product_without_group_id(
     mock_app: web.Application,
     monkeypatch: pytest.MonkeyPatch,
     mock_is_user_in_group: AsyncMock,
 ):
-    # s4llite has the flag, s4l has no group_id — can't check membership
-    s4llite = _create_fake_product(name="s4llite", group_id=20, marketing_login_tip_on_wrong_password=True)
-    s4l = _create_fake_product(name="s4l", group_id=None)
+    # s4llite configured to check s4l, but s4l has no group_id
+    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
+    s4l = _create_fake_product(name="s4l", display_name="sim4life.science", group_id=None)
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = True
 
     result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
-    assert result is False
+    assert result is None
+
+
+async def test_tip_skips_unknown_listed_product(
+    mock_app: web.Application,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_is_user_in_group: AsyncMock,
+):
+    # s4llite lists "nonexistent" and "s4l"; nonexistent is skipped, user is in s4l
+    s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l", "nonexistent"])
+    s4l = _create_fake_product(name="s4l", display_name="sim4life.science", group_id=10)
+    _patch_products(monkeypatch, [s4llite, s4l])
+    mock_is_user_in_group.return_value = True
+
+    result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+
+    # preferred is s4l (first in list)
+    assert result == "sim4life.science"

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -24,7 +24,7 @@ def _create_fake_product(
     product.name = name
     product.display_name = display_name or name
     product.group_id = group_id
-    product.vendor = {"marketing_login_tip_on_wrong_password": tip_products} if tip_products else {}
+    product.vendor = {"marketing_tip_fallback_product_on_wrong_password": tip_products} if tip_products else {}
     return product
 
 

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -34,7 +34,7 @@ def _create_fake_product(
     product.name = name
     product.display_name = display_name or name
     product.group_id = group_id
-    product.vendor = {"marketing_tip_fallback_products_on_wrong_password": tip_products} if tip_products else {}
+    product.vendor = {"marketing_fallback_products_on_wrong_password": tip_products} if tip_products else {}
     return product
 
 

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -12,7 +12,7 @@ from simcore_service_webserver.constants import RQ_PRODUCT_KEY
 from simcore_service_webserver.groups import api as groups_service
 from simcore_service_webserver.login._controller.rest._rest_exceptions import (
     _handle_legacy_error_response,
-    _try_show_login_tip,
+    _try_show_login_fallbacks_on_wrong_password,
 )
 from simcore_service_webserver.login.constants import (
     MSG_WRONG_PASSWORD,
@@ -94,7 +94,7 @@ async def test_tip_returns_preferred_product_display_name(
     patch_products([s4llite, s4l_product, osparc])
     mock_is_user_in_group.return_value = True
 
-    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_fallbacks_on_wrong_password(mock_app, user_id=42, product_name="s4llite")
 
     assert result == "Sim4Life"
 
@@ -110,7 +110,7 @@ async def test_tip_not_shown_when_no_tip_configured(
     patch_products([s4l, s4llite_product])
     mock_is_user_in_group.return_value = True
 
-    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4l")
+    result = await _try_show_login_fallbacks_on_wrong_password(mock_app, user_id=42, product_name="s4l")
 
     assert result is None
 
@@ -126,7 +126,7 @@ async def test_tip_not_shown_when_user_not_in_listed_products(
     patch_products([s4llite_product, s4l_product])
     # mock_is_user_in_group defaults to return_value=False
 
-    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_fallbacks_on_wrong_password(mock_app, user_id=42, product_name="s4llite")
 
     assert result is None
 
@@ -141,7 +141,7 @@ async def test_tip_handles_db_error_gracefully(
     patch_products([s4llite_product, s4l_product])
     mock_is_user_in_group.side_effect = RuntimeError("DB connection failed")
 
-    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_fallbacks_on_wrong_password(mock_app, user_id=42, product_name="s4llite")
 
     assert result is None
 
@@ -153,7 +153,7 @@ async def test_tip_handles_missing_current_product_gracefully(
 ):
     patch_products([])  # no products configured
 
-    result = await _try_show_login_tip(mock_app, user_id=42, product_name="unknown")
+    result = await _try_show_login_fallbacks_on_wrong_password(mock_app, user_id=42, product_name="unknown")
 
     assert result is None
 
@@ -169,7 +169,7 @@ async def test_tip_skips_listed_product_without_group_id(
     patch_products([s4llite_product, s4l_no_group])
     mock_is_user_in_group.return_value = True
 
-    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_fallbacks_on_wrong_password(mock_app, user_id=42, product_name="s4llite")
 
     assert result is None
 
@@ -185,7 +185,7 @@ async def test_tip_skips_unknown_listed_product(
     patch_products([s4llite, s4l_product])
     mock_is_user_in_group.return_value = True
 
-    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_fallbacks_on_wrong_password(mock_app, user_id=42, product_name="s4llite")
 
     assert result == "Sim4Life"
 
@@ -207,7 +207,7 @@ async def test_tip_returns_matching_product_not_first(
 
     mock_is_user_in_group.side_effect = _is_in_group
 
-    result = await _try_show_login_tip(mock_app, user_id=42, product_name="s4llite")
+    result = await _try_show_login_fallbacks_on_wrong_password(mock_app, user_id=42, product_name="s4llite")
 
     assert result == "o²S²PARC"
 

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -1,15 +1,24 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 
+import json
 from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from simcore_service_webserver.constants import RQ_PRODUCT_KEY
 from simcore_service_webserver.groups import api as groups_service
 from simcore_service_webserver.login._controller.rest._rest_exceptions import (
+    _handle_legacy_error_response,
     _try_show_login_tip,
 )
+from simcore_service_webserver.login.constants import (
+    MSG_WRONG_PASSWORD,
+    MSG_WRONG_PASSWORD_MERGED_ACCOUNTS,
+)
+from simcore_service_webserver.login.errors import WrongPasswordError
 from simcore_service_webserver.products import products_service
 from simcore_service_webserver.products.errors import ProductNotFoundError
 
@@ -180,3 +189,76 @@ async def test_tip_skips_unknown_listed_product(
 
     # preferred is s4l (first in list)
     assert result == "Sim4Life"
+
+
+# ---------------------------------------------------------------------------
+# Tests for _handle_legacy_error_response
+# ---------------------------------------------------------------------------
+
+
+def _make_request_with_product(app: web.Application, product_name: str) -> web.Request:
+    request = make_mocked_request("POST", "/v0/auth/login", app=app)
+    request[RQ_PRODUCT_KEY] = product_name
+    return request
+
+
+def _parse_enveloped_message(response: web.HTTPError) -> str:
+    assert response.text is not None
+    body = json.loads(response.text)
+    return body["error"]["message"]
+
+
+@pytest.mark.acceptance_test("For https://github.com/ITISFoundation/private-issues/issues/535")
+async def test_handler_returns_merged_accounts_message_when_tip_applies(
+    mock_app: web.Application,
+    patch_products: Callable,
+    mock_is_user_in_group: AsyncMock,
+    s4llite_product: MagicMock,
+    s4l_product: MagicMock,
+):
+    patch_products([s4llite_product, s4l_product])
+    mock_is_user_in_group.return_value = True
+    request = _make_request_with_product(mock_app, "s4llite")
+
+    response = await _handle_legacy_error_response(request, WrongPasswordError(user_id=42))
+
+    assert response.status == 401
+    msg = _parse_enveloped_message(response)
+    expected = MSG_WRONG_PASSWORD_MERGED_ACCOUNTS.format(suggested_product="Sim4Life")
+    assert msg == expected
+
+
+async def test_handler_returns_default_message_when_no_tip(
+    mock_app: web.Application,
+    patch_products: Callable,
+    mock_is_user_in_group: AsyncMock,
+):
+    # product with no tip configured
+    s4l = _create_fake_product(name="s4l", group_id=10)
+    patch_products([s4l])
+    request = _make_request_with_product(mock_app, "s4l")
+
+    response = await _handle_legacy_error_response(request, WrongPasswordError(user_id=42))
+
+    assert response.status == 401
+    msg = _parse_enveloped_message(response)
+    assert msg == MSG_WRONG_PASSWORD
+
+
+async def test_handler_returns_default_message_when_user_not_in_tip_products(
+    mock_app: web.Application,
+    patch_products: Callable,
+    mock_is_user_in_group: AsyncMock,
+    s4llite_product: MagicMock,
+    s4l_product: MagicMock,
+):
+    patch_products([s4llite_product, s4l_product])
+    # user is NOT in s4l group
+    mock_is_user_in_group.return_value = False
+    request = _make_request_with_product(mock_app, "s4llite")
+
+    response = await _handle_legacy_error_response(request, WrongPasswordError(user_id=42))
+
+    assert response.status == 401
+    msg = _parse_enveloped_message(response)
+    assert msg == MSG_WRONG_PASSWORD

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -68,14 +68,14 @@ async def test_tip_returns_preferred_product_display_name(
 ):
     # s4llite configured to suggest s4l; user belongs to s4l
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l", "osparc"])
-    s4l = _create_fake_product(name="s4l", display_name="sim4life.science", group_id=10)
+    s4l = _create_fake_product(name="s4l", display_name="sim4life.io", group_id=10)
     osparc = _create_fake_product(name="osparc", display_name="o²S²PARC", group_id=30)
     _patch_products(monkeypatch, [s4llite, s4l, osparc])
     mock_is_user_in_group.return_value = True
 
     result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
-    assert result == "sim4life.science"
+    assert result == "sim4life.io"
 
 
 async def test_tip_not_shown_when_no_tip_configured(
@@ -116,7 +116,7 @@ async def test_tip_handles_db_error_gracefully(
     mock_is_user_in_group: AsyncMock,
 ):
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
-    s4l = _create_fake_product(name="s4l", display_name="sim4life.science", group_id=10)
+    s4l = _create_fake_product(name="s4l", display_name="sim4life.io", group_id=10)
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.side_effect = RuntimeError("DB connection failed")
 
@@ -144,7 +144,7 @@ async def test_tip_skips_listed_product_without_group_id(
 ):
     # s4llite configured to check s4l, but s4l has no group_id
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l"])
-    s4l = _create_fake_product(name="s4l", display_name="sim4life.science", group_id=None)
+    s4l = _create_fake_product(name="s4l", display_name="sim4life.io", group_id=None)
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = True
 
@@ -160,11 +160,11 @@ async def test_tip_skips_unknown_listed_product(
 ):
     # s4llite lists "nonexistent" and "s4l"; nonexistent is skipped, user is in s4l
     s4llite = _create_fake_product(name="s4llite", group_id=20, tip_products=["s4l", "nonexistent"])
-    s4l = _create_fake_product(name="s4l", display_name="sim4life.science", group_id=10)
+    s4l = _create_fake_product(name="s4l", display_name="sim4life.io", group_id=10)
     _patch_products(monkeypatch, [s4llite, s4l])
     mock_is_user_in_group.return_value = True
 
     result = await _should_show_login_tip(mock_app, user_id=42, product_name="s4llite")
 
     # preferred is s4l (first in list)
-    assert result == "sim4life.science"
+    assert result == "sim4life.io"

--- a/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
+++ b/services/web/server/tests/unit/isolated/test_login_rest_exceptions.py
@@ -59,6 +59,7 @@ def _patch_products(
     )
 
 
+@pytest.mark.acceptance_test("For https://github.com/ITISFoundation/private-issues/issues/535")
 async def test_tip_shown_when_flag_enabled_and_user_in_other_product(
     mock_app: web.Application,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request enhances the login error handling to support users affected by the  databases merge. It introduces logic to detect users who belong to both merged products and provides them with a targeted error message when they enter the wrong password.

## Related issue/s
- closes https://github.com/ITISFoundation/private-issues/issues/535

## How to test
```sh
cd services/web/server
make install-dev
pytest -vv --pdb tests/unit/isolated/test_login_rest_exceptions.py
```
## 🗃️ Database

The `vendor` column in the `products` table now supports a `marketing_fallback_products_on_wrong_password` field: a list of product names suggested to the user when they enter an incorrect password, guiding them toward the product where their account may have been merged.

Example of `vendor` column content:
```json
{
   "marketing_fallback_products_on_wrong_password": ["s4l", "s4lacad"]
}
```
## :microphone: Q&A

- Q: Why not a single `bool` instead of a list?
  A: It's more flexible and I avoid to hardcode product names (pre-existing in the target deployment) in the codebase.

## Dev-ops
No changes.