### PR TITLE
🐛 Fix ZeroDivisionError in `test_time_overhead_on_handlers_of_auth_decorators`

### DIFF
--- a/services/web/server/tests/unit/isolated/test_security_web.py
+++ b/services/web/server/tests/unit/isolated/test_security_web.py
@@ -4,6 +4,7 @@
 # pylint: disable=too-many-arguments
 
 import statistics
+import sys
 import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
@@ -431,7 +432,7 @@ async def test_time_overhead_on_handlers_of_auth_decorators(
     # For a more robust, although less efficient, measure of central tendency, see median().
     ref_elapsed_ns = statistics.median(public_elapsed_times)
     elapsed_ns = statistics.median(admin_elapsed_times)
-    elapsed_ratio = elapsed_ns / max(ref_elapsed_ns, 1)
+    elapsed_ratio = elapsed_ns / max(ref_elapsed_ns, sys.float_info.min)
 
     # NOTE: 150% more wrt reference (basically ~ 2.5x more !!!!!!!!!!!)
     # and this is mocking the access to the database!


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->

Fixes a flaky `ZeroDivisionError` in `test_time_overhead_on_handlers_of_auth_decorators` that occurs when `ref_elapsed_ns` (the median of public endpoint timings) resolves to 0.

The previous guard `max(ref_elapsed_ns, 1)` used an integer floor of 1, which does not protect against a float 0.0 from `statistics.median`. Replaced with `max(ref_elapsed_ns, sys.float_info.min)` (~2.2e-308), the smallest positive normalized float, guaranteeing the denominator is never zero.


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- https://github.com/ITISFoundation/private-issues/issues/463
- Failing CI run: https://github.com/ITISFoundation/osparc-simcore/actions/runs/24714999583/job/72289037515
- Previous attempt: https://github.com/ITISFoundation/osparc-simcore/pull/9041

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
-->
