### PR TITLE
[e2e] TIP pers: Fix Simulation run checks

### DIFF
--- a/tests/e2e-playwright/tests/tip/test_ti_personalized_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_personalized_plan.py
@@ -142,7 +142,11 @@ def _log_simulation_progress(simulator_iframe: FrameLocator) -> None:
 )
 def _wait_for_simulation_complete(setup_button: Locator, simulator_iframe: FrameLocator) -> None:
     _log_simulation_progress(simulator_iframe)
-    icon_class = setup_button.locator("i").first.evaluate("el => el.className")
+    try:
+        icon_class = setup_button.locator("i").first.evaluate("el => el.className")
+    except PlaywrightError:
+        logging.info("Setup button icon not found — simulation likely completed")
+        return
     if "fa-spinner" in icon_class:
         msg = f"Simulation still running: {icon_class=}"
         raise ValueError(msg)
@@ -155,7 +159,11 @@ def _wait_for_simulation_complete(setup_button: Locator, simulator_iframe: Frame
 )
 def _wait_for_export_simulation_results(export_button: Locator) -> None:
     # Wait for the export to complete, spinner is on the button while exporting
-    icon_class = export_button.locator("i").first.evaluate("el => el.className")
+    try:
+        icon_class = export_button.locator("i").first.evaluate("el => el.className")
+    except PlaywrightError:
+        logging.info("Export button icon not found — export likely completed")
+        return
     if "fa-spinner" in icon_class:
         msg = f"Simulation is being exported: {icon_class=}"
         raise ValueError(msg)


### PR DESCRIPTION
## What do these changes do?

When the button icon element disappears from the DOM after the simulation/export finishes it means that the Simulations finished and the Export is done. This PR fixes those handles. 

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
