### PR TITLE
🐛 Fix progress bar RuntimeError on retry by cleaning up children in `__aexit__`

### DIFF
--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -106,15 +106,18 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
 
     async def __aexit__(self, exc_type, exc_value, traceback) -> None:
         if self._parent is not None:
-            if exc_type is not None:
-                # On error exit, rollback partial progress so a retry does not
-                # over-count. Skip finish() to avoid a spurious 100% report.
-                await self._parent._on_child_error(  # noqa: SLF001
-                    self._compute_progress(self._current_steps)
-                )
-            else:
-                await self.finish()
-            self._parent._on_child_exit(self)  # noqa: SLF001
+            try:
+                if exc_type is not None:
+                    # On error exit, rollback partial progress so a retry does not
+                    # over-count. Skip finish() to avoid a spurious 100% report.
+                    await self._parent._on_child_error(  # noqa: SLF001
+                        self._compute_progress(self._current_steps)
+                    )
+                else:
+                    await self.finish()
+            finally:
+                # Always remove child even on cancellation, so the slot is freed.
+                self._parent._on_child_exit(self)  # noqa: SLF001
         else:
             await self.finish()
 
@@ -126,7 +129,12 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
 
     async def _reset_report_baseline_upwards(self) -> None:
         """Reset _last_report_value to match current progress, then propagate
-        up to all ancestors so deeply nested retries report correctly."""
+        up to all ancestors so deeply nested retries report correctly.
+
+        NOTE: with concurrent siblings this can cause non-monotonic reports,
+        but the class already documents concurrency as unsupported with weights.
+        The retry use case (our primary target) is sequential by definition.
+        """
         async with self._continuous_value_lock:
             self._last_report_value = self._compute_progress(self._current_steps)
         if self._parent is not None:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -104,22 +104,28 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
         await self.start()
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+    async def __aexit__(
+        self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: object
+    ) -> None:
+        await self._finish(failed=exc_type is not None)
+
+    async def _finish(self, *, failed: bool = False) -> None:
+        _logger.debug("finishing %s", f"{self.num_steps} progress")
         if self._parent is not None:
             try:
-                if exc_type is not None:
+                if failed:
                     # On error exit, rollback partial progress so a retry does not
-                    # over-count. Skip finish() to avoid a spurious 100% report.
-                    await self._parent._on_child_error(  # noqa: SLF001
+                    # over-count. Skip set_ to avoid a spurious 100% report.
+                    await self._parent._on_child_error(  # pylint: disable=protected-access # noqa: SLF001
                         self._compute_progress(self._current_steps)
                     )
                 else:
-                    await self.finish()
+                    await self.set_(self.num_steps)
             finally:
                 # Always remove child even on cancellation, so the slot is freed.
-                self._parent._children.remove(self)  # noqa: SLF001
+                self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001
         else:
-            await self.finish()
+            await self.set_(self.num_steps)
 
     async def _on_child_error(self, child_progress_contribution: float) -> None:
         """Rollback a failed child's progress and reset the report baseline
@@ -138,7 +144,7 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
         async with self._continuous_value_lock:
             self._last_report_value = self._compute_progress(self._current_steps)
         if self._parent is not None:
-            await self._parent._reset_report_baseline_upwards()  # noqa: SLF001
+            await self._parent._reset_report_baseline_upwards()  # pylint: disable=protected-access # noqa: SLF001
 
     async def _update_parent(self, value: float) -> None:
         if self._parent:
@@ -232,10 +238,6 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
 
     async def set_(self, new_value: float) -> None:
         await self.update(new_value - self._current_steps)
-
-    async def finish(self) -> None:
-        _logger.debug("finishing %s", f"{self.num_steps} progress")
-        await self.set_(self.num_steps)
 
     def sub_progress(
         self,

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -202,8 +202,7 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
         async with self._continuous_value_lock:
             new_steps_value = self._current_steps + steps
             # NOTE: clamp to 0 because floating-point accumulation drift can
-            # produce tiny negatives (~ -1e-16) after __aexit__ rollback,
-            # and _compute_progress does not accept negative input.
+            # produce tiny negatives (~ -1e-16) after rollback.
             new_steps_value = max(new_steps_value, 0)
             if new_steps_value > self.num_steps:
                 new_steps_value = round(new_steps_value)

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -133,20 +133,15 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
         """Rollback a failed child's progress and reset the report baseline
         so a retry emits intermediate reports from the start."""
         await self.update(-child_progress_contribution)
-        await self._reset_report_baseline_upwards()
+        self._reset_report_baseline_upwards()
 
-    async def _reset_report_baseline_upwards(self) -> None:
-        """Reset _last_report_value to match current progress, then propagate
-        up to all ancestors so deeply nested retries report correctly.
-
-        NOTE: with concurrent siblings this can cause non-monotonic reports,
-        but the class already documents concurrency as unsupported with weights.
-        The retry use case (our primary target) is sequential by definition.
+    def _reset_report_baseline_upwards(self) -> None:
+        """Reset _last_report_value so subsequent reports are not suppressed,
+        then propagate up to all ancestors so deeply nested retries report correctly.
         """
-        async with self._continuous_value_lock:
-            self._last_report_value = self._compute_progress(self._current_steps)
+        self._last_report_value = _INITIAL_VALUE
         if self._parent is not None:
-            await self._parent._reset_report_baseline_upwards()  # pylint: disable=protected-access # noqa: SLF001
+            self._parent._reset_report_baseline_upwards()  # pylint: disable=protected-access # noqa: SLF001
 
     async def _update_parent(self, value: float) -> None:
         if self._parent:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -107,9 +107,14 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
     async def __aexit__(
         self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: object
     ) -> None:
-        await self._finish(failed=exc_type is not None)
+        # Only rollback on non-cancellation errors (retryable failures).
+        # Cancellation means the task is being torn down — no retry will follow,
+        # and running async rollback risks interruption by a second cancellation.
+        cancelled = exc_type is not None and issubclass(exc_type, asyncio.CancelledError)
+        failed = exc_type is not None and not cancelled
+        await self._finish(failed=failed, cancelled=cancelled)
 
-    async def _finish(self, *, failed: bool = False) -> None:
+    async def _finish(self, *, failed: bool = False, cancelled: bool = False) -> None:
         _logger.debug("finishing %s", f"{self.num_steps} progress")
         if self._parent is None:
             await self.set_(self.num_steps)
@@ -118,6 +123,10 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
         # Remove child first so stale state doesn't appear in progress reports
         # during rollback. Synchronous, so cancellation-safe.
         self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001
+        if cancelled:
+            # On cancellation: child removed above, no rollback or completion.
+            # The partial progress stays in the parent as-is.
+            return
         if failed:
             # On error exit, rollback partial progress so a retry does not
             # over-count. Skip set_ to avoid a spurious 100% report.

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -107,15 +107,15 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
     async def __aexit__(
         self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: object
     ) -> None:
-        await self._finish(failed=exc_type is not None)
+        await self._finish(exited_with_exception=exc_type is not None)
 
-    async def _finish(self, *, failed: bool = False) -> None:
+    async def _finish(self, *, exited_with_exception: bool = False) -> None:
         _logger.debug("finishing %s", f"{self.num_steps} progress")
         if self._parent is None:
             await self.set_(self.num_steps)
             return
 
-        if failed:
+        if exited_with_exception:
             # Remove child first so stale state doesn't appear in progress
             # reports during rollback.
             self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -115,19 +115,22 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
             await self.set_(self.num_steps)
             return
 
-        # Remove child first so stale state doesn't appear in progress reports
-        # during rollback. Synchronous, so cancellation-safe.
-        self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001
         if failed:
-            # Roll back partial progress for any non-successful exit so callers
-            # that catch the exception and retry the same sub-step do not
-            # over-count parent progress.
+            # Remove child first so stale state doesn't appear in progress
+            # reports during rollback.
+            self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001
+            # Roll back partial progress so callers that catch the exception
+            # and retry the same sub-step do not over-count parent progress.
             # Skip set_ to avoid a spurious 100% report.
             await self._parent._on_child_error(  # pylint: disable=protected-access # noqa: SLF001
                 self._compute_progress(self._current_steps)
             )
         else:
+            # Complete first, then remove — keeps the slot occupied until
+            # propagation finishes, preventing a concurrent task from
+            # creating a replacement child mid-update.
             await self.set_(self.num_steps)
+            self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001
 
     async def _on_child_error(self, child_progress_contribution: float) -> None:
         """Rollback a failed child's progress and reset the report baseline

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -105,15 +105,19 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback) -> None:
-        await self.finish()
         if self._parent is not None:
             if exc_type is not None:
-                # On error exit, rollback progress contribution so a retry
-                # does not over-count (the retry will create a fresh child)
+                # On error exit, rollback partial progress contribution so a
+                # retry does not over-count (the retry will create a fresh child).
+                # Skip finish() to avoid emitting a spurious 100% report.
                 progress_contribution = self._compute_progress(self._current_steps)
                 await self._parent.update(-progress_contribution)
+            else:
+                await self.finish()
             # Always remove child so the slot can be reused (e.g. on retry)
             self._parent._children.remove(self)  # noqa: SLF001
+        else:
+            await self.finish()
 
     async def _update_parent(self, value: float) -> None:
         if self._parent:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -107,24 +107,27 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
     async def __aexit__(self, exc_type, exc_value, traceback) -> None:
         if self._parent is not None:
             if exc_type is not None:
-                # On error exit, rollback partial progress contribution so a
-                # retry does not over-count (the retry will create a fresh child).
-                # Skip finish() to avoid emitting a spurious 100% report.
-                progress_contribution = self._compute_progress(self._current_steps)
-                await self._parent.update(-progress_contribution)
-                # Restore the parent's report baseline to match the rolled-back
-                # progress, otherwise _last_report_value stays at the failed
-                # attempt's high-water mark and suppresses early retry reports.
-                async with self._parent._continuous_value_lock:  # noqa: SLF001
-                    self._parent._last_report_value = self._parent._compute_progress(  # noqa: SLF001
-                        self._parent._current_steps  # noqa: SLF001
-                    )
+                # On error exit, rollback partial progress so a retry does not
+                # over-count. Skip finish() to avoid a spurious 100% report.
+                await self._parent._on_child_error(  # noqa: SLF001
+                    self._compute_progress(self._current_steps)
+                )
             else:
                 await self.finish()
-            # Always remove child so the slot can be reused (e.g. on retry)
-            self._parent._children.remove(self)  # noqa: SLF001
+            self._parent._on_child_exit(self)  # noqa: SLF001
         else:
             await self.finish()
+
+    async def _on_child_error(self, child_progress_contribution: float) -> None:
+        """Rollback a failed child's progress and reset the report baseline
+        so a retry emits intermediate reports from the start."""
+        await self.update(-child_progress_contribution)
+        async with self._continuous_value_lock:
+            self._last_report_value = self._compute_progress(self._current_steps)
+
+    def _on_child_exit(self, child: "ProgressBarData") -> None:
+        """Remove a child so its slot can be reused (e.g. on retry)."""
+        self._children.remove(child)
 
     async def _update_parent(self, value: float) -> None:
         if self._parent:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -115,18 +115,17 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
             await self.set_(self.num_steps)
             return
 
-        try:
-            if failed:
-                # On error exit, rollback partial progress so a retry does not
-                # over-count. Skip set_ to avoid a spurious 100% report.
-                await self._parent._on_child_error(  # pylint: disable=protected-access # noqa: SLF001
-                    self._compute_progress(self._current_steps)
-                )
-            else:
-                await self.set_(self.num_steps)
-        finally:
-            # Always remove child even on cancellation, so the slot is freed.
-            self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001
+        # Remove child first so stale state doesn't appear in progress reports
+        # during rollback. Synchronous, so cancellation-safe.
+        self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001
+        if failed:
+            # On error exit, rollback partial progress so a retry does not
+            # over-count. Skip set_ to avoid a spurious 100% report.
+            await self._parent._on_child_error(  # pylint: disable=protected-access # noqa: SLF001
+                self._compute_progress(self._current_steps)
+            )
+        else:
+            await self.set_(self.num_steps)
 
     async def _on_child_error(self, child_progress_contribution: float) -> None:
         """Rollback a failed child's progress and reset the report baseline

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -122,8 +122,15 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
         """Rollback a failed child's progress and reset the report baseline
         so a retry emits intermediate reports from the start."""
         await self.update(-child_progress_contribution)
+        await self._reset_report_baseline_upwards()
+
+    async def _reset_report_baseline_upwards(self) -> None:
+        """Reset _last_report_value to match current progress, then propagate
+        up to all ancestors so deeply nested retries report correctly."""
         async with self._continuous_value_lock:
             self._last_report_value = self._compute_progress(self._current_steps)
+        if self._parent is not None:
+            await self._parent._reset_report_baseline_upwards()  # noqa: SLF001
 
     def _on_child_exit(self, child: "ProgressBarData") -> None:
         """Remove a child so its slot can be reused (e.g. on retry)."""

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -112,6 +112,12 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
                 # Skip finish() to avoid emitting a spurious 100% report.
                 progress_contribution = self._compute_progress(self._current_steps)
                 await self._parent.update(-progress_contribution)
+                # Restore the parent's report baseline to match the rolled-back
+                # progress, otherwise _last_report_value stays at the failed
+                # attempt's high-water mark and suppresses early retry reports.
+                self._parent._last_report_value = self._parent._compute_progress(  # noqa: SLF001
+                    self._parent._current_steps  # noqa: SLF001
+                )
             else:
                 await self.finish()
             # Always remove child so the slot can be reused (e.g. on retry)

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -111,21 +111,22 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
 
     async def _finish(self, *, failed: bool = False) -> None:
         _logger.debug("finishing %s", f"{self.num_steps} progress")
-        if self._parent is not None:
-            try:
-                if failed:
-                    # On error exit, rollback partial progress so a retry does not
-                    # over-count. Skip set_ to avoid a spurious 100% report.
-                    await self._parent._on_child_error(  # pylint: disable=protected-access # noqa: SLF001
-                        self._compute_progress(self._current_steps)
-                    )
-                else:
-                    await self.set_(self.num_steps)
-            finally:
-                # Always remove child even on cancellation, so the slot is freed.
-                self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001
-        else:
+        if self._parent is None:
             await self.set_(self.num_steps)
+            return
+
+        try:
+            if failed:
+                # On error exit, rollback partial progress so a retry does not
+                # over-count. Skip set_ to avoid a spurious 100% report.
+                await self._parent._on_child_error(  # pylint: disable=protected-access # noqa: SLF001
+                    self._compute_progress(self._current_steps)
+                )
+            else:
+                await self.set_(self.num_steps)
+        finally:
+            # Always remove child even on cancellation, so the slot is freed.
+            self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001
 
     async def _on_child_error(self, child_progress_contribution: float) -> None:
         """Rollback a failed child's progress and reset the report baseline

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -106,6 +106,14 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
 
     async def __aexit__(self, exc_type, exc_value, traceback) -> None:
         await self.finish()
+        if self._parent is not None:
+            if exc_type is not None:
+                # On error exit, rollback progress contribution so a retry
+                # does not over-count (the retry will create a fresh child)
+                progress_contribution = self._compute_progress(self._current_steps)
+                await self._parent.update(-progress_contribution)
+            # Always remove child so the slot can be reused (e.g. on retry)
+            self._parent._children.remove(self)  # noqa: SLF001
 
     async def _update_parent(self, value: float) -> None:
         if self._parent:
@@ -162,6 +170,10 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
         parent_update_value = 0.0
         async with self._continuous_value_lock:
             new_steps_value = self._current_steps + steps
+            # NOTE: clamp to 0 because floating-point accumulation drift can
+            # produce tiny negatives (~ -1e-16) after __aexit__ rollback,
+            # and _compute_progress does not accept negative input.
+            new_steps_value = max(new_steps_value, 0)
             if new_steps_value > self.num_steps:
                 new_steps_value = round(new_steps_value)
             if new_steps_value > self.num_steps:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -115,9 +115,10 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
                 # Restore the parent's report baseline to match the rolled-back
                 # progress, otherwise _last_report_value stays at the failed
                 # attempt's high-water mark and suppresses early retry reports.
-                self._parent._last_report_value = self._parent._compute_progress(  # noqa: SLF001
-                    self._parent._current_steps  # noqa: SLF001
-                )
+                async with self._parent._continuous_value_lock:  # noqa: SLF001
+                    self._parent._last_report_value = self._parent._compute_progress(  # noqa: SLF001
+                        self._parent._current_steps  # noqa: SLF001
+                    )
             else:
                 await self.finish()
             # Always remove child so the slot can be reused (e.g. on retry)

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -133,7 +133,8 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
     async def _on_child_error(self, child_progress_contribution: float) -> None:
         """Rollback a failed child's progress and reset the report baseline
         so a retry emits intermediate reports from the start."""
-        await self.update(-child_progress_contribution)
+        contribution_to_rollback = max(child_progress_contribution, 0.0)
+        await self.update(-contribution_to_rollback)
         self._reset_report_baseline_upwards()
 
     def _reset_report_baseline_upwards(self) -> None:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -107,14 +107,12 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
     async def __aexit__(
         self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: object
     ) -> None:
-        await self._finish(exited_with_exception=exc_type is not None)
-
-    async def _finish(self, *, exited_with_exception: bool = False) -> None:
         _logger.debug("finishing %s", f"{self.num_steps} progress")
         if self._parent is None:
             await self.set_(self.num_steps)
             return
 
+        exited_with_exception = exc_type is not None
         if exited_with_exception:
             # Remove child first so stale state doesn't appear in progress
             # reports during rollback.

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -117,7 +117,7 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
                     await self.finish()
             finally:
                 # Always remove child even on cancellation, so the slot is freed.
-                self._parent._on_child_exit(self)  # noqa: SLF001
+                self._parent._children.remove(self)  # noqa: SLF001
         else:
             await self.finish()
 
@@ -139,10 +139,6 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
             self._last_report_value = self._compute_progress(self._current_steps)
         if self._parent is not None:
             await self._parent._reset_report_baseline_upwards()  # noqa: SLF001
-
-    def _on_child_exit(self, child: "ProgressBarData") -> None:
-        """Remove a child so its slot can be reused (e.g. on retry)."""
-        self._children.remove(child)
 
     async def _update_parent(self, value: float) -> None:
         if self._parent:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -199,10 +199,9 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
     async def update(self, steps: float = 1) -> None:
         parent_update_value = 0.0
         async with self._continuous_value_lock:
-            new_steps_value = self._current_steps + steps
             # NOTE: clamp to 0 because floating-point accumulation drift can
             # produce tiny negatives (~ -1e-16) after rollback.
-            new_steps_value = max(new_steps_value, 0)
+            new_steps_value = max(self._current_steps + steps, 0)
             if new_steps_value > self.num_steps:
                 new_steps_value = round(new_steps_value)
             if new_steps_value > self.num_steps:

--- a/packages/service-library/src/servicelib/progress_bar.py
+++ b/packages/service-library/src/servicelib/progress_bar.py
@@ -107,14 +107,9 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
     async def __aexit__(
         self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: object
     ) -> None:
-        # Only rollback on non-cancellation errors (retryable failures).
-        # Cancellation means the task is being torn down — no retry will follow,
-        # and running async rollback risks interruption by a second cancellation.
-        cancelled = exc_type is not None and issubclass(exc_type, asyncio.CancelledError)
-        failed = exc_type is not None and not cancelled
-        await self._finish(failed=failed, cancelled=cancelled)
+        await self._finish(failed=exc_type is not None)
 
-    async def _finish(self, *, failed: bool = False, cancelled: bool = False) -> None:
+    async def _finish(self, *, failed: bool = False) -> None:
         _logger.debug("finishing %s", f"{self.num_steps} progress")
         if self._parent is None:
             await self.set_(self.num_steps)
@@ -123,13 +118,11 @@ class ProgressBarData:  # pylint: disable=too-many-instance-attributes
         # Remove child first so stale state doesn't appear in progress reports
         # during rollback. Synchronous, so cancellation-safe.
         self._parent._children.remove(self)  # pylint: disable=protected-access # noqa: SLF001
-        if cancelled:
-            # On cancellation: child removed above, no rollback or completion.
-            # The partial progress stays in the parent as-is.
-            return
         if failed:
-            # On error exit, rollback partial progress so a retry does not
-            # over-count. Skip set_ to avoid a spurious 100% report.
+            # Roll back partial progress for any non-successful exit so callers
+            # that catch the exception and retry the same sub-step do not
+            # over-count parent progress.
+            # Skip set_ to avoid a spurious 100% report.
             await self._parent._on_child_error(  # pylint: disable=protected-access # noqa: SLF001
                 self._compute_progress(self._current_steps)
             )

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -698,3 +698,37 @@ async def test_sub_progress_deeply_nested_retry_emits_intermediate_reports(
         f"First retry report at {first_retry_report.percent_value:.0%} — "
         "ancestor _last_report_value was not reset after rollback"
     )
+
+
+async def test_sub_progress_child_removed_on_cancellation(
+    mocked_progress_bar_cb: mock.Mock,
+) -> None:
+    """When a task is cancelled inside a sub_progress context, the child must
+    still be removed from the parent so the slot is freed for a retry."""
+    async with ProgressBarData(
+        num_steps=2,
+        description="root",
+        progress_report_cb=mocked_progress_bar_cb,
+    ) as root:
+        # Simulate cancellation during first child
+        with pytest.raises(asyncio.CancelledError):  # noqa: PT012
+            async with root.sub_progress(steps=10, description="child-cancelled") as child:
+                await child.update(5)
+                raise asyncio.CancelledError
+
+        # Child must have been removed
+        assert len(root._children) == 0  # noqa: SLF001
+
+        # Parent is still usable — create a new child in the same slot
+        async with root.sub_progress(steps=10, description="child-retry") as child:
+            for _ in range(10):
+                await child.update()
+
+        # Second step proceeds normally
+        async with root.sub_progress(steps=5, description="child-2") as child:
+            for _ in range(5):
+                await child.update()
+
+    # Root completed successfully
+    final_report = mocked_progress_bar_cb.call_args_list[-1].args[0]
+    assert final_report.percent_value == 1.0

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -788,3 +788,40 @@ async def test_sub_progress_nested_exception_does_not_double_rollback():
         # Third step works normally
         await root.update()
         assert root._current_steps == pytest.approx(2)  # noqa: SLF001
+
+
+async def test_sub_progress_retry_with_async_callback(async_mocked_progress_bar_cb: mock.AsyncMock, faker: Faker):
+    """Exercise the retry/rollback path with an async progress_report_cb
+    to ensure awaitable callbacks don't break rollback or report behavior."""
+    async with ProgressBarData(
+        num_steps=1,
+        progress_report_cb=async_mocked_progress_bar_cb,
+        description=faker.pystr(),
+    ) as root:
+        async_mocked_progress_bar_cb.reset_mock()
+
+        # First attempt — partial progress then error
+        with contextlib.suppress(RuntimeError):
+            async with root.sub_progress(steps=100, description="attempt 1") as sub:
+                for _ in range(50):
+                    await sub.update()
+                msg = "simulated failure"
+                raise RuntimeError(msg)
+
+        # No spurious 100% report
+        reports_after_error = [call.args[0] for call in async_mocked_progress_bar_cb.call_args_list]
+        assert all(r.percent_value < 1.0 for r in reports_after_error)
+
+        async_mocked_progress_bar_cb.reset_mock()
+
+        # Retry — completes fully
+        async with root.sub_progress(steps=100, description="attempt 2") as sub:
+            for _ in range(100):
+                await sub.update()
+
+    # Retry reports include intermediates near 0% and end at 1.0
+    retry_reports = [call.args[0] for call in async_mocked_progress_bar_cb.call_args_list]
+    assert retry_reports[-1].percent_value == pytest.approx(1.0)
+    intermediate_reports = [r for r in retry_reports if r.percent_value < 1.0]
+    assert len(intermediate_reports) > 0
+    assert intermediate_reports[0].percent_value < 0.1

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -704,13 +704,13 @@ async def test_sub_progress_child_removed_on_cancellation(
     mocked_progress_bar_cb: mock.Mock,
 ):
     """When a task is cancelled inside a sub_progress context, the child must
-    still be removed from the parent so the slot is freed for a retry."""
+    still be removed and progress rolled back so the same slot can be retried."""
     async with ProgressBarData(
-        num_steps=2,
+        num_steps=1,
         description="root",
         progress_report_cb=mocked_progress_bar_cb,
     ) as root:
-        # Simulate cancellation during first child
+        # Simulate cancellation during child — same slot retry scenario
         with pytest.raises(asyncio.CancelledError):  # noqa: PT012
             async with root.sub_progress(steps=10, description="child-cancelled") as child:
                 await child.update(5)
@@ -718,33 +718,27 @@ async def test_sub_progress_child_removed_on_cancellation(
 
         # Child must have been removed
         assert len(root._children) == 0  # noqa: SLF001
+        # Progress rolled back so retry on same slot doesn't over-count
+        assert root._current_steps == pytest.approx(0)  # noqa: SLF001
 
-        # Parent is still usable — create a new child in the same slot
+        # Retry the same slot — must succeed without over-counting
         async with root.sub_progress(steps=10, description="child-retry") as child:
             for _ in range(10):
                 await child.update()
 
-        # Second step proceeds normally
-        async with root.sub_progress(steps=5, description="child-2") as child:
-            for _ in range(5):
-                await child.update()
-
-    # Root completed successfully
+    # Root completed successfully at exactly 1.0
     final_report = mocked_progress_bar_cb.call_args_list[-1].args[0]
     assert final_report.percent_value == 1.0
 
 
-async def test_sub_progress_cancellation_does_not_rollback(
+async def test_sub_progress_cancellation_rollback_enables_same_slot_retry(
     mocked_progress_bar_cb: mock.Mock,
 ):
-    """CancelledError must NOT trigger async rollback (_on_child_error).
-
-    Rollback involves multiple awaits (update + _reset_report_baseline_upwards)
-    which can be interrupted by a second cancellation if the callback is async,
-    leaving the parent progress in an inconsistent state.  Instead, cancellation
-    should only remove the child (synchronous) and leave parent progress as-is."""
+    """CancelledError must rollback partial progress just like other exceptions,
+    so a caller that catches CancelledError and retries the same sub-step
+    does not over-count parent progress."""
     async with ProgressBarData(
-        num_steps=2,
+        num_steps=1,
         description="root",
         progress_report_cb=mocked_progress_bar_cb,
     ) as root:
@@ -754,9 +748,15 @@ async def test_sub_progress_cancellation_does_not_rollback(
                 await child.update(5)  # 50% of child = 0.5 parent steps
                 raise asyncio.CancelledError
 
-        # Parent progress should NOT be rolled back — the partial contribution stays
-        # (unlike error exit where we rollback for retry)
-        assert root._current_steps == pytest.approx(0.5)  # noqa: SLF001
-
-        # Child was removed
+        # Parent progress must be rolled back to 0
+        assert root._current_steps == pytest.approx(0)  # noqa: SLF001
         assert len(root._children) == 0  # noqa: SLF001
+
+        # Retry on the same slot — completes fully
+        async with root.sub_progress(steps=10, description="retry-child") as child:
+            for _ in range(10):
+                await child.update()
+
+    # Ends at exactly 1.0, not 1.5 (which would happen without rollback)
+    final_report = mocked_progress_bar_cb.call_args_list[-1].args[0]
+    assert final_report.percent_value == pytest.approx(1.0)

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -563,9 +563,10 @@ async def test_sub_progress_parent_progress_decremented_on_error_exit(faker: Fak
 
 
 async def test_sub_progress_retry_reports_correct_progress(mocked_progress_bar_cb: mock.Mock, faker: Faker):
-    """Verify that after an error + retry, the progress callback reports
-    correct values: no spurious 100% from the failed attempt, and the
-    retry reports a monotonically increasing sequence ending at 1.0."""
+    """Verify that after an error + retry, the progress callback:
+    1. Does NOT emit a spurious 100% from the failed attempt
+    2. Emits intermediate reports from near 0% during the retry
+    3. Ends at 1.0"""
     async with ProgressBarData(
         num_steps=1,
         progress_report_cb=mocked_progress_bar_cb,
@@ -581,9 +582,8 @@ async def test_sub_progress_retry_reports_correct_progress(mocked_progress_bar_c
                 msg = "simulated failure"
                 raise RuntimeError(msg)
 
-        # Capture reports from the failed attempt
-        reports_after_error = [call.args[0] for call in mocked_progress_bar_cb.call_args_list]
         # The failed attempt must NOT emit a spurious 1.0 (100%) report
+        reports_after_error = [call.args[0] for call in mocked_progress_bar_cb.call_args_list]
         assert all(r.percent_value < 1.0 for r in reports_after_error), (
             "finish() on error exit emitted a spurious 100% report before rollback"
         )
@@ -595,49 +595,18 @@ async def test_sub_progress_retry_reports_correct_progress(mocked_progress_bar_c
             for _ in range(100):
                 await sub.update()
 
-    # Retry must end at 1.0
-    last_report: ProgressReport = mocked_progress_bar_cb.call_args_list[-1].args[0]
-    assert last_report.percent_value == pytest.approx(1.0)
-
-
-async def test_sub_progress_retry_emits_intermediate_reports(mocked_progress_bar_cb: mock.Mock, faker: Faker):
-    """After an error + retry, intermediate progress reports must be emitted
-    during the retry (not suppressed until the final 1.0).
-    Regression: finish() on error exit advanced _last_report_value to 1.0,
-    causing _report_external to skip all intermediate values in the retry."""
-    async with ProgressBarData(
-        num_steps=1,
-        progress_report_cb=mocked_progress_bar_cb,
-        description=faker.pystr(),
-    ) as root:
-        # First attempt — partial progress then error exit
-        with contextlib.suppress(RuntimeError):
-            async with root.sub_progress(steps=100, description="attempt 1") as sub:
-                for _ in range(50):
-                    await sub.update()
-                msg = "simulated failure"
-                raise RuntimeError(msg)
-
-        mocked_progress_bar_cb.reset_mock()
-
-        # Second attempt — completes fully
-        async with root.sub_progress(steps=100, description="attempt 2") as sub:
-            for _ in range(100):
-                await sub.update()
-
-    # Must have intermediate reports during the retry, not just the final 1.0
+    # Retry reports must include intermediates starting near 0%
     retry_reports = [call.args[0] for call in mocked_progress_bar_cb.call_args_list]
     intermediate_reports = [r for r in retry_reports if r.percent_value < 1.0]
-    assert len(intermediate_reports) > 0, (
-        "No intermediate progress reports emitted during retry — _last_report_value was not reset after rollback"
-    )
-    # The first emitted retry report must be near the beginning (< 10%),
-    # not stuck silent until surpassing the failed attempt's progress (~50%).
+    assert len(intermediate_reports) > 0, "No intermediate progress reports emitted during retry"
     first_retry_report = intermediate_reports[0]
     assert first_retry_report.percent_value < 0.1, (
         f"First retry report at {first_retry_report.percent_value:.0%} — "
         "expected near 0%; _last_report_value was not reset after rollback"
     )
+    # Retry must end at 1.0
+    last_report: ProgressReport = retry_reports[-1]
+    assert last_report.percent_value == pytest.approx(1.0)
 
 
 async def test_sub_progress_retry_with_weighted_parent(mocked_progress_bar_cb: mock.Mock, faker: Faker):
@@ -679,21 +648,6 @@ async def test_sub_progress_retry_with_weighted_parent(mocked_progress_bar_cb: m
             f"First retry report at {first_retry_report.percent_value:.0%} — "
             "weighted rollback did not reset report baseline"
         )
-
-
-async def test_sub_progress_guard_still_prevents_too_many_concurrent_children(faker: Faker):
-    """The RuntimeError guard must still trigger when trying to create
-    more sub_progress children than num_steps *concurrently*
-    (i.e., without exiting previous ones)."""
-    async with ProgressBarData(num_steps=2, description=faker.pystr()) as root:
-        sub1 = root.sub_progress(steps=10, description="child 1")
-        sub2 = root.sub_progress(steps=10, description="child 2")
-        with pytest.raises(RuntimeError, match="Too many sub progresses"):
-            root.sub_progress(steps=10, description="child 3")
-        async with sub1:
-            pass
-        async with sub2:
-            pass
 
 
 async def test_sub_progress_multiple_sequential_reuse(faker: Faker):

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -564,7 +564,8 @@ async def test_sub_progress_parent_progress_decremented_on_error_exit(faker: Fak
 
 async def test_sub_progress_retry_reports_correct_progress(mocked_progress_bar_cb: mock.Mock, faker: Faker):
     """Verify that after an error + retry, the progress callback reports
-    correct values (not over-counted from the previous attempt)."""
+    correct values: no spurious 100% from the failed attempt, and the
+    retry reports a monotonically increasing sequence ending at 1.0."""
     async with ProgressBarData(
         num_steps=1,
         progress_report_cb=mocked_progress_bar_cb,
@@ -580,13 +581,56 @@ async def test_sub_progress_retry_reports_correct_progress(mocked_progress_bar_c
                 msg = "simulated failure"
                 raise RuntimeError(msg)
 
+        # Capture reports from the failed attempt
+        reports_after_error = [call.args[0] for call in mocked_progress_bar_cb.call_args_list]
+        # The failed attempt must NOT emit a spurious 1.0 (100%) report
+        assert all(r.percent_value < 1.0 for r in reports_after_error), (
+            "finish() on error exit emitted a spurious 100% report before rollback"
+        )
+
+        mocked_progress_bar_cb.reset_mock()
+
         # Second attempt — completes fully
         async with root.sub_progress(steps=100, description="attempt 2") as sub:
             for _ in range(100):
                 await sub.update()
 
+    # Retry must end at 1.0
     last_report: ProgressReport = mocked_progress_bar_cb.call_args_list[-1].args[0]
     assert last_report.percent_value == pytest.approx(1.0)
+
+
+async def test_sub_progress_retry_emits_intermediate_reports(mocked_progress_bar_cb: mock.Mock, faker: Faker):
+    """After an error + retry, intermediate progress reports must be emitted
+    during the retry (not suppressed until the final 1.0).
+    Regression: finish() on error exit advanced _last_report_value to 1.0,
+    causing _report_external to skip all intermediate values in the retry."""
+    async with ProgressBarData(
+        num_steps=1,
+        progress_report_cb=mocked_progress_bar_cb,
+        description=faker.pystr(),
+    ) as root:
+        # First attempt — partial progress then error exit
+        with contextlib.suppress(RuntimeError):
+            async with root.sub_progress(steps=100, description="attempt 1") as sub:
+                for _ in range(50):
+                    await sub.update()
+                msg = "simulated failure"
+                raise RuntimeError(msg)
+
+        mocked_progress_bar_cb.reset_mock()
+
+        # Second attempt — completes fully
+        async with root.sub_progress(steps=100, description="attempt 2") as sub:
+            for _ in range(100):
+                await sub.update()
+
+    # Must have intermediate reports during the retry, not just the final 1.0
+    retry_reports = [call.args[0] for call in mocked_progress_bar_cb.call_args_list]
+    intermediate_reports = [r for r in retry_reports if r.percent_value < 1.0]
+    assert len(intermediate_reports) > 0, (
+        "No intermediate progress reports emitted during retry — _last_report_value was not reset after rollback"
+    )
 
 
 async def test_sub_progress_guard_still_prevents_too_many_concurrent_children(faker: Faker):

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -705,3 +705,42 @@ async def test_sub_progress_multiple_sequential_reuse(faker: Faker):
                 for _ in range(10):
                     await sub.update()
         assert len(root._children) == 0  # noqa: SLF001
+
+
+async def test_sub_progress_deeply_nested_retry_emits_intermediate_reports(
+    mocked_progress_bar_cb: mock.Mock, faker: Faker
+):
+    """In a root -> mid -> leaf nesting, when the leaf fails and retries,
+    intermediate reports must be emitted at the root level (not suppressed
+    because an ancestor's _last_report_value was left at the old high-water mark)."""
+    async with (
+        ProgressBarData(
+            num_steps=1,
+            progress_report_cb=mocked_progress_bar_cb,
+            description=faker.pystr(),
+        ) as root,
+        root.sub_progress(steps=1, description="mid") as mid,
+    ):
+        # First attempt at leaf — fails after partial progress
+        with contextlib.suppress(RuntimeError):
+            async with mid.sub_progress(steps=100, description="leaf attempt 1") as leaf:
+                for _ in range(50):
+                    await leaf.update()
+                msg = "simulated failure"
+                raise RuntimeError(msg)
+
+        mocked_progress_bar_cb.reset_mock()
+
+        # Retry leaf — should emit intermediate reports from near 0%
+        async with mid.sub_progress(steps=100, description="leaf attempt 2") as leaf:
+            for _ in range(100):
+                await leaf.update()
+
+    retry_reports = [call.args[0] for call in mocked_progress_bar_cb.call_args_list]
+    intermediate_reports = [r for r in retry_reports if r.percent_value < 1.0]
+    assert len(intermediate_reports) > 0, "No intermediate reports during deeply nested retry"
+    first_retry_report = intermediate_reports[0]
+    assert first_retry_report.percent_value < 0.1, (
+        f"First retry report at {first_retry_report.percent_value:.0%} — "
+        "ancestor _last_report_value was not reset after rollback"
+    )

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -640,6 +640,47 @@ async def test_sub_progress_retry_emits_intermediate_reports(mocked_progress_bar
     )
 
 
+async def test_sub_progress_retry_with_weighted_parent(mocked_progress_bar_cb: mock.Mock, faker: Faker):
+    """Retry on a weighted parent must correctly rollback and re-report
+    progress using weighted _compute_progress (not just steps/num_steps)."""
+    async with ProgressBarData(
+        num_steps=2,
+        step_weights=[3, 1],
+        progress_report_cb=mocked_progress_bar_cb,
+        description=faker.pystr(),
+    ) as root:
+        # First step (weight=3/4 of total) — fails after partial progress
+        with contextlib.suppress(RuntimeError):
+            async with root.sub_progress(steps=100, description="attempt 1") as sub:
+                for _ in range(50):
+                    await sub.update()
+                msg = "simulated failure"
+                raise RuntimeError(msg)
+
+        # Parent progress should be rolled back to 0
+        assert root._current_steps == pytest.approx(0)  # noqa: SLF001
+
+        mocked_progress_bar_cb.reset_mock()
+
+        # Retry the first step — completes fully
+        async with root.sub_progress(steps=100, description="attempt 2") as sub:
+            for _ in range(100):
+                await sub.update()
+
+        # Parent should have advanced by the first step's weight (3/4)
+        assert root._current_steps == pytest.approx(1)  # noqa: SLF001
+
+        # Reports during retry should start near 0%, not at 37.5% (half of 3/4)
+        retry_reports = [call.args[0] for call in mocked_progress_bar_cb.call_args_list]
+        intermediate_reports = [r for r in retry_reports if r.percent_value < 0.75]
+        assert len(intermediate_reports) > 0
+        first_retry_report = intermediate_reports[0]
+        assert first_retry_report.percent_value < 0.1, (
+            f"First retry report at {first_retry_report.percent_value:.0%} — "
+            "weighted rollback did not reset report baseline"
+        )
+
+
 async def test_sub_progress_guard_still_prevents_too_many_concurrent_children(faker: Faker):
     """The RuntimeError guard must still trigger when trying to create
     more sub_progress children than num_steps *concurrently*

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -702,7 +702,7 @@ async def test_sub_progress_deeply_nested_retry_emits_intermediate_reports(
 
 async def test_sub_progress_child_removed_on_cancellation(
     mocked_progress_bar_cb: mock.Mock,
-) -> None:
+):
     """When a task is cancelled inside a sub_progress context, the child must
     still be removed from the parent so the slot is freed for a retry."""
     async with ProgressBarData(

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -5,6 +5,7 @@
 # pylint: disable=protected-access
 
 import asyncio
+import contextlib
 from unittest import mock
 
 import pytest
@@ -309,13 +310,11 @@ async def test_too_many_sub_progress_bars_raises(faker: Faker):
         async with root.sub_progress(steps=50, description=faker.pystr()) as sub:
             for _ in range(50):
                 await sub.update()
-        async with root.sub_progress(steps=50, description=faker.pystr()) as sub:
-            for _ in range(50):
-                await sub.update()
-
-        with pytest.raises(RuntimeError):
-            async with root.sub_progress(steps=50, description=faker.pystr()) as sub:
-                ...
+            async with root.sub_progress(steps=50, description=faker.pystr()) as sub2:
+                for _ in range(50):
+                    await sub2.update()
+                with pytest.raises(RuntimeError):
+                    root.sub_progress(steps=50, description=faker.pystr())
 
 
 async def test_too_many_updates_does_not_raise_but_show_warning_with_stack(
@@ -503,3 +502,114 @@ async def test_concurrent_sub_progress_update_correct_sub_progress(mocked_progre
         assert sub_progress3._current_steps == 12  # noqa: SLF001
         assert mocked_progress_bar_cb.call_count == 2
         assert mocked_progress_bar_cb.call_args.args[0].percent_value == pytest.approx(2 / 6)
+
+
+# -------------------------------------------------------------------
+# Tests for sub_progress child cleanup on __aexit__ (retry support)
+# -------------------------------------------------------------------
+
+
+async def test_sub_progress_child_removed_from_parent_on_exit(faker: Faker):
+    """After a sub_progress context manager exits, the child should be
+    removed from the parent's _children list so a new sub_progress can
+    be created for the same step (e.g. on retry)."""
+    async with ProgressBarData(num_steps=1, description=faker.pystr()) as root:
+        async with root.sub_progress(steps=10, description=faker.pystr()) as sub:
+            for _ in range(10):
+                await sub.update()
+        assert len(root._children) == 0  # noqa: SLF001
+
+
+async def test_sub_progress_retry_creates_new_child_after_error_exit(faker: Faker):
+    """Simulates a retry scenario: first sub_progress exits via exception,
+    then a new sub_progress is created on the same parent with num_steps=1.
+    This should succeed (not raise RuntimeError)."""
+    async with ProgressBarData(num_steps=1, description=faker.pystr()) as root:
+        # First attempt — fails with an exception after partial progress
+        with contextlib.suppress(RuntimeError):
+            async with root.sub_progress(steps=100, description="attempt 1") as sub:
+                for _ in range(50):
+                    await sub.update()
+                msg = "simulated upload failure"
+                raise RuntimeError(msg)
+        # Second attempt (retry) — must NOT raise RuntimeError
+        async with root.sub_progress(steps=100, description="attempt 2") as sub:
+            for _ in range(100):
+                await sub.update()
+
+
+async def test_sub_progress_parent_progress_decremented_on_error_exit(faker: Faker):
+    """When a child exits via exception, the parent's _current_steps
+    should be rolled back so a retry doesn't over-count progress."""
+    async with ProgressBarData(num_steps=2, description=faker.pystr()) as root:
+        await root.update()
+        assert root._current_steps == pytest.approx(1)  # noqa: SLF001
+
+        # First attempt via sub_progress — fails with exception
+        with contextlib.suppress(RuntimeError):
+            async with root.sub_progress(steps=10, description="attempt 1") as sub:
+                for _ in range(5):
+                    await sub.update()
+                msg = "simulated failure"
+                raise RuntimeError(msg)
+        # Child exited via exception — parent progress rolled back
+        assert root._current_steps == pytest.approx(1)  # noqa: SLF001
+
+        # Retry creates a new child for the same step
+        async with root.sub_progress(steps=10, description="attempt 2") as sub:
+            for _ in range(10):
+                await sub.update()
+        assert root._current_steps == pytest.approx(2)  # noqa: SLF001
+
+
+async def test_sub_progress_retry_reports_correct_progress(mocked_progress_bar_cb: mock.Mock, faker: Faker):
+    """Verify that after an error + retry, the progress callback reports
+    correct values (not over-counted from the previous attempt)."""
+    async with ProgressBarData(
+        num_steps=1,
+        progress_report_cb=mocked_progress_bar_cb,
+        description=faker.pystr(),
+    ) as root:
+        mocked_progress_bar_cb.reset_mock()
+
+        # First attempt — partial progress then error exit
+        with contextlib.suppress(RuntimeError):
+            async with root.sub_progress(steps=100, description="attempt 1") as sub:
+                for _ in range(50):
+                    await sub.update()
+                msg = "simulated failure"
+                raise RuntimeError(msg)
+
+        # Second attempt — completes fully
+        async with root.sub_progress(steps=100, description="attempt 2") as sub:
+            for _ in range(100):
+                await sub.update()
+
+    last_report: ProgressReport = mocked_progress_bar_cb.call_args_list[-1].args[0]
+    assert last_report.percent_value == pytest.approx(1.0)
+
+
+async def test_sub_progress_guard_still_prevents_too_many_concurrent_children(faker: Faker):
+    """The RuntimeError guard must still trigger when trying to create
+    more sub_progress children than num_steps *concurrently*
+    (i.e., without exiting previous ones)."""
+    async with ProgressBarData(num_steps=2, description=faker.pystr()) as root:
+        sub1 = root.sub_progress(steps=10, description="child 1")
+        sub2 = root.sub_progress(steps=10, description="child 2")
+        with pytest.raises(RuntimeError, match="Too many sub progresses"):
+            root.sub_progress(steps=10, description="child 3")
+        async with sub1:
+            pass
+        async with sub2:
+            pass
+
+
+async def test_sub_progress_multiple_sequential_reuse(faker: Faker):
+    """Create and exit more sub_progress children than num_steps,
+    but sequentially (one at a time). Should succeed after fix."""
+    async with ProgressBarData(num_steps=1, description=faker.pystr()) as root:
+        for i in range(5):
+            async with root.sub_progress(steps=10, description=f"attempt {i}") as sub:
+                for _ in range(10):
+                    await sub.update()
+        assert len(root._children) == 0  # noqa: SLF001

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -631,6 +631,13 @@ async def test_sub_progress_retry_emits_intermediate_reports(mocked_progress_bar
     assert len(intermediate_reports) > 0, (
         "No intermediate progress reports emitted during retry — _last_report_value was not reset after rollback"
     )
+    # The first emitted retry report must be near the beginning (< 10%),
+    # not stuck silent until surpassing the failed attempt's progress (~50%).
+    first_retry_report = intermediate_reports[0]
+    assert first_retry_report.percent_value < 0.1, (
+        f"First retry report at {first_retry_report.percent_value:.0%} — "
+        "expected near 0%; _last_report_value was not reset after rollback"
+    )
 
 
 async def test_sub_progress_guard_still_prevents_too_many_concurrent_children(faker: Faker):

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -732,3 +732,31 @@ async def test_sub_progress_child_removed_on_cancellation(
     # Root completed successfully
     final_report = mocked_progress_bar_cb.call_args_list[-1].args[0]
     assert final_report.percent_value == 1.0
+
+
+async def test_sub_progress_cancellation_does_not_rollback(
+    mocked_progress_bar_cb: mock.Mock,
+):
+    """CancelledError must NOT trigger async rollback (_on_child_error).
+
+    Rollback involves multiple awaits (update + _reset_report_baseline_upwards)
+    which can be interrupted by a second cancellation if the callback is async,
+    leaving the parent progress in an inconsistent state.  Instead, cancellation
+    should only remove the child (synchronous) and leave parent progress as-is."""
+    async with ProgressBarData(
+        num_steps=2,
+        description="root",
+        progress_report_cb=mocked_progress_bar_cb,
+    ) as root:
+        # First child makes partial progress then gets cancelled
+        with pytest.raises(asyncio.CancelledError):  # noqa: PT012
+            async with root.sub_progress(steps=10, description="cancelled-child") as child:
+                await child.update(5)  # 50% of child = 0.5 parent steps
+                raise asyncio.CancelledError
+
+        # Parent progress should NOT be rolled back — the partial contribution stays
+        # (unlike error exit where we rollback for retry)
+        assert root._current_steps == pytest.approx(0.5)  # noqa: SLF001
+
+        # Child was removed
+        assert len(root._children) == 0  # noqa: SLF001

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -729,3 +729,62 @@ async def test_sub_progress_cancellation_rolls_back_and_allows_same_slot_retry(
     # Ends at exactly 1.0, not 1.5 (which would happen without rollback)
     final_report = mocked_progress_bar_cb.call_args_list[-1].args[0]
     assert final_report.percent_value == pytest.approx(1.0)
+
+
+async def test_sub_progress_real_task_cancellation_removes_child_and_rolls_back():
+    """Verify cleanup works with real task cancellation via task.cancel(),
+    not just a manually raised CancelledError."""
+
+    async def _worker(root: ProgressBarData) -> None:
+        async with root.sub_progress(steps=100, description="worker") as child:
+            for _ in range(50):
+                await child.update()
+            # Simulate a long await where cancellation arrives
+            await asyncio.sleep(10)
+
+    async with ProgressBarData(num_steps=1, description="root") as root:
+        task = asyncio.create_task(_worker(root))
+        # Let the worker make progress
+        await asyncio.sleep(0)
+        # Cancel the task for real
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        # Child must have been removed and progress rolled back
+        assert len(root._children) == 0  # noqa: SLF001
+        assert root._current_steps == pytest.approx(0)  # noqa: SLF001
+
+        # Same slot is reusable
+        async with root.sub_progress(steps=100, description="retry") as child:
+            for _ in range(100):
+                await child.update()
+
+    assert root._current_steps == pytest.approx(1)  # noqa: SLF001
+
+
+async def test_sub_progress_nested_exception_does_not_double_rollback():
+    """When root -> mid -> leaf and leaf raises, the exception propagates
+    through both mid and leaf __aexit__. Verify that root's steps completed
+    BEFORE mid are preserved (no double subtraction)."""
+    async with ProgressBarData(num_steps=3, description="root") as root:
+        # Complete first step manually
+        await root.update()
+        assert root._current_steps == pytest.approx(1)  # noqa: SLF001
+
+        # Second step via nested sub_progress that fails
+        with contextlib.suppress(RuntimeError):
+            async with root.sub_progress(steps=1, description="mid") as mid:
+                async with mid.sub_progress(steps=100, description="leaf") as leaf:
+                    for _ in range(50):
+                        await leaf.update()
+                    msg = "boom"
+                    raise RuntimeError(msg)
+
+        # Root should be at exactly 1 — the first manual step is preserved,
+        # mid's partial contribution (from leaf) is fully rolled back.
+        assert root._current_steps == pytest.approx(1)  # noqa: SLF001
+
+        # Third step works normally
+        await root.update()
+        assert root._current_steps == pytest.approx(2)  # noqa: SLF001

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -585,7 +585,7 @@ async def test_sub_progress_retry_reports_correct_progress(mocked_progress_bar_c
         # The failed attempt must NOT emit a spurious 1.0 (100%) report
         reports_after_error = [call.args[0] for call in mocked_progress_bar_cb.call_args_list]
         assert all(r.percent_value < 1.0 for r in reports_after_error), (
-            "finish() on error exit emitted a spurious 100% report before rollback"
+            "Error exit emitted a spurious 100% report before rollback"
         )
 
         mocked_progress_bar_cb.reset_mock()

--- a/packages/service-library/tests/test_progress_bar.py
+++ b/packages/service-library/tests/test_progress_bar.py
@@ -700,41 +700,10 @@ async def test_sub_progress_deeply_nested_retry_emits_intermediate_reports(
     )
 
 
-async def test_sub_progress_child_removed_on_cancellation(
+async def test_sub_progress_cancellation_rolls_back_and_allows_same_slot_retry(
     mocked_progress_bar_cb: mock.Mock,
 ):
-    """When a task is cancelled inside a sub_progress context, the child must
-    still be removed and progress rolled back so the same slot can be retried."""
-    async with ProgressBarData(
-        num_steps=1,
-        description="root",
-        progress_report_cb=mocked_progress_bar_cb,
-    ) as root:
-        # Simulate cancellation during child — same slot retry scenario
-        with pytest.raises(asyncio.CancelledError):  # noqa: PT012
-            async with root.sub_progress(steps=10, description="child-cancelled") as child:
-                await child.update(5)
-                raise asyncio.CancelledError
-
-        # Child must have been removed
-        assert len(root._children) == 0  # noqa: SLF001
-        # Progress rolled back so retry on same slot doesn't over-count
-        assert root._current_steps == pytest.approx(0)  # noqa: SLF001
-
-        # Retry the same slot — must succeed without over-counting
-        async with root.sub_progress(steps=10, description="child-retry") as child:
-            for _ in range(10):
-                await child.update()
-
-    # Root completed successfully at exactly 1.0
-    final_report = mocked_progress_bar_cb.call_args_list[-1].args[0]
-    assert final_report.percent_value == 1.0
-
-
-async def test_sub_progress_cancellation_rollback_enables_same_slot_retry(
-    mocked_progress_bar_cb: mock.Mock,
-):
-    """CancelledError must rollback partial progress just like other exceptions,
+    """CancelledError must rollback partial progress and remove the child,
     so a caller that catches CancelledError and retries the same sub-step
     does not over-count parent progress."""
     async with ProgressBarData(
@@ -742,15 +711,15 @@ async def test_sub_progress_cancellation_rollback_enables_same_slot_retry(
         description="root",
         progress_report_cb=mocked_progress_bar_cb,
     ) as root:
-        # First child makes partial progress then gets cancelled
+        # Child makes partial progress then gets cancelled
         with pytest.raises(asyncio.CancelledError):  # noqa: PT012
             async with root.sub_progress(steps=10, description="cancelled-child") as child:
                 await child.update(5)  # 50% of child = 0.5 parent steps
                 raise asyncio.CancelledError
 
-        # Parent progress must be rolled back to 0
-        assert root._current_steps == pytest.approx(0)  # noqa: SLF001
+        # Child removed and parent progress rolled back to 0
         assert len(root._children) == 0  # noqa: SLF001
+        assert root._current_steps == pytest.approx(0)  # noqa: SLF001
 
         # Retry on the same slot — completes fully
         async with root.sub_progress(steps=10, description="retry-child") as child:

--- a/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
+++ b/packages/simcore-sdk/tests/unit/test_node_data_data_manager.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterator
 from filecmp import cmpfiles
 from pathlib import Path
 from shutil import copy, make_archive
+from unittest import mock
 
 import pytest
 from faker import Faker
@@ -221,15 +222,16 @@ async def test_pull_legacy_archive(
         )
     assert progress_bar._current_steps == pytest.approx(1)  # noqa: SLF001
     mock_temporary_directory.assert_called_once()
+    archive_stem = f"{test_folder.stem}_legacy" if create_legacy_archive else test_folder.stem
     mock_filemanager.download_path_from_s3.assert_called_once_with(
         user_id=user_id,
         local_path=test_compression_folder,
-        s3_object=f"{project_id}/{node_uuid}/{f'{test_folder.stem}_legacy' if create_legacy_archive else test_folder.stem}.zip",
+        s3_object=f"{project_id}/{node_uuid}/{archive_stem}.zip",
         store_id=SIMCORE_LOCATION,
         store_name=None,
         io_log_redirect_cb=mock_io_log_redirect_cb,
         r_clone_settings=None,
-        progress_bar=progress_bar._children[0],  # noqa: SLF001
+        progress_bar=mock.ANY,
     )
 
     matches, mismatches, errors = cmpfiles(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->

Addresses this issue https://github.com/ITISFoundation/osparc-issues/issues/2025 which presents when a progress bar was mixed with a retry.

### Before (broken)

`__aexit__` called `set_(num_steps)` unconditionally and **never removed the child** from `_parent._children`. This meant:

1. **Retry impossible** — calling `sub_progress()` in a retry loop raised `RuntimeError("Too many sub progresses")` because completed/failed children permanently occupied slots.
2. **Progress over-counting on error** — a failed child's partial progress was kept in the parent, and `set_(num_steps)` emitted a spurious 100% completion report before the exception propagated.
3. **No intermediate reports on retry** — `_last_report_value` kept the high-water mark from the failed attempt, suppressing all reports below it on retry.

### After (fixed)

`__aexit__` delegates to `_finish(failed=...)` which handles two paths:

| Exit type | Behavior |
|---|---|
| **Success** | Complete child (`set_`), then remove from parent — slot stays occupied during propagation to prevent races with concurrent `sub_progress()` calls |
| **Error/Cancellation** | Remove child immediately, then rollback partial progress from parent and reset report baseline upwards through all ancestors |

**Key properties:**
- `sub_progress()` slots are now freed on exit, enabling sequential retry on the same slot
- The `len(children) == num_steps` guard still prevents too many *simultaneous* children
- Failed children never emit a 100% report
- Retry attempts emit intermediate progress reports starting from near 0%
- Deeply nested retries (root → mid → leaf) correctly propagate baseline resets
- Floating-point drift after rollback is clamped to 0

---


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-issues/issues/2025
- https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
