### PR TITLE
🎨 [Frontend] Enh: App Release Notes

### DIFF
--- a/services/static-webserver/client/source/class/osparc/info/ServiceLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/ServiceLarge.js
@@ -426,10 +426,13 @@ qx.Class.define("osparc.info.ServiceLarge", {
         const link = new osparc.ui.basic.LinkLabel(url, url).set({
           font: "link-label-14",
           toolTipText: url,
-          width: 220,
           maxWidth: 220,
-          wrap: false,
           allowGrowX: false,
+        });
+        // leave ``rich`` set to true. Ellipsis will be handled here:
+        link.getContentElement().setStyles({
+          "text-overflow": "ellipsis",
+          "white-space": "nowrap",
         });
         return link;
       }

--- a/services/static-webserver/client/source/class/osparc/info/ServiceLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/ServiceLarge.js
@@ -427,6 +427,7 @@ qx.Class.define("osparc.info.ServiceLarge", {
           font: "link-label-14",
           toolTipText: url,
           maxWidth: 220,
+          maxHeight: 20,
           allowGrowX: false,
         });
         // leave ``rich`` set to true. Ellipsis will be handled here:

--- a/services/static-webserver/client/source/class/osparc/info/ServiceLarge.js
+++ b/services/static-webserver/client/source/class/osparc/info/ServiceLarge.js
@@ -284,13 +284,13 @@ qx.Class.define("osparc.info.ServiceLarge", {
         },
       };
 
-      if (canIWrite) {
+      if (canIWrite || this.getService()["releaseNotesUrl"]) {
         infoLayout["RELEASE_NOTES_URL"] = {
-          label: this.tr("Release Notes URL"),
+          label: this.tr("Release Notes"),
           view: this.__createReleaseNotesUrl(),
           action: {
             button: osparc.utils.Utils.getEditButton(canIWrite, this.tr("Edit release notes URL")),
-            callback: this.__openReleaseNotesUrlEditor,
+            callback: canIWrite ? this.__openReleaseNotesUrlEditor : null,
             ctx: this,
           },
         };


### PR DESCRIPTION
## What do these changes do?

- [x] Show Release Notes to all users. Only owners can edit them
- [x] Show ellipsis when the Release Notes URL overflows in the service info panel

## Related issue/s
- follows https://github.com/ITISFoundation/osparc-simcore/pull/8874
- closes https://github.com/ITISFoundation/osparc-simcore/issues/9048


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
