### PR TITLE
🐛 [Frontend] Redesign Logger log renderer

### DIFF
--- a/services/static-webserver/client/source/class/osparc/conversation/NotificationUI.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/NotificationUI.js
@@ -40,7 +40,7 @@ qx.Class.define("osparc.conversation.NotificationUI", {
       this.getChildControl("menu-button").hide();
       this.getChildControl("message-bubble").exclude();
 
-      const isMyMessage = osparc.conversation.MessageUI.isMyMessage(message);
+      const isMyMessage = osparc.data.model.Message.isMyMessage(message);
 
       let msgContent = "🔔 ";
       const messageContent = this.getChildControl("notification-content");

--- a/services/static-webserver/client/source/class/osparc/theme/mixin/Color.js
+++ b/services/static-webserver/client/source/class/osparc/theme/mixin/Color.js
@@ -48,9 +48,6 @@ qx.Theme.define("osparc.theme.mixin.Color", {
 
     "visual-blue": "#007fd4", // Visual Studio blue
 
-    "logger-warning-message": "warning-yellow",
-    "logger-error-message": "failed-red",
-
     "workbench-edge": "#787878",
     "workbench-edge-selected": "busy-orange",
 

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -16,10 +16,10 @@
 ************************************************************************ */
 
 /**
- * Row renderer for the Logger table that shows a floating overlay with
+ * Row renderer for the Logger table that shows a popup with
  * the full log message, timestamp, origin, and log level when a row is clicked.
  *
- * Uses a fixed-position overlay appended to document.body, which avoids
+ * The popup is added to the application root to avoid
  * qooxdoo table pane clipping constraints (overflow:hidden at multiple levels).
  */
 qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
@@ -30,9 +30,7 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
 
     this.__table = table;
     this.__messageColPos = messageColPos;
-    this.__overlay = null;
-    this.__dismissHandler = null;
-    this.__scrollDismissHandler = null;
+    this.__popup = null;
     this.__activeRowIndex = null;
   },
 
@@ -48,28 +46,22 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
   members: {
     __table: null,
     __messageColPos: null,
-    __overlay: null,
-    __dismissHandler: null,
-    __scrollDismissHandler: null,
+    __popup: null,
     __activeRowIndex: null,
 
-    __closeOverlay: function() {
-      if (this.__overlay && this.__overlay.parentNode) {
-        this.__overlay.parentNode.removeChild(this.__overlay);
+    __closePopup: function() {
+      if (this.__popup) {
+        const root = qx.core.Init.getApplication().getRoot();
+        if (root.indexOf(this.__popup) >= 0) {
+          root.remove(this.__popup);
+        }
+        this.__popup.dispose();
+        this.__popup = null;
       }
-      this.__overlay = null;
       this.__activeRowIndex = null;
-      if (this.__dismissHandler) {
-        document.removeEventListener("mousedown", this.__dismissHandler, true);
-        this.__dismissHandler = null;
-      }
-      if (this.__scrollDismissHandler) {
-        document.removeEventListener("scroll", this.__scrollDismissHandler, true);
-        this.__scrollDismissHandler = null;
-      }
     },
 
-    __getLogLevelBadge: function(rowData) {
+    __createBadge: function(rowData) {
       if (!rowData || rowData.logLevel == null) {
         return null;
       }
@@ -77,173 +69,148 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       if (!entry) {
         return null;
       }
-      const colorManager = qx.theme.manager.Color.getInstance();
-      const resolvedColor = colorManager.resolve(entry.themeColor);
-      return { label: entry.label, color: resolvedColor };
+      const badge = new qx.ui.basic.Label(entry.label).set({
+        font: "text-10",
+        padding: [1, 6],
+        textColor: "text",
+        backgroundColor: entry.themeColor,
+      });
+      return badge;
     },
 
-    __showOverlay: function(rowElem, rowIndex, rowData) {
+    __showPopup: function(rowElem, rowIndex, rowData) {
       const messageDiv = rowElem.children.item(this.__messageColPos);
       if (!messageDiv) {
         return;
       }
 
-      this.__closeOverlay();
+      this.__closePopup();
 
-      const cellStyle = window.getComputedStyle(messageDiv);
-      const rowStyle = window.getComputedStyle(rowElem);
       const rect = rowElem.getBoundingClientRect();
-      const bgColor = rowElem.style.backgroundColor || rowStyle.backgroundColor || "#222";
 
-      // Build overlay
-      const overlay = document.createElement("div");
-      const baseStyles = [
-        "position: fixed",
-        "left: " + rect.left + "px",
-        "width: " + rect.width + "px",
-        "max-height: 50vh",
-        "overflow-y: auto",
-        "padding: 8px",
-        "border-radius: 4px",
-        "border: 1px solid rgba(255,255,255,0.15)",
-        "box-shadow: 0 6px 20px rgba(0,0,0,0.4)",
-        "z-index: 100000",
-        "font-family: " + cellStyle.fontFamily,
-        "font-size: " + cellStyle.fontSize,
-        "color: " + cellStyle.color,
-        "background-color: " + bgColor,
-      ];
+      // Container
+      const popup = new qx.ui.container.Composite(new qx.ui.layout.VBox(4)).set({
+        backgroundColor: "background-main-2",
+        padding: 8,
+        maxHeight: Math.round(window.innerHeight * 0.5),
+        width: Math.round(rect.width),
+        zIndex: osparc.utils.Utils.FLOATING_Z_INDEX,
+        decorator: "material-textfield",
+      });
 
-      // If the row is in the bottom half of the viewport, render the overlay above
-      const viewportHeight = window.innerHeight;
-      if (rect.bottom > viewportHeight * 0.65) {
-        baseStyles.push("bottom: " + (viewportHeight - rect.bottom) + "px");
-      } else {
-        baseStyles.push("top: " + rect.top + "px");
-      }
-
-      overlay.style.cssText = baseStyles.join("; ");
-
-      // Header row: [badge] [timestamp] [origin] ... [x]
-      const header = document.createElement("div");
-      header.style.cssText = [
-        "display: flex",
-        "align-items: center",
-        "gap: 8px",
-        "margin-bottom: 6px",
-        "padding-bottom: 6px",
-        "border-bottom: 1px solid rgba(255,255,255,0.12)",
-        "font-size: 11px",
-        "opacity: 0.85",
-      ].join("; ");
+      // Header
+      const header = new qx.ui.container.Composite(new qx.ui.layout.HBox(8).set({
+        alignY: "middle",
+      }));
 
       // Log level badge
-      const badgeInfo = this.__getLogLevelBadge(rowData);
-      if (badgeInfo) {
-        const badge = document.createElement("span");
-        badge.textContent = badgeInfo.label;
-        badge.style.cssText = [
-          "background-color: " + badgeInfo.color,
-          "color: #000",
-          "padding: 1px 6px",
-          "border-radius: 3px",
-          "font-weight: 600",
-          "font-size: 10px",
-          "letter-spacing: 0.5px",
-        ].join("; ");
-        header.appendChild(badge);
+      const badge = this.__createBadge(rowData);
+      if (badge) {
+        header.add(badge);
       }
 
       // Timestamp
       if (rowData && rowData.timeStamp) {
-        const time = document.createElement("span");
-        time.textContent = rowData.timeStamp;
-        time.style.cssText = "opacity: 0.7; font-variant-numeric: tabular-nums";
-        header.appendChild(time);
+        header.add(new qx.ui.basic.Label(String(rowData.timeStamp)).set({
+          font: "text-11",
+          textColor: "text-opa70",
+        }));
       }
 
       // Origin
       if (rowData && rowData.label) {
-        const origin = document.createElement("span");
-        origin.textContent = rowData.label;
-        origin.style.cssText = "opacity: 0.7; margin-left: auto";
-        header.appendChild(origin);
+        header.add(new qx.ui.basic.Label(rowData.label).set({
+          font: "text-11",
+          textColor: "text-opa70",
+        }));
       }
 
-      // Copy button (FontAwesome5 copy icon, matching the app's standard clipboard button)
-      const copyBtn = document.createElement("span");
-      copyBtn.textContent = "\uf0c5";
-      copyBtn.title = "Copy to clipboard";
-      copyBtn.style.cssText = [
-        "font-family: FontAwesome5Solid, FontAwesome5Free",
-        "cursor: pointer",
-        "font-size: 12px",
-        "line-height: 1",
-        "opacity: 0.6",
-        "padding: 0 2px",
-      ].join("; ");
-      copyBtn.onclick = function(e) {
-        e.stopPropagation();
+      // Spacer
+      header.add(new qx.ui.core.Spacer(), { flex: 1 });
+
+      // Copy button
+      const copyBtn = osparc.utils.Utils.getCopyButton();
+      copyBtn.addListener("execute", () => {
         const text = osparc.widget.logger.LoggerView.printRow(rowData);
         osparc.utils.Utils.copyTextToClipboard(text);
-        // Check mark icon (FontAwesome5)
-        copyBtn.textContent = "\uf00c";
-        setTimeout(function() {
-          copyBtn.textContent = "\uf0c5";
-        }, 1500);
-      };
-      header.appendChild(copyBtn);
+      });
+      header.add(copyBtn);
 
       // Close button
-      const closeBtn = document.createElement("span");
-      closeBtn.textContent = "\u00d7";
-      closeBtn.style.cssText = [
-        "margin-left: auto",
-        "cursor: pointer",
-        "font-size: 16px",
-        "line-height: 1",
-        "opacity: 0.6",
-        "padding: 0 2px",
-      ].join("; ");
-      const self = this;
-      closeBtn.onclick = function(e) {
-        e.stopPropagation();
-        self.__closeOverlay();
-      };
-      header.appendChild(closeBtn);
+      const closeBtn = new qx.ui.form.Button(null, "@MaterialIcons/close/12").set({
+        allowGrowY: false,
+        padding: 3,
+        maxWidth: 20,
+      });
+      closeBtn.addListener("execute", () => this.__closePopup());
+      header.add(closeBtn);
 
-      overlay.appendChild(header);
+      popup.add(header);
 
-      // Message body
-      const body = document.createElement("div");
-      body.innerHTML = messageDiv.innerHTML;
-      body.style.cssText = [
-        "white-space: pre-wrap",
-        "word-break: break-word",
-        "user-select: text",
-        "line-height: 1.5",
-      ].join("; ");
-      overlay.appendChild(body);
+      // Separator
+      popup.add(new qx.ui.menu.Separator());
 
-      document.body.appendChild(overlay);
-      this.__overlay = overlay;
+      // Message body (scrollable)
+      const scroll = new qx.ui.container.Scroll();
+      const messageLabel = new qx.ui.basic.Label(messageDiv.innerHTML).set({
+        rich: true,
+        selectable: true,
+        wrap: true,
+      });
+      scroll.add(messageLabel);
+      popup.add(scroll, { flex: 1 });
+
+      // Position: anchor to row, flip above if near bottom
+      const root = qx.core.Init.getApplication().getRoot();
+      const viewportHeight = window.innerHeight;
+      let top;
+      if (rect.bottom > viewportHeight * 0.65) {
+        // Place above: we'll adjust after rendering
+        top = Math.max(0, Math.round(rect.top) - 200);
+      } else {
+        top = Math.round(rect.top);
+      }
+      root.add(popup, {
+        left: Math.round(rect.left),
+        top: top,
+      });
+
+      // Adjust position after popup is rendered and has actual height
+      if (rect.bottom > viewportHeight * 0.65) {
+        popup.addListenerOnce("appear", () => {
+          const bounds = popup.getBounds();
+          if (bounds) {
+            const adjustedTop = Math.max(0, Math.round(rect.bottom) - bounds.height);
+            root.setWidgetLeft(popup, Math.round(rect.left));
+            root.setWidgetTop(popup, adjustedTop);
+          }
+        });
+      }
+
+      this.__popup = popup;
       this.__activeRowIndex = rowIndex;
 
-      // Close when clicking outside
-      this.__dismissHandler = function(e) {
-        if (!overlay.contains(e.target)) {
-          self.__closeOverlay();
-        }
-      };
-      setTimeout(function() {
-        document.addEventListener("mousedown", self.__dismissHandler, true);
-      }, 0);
-
       // Close on scroll since the fixed position becomes stale
-      this.__scrollDismissHandler = function() {
-        self.__closeOverlay();
+      const scrollHandler = () => {
+        this.__closePopup();
+        document.removeEventListener("scroll", scrollHandler, true);
       };
-      document.addEventListener("scroll", this.__scrollDismissHandler, true);
+      document.addEventListener("scroll", scrollHandler, true);
+
+      // Close on click outside
+      popup.addListenerOnce("appear", () => {
+        const clickHandler = e => {
+          const popupElem = popup.getContentElement().getDomElement();
+          if (popupElem && !popupElem.contains(e.target)) {
+            this.__closePopup();
+            document.removeEventListener("mousedown", clickHandler, true);
+          }
+        };
+        setTimeout(() => document.addEventListener("mousedown", clickHandler, true), 0);
+        popup.addListenerOnce("disappear", () => {
+          document.removeEventListener("mousedown", clickHandler, true);
+        });
+      });
     },
 
     // overridden
@@ -257,9 +224,9 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       rowElem.style.cursor = "pointer";
       rowElem.onclick = function() {
         if (self.__activeRowIndex === rowIndex) {
-          self.__closeOverlay();
+          self.__closePopup();
         } else {
-          self.__showOverlay(rowElem, rowIndex, rowData);
+          self.__showPopup(rowElem, rowIndex, rowData);
         }
       };
     }

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -30,8 +30,6 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
 
     this.__table = table;
     this.__messageColPos = messageColPos;
-    this.__popup = null;
-    this.__activeRowIndex = null;
   },
 
   statics: {
@@ -126,7 +124,9 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       }
 
       // Spacer
-      header.add(new qx.ui.core.Spacer(), { flex: 1 });
+      header.add(new qx.ui.core.Spacer(), {
+        flex: 1
+      });
 
       // Copy button
       const copyBtn = osparc.utils.Utils.getCopyButton();
@@ -181,8 +181,10 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
           const bounds = popup.getBounds();
           if (bounds) {
             const adjustedTop = Math.max(0, Math.round(rect.bottom) - bounds.height);
-            root.setWidgetLeft(popup, Math.round(rect.left));
-            root.setWidgetTop(popup, adjustedTop);
+            popup.setLayoutProperties({
+              left: Math.round(rect.left),
+              top: adjustedTop,
+            });
           }
         });
       }
@@ -198,18 +200,22 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       document.addEventListener("scroll", scrollHandler, true);
 
       // Close on click outside
-      popup.addListenerOnce("appear", () => {
-        const clickHandler = e => {
-          const popupElem = popup.getContentElement().getDomElement();
-          if (popupElem && !popupElem.contains(e.target)) {
-            this.__closePopup();
-            document.removeEventListener("mousedown", clickHandler, true);
-          }
-        };
-        setTimeout(() => document.addEventListener("mousedown", clickHandler, true), 0);
-        popup.addListenerOnce("disappear", () => {
+      const clickHandler = e => {
+        if (popup.isDisposed()) {
           document.removeEventListener("mousedown", clickHandler, true);
-        });
+          return;
+        }
+        const popupElem = popup.getContentElement().getDomElement();
+        if (popupElem && !popupElem.contains(e.target)) {
+          document.removeEventListener("mousedown", clickHandler, true);
+          this.__closePopup();
+        }
+      };
+      popup.addListenerOnce("appear", () => {
+        setTimeout(() => document.addEventListener("mousedown", clickHandler, true), 0);
+      });
+      popup.addListenerOnce("disappear", () => {
+        document.removeEventListener("mousedown", clickHandler, true);
       });
     },
 

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -1,0 +1,240 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2026 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+/**
+ * Row renderer for the Logger table that shows a floating overlay with
+ * the full log message, timestamp, origin, and log level when a row is clicked.
+ *
+ * Uses a fixed-position overlay appended to document.body, which avoids
+ * qooxdoo table pane clipping constraints (overflow:hidden at multiple levels).
+ */
+qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
+  extend: qx.ui.table.rowrenderer.Default,
+
+  construct: function(table, messageColPos) {
+    this.base(arguments);
+
+    this.__table = table;
+    this.__messageColPos = messageColPos;
+    this.__overlay = null;
+    this.__dismissHandler = null;
+    this.__scrollDismissHandler = null;
+    this.__activeRowIndex = null;
+  },
+
+  statics: {
+    LOG_LEVEL_COLORS: {
+      "-1": { label: "DEBUG", color: "#888" },
+      "0": { label: "INFO", color: "#4fc3f7" },
+      "1": { label: "WARNING", color: "#ffb74d" },
+      "2": { label: "ERROR", color: "#ef5350" },
+    },
+  },
+
+  members: {
+    __table: null,
+    __messageColPos: null,
+    __overlay: null,
+    __dismissHandler: null,
+    __scrollDismissHandler: null,
+    __activeRowIndex: null,
+
+    __closeOverlay: function() {
+      if (this.__overlay && this.__overlay.parentNode) {
+        this.__overlay.parentNode.removeChild(this.__overlay);
+      }
+      this.__overlay = null;
+      this.__activeRowIndex = null;
+      if (this.__dismissHandler) {
+        document.removeEventListener("mousedown", this.__dismissHandler, true);
+        this.__dismissHandler = null;
+      }
+      if (this.__scrollDismissHandler) {
+        document.removeEventListener("scroll", this.__scrollDismissHandler, true);
+        this.__scrollDismissHandler = null;
+      }
+    },
+
+    __getLogLevelBadge: function(rowData) {
+      if (!rowData || rowData.logLevel == null) {
+        return null;
+      }
+      const entry = this.self().LOG_LEVEL_COLORS[String(rowData.logLevel)];
+      if (!entry) {
+        return null;
+      }
+      return { label: entry.label, color: entry.color };
+    },
+
+    __showOverlay: function(rowElem, rowInfo) {
+      const messageDiv = rowElem.children.item(this.__messageColPos);
+      if (!messageDiv) {
+        return;
+      }
+
+      this.__closeOverlay();
+
+      const rowData = rowInfo.rowData;
+      const cellStyle = window.getComputedStyle(messageDiv);
+      const rowStyle = window.getComputedStyle(rowElem);
+      const rect = rowElem.getBoundingClientRect();
+      const bgColor = rowElem.style.backgroundColor || rowStyle.backgroundColor || "#222";
+
+      // Build overlay
+      const overlay = document.createElement("div");
+      const baseStyles = [
+        "position: fixed",
+        "left: " + rect.left + "px",
+        "width: " + rect.width + "px",
+        "max-height: 50vh",
+        "overflow-y: auto",
+        "padding: 8px 12px",
+        "border-radius: 4px",
+        "border: 1px solid rgba(255,255,255,0.15)",
+        "box-shadow: 0 6px 20px rgba(0,0,0,0.4)",
+        "z-index: 100000",
+        "font-family: " + cellStyle.fontFamily,
+        "font-size: " + cellStyle.fontSize,
+        "color: " + cellStyle.color,
+        "background-color: " + bgColor,
+      ];
+
+      // If the row is in the bottom half of the viewport, render the overlay above
+      const viewportHeight = window.innerHeight;
+      if (rect.bottom > viewportHeight * 0.65) {
+        baseStyles.push("bottom: " + (viewportHeight - rect.bottom) + "px");
+      } else {
+        baseStyles.push("top: " + rect.top + "px");
+      }
+
+      overlay.style.cssText = baseStyles.join("; ");
+
+      // Header row: [badge] [timestamp] [origin] ... [x]
+      const header = document.createElement("div");
+      header.style.cssText = [
+        "display: flex",
+        "align-items: center",
+        "gap: 8px",
+        "margin-bottom: 6px",
+        "padding-bottom: 6px",
+        "border-bottom: 1px solid rgba(255,255,255,0.12)",
+        "font-size: 11px",
+        "opacity: 0.85",
+      ].join("; ");
+
+      // Log level badge
+      const badgeInfo = this.__getLogLevelBadge(rowData);
+      if (badgeInfo) {
+        const badge = document.createElement("span");
+        badge.textContent = badgeInfo.label;
+        badge.style.cssText = [
+          "background-color: " + badgeInfo.color,
+          "color: #000",
+          "padding: 1px 6px",
+          "border-radius: 3px",
+          "font-weight: 600",
+          "font-size: 10px",
+          "letter-spacing: 0.5px",
+        ].join("; ");
+        header.appendChild(badge);
+      }
+
+      // Timestamp
+      if (rowData && rowData.timeStamp) {
+        const time = document.createElement("span");
+        time.textContent = rowData.timeStamp;
+        time.style.cssText = "opacity: 0.7; font-variant-numeric: tabular-nums";
+        header.appendChild(time);
+      }
+
+      // Origin
+      if (rowData && rowData.label) {
+        const origin = document.createElement("span");
+        origin.textContent = rowData.label;
+        origin.style.cssText = "opacity: 0.7; margin-left: auto";
+        header.appendChild(origin);
+      }
+
+      // Close button
+      const closeBtn = document.createElement("span");
+      closeBtn.textContent = "\u00d7";
+      closeBtn.style.cssText = [
+        "margin-left: auto",
+        "cursor: pointer",
+        "font-size: 16px",
+        "line-height: 1",
+        "opacity: 0.6",
+        "padding: 0 2px",
+      ].join("; ");
+      const self = this;
+      closeBtn.onclick = function(e) {
+        e.stopPropagation();
+        self.__closeOverlay();
+      };
+      header.appendChild(closeBtn);
+
+      overlay.appendChild(header);
+
+      // Message body
+      const body = document.createElement("div");
+      body.innerHTML = messageDiv.innerHTML;
+      body.style.cssText = [
+        "white-space: pre-wrap",
+        "word-break: break-word",
+        "user-select: text",
+        "line-height: 1.5",
+      ].join("; ");
+      overlay.appendChild(body);
+
+      document.body.appendChild(overlay);
+      this.__overlay = overlay;
+      this.__activeRowIndex = rowInfo.row;
+
+      // Close when clicking outside
+      this.__dismissHandler = function(e) {
+        if (!overlay.contains(e.target)) {
+          self.__closeOverlay();
+        }
+      };
+      setTimeout(function() {
+        document.addEventListener("mousedown", self.__dismissHandler, true);
+      }, 0);
+
+      // Close on scroll since the fixed position becomes stale
+      this.__scrollDismissHandler = function() {
+        self.__closeOverlay();
+      };
+      document.addEventListener("scroll", this.__scrollDismissHandler, true);
+    },
+
+    // overridden
+    updateDataRowElement: function(rowInfo, rowElem) {
+      this.base(arguments, rowInfo, rowElem);
+
+      const self = this;
+      const rowIndex = rowInfo.row;
+      rowElem.style.cursor = "pointer";
+      rowElem.onclick = function() {
+        if (self.__activeRowIndex === rowIndex) {
+          self.__closeOverlay();
+        } else {
+          self.__showOverlay(rowElem, rowInfo);
+        }
+      };
+    }
+  }
+});

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -76,9 +76,6 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
         allowGrowY: false,
         allowGrowX: false,
       });
-      badge.getContentElement().setStyles({
-        "letter-spacing": "0.5px",
-      });
       return badge;
     },
 
@@ -94,7 +91,7 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
 
       // Container
       const popup = new qx.ui.container.Composite(new qx.ui.layout.VBox(4)).set({
-        backgroundColor: "background-main-2",
+        backgroundColor: "background-main-1",
         padding: 8,
         maxHeight: Math.round(window.innerHeight * 0.5),
         width: Math.round(rect.width),
@@ -123,7 +120,7 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
         }));
       }
 
-      // Origin
+      // Node
       if (rowData && rowData.label) {
         header.add(new qx.ui.basic.Label(rowData.label).set({
           font: "text-11",
@@ -137,7 +134,10 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       });
 
       // Copy button
-      const copyBtn = osparc.utils.Utils.getCopyButton();
+      const copyBtn = osparc.utils.Utils.getCopyButton().set({
+        backgroundColor: "transparent",
+        padding: 2,
+      });
       copyBtn.addListener("execute", () => {
         const text = osparc.widget.logger.LoggerView.printRow(rowData);
         osparc.utils.Utils.copyTextToClipboard(text);
@@ -146,8 +146,8 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
 
       // Close button
       const closeBtn = new qx.ui.form.Button(null, "@MaterialIcons/close/14").set({
+        backgroundColor: "transparent",
         allowGrowY: false,
-        appearance: "form-button-outlined",
         padding: 2,
       });
       closeBtn.addListener("execute", () => this.__closePopup());

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -37,11 +37,11 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
   },
 
   statics: {
-    LOG_LEVEL_COLORS: {
-      "-1": { label: "DEBUG", color: "#888" },
-      "0": { label: "INFO", color: "#4fc3f7" },
-      "1": { label: "WARNING", color: "#ffb74d" },
-      "2": { label: "ERROR", color: "#ef5350" },
+    LOG_LEVEL_INFO: {
+      "-1": { label: "DEBUG", themeColor: "logger-debug-message" },
+      "0": { label: "INFO", themeColor: "logger-info-message" },
+      "1": { label: "WARNING", themeColor: "logger-warning-message" },
+      "2": { label: "ERROR", themeColor: "logger-error-message" },
     },
   },
 
@@ -73,11 +73,13 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       if (!rowData || rowData.logLevel == null) {
         return null;
       }
-      const entry = this.self().LOG_LEVEL_COLORS[String(rowData.logLevel)];
+      const entry = this.self().LOG_LEVEL_INFO[String(rowData.logLevel)];
       if (!entry) {
         return null;
       }
-      return { label: entry.label, color: entry.color };
+      const colorManager = qx.theme.manager.Color.getInstance();
+      const resolvedColor = colorManager.resolve(entry.themeColor);
+      return { label: entry.label, color: resolvedColor };
     },
 
     __showOverlay: function(rowElem, rowInfo) {

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -103,7 +103,7 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
         "width: " + rect.width + "px",
         "max-height: 50vh",
         "overflow-y: auto",
-        "padding: 8px 12px",
+        "padding: 8px",
         "border-radius: 4px",
         "border: 1px solid rgba(255,255,255,0.15)",
         "box-shadow: 0 6px 20px rgba(0,0,0,0.4)",
@@ -169,6 +169,30 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
         origin.style.cssText = "opacity: 0.7; margin-left: auto";
         header.appendChild(origin);
       }
+
+      // Copy button (FontAwesome5 copy icon, matching the app's standard clipboard button)
+      const copyBtn = document.createElement("span");
+      copyBtn.textContent = "\uf0c5";
+      copyBtn.title = "Copy to clipboard";
+      copyBtn.style.cssText = [
+        "font-family: FontAwesome5Solid, FontAwesome5Free",
+        "cursor: pointer",
+        "font-size: 12px",
+        "line-height: 1",
+        "opacity: 0.6",
+        "padding: 0 2px",
+      ].join("; ");
+      copyBtn.onclick = function(e) {
+        e.stopPropagation();
+        const text = osparc.widget.logger.LoggerView.printRow(rowData);
+        osparc.utils.Utils.copyTextToClipboard(text);
+        // Check mark icon (FontAwesome5)
+        copyBtn.textContent = "\uf00c";
+        setTimeout(function() {
+          copyBtn.textContent = "\uf0c5";
+        }, 1500);
+      };
+      header.appendChild(copyBtn);
 
       // Close button
       const closeBtn = document.createElement("span");

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -17,7 +17,7 @@
 
 /**
  * Row renderer for the Logger table that shows a popup with
- * the full log message, timestamp, origin, and log level when a row is clicked.
+ * the full log message, timestamp, Node label, and log level when a row is clicked.
  *
  * The popup is added to the application root to avoid
  * qooxdoo table pane clipping constraints (overflow:hidden at multiple levels).

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -34,10 +34,26 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
 
   statics: {
     LOG_LEVEL_INFO: {
-      "-1": { label: "DEBUG", textColor: "logger-debug-message", bgColor: "background-main-4" },
-      "0": { label: "INFO", textColor: "logger-info-message", bgColor: "background-main-4" },
-      "1": { label: "WARNING", textColor: "background-main-1", bgColor: "logger-warning-message" },
-      "2": { label: "ERROR", textColor: "background-main-1", bgColor: "logger-error-message" },
+      "-1": {
+        label: "DEBUG",
+        textColor: "white",
+        bgColor: "product-color"
+      },
+      "0": {
+        label: "INFO",
+        textColor: "white",
+        bgColor: "product-color"
+      },
+      "1": {
+        label: "WARNING",
+        textColor: "black",
+        bgColor: "warning-yellow"
+      },
+      "2": {
+        label: "ERROR",
+        textColor: "black",
+        bgColor: "failed-red"
+      },
     },
   },
 
@@ -96,7 +112,6 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
         maxHeight: Math.round(window.innerHeight * 0.5),
         width: Math.round(rect.width),
         zIndex: osparc.utils.Utils.FLOATING_Z_INDEX,
-        decorator: "material-textfield",
       });
 
       // Header

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -34,10 +34,10 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
 
   statics: {
     LOG_LEVEL_INFO: {
-      "-1": { label: "DEBUG", themeColor: "logger-debug-message" },
-      "0": { label: "INFO", themeColor: "logger-info-message" },
-      "1": { label: "WARNING", themeColor: "logger-warning-message" },
-      "2": { label: "ERROR", themeColor: "logger-error-message" },
+      "-1": { label: "DEBUG", textColor: "logger-debug-message", bgColor: "background-main-4" },
+      "0": { label: "INFO", textColor: "logger-info-message", bgColor: "background-main-4" },
+      "1": { label: "WARNING", textColor: "background-main-1", bgColor: "logger-warning-message" },
+      "2": { label: "ERROR", textColor: "background-main-1", bgColor: "logger-error-message" },
     },
   },
 
@@ -70,8 +70,8 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       const badge = new qx.ui.basic.Label(entry.label).set({
         font: "text-10",
         padding: [2, 8],
-        textColor: "text",
-        backgroundColor: entry.themeColor,
+        textColor: entry.textColor,
+        backgroundColor: entry.bgColor,
         decorator: "rounded",
         allowGrowY: false,
         allowGrowX: false,

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -69,9 +69,15 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       }
       const badge = new qx.ui.basic.Label(entry.label).set({
         font: "text-10",
-        padding: [1, 6],
+        padding: [2, 8],
         textColor: "text",
         backgroundColor: entry.themeColor,
+        decorator: "rounded",
+        allowGrowY: false,
+        allowGrowX: false,
+      });
+      badge.getContentElement().setStyles({
+        "letter-spacing": "0.5px",
       });
       return badge;
     },
@@ -97,9 +103,11 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       });
 
       // Header
-      const header = new qx.ui.container.Composite(new qx.ui.layout.HBox(8).set({
+      const header = new qx.ui.container.Composite(new qx.ui.layout.HBox(10).set({
         alignY: "middle",
-      }));
+      })).set({
+        paddingBottom: 4,
+      });
 
       // Log level badge
       const badge = this.__createBadge(rowData);
@@ -137,18 +145,23 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       header.add(copyBtn);
 
       // Close button
-      const closeBtn = new qx.ui.form.Button(null, "@MaterialIcons/close/12").set({
+      const closeBtn = new qx.ui.form.Button(null, "@MaterialIcons/close/14").set({
         allowGrowY: false,
-        padding: 3,
-        maxWidth: 20,
+        appearance: "form-button-outlined",
+        padding: 2,
       });
       closeBtn.addListener("execute", () => this.__closePopup());
       header.add(closeBtn);
 
       popup.add(header);
 
-      // Separator
-      popup.add(new qx.ui.menu.Separator());
+      // Divider
+      const divider = new qx.ui.core.Widget().set({
+        height: 1,
+        backgroundColor: "text-opa30",
+        allowGrowY: false,
+      });
+      popup.add(divider);
 
       // Message body (scrollable)
       const scroll = new qx.ui.container.Scroll();

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -62,8 +62,22 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
     __messageColPos: null,
     __popup: null,
     __activeRowIndex: null,
+    __scrollHandler: null,
+    __clickHandler: null,
+
+    __removeGlobalListeners: function() {
+      if (this.__scrollHandler) {
+        document.removeEventListener("scroll", this.__scrollHandler, true);
+        this.__scrollHandler = null;
+      }
+      if (this.__clickHandler) {
+        document.removeEventListener("mousedown", this.__clickHandler, true);
+        this.__clickHandler = null;
+      }
+    },
 
     __closePopup: function() {
+      this.__removeGlobalListeners();
       if (this.__popup) {
         const root = qx.core.Init.getApplication().getRoot();
         if (root.indexOf(this.__popup) >= 0) {
@@ -96,11 +110,6 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
     },
 
     __showPopup: function(rowElem, rowIndex, rowData) {
-      const messageDiv = rowElem.children.item(this.__messageColPos);
-      if (!messageDiv) {
-        return;
-      }
-
       this.__closePopup();
 
       const rect = rowElem.getBoundingClientRect();
@@ -180,7 +189,7 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
 
       // Message body (scrollable)
       const scroll = new qx.ui.container.Scroll();
-      const messageLabel = new qx.ui.basic.Label(messageDiv.innerHTML).set({
+      const messageLabel = new qx.ui.basic.Label(rowData.msgRich || rowData.msg || "").set({
         rich: true,
         selectable: true,
         wrap: true,
@@ -221,29 +230,22 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       this.__activeRowIndex = rowIndex;
 
       // Close on scroll since the fixed position becomes stale
-      const scrollHandler = () => {
-        this.__closePopup();
-        document.removeEventListener("scroll", scrollHandler, true);
-      };
-      document.addEventListener("scroll", scrollHandler, true);
+      this.__scrollHandler = () => this.__closePopup();
+      document.addEventListener("scroll", this.__scrollHandler, true);
 
       // Close on click outside
-      const clickHandler = e => {
+      this.__clickHandler = e => {
         if (popup.isDisposed()) {
-          document.removeEventListener("mousedown", clickHandler, true);
+          this.__removeGlobalListeners();
           return;
         }
         const popupElem = popup.getContentElement().getDomElement();
         if (popupElem && !popupElem.contains(e.target)) {
-          document.removeEventListener("mousedown", clickHandler, true);
           this.__closePopup();
         }
       };
       popup.addListenerOnce("appear", () => {
-        setTimeout(() => document.addEventListener("mousedown", clickHandler, true), 0);
-      });
-      popup.addListenerOnce("disappear", () => {
-        document.removeEventListener("mousedown", clickHandler, true);
+        setTimeout(() => document.addEventListener("mousedown", this.__clickHandler, true), 0);
       });
     },
 

--- a/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
+++ b/services/static-webserver/client/source/class/osparc/ui/table/rowrenderer/PopUpLogMessage.js
@@ -82,7 +82,7 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
       return { label: entry.label, color: resolvedColor };
     },
 
-    __showOverlay: function(rowElem, rowInfo) {
+    __showOverlay: function(rowElem, rowIndex, rowData) {
       const messageDiv = rowElem.children.item(this.__messageColPos);
       if (!messageDiv) {
         return;
@@ -90,7 +90,6 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
 
       this.__closeOverlay();
 
-      const rowData = rowInfo.rowData;
       const cellStyle = window.getComputedStyle(messageDiv);
       const rowStyle = window.getComputedStyle(rowElem);
       const rect = rowElem.getBoundingClientRect();
@@ -204,7 +203,7 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
 
       document.body.appendChild(overlay);
       this.__overlay = overlay;
-      this.__activeRowIndex = rowInfo.row;
+      this.__activeRowIndex = rowIndex;
 
       // Close when clicking outside
       this.__dismissHandler = function(e) {
@@ -229,12 +228,14 @@ qx.Class.define("osparc.ui.table.rowrenderer.PopUpLogMessage", {
 
       const self = this;
       const rowIndex = rowInfo.row;
+      // Capture rowData now — rowInfo is a shared mutable object reused across rows
+      const rowData = rowInfo.rowData;
       rowElem.style.cursor = "pointer";
       rowElem.onclick = function() {
         if (self.__activeRowIndex === rowIndex) {
           self.__closeOverlay();
         } else {
-          self.__showOverlay(rowElem, rowInfo);
+          self.__showOverlay(rowElem, rowIndex, rowData);
         }
       };
     }

--- a/services/static-webserver/client/source/class/osparc/widget/logger/LoggerModel.js
+++ b/services/static-webserver/client/source/class/osparc/widget/logger/LoggerModel.js
@@ -26,7 +26,7 @@
  *
  * <pre class='javascript'>
  *   let tableModel = this.__logModel = new osparc.widget.logger.LoggerTable();
- *   tableModel.setColumns(["Level", "Time", "Origin", "Message"], ["level", "time", "who", "whatRich"]);
+ *   tableModel.setColumns(["Level", "Time", "Node", "Message"], ["level", "time", "who", "whatRich"]);
  *   let custom = {
  *     tableColumnModel : function(obj) {
  *       return new qx.ui.table.columnmodel.Resize(obj);
@@ -51,7 +51,7 @@ qx.Class.define("osparc.widget.logger.LoggerModel", {
     this.setColumns([
       "",
       "Time",
-      "Origin",
+      "Node",
       "Message"
     ], [
       "level",

--- a/services/static-webserver/client/source/class/osparc/widget/logger/LoggerModel.js
+++ b/services/static-webserver/client/source/class/osparc/widget/logger/LoggerModel.js
@@ -26,7 +26,7 @@
  *
  * <pre class='javascript'>
  *   let tableModel = this.__logModel = new osparc.widget.logger.LoggerTable();
- *   tableModel.setColumns(["Level", "Time", "Node", "Message"], ["level", "time", "who", "whatRich"]);
+ *   tableModel.setColumns(["Level", "Time", "Node", "Message"], ["level", "time", "who", "msgRich"]);
  *   let custom = {
  *     tableColumnModel : function(obj) {
  *       return new qx.ui.table.columnmodel.Resize(obj);

--- a/services/static-webserver/client/source/class/osparc/widget/logger/LoggerModel.js
+++ b/services/static-webserver/client/source/class/osparc/widget/logger/LoggerModel.js
@@ -78,6 +78,8 @@ qx.Class.define("osparc.widget.logger.LoggerModel", {
   },
 
   statics: {
+    MAX_ROWS: 2000,
+
     getLevelIcon: function(logLevel) {
       const logLevels = osparc.widget.logger.LoggerView.LOG_LEVELS;
       let iconSource = "";
@@ -121,6 +123,11 @@ qx.Class.define("osparc.widget.logger.LoggerModel", {
 
         this.__rawData.push(newRow);
       });
+
+      const max = this.self().MAX_ROWS;
+      if (this.__rawData.length > max) {
+        this.__rawData.splice(0, this.__rawData.length - max);
+      }
     },
 
     nodeLabelChanged: function(nodeId, newLabel) {

--- a/services/static-webserver/client/source/class/osparc/widget/logger/LoggerView.js
+++ b/services/static-webserver/client/source/class/osparc/widget/logger/LoggerView.js
@@ -25,10 +25,10 @@
  *   - some log type filtering buttons
  * - log messages table
  *
- * Log messages have two inputs: "Origin" and "Message".
+ * Log messages have two inputs: "Node" and "Message".
  *
- *   Depending on the log level, "Origin"'s color will change, also "Message"s coming from the same
- * origin will be rendered with the same color.
+ *   Depending on the log level, "Node"'s color will change, also "Message"s coming from the same
+ * node will be rendered with the same color.
  *
  * *Example*
  *

--- a/services/static-webserver/client/source/class/osparc/widget/logger/LoggerView.js
+++ b/services/static-webserver/client/source/class/osparc/widget/logger/LoggerView.js
@@ -298,7 +298,7 @@ qx.Class.define("osparc.widget.logger.LoggerView", {
       resizeBehavior.setWidth(this.self().POS.TIMESTAMP, 80);
       resizeBehavior.setWidth(this.self().POS.ORIGIN, 100);
 
-      table.setDataRowRenderer(new osparc.ui.table.rowrenderer.ExpandSelection(table, this.self().POS.MESSAGE));
+      table.setDataRowRenderer(new osparc.ui.table.rowrenderer.PopUpLogMessage(table, this.self().POS.MESSAGE));
 
       this.__applyFilters();
 


### PR DESCRIPTION
## What do these changes do?

There were a couple of issues with the old rowrenderer in the logger: the last row would not be properly rendered and it wasn't very aesthetic.

This PR brings a new log rendererer, when clicking on a log row opens a popup widget showing: the full message, log level badge, timestamp, node, copy-to-clipboard button, and close button.

Bonus:
- [x] Fixes the user ``🔔  Notified`` widget in the project conversations (reported by @matusdrobuliak66 )

<img width="1440" height="850" alt="LogViewer" src="https://github.com/user-attachments/assets/ec701d7d-ac61-4678-b3bf-f1022425a6cd" />




## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
