### PR TITLE
update attrs - tests + tools

### DIFF
--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -6,7 +6,7 @@ aiohttp==3.13.3
     #   -r requirements.in
 aiosignal==1.4.0
     # via aiohttp
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   aiohttp
     #   jsonschema

--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -55,7 +55,7 @@ arrow==1.4.0
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   aiohttp
     #   jsonschema

--- a/packages/aws-library/requirements/_test.txt
+++ b/packages/aws-library/requirements/_test.txt
@@ -13,7 +13,7 @@ anyio==4.12.1
     #   -c requirements/_base.txt
     #   httpx
     #   starlette
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/_base.txt
     #   jsonschema

--- a/packages/celery-library/requirements/_base.txt
+++ b/packages/celery-library/requirements/_base.txt
@@ -45,7 +45,7 @@ arrow==1.4.0
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   aiohttp
     #   jsonschema

--- a/packages/dask-task-models-library/requirements/_base.txt
+++ b/packages/dask-task-models-library/requirements/_base.txt
@@ -4,7 +4,7 @@ annotated-types==0.7.0
     # via pydantic
 arrow==1.4.0
     # via -r requirements/../../../packages/models-library/requirements/_base.in
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   referencing

--- a/packages/models-library/requirements/_base.txt
+++ b/packages/models-library/requirements/_base.txt
@@ -2,7 +2,7 @@ annotated-types==0.7.0
     # via pydantic
 arrow==1.4.0
     # via -r requirements/_base.in
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   referencing

--- a/packages/models-library/requirements/_test.txt
+++ b/packages/models-library/requirements/_test.txt
@@ -1,4 +1,4 @@
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/_base.txt
     #   referencing

--- a/packages/notifications-library/requirements/_base.txt
+++ b/packages/notifications-library/requirements/_base.txt
@@ -12,7 +12,7 @@ arrow==1.4.0
     # via -r requirements/../../../packages/models-library/requirements/_base.in
 asyncpg==0.31.0
     # via sqlalchemy
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   referencing

--- a/packages/notifications-library/requirements/_test.txt
+++ b/packages/notifications-library/requirements/_test.txt
@@ -8,7 +8,7 @@ aiohttp==3.13.3
     #   aiodocker
 aiosignal==1.4.0
     # via aiohttp
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/packages/pytest-simcore/requirements/_test.txt
+++ b/packages/pytest-simcore/requirements/_test.txt
@@ -16,7 +16,7 @@ anyio==4.12.1
     # via starlette
 arrow==1.4.0
     # via -r requirements/_test.in
-attrs==25.4.0
+attrs==26.1.0
     # via aiohttp
 bidict==0.23.1
     # via python-socketio

--- a/packages/service-integration/requirements/_base.txt
+++ b/packages/service-integration/requirements/_base.txt
@@ -7,7 +7,7 @@ arrow==1.4.0
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   cookiecutter
     #   jinja2-time
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   referencing

--- a/packages/service-integration/requirements/_test.txt
+++ b/packages/service-integration/requirements/_test.txt
@@ -1,4 +1,4 @@
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/_base.txt
     #   referencing

--- a/packages/service-library/requirements/_aiohttp.txt
+++ b/packages/service-library/requirements/_aiohttp.txt
@@ -6,7 +6,7 @@ aiohttp==3.13.3
     #   -r requirements/_aiohttp.in
 aiosignal==1.4.0
     # via aiohttp
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -r requirements/_aiohttp.in
     #   aiohttp

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -36,7 +36,7 @@ arrow==1.4.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/_base.in
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   aiohttp
     #   jsonschema

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -23,7 +23,7 @@ asgi-lifespan==2.1.0
     # via
     #   -c requirements/_fastapi.txt
     #   -r requirements/_test.in
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/_aiohttp.txt
     #   -c requirements/_base.txt

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -54,7 +54,7 @@ arrow==1.4.0
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 asyncpg==0.31.0
     # via sqlalchemy
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   aiohttp
     #   jsonschema

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -34,7 +34,7 @@ annotated-types==0.7.0
     #   pydantic
 antlr4-python3-runtime==4.13.2
     # via moto
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   -c requirements/_base.txt
     #   aiohttp

--- a/services/docker-api-proxy/requirements/_test.txt
+++ b/services/docker-api-proxy/requirements/_test.txt
@@ -51,7 +51,7 @@ arrow==1.4.0
     #   -r requirements/_test.in
 asgi-lifespan==2.1.0
     # via -r requirements/_test.in
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   aiohttp
     #   jsonschema

--- a/services/migration/requirements/_test.txt
+++ b/services/migration/requirements/_test.txt
@@ -1,4 +1,4 @@
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   pytest-docker

--- a/tests/performance/requirements/_test.txt
+++ b/tests/performance/requirements/_test.txt
@@ -1,6 +1,6 @@
 annotated-types==0.7.0
     # via pydantic
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   jsonschema
     #   referencing

--- a/tests/public-api/requirements/_test.txt
+++ b/tests/public-api/requirements/_test.txt
@@ -11,7 +11,7 @@ aiosignal==1.4.0
     # via aiohttp
 anyio==4.12.1
     # via httpx
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   aiohttp
     #   jsonschema


### PR DESCRIPTION
###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 1
- #packages after ~ 1

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | attrs                     | 25.4.0          | 26.1.0     | **MAJOR**  | 21 | aws-library🧪🧪</br>celery-library🧪</br>dask-task-models-library🧪</br>docker-api-proxy🧪</br>migration🧪</br>models-library🧪🧪</br>notifications-library🧪🧪</br>performance🧪</br>public-api🧪</br>pytest-simcore🧪</br>service-integration🧪🧪</br>service-library🧪🧪🧪</br>simcore-sdk🧪🧪</br>tests🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 107

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.6.2                     | 9.6.2                     |                           |
|   2 | aioboto3                  | 14.3.0, 15.0.0, 15.5.0    | 7.0.0, 15.5.0             |                           |
|   3 | aiobotocore               | 2.22.0, 2.23.0, 2.25.1, 2.25.2 | 2.25.1, 2.25.2            |                           |
|   4 | aiocache                  | 0.11.1, 0.12.2, 0.12.3    | 0.12.3                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0, 0.24.0, 0.26.0    | 0.24.0, 0.26.0            |                           |
|   7 | aiofiles                  | 0.8.0, 23.2.1, 24.1.0, 25.1.0 | 24.1.0, 25.1.0            |                           |
|   8 | aiohappyeyeballs          | 2.5.0, 2.6.1              | 2.5.0, 2.6.1              |                           |
|   9 | aiohttp                   | 3.12.12, 3.12.13, 3.13.2, 3.13.3 | 3.12.12, 3.12.13, 3.13.2, 3.13.3 |                           |
|  10 | aiohttp-jinja2            | 1.6                       |                           |                           |
|  11 | aiohttp-security          | 0.5.0                     |                           |                           |
|  12 | aiohttp-session           | 2.11.0                    |                           |                           |
|  13 | aioitertools              | 0.11.0, 0.12.0, 0.13.0    | 0.13.0                    |                           |
|  14 | aioprocessing             | 2.0.1                     |                           |                           |
|  15 | aioresponses              |                           | 0.7.8                     |                           |
|  16 | aiormq                    | 6.8.0, 6.8.1, 6.9.2, 6.9.3, 6.9.4 | 6.9.2, 6.9.3              |                           |
|  17 | aiosignal                 | 1.2.0, 1.3.1, 1.3.2, 1.4.0 | 1.2.0, 1.3.1, 1.3.2, 1.4.0 |                           |
|  18 | aiosmtplib                | 1.1.6, 5.0.0, 5.1.0       |                           |                           |
|  19 | alembic                   | 1.8.1, 1.13.1, 1.14.0, 1.14.1, 1.15.1, 1.16.2, 1.17.2, 1.18.4 | 1.8.1, 1.13.1, 1.14.0, 1.15.1, 1.17.2, 1.18.4 |                           |
|  20 | amqp                      | 5.3.1                     | 5.3.1                     |                           |
|  21 | annotated-doc             | 0.0.4                     | 0.0.4                     | 0.0.4                     |
|  22 | annotated-types           | 0.7.0                     | 0.7.0                     |                           |
|  23 | antlr4-python3-runtime    |                           | 4.13.2                    |                           |
|  24 | anyio                     | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0, 4.9.0, 4.11.0, 4.12.1 | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0, 4.9.0, 4.11.0, 4.12.1 |                           |
|  25 | arrow                     | 1.3.0, 1.4.0              | 1.4.0                     |                           |
|  26 | asgi-lifespan             | 2.1.0                     | 2.1.0                     |                           |
|  27 | asgiref                   | 3.8.1, 3.10.0             |                           |                           |
|  28 | astroid                   |                           |                           | 4.0.4                     |
|  29 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  30 | asyncpg                   | 0.30.0, 0.31.0            | 0.30.0                    |                           |
|  31 | asyncpg-stubs             |                           | 0.30.2                    |                           |
|  32 | attrs                     | 23.2.0, 24.2.0, 25.1.0, 25.2.0, 25.3.0, 25.4.0, 26.1.0 | 23.2.0, 24.2.0, 25.1.0, 25.2.0, 25.3.0, 25.4.0, 26.1.0 |                           |
|  33 | aws-sam-translator        |                           | 1.55.0, 1.103.0           |                           |
|  34 | aws-xray-sdk              |                           | 2.15.0                    |                           |
|  35 | bidict                    | 0.22.0, 0.23.1            | 0.23.1                    |                           |
|  36 | billiard                  | 4.2.1, 4.2.3, 4.2.4       | 4.2.1, 4.2.3, 4.2.4       |                           |
|  37 | binaryornot               | 0.6.0                     |                           |                           |
|  38 | black                     |                           |                           | 26.3.1                    |
|  39 | blinker                   |                           | 1.9.0                     |                           |
|  40 | blosc                     | 1.11.3                    |                           |                           |
|  41 | bokeh                     | 3.8.1                     | 3.9.0                     |                           |
|  42 | boto3                     | 1.37.3, 1.38.27, 1.40.60, 1.40.61 | 1.37.3, 1.38.27, 1.40.61, 1.40.70, 1.42.70 |                           |
|  43 | boto3-stubs               |                           | 1.42.70                   |                           |
|  44 | botocore                  | 1.37.3, 1.38.27, 1.40.60, 1.40.61, 1.40.70 | 1.37.3, 1.38.27, 1.40.61, 1.40.70, 1.42.70 |                           |
|  45 | botocore-stubs            | 1.34.69, 1.36.17, 1.38.46, 1.40.74, 1.42.41 | 1.40.74, 1.42.41          |                           |
|  46 | brotli                    |                           | 1.2.0                     |                           |
|  47 | build                     |                           |                           | 1.4.0                     |
|  48 | bump2version              |                           |                           | 1.0.1                     |
|  49 | captcha                   | 0.5.0                     |                           |                           |
|  50 | celery                    | 5.6.3                     | 5.6.3                     |                           |
|  51 | certifi                   | 2023.7.22, 2024.2.2, 2024.8.30, 2025.1.31, 2025.6.15, 2025.11.12, 2026.2.25 | 2023.7.22, 2024.2.2, 2024.8.30, 2025.1.31, 2025.6.15, 2025.11.12, 2026.2.25 |                           |
|  52 | cffi                      | 1.17.1                    | 1.17.1, 2.0.0             |                           |
|  53 | cfgv                      |                           |                           | 3.5.0                     |
|  54 | cfn-lint                  |                           | 0.72.0, 1.41.0            |                           |
|  55 | change-case               |                           |                           | 0.5.2                     |
|  56 | charset-normalizer        | 2.0.12, 3.3.2, 3.4.0, 3.4.1, 3.4.2, 3.4.4, 3.4.6 | 2.0.12, 3.3.2, 3.4.0, 3.4.1, 3.4.2, 3.4.4, 3.4.6 |                           |
|  57 | click                     | 8.2.1, 8.3.1              | 8.2.1, 8.3.1              | 8.2.1, 8.3.1              |
|  58 | click-didyoumean          | 0.3.1                     | 0.3.1                     |                           |
|  59 | click-plugins             | 1.1.1, 1.1.1.2            | 1.1.1, 1.1.1.2            |                           |
|  60 | click-repl                | 0.3.0                     | 0.3.0                     |                           |
|  61 | cloudpickle               | 3.1.2                     | 3.1.2                     |                           |
|  62 | configargparse            |                           | 1.7.5                     |                           |
|  63 | contourpy                 | 1.3.3                     | 1.3.3                     |                           |
|  64 | cookiecutter              | 2.7.1                     |                           |                           |
|  65 | coverage                  |                           | 7.13.5                    |                           |
|  66 | cryptography              | 41.0.7, 44.0.0, 44.0.2    | 44.0.0, 46.0.5            |                           |
|  67 | cycler                    | 0.12.1                    |                           |                           |
|  68 | dask                      | 2025.11.0, 2026.3.0       | 2025.11.0                 |                           |
|  69 | dateparser                | 1.2.0                     |                           |                           |
|  70 | debugpy                   |                           | 1.8.20                    |                           |
|  71 | deepdiff                  | 8.1.1                     | 8.6.1                     |                           |
|  72 | dill                      |                           |                           | 0.4.1                     |
|  73 | distlib                   |                           |                           | 0.4.0                     |
|  74 | distributed               | 2025.11.0, 2026.3.0       | 2025.11.0                 |                           |
|  75 | dnspython                 | 2.2.1, 2.6.1, 2.7.0, 2.8.0 | 2.2.1, 2.8.0              |                           |
|  76 | docker                    | 7.1.0                     | 7.1.0                     |                           |
|  77 | docutils                  | 0.21.2                    |                           |                           |
|  78 | ecdsa                     | 0.19.0                    | 0.19.1                    |                           |
|  79 | email-validator           | 2.1.1, 2.2.0, 2.3.0       | 2.2.0, 2.3.0              |                           |
|  80 | et-xmlfile                | 1.1.0                     |                           |                           |
|  81 | exceptiongroup            |                           | 1.3.1                     |                           |
|  82 | execnet                   |                           | 2.1.2                     |                           |
|  83 | faker                     | 19.6.1                    | 19.6.1, 40.11.0           |                           |
|  84 | fakeredis                 |                           | 2.34.1                    |                           |
|  85 | fast-depends              | 3.0.3, 3.0.8              | 3.0.8                     |                           |
|  86 | fastapi                   | 0.116.1, 0.121.2          | 0.116.1, 0.135.1          |                           |
|  87 | fastapi-cli               | 0.0.8, 0.0.16             | 0.0.24                    |                           |
|  88 | fastapi-cloud-cli         | 0.1.5, 0.3.1              | 0.15.0                    |                           |
|  89 | fastapi-lifespan-manager  | 0.1.4                     | 0.1.4                     |                           |
|  90 | fastapi-pagination        | 0.12.34, 0.14.0           | 0.15.10                   |                           |
|  91 | fastar                    |                           | 0.8.0                     |                           |
|  92 | faststream                | 0.6.7                     | 0.6.7                     |                           |
|  93 | filelock                  |                           |                           | 3.25.2                    |
|  94 | flaky                     |                           | 3.8.1                     |                           |
|  95 | flask                     |                           | 2.1.3, 3.1.3              |                           |
|  96 | flask-cors                |                           | 6.0.2                     |                           |
|  97 | flask-login               |                           | 0.6.3                     |                           |
|  98 | flexcache                 | 0.3                       | 0.3                       |                           |
|  99 | flexparser                | 0.4                       | 0.4                       |                           |
| 100 | fonttools                 | 4.50.0                    |                           |                           |
| 101 | frozenlist                | 1.4.1, 1.5.0, 1.7.0, 1.8.0 | 1.4.1, 1.5.0, 1.7.0, 1.8.0 |                           |
| 102 | fsspec                    | 2025.10.0, 2026.2.0       | 2025.10.0                 |                           |
| 103 | gevent                    |                           | 25.9.1                    |                           |
| 104 | geventhttpclient          |                           | 2.3.9                     |                           |
| 105 | googleapis-common-protos  | 1.70.0, 1.72.0, 1.73.0    | 1.73.0                    |                           |
| 106 | graphql-core              |                           | 3.2.8                     |                           |
| 107 | greenlet                  | 3.2.4, 3.3.2              | 3.2.4, 3.3.2              |                           |
| 108 | grpcio                    | 1.68.0, 1.68.1, 1.70.0, 1.71.0, 1.73.1, 1.76.0, 1.78.0 | 1.78.0                    |                           |
| 109 | gunicorn                  | 23.0.0                    |                           |                           |
| 110 | h11                       | 0.16.0                    | 0.16.0                    |                           |
| 111 | h2                        | 4.1.0, 4.2.0, 4.3.0       | 4.2.0, 4.3.0              |                           |
| 112 | hpack                     | 4.0.0, 4.1.0              | 4.1.0                     |                           |
| 113 | httmock                   | 1.4.0                     |                           |                           |
| 114 | httpcore                  | 1.0.9                     | 1.0.9                     |                           |
| 115 | httptools                 | 0.6.4, 0.7.1              | 0.7.1                     |                           |
| 116 | httpx                     | 0.28.1                    | 0.28.1                    |                           |
| 117 | hypercorn                 |                           | 0.17.3                    |                           |
| 118 | hyperframe                | 6.0.1, 6.1.0              | 6.1.0                     |                           |
| 119 | hypothesis                |                           | 6.151.9                   |                           |
| 120 | icdiff                    |                           | 2.0.10                    |                           |
| 121 | identify                  |                           |                           | 2.6.18                    |
| 122 | idna                      | 3.3, 3.6, 3.10, 3.11      | 3.3, 3.6, 3.10, 3.11      |                           |
| 123 | ifaddr                    | 0.2.0                     |                           |                           |
| 124 | importlib-metadata        | 8.0.0, 8.5.0, 8.6.1, 8.7.0, 8.7.1 | 8.7.1                     |                           |
| 125 | iniconfig                 | 2.3.0                     | 2.3.0                     |                           |
| 126 | inotify                   |                           |                           | 0.2.12                    |
| 127 | isort                     |                           |                           | 8.0.1                     |
| 128 | itsdangerous              | 2.2.0                     | 2.2.0                     |                           |
| 129 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 130 | jinja2                    | 3.1.6                     | 3.1.6                     | 3.1.6                     |
| 131 | jinja2-time               | 0.2.0                     |                           |                           |
| 132 | jmespath                  | 1.0.1, 1.1.0              | 1.0.1, 1.1.0              |                           |
| 133 | joserfc                   |                           | 1.6.3                     |                           |
| 134 | jschema-to-python         |                           | 1.2.3                     |                           |
| 135 | jsf                       |                           | 0.11.2                    |                           |
| 136 | jsondiff                  | 2.0.0                     | 2.2.1                     |                           |
| 137 | jsonpatch                 |                           | 1.33                      |                           |
| 138 | jsonpath-ng               |                           | 1.8.0                     |                           |
| 139 | jsonpickle                |                           | 4.1.1                     |                           |
| 140 | jsonpointer               |                           | 3.0.0                     |                           |
| 141 | jsonref                   | 1.1.0                     | 1.1.0                     |                           |
| 142 | jsonschema                | 3.2.0, 4.25.1, 4.26.0     | 3.2.0, 4.25.1, 4.26.0     |                           |
| 143 | jsonschema-path           |                           | 0.3.4                     |                           |
| 144 | jsonschema-specifications | 2023.7.1, 2024.10.1, 2025.4.1, 2025.9.1 | 2023.7.1, 2024.10.1, 2025.4.1, 2025.9.1 |                           |
| 145 | junit-xml                 |                           | 1.9                       |                           |
| 146 | kiwisolver                | 1.4.9                     |                           |                           |
| 147 | kombu                     | 5.6.2                     | 5.6.2                     |                           |
| 148 | lazy-object-proxy         |                           | 1.12.0                    |                           |
| 149 | librt                     |                           | 0.8.1                     | 0.8.1                     |
| 150 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 151 | locust                    |                           | 2.43.3                    |                           |
| 152 | locust-plugins            |                           | 5.0.0                     |                           |
| 153 | lupa                      |                           | 2.6                       |                           |
| 154 | lz4                       | 4.4.5                     |                           |                           |
| 155 | mako                      | 1.3.10                    | 1.3.10                    |                           |
| 156 | markdown-it-py            | 3.0.0, 4.0.0              | 3.0.0, 4.0.0              | 4.0.0                     |
| 157 | markdown2                 | 2.5.3                     |                           |                           |
| 158 | markupsafe                | 3.0.2, 3.0.3              | 3.0.2, 3.0.3              | 3.0.2                     |
| 159 | matplotlib                | 3.10.7                    |                           |                           |
| 160 | mccabe                    |                           |                           | 0.7.0                     |
| 161 | mdurl                     | 0.1.2                     | 0.1.2                     | 0.1.2                     |
| 162 | moto                      |                           | 4.0.1, 5.1.22             |                           |
| 163 | mpmath                    |                           | 1.3.0                     |                           |
| 164 | msgpack                   | 1.1.0, 1.1.2              | 1.1.2                     |                           |
| 165 | multidict                 | 6.0.5, 6.1.0, 6.2.0, 6.6.2, 6.7.0, 6.7.1 | 6.1.0, 6.6.2, 6.7.0, 6.7.1 |                           |
| 166 | mypy                      |                           | 1.19.1                    | 1.19.1                    |
| 167 | mypy-extensions           |                           | 1.1.0                     | 1.1.0                     |
| 168 | narwhals                  | 2.11.0                    | 2.18.0                    |                           |
| 169 | nest-asyncio              | 1.6.0                     |                           |                           |
| 170 | networkx                  | 3.5                       | 2.8.8, 3.6.1              |                           |
| 171 | nicegui                   | 2.23.3                    |                           |                           |
| 172 | nodeenv                   |                           |                           | 1.10.0                    |
| 173 | numpy                     | 2.3.4, 2.3.5              | 2.3.5, 2.4.3              |                           |
| 174 | openapi-schema-validator  |                           | 0.2.3, 0.6.3              |                           |
| 175 | openapi-spec-validator    |                           | 0.4.0, 0.7.2              |                           |
| 176 | openpyxl                  | 3.0.9                     |                           |                           |
| 177 | opentelemetry-api         | 1.40.0                    | 1.40.0                    |                           |
| 178 | opentelemetry-exporter-otlp | 1.40.0                    | 1.40.0                    |                           |
| 179 | opentelemetry-exporter-otlp-proto-common | 1.40.0                    | 1.40.0                    |                           |
| 180 | opentelemetry-exporter-otlp-proto-grpc | 1.40.0                    | 1.40.0                    |                           |
| 181 | opentelemetry-exporter-otlp-proto-http | 1.40.0                    | 1.40.0                    |                           |
| 182 | opentelemetry-instrumentation | 0.61b0                    | 0.61b0                    |                           |
| 183 | opentelemetry-instrumentation-aio-pika | 0.61b0                    | 0.61b0                    |                           |
| 184 | opentelemetry-instrumentation-aiohttp-client | 0.61b0                    |                           |                           |
| 185 | opentelemetry-instrumentation-aiohttp-server | 0.61b0                    |                           |                           |
| 186 | opentelemetry-instrumentation-asgi | 0.61b0                    |                           |                           |
| 187 | opentelemetry-instrumentation-asyncpg | 0.61b0                    | 0.61b0                    |                           |
| 188 | opentelemetry-instrumentation-botocore | 0.61b0                    |                           |                           |
| 189 | opentelemetry-instrumentation-celery | 0.61b0                    |                           |                           |
| 190 | opentelemetry-instrumentation-fastapi | 0.61b0                    |                           |                           |
| 191 | opentelemetry-instrumentation-httpx | 0.61b0                    | 0.61b0                    |                           |
| 192 | opentelemetry-instrumentation-logging | 0.61b0                    | 0.61b0                    |                           |
| 193 | opentelemetry-instrumentation-redis | 0.61b0                    | 0.61b0                    |                           |
| 194 | opentelemetry-instrumentation-requests | 0.61b0                    | 0.61b0                    |                           |
| 195 | opentelemetry-propagator-aws-xray | 1.0.2                     |                           |                           |
| 196 | opentelemetry-proto       | 1.40.0                    | 1.40.0                    |                           |
| 197 | opentelemetry-sdk         | 1.40.0                    | 1.40.0                    |                           |
| 198 | opentelemetry-semantic-conventions | 0.61b0                    | 0.61b0                    |                           |
| 199 | opentelemetry-util-http   | 0.61b0                    | 0.61b0                    |                           |
| 200 | ordered-set               | 4.1.0                     |                           |                           |
| 201 | orderly-set               | 5.2.3                     | 5.5.0                     |                           |
| 202 | orjson                    | 3.11.4, 3.11.7            | 3.11.7                    |                           |
| 203 | osparc                    | 0.8.3                     |                           |                           |
| 204 | osparc-client             | 0.8.3                     |                           |                           |
| 205 | packaging                 | 24.0, 24.1, 24.2, 25.0, 26.0 | 24.0, 24.1, 24.2, 25.0, 26.0 | 24.0, 24.1, 24.2, 25.0, 26.0 |
| 206 | pact-python               |                           | 3.2.1                     |                           |
| 207 | pact-python-ffi           |                           | 0.4.28.1                  |                           |
| 208 | pamqp                     | 3.3.0                     | 3.3.0                     |                           |
| 209 | pandas                    | 2.3.3                     | 3.0.1                     |                           |
| 210 | parse                     | 1.20.2                    | 1.21.1                    |                           |
| 211 | partd                     | 1.4.2                     | 1.4.2                     |                           |
| 212 | passlib                   | 1.7.4                     |                           |                           |
| 213 | pathable                  |                           | 0.4.4                     |                           |
| 214 | pathspec                  |                           | 1.0.4                     | 1.0.4                     |
| 215 | pbr                       |                           | 7.0.3                     |                           |
| 216 | phonenumbers              | 9.0.9                     |                           |                           |
| 217 | pillow                    | 12.0.0                    | 12.1.1                    |                           |
| 218 | pint                      | 0.25, 0.25.2              | 0.25.2                    |                           |
| 219 | pip                       |                           | 26.0.1                    |                           |
| 220 | platformdirs              | 4.3.6, 4.5.0, 4.9.4       | 4.9.4                     | 4.3.6, 4.5.0, 4.9.4       |
| 221 | playwright                |                           | 1.58.0                    |                           |
| 222 | pluggy                    | 1.6.0                     | 1.6.0                     |                           |
| 223 | pprintpp                  |                           | 0.4.0                     |                           |
| 224 | pre-commit                |                           |                           | 4.5.1                     |
| 225 | priority                  |                           | 2.0.0                     |                           |
| 226 | prometheus-api-client     | 0.6.0                     |                           |                           |
| 227 | prometheus-client         | 0.14.1, 0.20.0, 0.21.0, 0.21.1, 0.22.1, 0.23.1 |                           |                           |
| 228 | prompt-toolkit            | 3.0.50, 3.0.51, 3.0.52    | 3.0.50, 3.0.51, 3.0.52    |                           |
| 229 | propcache                 | 0.2.0, 0.2.1, 0.3.0, 0.3.1, 0.3.2, 0.4.1 | 0.2.0, 0.2.1, 0.3.0, 0.3.1, 0.3.2, 0.4.1 |                           |
| 230 | protobuf                  | 5.29.6, 6.33.5            | 6.33.5                    |                           |
| 231 | pscript                   | 0.7.7                     |                           |                           |
| 232 | psutil                    | 6.0.0, 6.1.0, 7.0.0, 7.1.3, 7.2.2 | 6.1.0, 7.0.0, 7.1.3, 7.2.2 |                           |
| 233 | psycogreen                |                           | 1.0.2                     |                           |
| 234 | psycopg2-binary           | 2.9.11                    | 2.9.11                    |                           |
| 235 | ptvsd                     |                           | 4.3.2                     |                           |
| 236 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 237 | py-partiql-parser         |                           | 0.6.3                     |                           |
| 238 | pyasn1                    | 0.6.1                     | 0.6.3                     |                           |
| 239 | pyasynchat                |                           | 1.0.5                     |                           |
| 240 | pyasyncore                |                           | 1.0.5                     |                           |
| 241 | pycountry                 | 23.12.11                  |                           |                           |
| 242 | pycparser                 | 2.21, 2.22                | 2.22, 3.0                 |                           |
| 243 | pycryptodome              | 3.21.0, 3.22.0, 3.23.0    | 3.23.0                    |                           |
| 244 | pydantic                  | 2.11.7, 2.11.10           | 2.11.7, 2.11.10, 2.12.5   |                           |
| 245 | pydantic-core             | 2.33.2                    | 2.33.2, 2.41.5            |                           |
| 246 | pydantic-extra-types      | 2.10.5, 2.10.6, 2.11.1    | 2.11.1                    |                           |
| 247 | pydantic-settings         | 2.7.0                     | 2.7.0, 2.13.1             |                           |
| 248 | pyee                      |                           | 13.0.1                    |                           |
| 249 | pyftpdlib                 |                           | 2.2.0                     |                           |
| 250 | pygments                  | 2.15.1, 2.17.2, 2.18.0, 2.19.1, 2.19.2 | 2.15.1, 2.17.2, 2.18.0, 2.19.1, 2.19.2 | 2.19.2                    |
| 251 | pyinstrument              | 5.1.1, 5.1.2              | 5.1.1, 5.1.2              |                           |
| 252 | pyjwt                     | 2.4.0                     |                           |                           |
| 253 | pyleak                    |                           | 0.2.0                     |                           |
| 254 | pylint                    |                           |                           | 4.0.5                     |
| 255 | pyopenssl                 |                           | 26.0.0                    |                           |
| 256 | pyparsing                 | 3.1.2                     | 3.1.2, 3.3.2              |                           |
| 257 | pyproject-hooks           |                           |                           | 1.2.0                     |
| 258 | pyrsistent                | 0.20.0                    | 0.20.0                    |                           |
| 259 | pytest                    | 9.0.2                     | 9.0.2                     |                           |
| 260 | pytest-aiohttp            |                           | 1.1.0                     |                           |
| 261 | pytest-asyncio            |                           | 1.3.0                     |                           |
| 262 | pytest-base-url           |                           | 2.1.0                     |                           |
| 263 | pytest-benchmark          |                           | 5.2.3                     |                           |
| 264 | pytest-celery             |                           | 1.1.3, 1.3.0              |                           |
| 265 | pytest-cov                |                           | 7.0.0                     |                           |
| 266 | pytest-docker             |                           | 3.2.5                     |                           |
| 267 | pytest-docker-tools       |                           | 3.1.9                     |                           |
| 268 | pytest-html               |                           | 4.2.0                     |                           |
| 269 | pytest-icdiff             |                           | 0.9                       |                           |
| 270 | pytest-instafail          |                           | 0.5.0                     |                           |
| 271 | pytest-localftpserver     |                           | 1.5.0                     |                           |
| 272 | pytest-metadata           |                           | 3.1.1                     |                           |
| 273 | pytest-mock               |                           | 3.15.1                    |                           |
| 274 | pytest-playwright         |                           | 0.7.2                     |                           |
| 275 | pytest-runner             |                           | 6.0.1                     |                           |
| 276 | pytest-sugar              |                           | 1.1.1                     |                           |
| 277 | pytest-timeout            |                           | 2.4.0                     |                           |
| 278 | pytest-xdist              |                           | 3.8.0                     |                           |
| 279 | python-dateutil           | 2.8.2, 2.9.0.post0        | 2.8.2, 2.9.0.post0        |                           |
| 280 | python-discovery          |                           |                           | 1.1.3, 1.2.0              |
| 281 | python-dotenv             | 1.0.1, 1.1.0, 1.1.1, 1.2.1, 1.2.2 | 1.0.1, 1.1.0, 1.1.1, 1.2.1, 1.2.2 |                           |
| 282 | python-engineio           | 4.11.2, 4.12.2, 4.12.3    | 4.12.2, 4.13.1            |                           |
| 283 | python-jose               | 3.3.0                     | 3.5.0                     |                           |
| 284 | python-magic              | 0.4.25, 0.4.27            |                           |                           |
| 285 | python-multipart          | 0.0.19, 0.0.20            | 0.0.22                    |                           |
| 286 | python-slugify            | 8.0.4                     | 8.0.4                     |                           |
| 287 | python-socketio           | 5.13.0, 5.14.3            | 5.13.0, 5.16.1            |                           |
| 288 | pytokens                  |                           |                           | 0.4.1                     |
| 289 | pytz                      | 2022.1, 2024.1, 2025.2    | 2026.1.post1              |                           |
| 290 | pyyaml                    | 6.0.3                     | 6.0.3                     | 6.0.3                     |
| 291 | pyzmq                     |                           | 27.1.0                    |                           |
| 292 | redis                     | 6.4.0, 7.4.0              | 6.4.0, 7.4.0              |                           |
| 293 | referencing               | 0.29.3, 0.35.1            | 0.29.3, 0.35.1, 0.37.0    |                           |
| 294 | regex                     | 2025.11.3                 | 2025.11.3, 2026.2.28      |                           |
| 295 | repro-zipfile             | 0.4.1                     |                           |                           |
| 296 | requests                  | 2.32.4, 2.32.5            | 2.32.4, 2.32.5            |                           |
| 297 | requests-mock             |                           | 1.12.1                    |                           |
| 298 | responses                 |                           | 0.26.0                    |                           |
| 299 | respx                     |                           | 0.22.0                    |                           |
| 300 | rfc3339-validator         |                           | 0.1.4                     |                           |
| 301 | rich                      | 14.1.0, 14.2.0, 14.3.3    | 14.1.0, 14.3.3            | 14.3.3                    |
| 302 | rich-toolkit              | 0.15.0, 0.15.1            | 0.19.7                    |                           |
| 303 | rignore                   | 0.6.4, 0.7.6              | 0.7.6                     |                           |
| 304 | rpds-py                   | 0.28.0, 0.29.0, 0.30.0    | 0.28.0, 0.29.0, 0.30.0    |                           |
| 305 | rsa                       | 4.9                       | 4.9.1                     |                           |
| 306 | rstr                      |                           | 3.2.2                     |                           |
| 307 | ruff                      |                           |                           | 0.15.6, 0.15.7            |
| 308 | s3fs                      | 2025.10.0                 |                           |                           |
| 309 | s3transfer                | 0.11.3, 0.13.0, 0.14.0    | 0.11.3, 0.13.0, 0.14.0, 0.16.0 |                           |
| 310 | sarif-om                  |                           | 1.0.4                     |                           |
| 311 | sentry-sdk                | 2.35.0, 2.44.0            | 2.55.0                    |                           |
| 312 | setproctitle              | 1.3.7                     |                           |                           |
| 313 | setuptools                | 80.9.0                    | 80.9.0, 82.0.1            |                           |
| 314 | sh                        | 2.0.6, 2.2.1, 2.2.2       |                           |                           |
| 315 | shellingham               | 1.5.4                     | 1.5.4                     | 1.5.4                     |
| 316 | shortuuid                 | 1.0.13                    |                           |                           |
| 317 | simple-websocket          | 1.1.0                     | 1.1.0                     |                           |
| 318 | six                       | 1.16.0, 1.17.0            | 1.16.0, 1.17.0            |                           |
| 319 | smart-open                |                           | 7.5.1                     |                           |
| 320 | sniffio                   | 1.3.1                     | 1.3.1                     |                           |
| 321 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 322 | sqlalchemy                | 1.4.54                    | 1.4.54                    |                           |
| 323 | sqlalchemy2-stubs         |                           | 0.0.2a38                  |                           |
| 324 | sshpubkeys                |                           | 3.3.1                     |                           |
| 325 | starlette                 | 0.47.2, 0.49.3            | 0.47.3, 0.52.1            |                           |
| 326 | stream-zip                | 0.0.84                    | 0.0.84                    |                           |
| 327 | swagger-ui-py             | 23.9.23                   |                           |                           |
| 328 | sympy                     |                           | 1.14.0                    |                           |
| 329 | tblib                     | 3.2.2                     | 3.2.2                     |                           |
| 330 | tenacity                  | 8.5.0, 9.0.0, 9.1.2, 9.1.4 | 8.5.0, 9.0.0, 9.1.4       |                           |
| 331 | termcolor                 |                           | 3.3.0                     |                           |
| 332 | text-unidecode            | 1.3                       | 1.3                       |                           |
| 333 | tomlkit                   |                           |                           | 0.14.0                    |
| 334 | toolz                     | 0.12.0, 0.12.1, 1.0.0, 1.1.0 | 1.1.0                     |                           |
| 335 | tornado                   | 6.5.2, 6.5.5              | 6.5.2                     |                           |
| 336 | tqdm                      | 4.64.0, 4.66.2, 4.67.1, 4.67.3 | 4.67.3                    |                           |
| 337 | twilio                    | 7.12.0                    |                           |                           |
| 338 | typer                     | 0.16.1, 0.20.0, 0.24.1    | 0.16.1, 0.24.1            | 0.24.1                    |
| 339 | types-aioboto3            |                           | 15.5.0                    |                           |
| 340 | types-aiobotocore         | 3.3.0                     | 3.3.0                     |                           |
| 341 | types-aiobotocore-ec2     | 3.3.0                     | 3.3.0                     |                           |
| 342 | types-aiobotocore-iam     |                           | 3.3.0                     |                           |
| 343 | types-aiobotocore-s3      | 3.3.0                     | 3.2.1, 3.3.0              |                           |
| 344 | types-aiobotocore-ssm     | 3.3.0                     | 3.3.0                     |                           |
| 345 | types-aiofiles            |                           | 25.1.0.20251011, 25.1.0.20260409 |                           |
| 346 | types-awscrt              | 0.20.5, 0.23.10, 0.27.4, 0.28.4, 0.31.3 | 0.28.4, 0.31.3            |                           |
| 347 | types-boto3               |                           | 1.42.70                   |                           |
| 348 | types-cachetools          |                           |                           | 6.2.0.20260317            |
| 349 | types-docker              |                           | 7.1.0.20260109            |                           |
| 350 | types-jsonschema          |                           | 4.26.0.20260202           |                           |
| 351 | types-networkx            |                           | 3.6.1.20260303            |                           |
| 352 | types-openpyxl            |                           | 3.1.5.20260316            |                           |
| 353 | types-paramiko            |                           | 4.0.0.20250822            |                           |
| 354 | types-passlib             |                           | 1.7.7.20260211            |                           |
| 355 | types-psutil              |                           | 7.2.2.20260130            |                           |
| 356 | types-psycopg2            |                           | 2.9.21.20260223           |                           |
| 357 | types-pyasn1              |                           | 0.6.0.20250914            |                           |
| 358 | types-python-dateutil     | 2.9.0.20240316, 2.9.0.20241003, 2.9.0.20241206, 2.9.0.20250516 |                           |                           |
| 359 | types-python-jose         |                           | 3.5.0.20250531            |                           |
| 360 | types-pyyaml              |                           | 6.0.12.20250915           |                           |
| 361 | types-requests            |                           | 2.32.4.20260107           |                           |
| 362 | types-s3transfer          |                           | 0.16.0                    |                           |
| 363 | types-tqdm                |                           | 4.67.3.20260303           |                           |
| 364 | typing-extensions         | 4.14.1, 4.15.0            | 4.14.1, 4.15.0            | 4.14.1, 4.15.0            |
| 365 | typing-inspection         | 0.4.0, 0.4.1, 0.4.2       | 0.4.1, 0.4.2              |                           |
| 366 | tzdata                    | 2024.1, 2025.2, 2025.3    | 2025.2, 2025.3            |                           |
| 367 | tzlocal                   | 5.2, 5.3.1                | 5.3.1                     |                           |
| 368 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 369 | urllib3                   | 2.6.3                     | 2.6.3                     |                           |
| 370 | uvicorn                   | 0.34.2, 0.35.0, 0.38.0    | 0.42.0                    |                           |
| 371 | uvloop                    | 0.21.0, 0.22.1            | 0.21.0, 0.22.1            |                           |
| 372 | vbuild                    | 0.8.2                     |                           |                           |
| 373 | vine                      | 5.1.0                     | 5.1.0                     |                           |
| 374 | virtualenv                |                           |                           | 21.2.0                    |
| 375 | watchdog                  | 6.0.0                     |                           | 6.0.0                     |
| 376 | watchfiles                | 1.1.1                     | 1.1.1                     |                           |
| 377 | wcwidth                   | 0.2.13, 0.2.14, 0.6.0     | 0.2.13, 0.2.14, 0.6.0     |                           |
| 378 | websocket-client          |                           | 1.9.0                     |                           |
| 379 | websockets                | 12.0, 14.1, 14.2, 15.0.1  | 16.0                      |                           |
| 380 | werkzeug                  | 2.1.2                     | 2.1.2, 3.1.6              |                           |
| 381 | wrapt                     | 1.16.0, 1.17.0, 1.17.2, 1.17.3 | 1.16.0, 1.17.0, 1.17.2, 1.17.3, 2.1.2 |                           |
| 382 | wsproto                   | 1.2.0, 1.3.1              | 1.2.0, 1.3.2              |                           |
| 383 | xmltodict                 |                           | 1.0.4                     |                           |
| 384 | xyzservices               | 2025.10.0                 | 2025.11.0                 |                           |
| 385 | yarl                      | 1.18.0, 1.18.3, 1.20.0, 1.20.1, 1.22.0, 1.23.0 | 1.18.0, 1.18.3, 1.20.0, 1.20.1, 1.22.0, 1.23.0 |                           |
| 386 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 387 | zipp                      | 3.20.1, 3.21.0, 3.23.0    | 3.23.0                    |                           |
| 388 | zope-event                |                           | 6.1                       |                           |
| 389 | zope-interface            |                           | 8.2                       |                           |
