### PR TITLE
🐛 Fixes flaky jupyter-large-files

### DIFF
--- a/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
+++ b/tests/e2e-playwright/tests/jupyterlabs/helpers_jupyter_code.py
@@ -75,10 +75,14 @@ def _execute_cell_and_wait_for_marker(iframe: FrameLocator, code: str, phase_lab
 
         _expect_with_dialog_dismissal(iframe, output_locator, timeout)
 
+        _dismiss_dialogs(iframe)
+
         expect(output_locator).not_to_contain_text(FAIL_MARKER)
 
         # scroll the notebook so the latest output is visible
         output_locator.scroll_into_view_if_needed()
+
+        _dismiss_dialogs(iframe)
 
 
 def _replace_line(s: str, line_start_with: str, replace_with: str) -> str:
@@ -131,3 +135,5 @@ def create_files_in_jupyter(iframe: FrameLocator, large_file_size: ByteSize, lar
                 phase_label=phase_func_name,
                 timeout=timeout,
             )
+
+        _dismiss_dialogs(iframe)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?


<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->

The file changed dialog was not dismissed causing test to get stuck as shown below.
This addresses the issue

<img width="1750" height="686" alt="Screenshot 2026-04-28 at 10 46 50" src="https://github.com/user-attachments/assets/e028268c-27f7-404c-8288-1411a6cdbf5f" />


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
