### PR TITLE
🐛 Stabilize flaky auth decorator overhead test by using high-resolution timing and safe ratio calculation

### DIFF
--- a/services/web/server/tests/unit/isolated/test_security_web.py
+++ b/services/web/server/tests/unit/isolated/test_security_web.py
@@ -3,8 +3,8 @@
 # pylint: disable=unused-variable
 # pylint: disable=too-many-arguments
 
-import asyncio
 import statistics
+import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -414,13 +414,13 @@ async def test_time_overhead_on_handlers_of_auth_decorators(
     get_active_user_or_none_dbmock: MagicMock,
     is_user_in_product_name_dbmock: MagicMock,
 ):
-    async def _req(url_):
-        start = asyncio.get_event_loop().time()
+    async def _req(url_: str) -> int:
+        start_ns = time.perf_counter_ns()
         resp = await client.post(url_)
-        stop = asyncio.get_event_loop().time()
+        elapsed_ns = time.perf_counter_ns() - start_ns
 
         assert resp.ok, f"error: {await resp.text()}"
-        return stop - start
+        return elapsed_ns
 
     num_of_rounds = 100
     public_elapsed_times = [await _req("/v0/public") for _ in range(num_of_rounds)]
@@ -429,11 +429,12 @@ async def test_time_overhead_on_handlers_of_auth_decorators(
     # SEE https://docs.python.org/3/library/statistics.html#function-details
     # Note The mean is strongly affected by outliers and is not necessarily a typical example of the data points.
     # For a more robust, although less efficient, measure of central tendency, see median().
-    ref_elapsed = statistics.median(public_elapsed_times)
-    elapsed = statistics.median(admin_elapsed_times)
+    ref_elapsed_ns = statistics.median(public_elapsed_times)
+    elapsed_ns = statistics.median(admin_elapsed_times)
+    elapsed_ratio = elapsed_ns / max(ref_elapsed_ns, 1)
 
     # NOTE: 150% more wrt reference (basically ~ 2.5x more !!!!!!!!!!!)
     # and this is mocking the access to the database!
-    msg = f"got {elapsed/ref_elapsed=} from medians {elapsed=} and {ref_elapsed=} after {num_of_rounds=}"
+    msg = f"got {elapsed_ratio=} from medians {elapsed_ns=}ns and {ref_elapsed_ns=}ns after {num_of_rounds=}"
     print(msg.capitalize())
-    assert elapsed < ref_elapsed * (1 + 1.6), msg
+    assert elapsed_ns < ref_elapsed_ns * (1 + 1.6), msg


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->

This PR fixes a flaky unit test in test_security_web.py, specifically test_time_overhead_on_handlers_of_auth_decorators.

Root cause:
1. On fast CI runners, the reference median latency could be 0 because of timer granularity.
2. The test built a diagnostic string with a division by the reference median, which could raise ZeroDivisionError before the assertion.

What changed:
1. Replaced timing with a high-resolution monotonic clock using perf_counter_ns.
2. Kept the same performance intent (admin handler overhead vs public handler baseline).
3. Made ratio computation safe to avoid division-by-zero in diagnostics.
4. Updated debug output to nanoseconds for clearer CI observability.

Impact:
1. Removes intermittent CI failures caused by ZeroDivisionError.
2. Preserves the behavioral purpose of the test.
3. No production code changes, test-only stabilization.



## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
