### PR TITLE
🎨 [Frontend] ``State paths`` feedback

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_dynamic_sidecar/state_paths.py
+++ b/packages/models-library/src/models_library/api_schemas_dynamic_sidecar/state_paths.py
@@ -8,7 +8,9 @@ from models_library.utils.enums import StrAutoEnum
 
 
 class MountActivityStatus(StrAutoEnum):
-    FILES_UPLOAD_ONGOING = auto()
+    FILES_UPLOAD_QUEUED = auto()
+    FILES_UPLOAD_UPLOADING = auto()
+    FILES_UPLOAD_QUEUED_AND_UPLOADING = auto()
     FILES_UPLOAD_ENDED = auto()
 
 

--- a/packages/models-library/src/models_library/api_schemas_dynamic_sidecar/state_paths.py
+++ b/packages/models-library/src/models_library/api_schemas_dynamic_sidecar/state_paths.py
@@ -1,6 +1,6 @@
 from enum import auto
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
@@ -18,3 +18,6 @@ class StatePathsStatus(BaseModel):
     project_id: ProjectID
     node_id: NodeID
     status: MountActivityStatus
+    vfs_write_back_s: int = Field(
+        description="Effective --vfs-write-back value in seconds from rclone mount settings",
+    )

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_container.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_container.py
@@ -23,7 +23,7 @@ from tenacity import (
     wait_fixed,
 )
 
-from ..r_clone_utils import overwrite_command
+from ..r_clone_utils import get_effective_vfs_write_back_seconds, overwrite_command
 from . import _docker_utils
 from ._config_provider import CONFIG_KEY
 from ._errors import (
@@ -101,7 +101,7 @@ async def _get_rclone_mount_command(
     index: NonNegativeInt,
     rc_user: str,
     rc_password: str,
-) -> str:
+) -> tuple[str, int]:
     escaped_remote_path = f"{remote_path}".lstrip("/")
     target_cache_path = get_vfs_cache_path(index)
 
@@ -164,20 +164,20 @@ async def _get_rclone_mount_command(
         "--allow-non-empty",
         "--allow-other",
     ]
-    r_clone_command = " ".join(
-        overwrite_command(
-            command_parts,
-            edit=mount_settings.R_CLONE_SIMCORE_SDK_MOUNT_COMMAND_EDIT_ARGUMENTS,
-            remove=mount_settings.R_CLONE_SIMCORE_SDK_MOUNT_COMMAND_REMOVE_ARGUMENTS,
-        )
+    resolved_parts = overwrite_command(
+        command_parts,
+        edit=mount_settings.R_CLONE_SIMCORE_SDK_MOUNT_COMMAND_EDIT_ARGUMENTS,
+        remove=mount_settings.R_CLONE_SIMCORE_SDK_MOUNT_COMMAND_REMOVE_ARGUMENTS,
     )
+    vfs_write_back_s = get_effective_vfs_write_back_seconds(resolved_parts)
+    r_clone_command = " ".join(resolved_parts)
     return _R_CLONE_MOUNT_TEMPLATE.format(
         r_clone_config_path=mount_settings.R_CLONE_SIMCORE_SDK_MOUNT_CONTAINER_CONFIG_FILE_PATH,
         r_clone_config_content=r_clone_config_content,
         r_clone_command=r_clone_command,
         local_mount_path=local_mount_path,
         target_cache_path=target_cache_path,
-    )
+    ), vfs_write_back_s
 
 
 class ContainerManager:  # pylint:disable=too-many-instance-attributes
@@ -207,35 +207,39 @@ class ContainerManager:  # pylint:disable=too-many-instance-attributes
 
         self.delegate = delegate
 
+        self.vfs_write_back_s: NonNegativeInt = 0
+
     @cached_property
     def _r_clone_container_name(self) -> str:
         mount_id = get_mount_id(self.local_mount_path, self.index)
         return f"{DYNAMIC_SIDECAR_RCLONE_CONTAINER_PREFIX}-{self.node_id}-{mount_id}"[:63]
 
-    async def create(self):
+    async def create(self) -> None:
         # ensure nothing was left from previous runs
         await self.delegate.remove_container(self._r_clone_container_name)
 
         mount_settings = self.r_clone_settings.R_CLONE_SIMCORE_SDK_MOUNT_SETTINGS
+        command, vfs_write_back_s = await _get_rclone_mount_command(
+            self.delegate,
+            mount_settings=mount_settings,
+            r_clone_config_content=self.r_clone_config_content,
+            remote_path=self.remote_path,
+            local_mount_path=self.local_mount_path,
+            index=self.index,
+            rc_user=self.rc_user,
+            rc_password=self.rc_password,
+        )
         await _docker_utils.create_r_clone_container(
             self.delegate,
             self._r_clone_container_name,
-            command=await _get_rclone_mount_command(
-                self.delegate,
-                mount_settings=mount_settings,
-                r_clone_config_content=self.r_clone_config_content,
-                remote_path=self.remote_path,
-                local_mount_path=self.local_mount_path,
-                index=self.index,
-                rc_user=self.rc_user,
-                rc_password=self.rc_password,
-            ),
+            command=command,
             r_clone_version=await get_r_clone_version(),
             rc_port=self.rc_port,
             local_mount_path=self.local_mount_path,
             memory_limit=mount_settings.R_CLONE_SIMCORE_SDK_MOUNT_CONTAINER_MEMORY_LIMIT,
             nano_cpus=mount_settings.R_CLONE_SIMCORE_SDK_MOUNT_CONTAINER_NANO_CPUS,
         )
+        self.vfs_write_back_s = vfs_write_back_s
 
     async def remove(self):
         await self.delegate.remove_container(self._r_clone_container_name)

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_manager.py
@@ -59,6 +59,7 @@ class _TrackedMount:  # pylint:disable=too-many-instance-attributes
         self._last_mount_activity_update: datetime = datetime.fromtimestamp(0, UTC)
         self._task_mount_activity: asyncio.Task[None] | None = None
         self._consecutive_unresponsive_count: int = 0
+        self._vfs_write_back_s: NonNegativeInt = 0
 
         rc_user = f"{uuid4()}"
         rc_password = f"{uuid4()}"
@@ -99,10 +100,12 @@ class _TrackedMount:  # pylint:disable=too-many-instance-attributes
     async def _worker_mount_activity(self) -> None:
         with log_catch(logger=_logger, reraise=False):
             mount_activity = await self._rc_http_client.get_mount_activity()
+            mount_activity.vfs_write_back_s = self._vfs_write_back_s
             await self._update_and_notify_mount_activity(mount_activity)
 
     async def start_mount(self) -> None:
         await self._container_manager.create()
+        self._vfs_write_back_s = self._container_manager.vfs_write_back_s
 
         await self._rc_http_client.wait_for_interface_to_be_ready()
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_models.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_models.py
@@ -16,6 +16,7 @@ type FilesInTransfer = dict[FileName, ProgressReport]
 class MountActivity(BaseModel):
     in_transfer: FilesInTransfer
     queued: list[FileName]
+    vfs_write_back_s: int = 0
 
 
 class DelegateInterface(ABC):

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_utils.py
@@ -1,7 +1,9 @@
+import contextlib
 import datetime
 import logging
+import re
 from copy import deepcopy
-from typing import Union
+from typing import Final, Union
 
 from models_library.utils.change_case import snake_to_camel
 from pydantic import BaseModel, ByteSize, ConfigDict, Field, TypeAdapter, validate_call
@@ -146,3 +148,33 @@ def overwrite_command(source_command: list[str], *, edit: EditArguments, remove:
             )
 
     return new_command
+
+
+_VFS_WRITE_BACK_FLAG: Final[str] = "--vfs-write-back"
+
+
+def get_effective_vfs_write_back_seconds(resolved_command: list[str]) -> int:
+    """Extracts the effective --vfs-write-back value in seconds from a resolved rclone command."""
+    if _VFS_WRITE_BACK_FLAG not in resolved_command:
+        return 0
+    idx = resolved_command.index(_VFS_WRITE_BACK_FLAG)
+    value_str = resolved_command[idx + 1]
+    return _parse_rclone_duration_to_seconds(value_str)
+
+
+def _parse_rclone_duration_to_seconds(duration_str: str) -> int:
+    """Parse rclone-style duration strings like '30s', '1m', '1m30s', '2h' to seconds."""
+    total = 0
+    for match in re.finditer(r"(\d+)\s*(h|m|s)", duration_str):
+        value = int(match.group(1))
+        unit = match.group(2)
+        if unit == "h":
+            total += value * 3600
+        elif unit == "m":
+            total += value * 60
+        elif unit == "s":
+            total += value
+    if total == 0:
+        with contextlib.suppress(ValueError):
+            total = int(duration_str)
+    return total

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_utils.py
@@ -183,7 +183,7 @@ def get_effective_vfs_write_back_seconds(resolved_command: list[str]) -> int:
 def _parse_rclone_duration_to_seconds(duration_str: str) -> int:
     """Parse rclone-style duration strings like '30s', '1m', '1m30s', '2h' to seconds."""
     total = 0
-    for match in re.finditer(r"(\d+)\s*(h|m|s)", duration_str):
+    for match in re.finditer(r"(\d+)\s*([hms])", duration_str):
         value = int(match.group(1))
         unit = match.group(2)
         if unit == "h":

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_utils.py
@@ -154,12 +154,30 @@ _VFS_WRITE_BACK_FLAG: Final[str] = "--vfs-write-back"
 
 
 def get_effective_vfs_write_back_seconds(resolved_command: list[str]) -> int:
-    """Extracts the effective --vfs-write-back value in seconds from a resolved rclone command."""
+    """Extracts the effective --vfs-write-back value in seconds from a resolved rclone command.
+
+    Raises:
+        ValueError: If the flag is missing or has no value
+    """
     if _VFS_WRITE_BACK_FLAG not in resolved_command:
-        return 0
+        msg = f"'{_VFS_WRITE_BACK_FLAG}' not found in resolved command={resolved_command}"
+        raise ValueError(msg)
+
     idx = resolved_command.index(_VFS_WRITE_BACK_FLAG)
+    if idx + 1 >= len(resolved_command):
+        msg = f"'{_VFS_WRITE_BACK_FLAG}' is missing its value in resolved command={resolved_command}"
+        raise ValueError(msg)
+
     value_str = resolved_command[idx + 1]
-    return _parse_rclone_duration_to_seconds(value_str)
+    total = _parse_rclone_duration_to_seconds(value_str)
+    if total == 0 and value_str.strip() not in {"0", "0s", "0m", "0h"}:
+        _logger.warning(
+            "could not parse value '%s' for '%s' in resolved command='%s'",
+            value_str,
+            _VFS_WRITE_BACK_FLAG,
+            resolved_command,
+        )
+    return total
 
 
 def _parse_rclone_duration_to_seconds(duration_str: str) -> int:

--- a/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_mount_vfs_write_back.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_mount_vfs_write_back.py
@@ -1,0 +1,63 @@
+# pylint: disable=protected-access
+
+import pytest
+from settings_library.r_clone import SimcoreSDKMountSettings
+from simcore_sdk.node_ports_common.r_clone_utils import (
+    _parse_rclone_duration_to_seconds,
+    get_effective_vfs_write_back_seconds,
+    overwrite_command,
+)
+
+
+@pytest.mark.parametrize(
+    "duration_str, expected_seconds",
+    [
+        pytest.param("30s", 30, id="30s"),
+        pytest.param("5s", 5, id="5s"),
+        pytest.param("1m", 60, id="1m"),
+        pytest.param("1m30s", 90, id="1m30s"),
+        pytest.param("2h", 7200, id="2h"),
+        pytest.param("1h30m", 5400, id="1h30m"),
+        pytest.param("60", 60, id="plain-integer"),
+    ],
+)
+def test_parse_rclone_duration_to_seconds(duration_str: str, expected_seconds: int):
+    assert _parse_rclone_duration_to_seconds(duration_str) == expected_seconds
+
+
+def test_parse_rclone_duration_invalid_returns_zero():
+    assert _parse_rclone_duration_to_seconds("invalid") == 0
+
+
+def _resolve(settings: SimcoreSDKMountSettings) -> list[str]:
+    command_parts = ["rclone", "mount", "--vfs-write-back", "30s", "--cache-dir", "/some-folder"]
+    return overwrite_command(
+        command_parts,
+        edit=settings.R_CLONE_SIMCORE_SDK_MOUNT_COMMAND_EDIT_ARGUMENTS,
+        remove=settings.R_CLONE_SIMCORE_SDK_MOUNT_COMMAND_REMOVE_ARGUMENTS,
+    )
+
+
+def test_get_effective_vfs_write_back_seconds_default():
+    resolved = _resolve(SimcoreSDKMountSettings())
+    assert get_effective_vfs_write_back_seconds(resolved) == 30
+
+
+def test_get_effective_vfs_write_back_seconds_with_edit():
+    settings = SimcoreSDKMountSettings(
+        R_CLONE_SIMCORE_SDK_MOUNT_COMMAND_EDIT_ARGUMENTS={
+            "--vfs-write-back": ("--vfs-write-back", "5s"),
+        }
+    )
+    resolved = _resolve(settings)
+    assert get_effective_vfs_write_back_seconds(resolved) == 5
+
+
+def test_get_effective_vfs_write_back_seconds_with_removal():
+    settings = SimcoreSDKMountSettings(
+        R_CLONE_SIMCORE_SDK_MOUNT_COMMAND_REMOVE_ARGUMENTS=[
+            ("--vfs-write-back", 2),
+        ]
+    )
+    resolved = _resolve(settings)
+    assert get_effective_vfs_write_back_seconds(resolved) == 0

--- a/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_mount_vfs_write_back.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_mount_vfs_write_back.py
@@ -60,4 +60,10 @@ def test_get_effective_vfs_write_back_seconds_with_removal():
         ]
     )
     resolved = _resolve(settings)
-    assert get_effective_vfs_write_back_seconds(resolved) == 0
+    with pytest.raises(ValueError, match="not found"):
+        get_effective_vfs_write_back_seconds(resolved)
+
+
+def test_get_effective_vfs_write_back_seconds_flag_without_value():
+    with pytest.raises(ValueError, match="missing its value"):
+        get_effective_vfs_write_back_seconds(["rclone", "mount", "--vfs-write-back"])

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/notifications/_notifications_state_paths.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/notifications/_notifications_state_paths.py
@@ -16,6 +16,12 @@ class StatePathsNotifier:
     project_id: ProjectID
     node_id: NodeID
 
-    async def send_state_paths_status(self, status: MountActivityStatus) -> None:
+    async def send_state_paths_status(self, status: MountActivityStatus, *, vfs_write_back_s: int) -> None:
         notifier: Notifier = Notifier.get_from_app_state(self.app)
-        await notifier.notify_state_paths_status(self.user_id, self.project_id, self.node_id, status)
+        await notifier.notify_state_paths_status(
+            self.user_id,
+            self.project_id,
+            self.node_id,
+            status,
+            vfs_write_back_s=vfs_write_back_s,
+        )

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/notifications/_notifier.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/notifications/_notifier.py
@@ -90,7 +90,13 @@ class Notifier(SingletonInAppStateMixin):
         )
 
     async def notify_state_paths_status(
-        self, user_id: UserID, project_id: ProjectID, node_id: NodeID, status: MountActivityStatus
+        self,
+        user_id: UserID,
+        project_id: ProjectID,
+        node_id: NodeID,
+        status: MountActivityStatus,
+        *,
+        vfs_write_back_s: int,
     ) -> None:
         await self._sio_manager.emit(
             SOCKET_IO_STATE_PATHS_EVENT,
@@ -99,6 +105,7 @@ class Notifier(SingletonInAppStateMixin):
                     project_id=project_id,
                     node_id=node_id,
                     status=status,
+                    vfs_write_back_s=vfs_write_back_s,
                 )
             ),
             room=SocketIORoomStr.from_user_id(user_id),

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/r_clone_mount_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/r_clone_mount_manager.py
@@ -140,7 +140,7 @@ class DynamicSidecarRCloneMountDelegate(DelegateInterface):
         _logger.info("%s mount activity for  %s", state_path, summary)
 
         status_ = resolve_mount_activity_status(summary)
-        await self.state_paths_notifier.send_state_paths_status(status_)
+        await self.state_paths_notifier.send_state_paths_status(status_, vfs_write_back_s=activity.vfs_write_back_s)
 
     async def request_shutdown(self) -> None:
         client = get_rabbitmq_rpc_client(self.app)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/r_clone_mount_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/r_clone_mount_manager.py
@@ -129,7 +129,17 @@ class DynamicSidecarRCloneMountDelegate(DelegateInterface):
         if summary.files_queued == 0 and len(summary.files_in_transfer) == 0:
             await self.state_paths_notifier.send_state_paths_status(MountActivityStatus.FILES_UPLOAD_ENDED)
             return
-        await self.state_paths_notifier.send_state_paths_status(MountActivityStatus.FILES_UPLOAD_ONGOING)
+        if summary.files_queued > 0 and len(summary.files_in_transfer) == 0:
+            await self.state_paths_notifier.send_state_paths_status(MountActivityStatus.FILES_UPLOAD_QUEUED)
+            return
+        if summary.files_queued == 0 and len(summary.files_in_transfer) > 0:
+            await self.state_paths_notifier.send_state_paths_status(MountActivityStatus.FILES_UPLOAD_UPLOADING)
+            return
+        if summary.files_queued > 0 and len(summary.files_in_transfer) > 0:
+            await self.state_paths_notifier.send_state_paths_status(
+                MountActivityStatus.FILES_UPLOAD_QUEUED_AND_UPLOADING
+            )
+            return
 
     async def request_shutdown(self) -> None:
         client = get_rabbitmq_rpc_client(self.app)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/r_clone_mount_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/r_clone_mount_manager.py
@@ -54,6 +54,19 @@ class _MountActivitySummary:
     files_in_transfer: FilesInTransfer
 
 
+def resolve_mount_activity_status(summary: _MountActivitySummary) -> MountActivityStatus:
+    has_queued = summary.files_queued > 0
+    has_in_transfer = len(summary.files_in_transfer) > 0
+
+    if has_queued and has_in_transfer:
+        return MountActivityStatus.FILES_UPLOAD_QUEUED_AND_UPLOADING
+    if has_queued:
+        return MountActivityStatus.FILES_UPLOAD_QUEUED
+    if has_in_transfer:
+        return MountActivityStatus.FILES_UPLOAD_UPLOADING
+    return MountActivityStatus.FILES_UPLOAD_ENDED
+
+
 @asynccontextmanager
 async def _get_docker_client() -> AsyncIterator[Docker]:
     async with Docker() as client:
@@ -126,20 +139,8 @@ class DynamicSidecarRCloneMountDelegate(DelegateInterface):
         summary = _MountActivitySummary(files_queued=len(activity.queued), files_in_transfer=activity.in_transfer)
         _logger.info("%s mount activity for  %s", state_path, summary)
 
-        if summary.files_queued == 0 and len(summary.files_in_transfer) == 0:
-            await self.state_paths_notifier.send_state_paths_status(MountActivityStatus.FILES_UPLOAD_ENDED)
-            return
-        if summary.files_queued > 0 and len(summary.files_in_transfer) == 0:
-            await self.state_paths_notifier.send_state_paths_status(MountActivityStatus.FILES_UPLOAD_QUEUED)
-            return
-        if summary.files_queued == 0 and len(summary.files_in_transfer) > 0:
-            await self.state_paths_notifier.send_state_paths_status(MountActivityStatus.FILES_UPLOAD_UPLOADING)
-            return
-        if summary.files_queued > 0 and len(summary.files_in_transfer) > 0:
-            await self.state_paths_notifier.send_state_paths_status(
-                MountActivityStatus.FILES_UPLOAD_QUEUED_AND_UPLOADING
-            )
-            return
+        status_ = resolve_mount_activity_status(summary)
+        await self.state_paths_notifier.send_state_paths_status(status_)
 
     async def request_shutdown(self) -> None:
         client = get_rabbitmq_rpc_client(self.app)

--- a/services/dynamic-sidecar/tests/unit/test_modules_notifier.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_notifier.py
@@ -409,7 +409,7 @@ async def test_state_paths_notifier_send_state_paths_status(
         on_state_paths_events: list[AsyncMock] = [_get_on_state_paths_spy(c) for c in frontend_clients]
 
         state_paths_notifier = StatePathsNotifier(app, user_id, project_id, node_id)
-        await state_paths_notifier.send_state_paths_status(mount_activity_status)
+        await state_paths_notifier.send_state_paths_status(mount_activity_status, vfs_write_back_s=30)
 
         # check that all clients received it
         for on_state_paths_event in on_state_paths_events:
@@ -420,6 +420,7 @@ async def test_state_paths_notifier_send_state_paths_status(
                         project_id=project_id,
                         node_id=node_id,
                         status=mount_activity_status,
+                        vfs_write_back_s=30,
                     )
                 )
             )

--- a/services/dynamic-sidecar/tests/unit/test_modules_r_clone_mount_manager.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_r_clone_mount_manager.py
@@ -1,0 +1,47 @@
+import pytest
+from models_library.api_schemas_dynamic_sidecar.state_paths import MountActivityStatus
+from simcore_service_dynamic_sidecar.modules.r_clone_mount_manager import (
+    _MountActivitySummary,
+    resolve_mount_activity_status,
+)
+
+
+@pytest.mark.parametrize(
+    "files_queued, files_in_transfer, expected_status",
+    [
+        pytest.param(
+            0,
+            {},
+            MountActivityStatus.FILES_UPLOAD_ENDED,
+            id=MountActivityStatus.FILES_UPLOAD_ENDED,
+        ),
+        pytest.param(
+            3,
+            {},
+            MountActivityStatus.FILES_UPLOAD_QUEUED,
+            id=MountActivityStatus.FILES_UPLOAD_QUEUED,
+        ),
+        pytest.param(
+            0,
+            {"file1.dat": {"bytes_transferred": 100, "total_bytes": 200}},
+            MountActivityStatus.FILES_UPLOAD_UPLOADING,
+            id=MountActivityStatus.FILES_UPLOAD_UPLOADING,
+        ),
+        pytest.param(
+            2,
+            {"file1.dat": {"bytes_transferred": 50, "total_bytes": 100}},
+            MountActivityStatus.FILES_UPLOAD_QUEUED_AND_UPLOADING,
+            id=MountActivityStatus.FILES_UPLOAD_QUEUED_AND_UPLOADING,
+        ),
+    ],
+)
+def test_resolve_mount_activity_status(
+    files_queued: int,
+    files_in_transfer: dict,
+    expected_status: MountActivityStatus,
+):
+    summary = _MountActivitySummary(
+        files_queued=files_queued,
+        files_in_transfer=files_in_transfer,
+    )
+    assert resolve_mount_activity_status(summary) == expected_status

--- a/services/static-webserver/client/source/class/osparc/dashboard/ContextBreadcrumbs.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/ContextBreadcrumbs.js
@@ -112,8 +112,8 @@ qx.Class.define("osparc.dashboard.ContextBreadcrumbs", {
           this.__changeFolder(folderId);
         }, this);
         folderButton.set({
-          backgroundColor: "transparent",
-          textColor: "text",
+          appearance: "form-button-transparent",
+          font: "text-14",
           gap: 5
         });
         return folderButton;
@@ -122,7 +122,9 @@ qx.Class.define("osparc.dashboard.ContextBreadcrumbs", {
     },
 
     __createArrow: function() {
-      return new qx.ui.basic.Label("/");
+      return new qx.ui.basic.Label("/").set({
+        font: "text-14",
+      });
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowserHeader.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowserHeader.js
@@ -26,7 +26,9 @@ qx.Class.define("osparc.dashboard.StudyBrowserHeader", {
   construct: function() {
     this.base(arguments);
 
-    this._setLayout(new qx.ui.layout.HBox(10));
+    this._setLayout(new qx.ui.layout.HBox(10).set({
+      alignY: "middle",
+    }));
 
     this.set({
       minHeight: this.self().HEIGHT,
@@ -113,7 +115,7 @@ qx.Class.define("osparc.dashboard.StudyBrowserHeader", {
           break;
         case "title":
           control = new qx.ui.basic.Label().set({
-            font: "text-16",
+            font: "text-14",
             alignY: "middle",
           });
           this._addAt(control, this.self().POS.TITLE);
@@ -288,7 +290,7 @@ qx.Class.define("osparc.dashboard.StudyBrowserHeader", {
             workspace.bind("accessRights", this, "accessRights");
             workspace.bind("myAccessRights", this, "myAccessRights");
           } else {
-            this.__setIcon("@FontAwesome5Solid/home/24");
+            this.__setIcon("@FontAwesome5Solid/home/18");
             title.setValue(this.tr("My Workspace"));
           }
           break;
@@ -298,22 +300,22 @@ qx.Class.define("osparc.dashboard.StudyBrowserHeader", {
           title.setValue(this.tr("Shared Workspaces"));
           break;
         case osparc.dashboard.StudyBrowser.CONTEXT.TEMPLATES: {
-          this.__setIcon("@FontAwesome5Solid/copy/24");
+          this.__setIcon("@FontAwesome5Solid/copy/18");
           title.setValue(this.tr("Templates"));
           break;
         }
         case osparc.dashboard.StudyBrowser.CONTEXT.PUBLIC_TEMPLATES: {
-          this.__setIcon("@FontAwesome5Solid/globe/24");
+          this.__setIcon("@FontAwesome5Solid/globe/18");
           title.setValue(this.tr("Public Projects"));
           break;
         }
         case osparc.dashboard.StudyBrowser.CONTEXT.FUNCTIONS: {
-          this.__setIcon("@MaterialIcons/functions/26");
+          this.__setIcon("@MaterialIcons/functions/20");
           title.setValue(this.tr("Functions"));
           break;
         }
         case osparc.dashboard.StudyBrowser.CONTEXT.TRASH: {
-          this.__setIcon("@FontAwesome5Solid/trash/24");
+          this.__setIcon("@FontAwesome5Solid/trash/18");
           title.setValue(this.tr("Recently Deleted"));
           const trashDays = osparc.store.StaticInfo.getTrashRetentionDays();
           description.set({
@@ -323,23 +325,23 @@ qx.Class.define("osparc.dashboard.StudyBrowserHeader", {
           break;
         }
         case osparc.dashboard.StudyBrowser.CONTEXT.SEARCH_PROJECTS:
-          this.__setIcon("@FontAwesome5Solid/search/24");
+          this.__setIcon("@FontAwesome5Solid/search/18");
           title.setValue(this.tr("My Projects results"));
           break;
         case osparc.dashboard.StudyBrowser.CONTEXT.SEARCH_TEMPLATES:
-          this.__setIcon("@FontAwesome5Solid/search/24");
+          this.__setIcon("@FontAwesome5Solid/search/18");
           title.setValue(this.tr("Templates results"));
           break;
         case osparc.dashboard.StudyBrowser.CONTEXT.SEARCH_PUBLIC_TEMPLATES:
-          this.__setIcon("@FontAwesome5Solid/search/24");
+          this.__setIcon("@FontAwesome5Solid/search/18");
           title.setValue(this.tr("Public Projects results"));
           break;
         case osparc.dashboard.StudyBrowser.CONTEXT.SEARCH_FUNCTIONS:
-          this.__setIcon("@FontAwesome5Solid/search/24");
+          this.__setIcon("@FontAwesome5Solid/search/18");
           title.setValue(this.tr("Functions results"));
           break;
         case osparc.dashboard.StudyBrowser.CONTEXT.SEARCH_FILES:
-          this.__setIcon("@FontAwesome5Solid/search/24");
+          this.__setIcon("@FontAwesome5Solid/search/18");
           title.setValue(this.tr("Files results"));
           break;
       }

--- a/services/static-webserver/client/source/class/osparc/data/model/Study.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Study.js
@@ -255,6 +255,13 @@ qx.Class.define("osparc.data.model.Study", {
       event: "changeSavePending",
       init: false
     },
+
+    saveFilesPending: {
+      check: [null, "Uploading", "Queued"],
+      nullable: true,
+      event: "changeSaveFilesPending",
+      init: false
+    },
   },
 
   events: {
@@ -289,6 +296,7 @@ qx.Class.define("osparc.data.model.Study", {
       // "trashedAt", // backend sets it
       // "trashedBy", // backend sets it
       // "savePending", // frontend only
+      // "saveFilesPending", // frontend only
     ],
 
     // Properties of the Study class that should not be serialized
@@ -300,6 +308,7 @@ qx.Class.define("osparc.data.model.Study", {
       "readOnly",
       "trashedAt",
       "savePending",
+      "saveFilesPending",
     ],
 
     OwnPatch: [

--- a/services/static-webserver/client/source/class/osparc/data/model/Study.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Study.js
@@ -260,7 +260,7 @@ qx.Class.define("osparc.data.model.Study", {
       check: [null, "Uploading", "Queued"],
       nullable: true,
       event: "changeSaveFilesPending",
-      init: false
+      init: null,
     },
   },
 

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -354,8 +354,9 @@ qx.Class.define("osparc.desktop.StudyEditor", {
         }, this);
       }
 
+      // Show real-time feedback in the navigation bar when the dynamic-sidecar backend is syncing/uploading files via rclone.
       if (!socket.slotExists("statePaths")) {
-        // rclone queues files for 30s (--vfs-write-back) before uploading.
+        // rclone queues files for 30s (--vfs-write-back) before uploading. The backend will push this value.
         // To avoid showing "Queued" for that long, we delay the first display
         // so it only appears briefly before uploading starts.
         // After the first upload cycle, subsequent queues are shown immediately.
@@ -365,21 +366,21 @@ qx.Class.define("osparc.desktop.StudyEditor", {
 
         let queuedTimerId = null;
         let isFirstCycle = true;
-
         const showQueued = () => {
           if (this.getStudy()) {
             this.getStudy().setSaveFilesPending("Queued");
           }
         };
-
         const showUploading = () => {
-          this.getStudy().setSaveFilesPending("Uploading");
+          if (this.getStudy()) {
+            this.getStudy().setSaveFilesPending("Uploading");
+          }
         };
-
         const clearStatus = () => {
-          this.getStudy().setSaveFilesPending(null);
+          if (this.getStudy()) {
+            this.getStudy().setSaveFilesPending(null);
+          }
         };
-
         const cancelTimer = () => {
           if (queuedTimerId !== null) {
             clearTimeout(queuedTimerId);

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -358,10 +358,12 @@ qx.Class.define("osparc.desktop.StudyEditor", {
         socket.on("statePaths", data => {
           console.log("Received statePaths update", data);
           if (data["project_id"] === this.getStudy().getUuid()) {
-            if (data["status"] === "FILES_UPLOAD_ONGOING") {
-              this.getStudy().setSavePending(true);
+            if (data["status"] === "FILES_UPLOAD_QUEUED") {
+              this.getStudy().setSaveFilesPending("Queued");
+            } else if (["FILES_UPLOAD_UPLOADING", "FILES_UPLOAD_QUEUED_AND_UPLOADING"].includes(data["status"])) {
+              this.getStudy().setSaveFilesPending("Uploading");
             } else if (data["status"] === "FILES_UPLOAD_ENDED") {
-              this.getStudy().setSavePending(false);
+              this.getStudy().setSaveFilesPending(null);
             }
           }
         }, this);

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -391,9 +391,7 @@ qx.Class.define("osparc.desktop.StudyEditor", {
           if (!this.getStudy() || data["project_id"] !== this.getStudy().getUuid()) {
             return;
           }
-
           const status = data["status"];
-
           if (status === "FILES_UPLOAD_QUEUED") {
             if (!isFirstCycle) {
               showQueued();

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -360,7 +360,7 @@ qx.Class.define("osparc.desktop.StudyEditor", {
           if (data["project_id"] === this.getStudy().getUuid()) {
             if (data["status"] === "FILES_UPLOAD_ONGOING") {
               this.getStudy().setSavePending(true);
-            } else if (data["status"] === "FILES_UPLOADED") {
+            } else if (data["status"] === "FILES_UPLOAD_ENDED") {
               this.getStudy().setSavePending(false);
             }
           }

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -358,30 +358,42 @@ qx.Class.define("osparc.desktop.StudyEditor", {
         // Delay showing the "Queued" state to avoid a long 30s wait
         // caused by rclone's --vfs-write-back interval.
         // If uploading starts or ends before the delay, the timer is cancelled.
+        // If files are re-queued after an upload cycle, show "Queued" immediately.
         const rcloneQueuingTime = 30;
         const displayMessageFor = 5;
         const queuedDisplayDelay = (rcloneQueuingTime - displayMessageFor) * 1000;
         let queuedTimerId = null;
+        let hadActivity = false;
         socket.on("statePaths", data => {
-          if (data["project_id"] === this.getStudy().getUuid()) {
-            const status = data["status"];
-            if (status === "FILES_UPLOAD_QUEUED") {
-              if (queuedTimerId === null) {
-                queuedTimerId = setTimeout(() => {
-                  queuedTimerId = null;
-                  this.getStudy().setSaveFilesPending("Queued");
-                }, queuedDisplayDelay);
-              }
-            } else {
-              if (queuedTimerId !== null) {
-                clearTimeout(queuedTimerId);
+          if (!this.getStudy() || data["project_id"] !== this.getStudy().getUuid()) {
+            return;
+          }
+          const status = data["status"];
+          if (status === "FILES_UPLOAD_QUEUED") {
+            if (hadActivity) {
+              // Already shown activity before, show "Queued" immediately
+              this.getStudy().setSaveFilesPending("Queued");
+            } else if (queuedTimerId === null) {
+              queuedTimerId = setTimeout(() => {
                 queuedTimerId = null;
-              }
-              if (["FILES_UPLOAD_UPLOADING", "FILES_UPLOAD_QUEUED_AND_UPLOADING"].includes(status)) {
-                this.getStudy().setSaveFilesPending("Uploading");
-              } else if (status === "FILES_UPLOAD_ENDED") {
-                this.getStudy().setSaveFilesPending(null);
-              }
+                if (!this.getStudy()) {
+                  return;
+                }
+                hadActivity = true;
+                this.getStudy().setSaveFilesPending("Queued");
+              }, queuedDisplayDelay);
+            }
+          } else {
+            if (queuedTimerId !== null) {
+              clearTimeout(queuedTimerId);
+              queuedTimerId = null;
+            }
+            if (["FILES_UPLOAD_UPLOADING", "FILES_UPLOAD_QUEUED_AND_UPLOADING"].includes(status)) {
+              hadActivity = true;
+              this.getStudy().setSaveFilesPending("Uploading");
+            } else if (status === "FILES_UPLOAD_ENDED") {
+              hadActivity = false;
+              this.getStudy().setSaveFilesPending(null);
             }
           }
         }, this);

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -354,11 +354,20 @@ qx.Class.define("osparc.desktop.StudyEditor", {
         }, this);
       }
 
-      // Show real-time feedback in the navigation bar when the dynamic-sidecar backend is syncing/uploading files via rclone.
+      // Show real-time feedback in the navigation bar when the dynamic-sidecar backend
+      // is syncing/uploading files to S3 via rclone.
+      //
+      // The backend emits periodic "statePaths" socket events with these statuses:
+      //   - FILES_UPLOAD_QUEUED: rclone is waiting (--vfs-write-back) before uploading.
+      //     The field `vfs_write_back_s` contains the configured write-back delay in seconds.
+      //   - FILES_UPLOAD_UPLOADING / FILES_UPLOAD_QUEUED_AND_UPLOADING: rclone is actively uploading.
+      //   - FILES_UPLOAD_ENDED: the upload cycle is complete.
+      //
+      // UX goal: avoid showing "Queued" for the full write-back period (~30s) so the user
+      // doesn't feel they need to stop working. Instead, delay displaying "Queued" so it
+      // only appears briefly (~SHOW_QUEUED_LAST_SECS) right before the upload starts.
+      // Each new QUEUED event resets the timer, so continuous editing keeps the UI clean.
       if (!socket.slotExists("statePaths")) {
-        // QUEUED: schedule showing "Queued" so it only appears for the last ~3s before upload.
-        // UPLOADING: show "Uploading" (only for large files that take time).
-        // ENDED: clear any displayed status.
         const SHOW_QUEUED_LAST_SECS = 5;
 
         let queuedTimerId = null;
@@ -389,10 +398,10 @@ qx.Class.define("osparc.desktop.StudyEditor", {
             return;
           }
           const status = data["status"];
-          console.log(`Received statePaths update with status ${status}`);
           if (status === "FILES_UPLOAD_QUEUED") {
-            // Schedule "Queued" to appear only for the last ~5s before the upload starts.
-            // Each new QUEUED resets the timer (handles repeated saves).
+            // Delay showing "Queued" so it only appears for the last ~SHOW_QUEUED_LAST_SECS
+            // before rclone starts uploading. Each new QUEUED resets the timer, so while
+            // the user keeps editing, the label never appears.
             cancelQueuedTimer();
             const vfsWriteBackS = data["vfs_write_back_s"];
             const delay = Math.max(0, vfsWriteBackS - SHOW_QUEUED_LAST_SECS) * 1000;
@@ -404,6 +413,8 @@ qx.Class.define("osparc.desktop.StudyEditor", {
             cancelQueuedTimer();
             showUploading();
           } else if (status === "FILES_UPLOAD_ENDED") {
+            // Upload finished — clear any displayed status.
+            // "Queued" disappearing on its own signals the upload completed successfully.
             cancelQueuedTimer();
             clearStatus();
           }

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -353,6 +353,19 @@ qx.Class.define("osparc.desktop.StudyEditor", {
           }
         }, this);
       }
+
+      if (!socket.slotExists("statePaths")) {
+        socket.on("statePaths", data => {
+          console.log("Received statePaths update", data);
+          if (data["project_id"] === this.getStudy().getUuid()) {
+            if (data["status"] === "FILES_UPLOAD_ONGOING") {
+              this.getStudy().setSavePending(true);
+            } else if (data["status"] === "FILES_UPLOADED") {
+              this.getStudy().setSavePending(false);
+            }
+          }
+        }, this);
+      }
     },
 
     __projectDocumentReceived: function(data) {

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -392,7 +392,7 @@ qx.Class.define("osparc.desktop.StudyEditor", {
             return;
           }
           const status = data["status"];
-          const vfsWriteBackS = data["vfs_write_back_s"] || 30;
+          const vfsWriteBackS = data["vfs_write_back_s"];
           if (status === "FILES_UPLOAD_QUEUED") {
             if (!isFirstCycle) {
               showQueued();

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -355,46 +355,63 @@ qx.Class.define("osparc.desktop.StudyEditor", {
       }
 
       if (!socket.slotExists("statePaths")) {
-        // Delay showing the "Queued" state to avoid a long 30s wait
-        // caused by rclone's --vfs-write-back interval.
-        // If uploading starts or ends before the delay, the timer is cancelled.
-        // If files are re-queued after an upload cycle, show "Queued" immediately.
-        const rcloneQueuingTime = 30;
-        const displayMessageFor = 5;
-        const queuedDisplayDelay = (rcloneQueuingTime - displayMessageFor) * 1000;
+        // rclone queues files for 30s (--vfs-write-back) before uploading.
+        // To avoid showing "Queued" for that long, we delay the first display
+        // so it only appears briefly before uploading starts.
+        // After the first upload cycle, subsequent queues are shown immediately.
+        const RCLONE_WRITE_BACK_SECS = 30;
+        const SHOW_QUEUED_FOR_SECS = 5;
+        const FIRST_QUEUED_DELAY = (RCLONE_WRITE_BACK_SECS - SHOW_QUEUED_FOR_SECS) * 1000;
+
         let queuedTimerId = null;
-        let hadActivity = false;
+        let isFirstCycle = true;
+
+        const showQueued = () => {
+          if (this.getStudy()) {
+            this.getStudy().setSaveFilesPending("Queued");
+          }
+        };
+
+        const showUploading = () => {
+          this.getStudy().setSaveFilesPending("Uploading");
+        };
+
+        const clearStatus = () => {
+          this.getStudy().setSaveFilesPending(null);
+        };
+
+        const cancelTimer = () => {
+          if (queuedTimerId !== null) {
+            clearTimeout(queuedTimerId);
+            queuedTimerId = null;
+          }
+        };
+
         socket.on("statePaths", data => {
           if (!this.getStudy() || data["project_id"] !== this.getStudy().getUuid()) {
             return;
           }
+
           const status = data["status"];
+
           if (status === "FILES_UPLOAD_QUEUED") {
-            if (hadActivity) {
-              // Already shown activity before, show "Queued" immediately
-              this.getStudy().setSaveFilesPending("Queued");
+            if (!isFirstCycle) {
+              showQueued();
             } else if (queuedTimerId === null) {
               queuedTimerId = setTimeout(() => {
                 queuedTimerId = null;
-                if (!this.getStudy()) {
-                  return;
-                }
-                hadActivity = true;
-                this.getStudy().setSaveFilesPending("Queued");
-              }, queuedDisplayDelay);
+                isFirstCycle = false;
+                showQueued();
+              }, FIRST_QUEUED_DELAY);
             }
-          } else {
-            if (queuedTimerId !== null) {
-              clearTimeout(queuedTimerId);
-              queuedTimerId = null;
-            }
-            if (["FILES_UPLOAD_UPLOADING", "FILES_UPLOAD_QUEUED_AND_UPLOADING"].includes(status)) {
-              hadActivity = true;
-              this.getStudy().setSaveFilesPending("Uploading");
-            } else if (status === "FILES_UPLOAD_ENDED") {
-              hadActivity = false;
-              this.getStudy().setSaveFilesPending(null);
-            }
+          } else if (["FILES_UPLOAD_UPLOADING", "FILES_UPLOAD_QUEUED_AND_UPLOADING"].includes(status)) {
+            cancelTimer();
+            isFirstCycle = false;
+            showUploading();
+          } else if (status === "FILES_UPLOAD_ENDED") {
+            cancelTimer();
+            isFirstCycle = true;
+            clearStatus();
           }
         }, this);
       }

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -356,13 +356,12 @@ qx.Class.define("osparc.desktop.StudyEditor", {
 
       // Show real-time feedback in the navigation bar when the dynamic-sidecar backend is syncing/uploading files via rclone.
       if (!socket.slotExists("statePaths")) {
-        // rclone queues files for 30s (--vfs-write-back) before uploading. The backend will push this value.
+        // rclone queues files for N seconds (--vfs-write-back) before uploading.
+        // The backend sends this value as `write_back_secs` in the socket message.
         // To avoid showing "Queued" for that long, we delay the first display
         // so it only appears briefly before uploading starts.
         // After the first upload cycle, subsequent queues are shown immediately.
-        const RCLONE_WRITE_BACK_SECS = 30;
         const SHOW_QUEUED_FOR_SECS = 5;
-        const FIRST_QUEUED_DELAY = (RCLONE_WRITE_BACK_SECS - SHOW_QUEUED_FOR_SECS) * 1000;
 
         let queuedTimerId = null;
         let isFirstCycle = true;
@@ -393,15 +392,17 @@ qx.Class.define("osparc.desktop.StudyEditor", {
             return;
           }
           const status = data["status"];
+          const writeBackSecs = data["write_back_secs"] || 30;
           if (status === "FILES_UPLOAD_QUEUED") {
             if (!isFirstCycle) {
               showQueued();
             } else if (queuedTimerId === null) {
+              const firstQueuedDelay = Math.max(0, writeBackSecs - SHOW_QUEUED_FOR_SECS) * 1000;
               queuedTimerId = setTimeout(() => {
                 queuedTimerId = null;
                 isFirstCycle = false;
                 showQueued();
-              }, FIRST_QUEUED_DELAY);
+              }, firstQueuedDelay);
             }
           } else if (["FILES_UPLOAD_UPLOADING", "FILES_UPLOAD_QUEUED_AND_UPLOADING"].includes(status)) {
             cancelTimer();

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -356,15 +356,12 @@ qx.Class.define("osparc.desktop.StudyEditor", {
 
       // Show real-time feedback in the navigation bar when the dynamic-sidecar backend is syncing/uploading files via rclone.
       if (!socket.slotExists("statePaths")) {
-        // rclone queues files for N seconds (--vfs-write-back) before uploading.
-        // The backend sends this value as `write_back_secs` in the socket message.
-        // To avoid showing "Queued" for that long, we delay the first display
-        // so it only appears briefly before uploading starts.
-        // After the first upload cycle, subsequent queues are shown immediately.
-        const SHOW_QUEUED_FOR_SECS = 5;
+        // QUEUED: schedule showing "Queued" so it only appears for the last ~3s before upload.
+        // UPLOADING: show "Uploading" (only for large files that take time).
+        // ENDED: clear any displayed status.
+        const SHOW_QUEUED_LAST_SECS = 5;
 
         let queuedTimerId = null;
-        let isFirstCycle = true;
         const showQueued = () => {
           if (this.getStudy()) {
             this.getStudy().setSaveFilesPending("Queued");
@@ -380,7 +377,7 @@ qx.Class.define("osparc.desktop.StudyEditor", {
             this.getStudy().setSaveFilesPending(null);
           }
         };
-        const cancelTimer = () => {
+        const cancelQueuedTimer = () => {
           if (queuedTimerId !== null) {
             clearTimeout(queuedTimerId);
             queuedTimerId = null;
@@ -392,25 +389,22 @@ qx.Class.define("osparc.desktop.StudyEditor", {
             return;
           }
           const status = data["status"];
-          const vfsWriteBackS = data["vfs_write_back_s"];
+          console.log(`Received statePaths update with status ${status}`);
           if (status === "FILES_UPLOAD_QUEUED") {
-            if (!isFirstCycle) {
+            // Schedule "Queued" to appear only for the last ~5s before the upload starts.
+            // Each new QUEUED resets the timer (handles repeated saves).
+            cancelQueuedTimer();
+            const vfsWriteBackS = data["vfs_write_back_s"];
+            const delay = Math.max(0, vfsWriteBackS - SHOW_QUEUED_LAST_SECS) * 1000;
+            queuedTimerId = setTimeout(() => {
+              queuedTimerId = null;
               showQueued();
-            } else if (queuedTimerId === null) {
-              const firstQueuedDelay = Math.max(0, vfsWriteBackS - SHOW_QUEUED_FOR_SECS) * 1000;
-              queuedTimerId = setTimeout(() => {
-                queuedTimerId = null;
-                isFirstCycle = false;
-                showQueued();
-              }, firstQueuedDelay);
-            }
+            }, delay);
           } else if (["FILES_UPLOAD_UPLOADING", "FILES_UPLOAD_QUEUED_AND_UPLOADING"].includes(status)) {
-            cancelTimer();
-            isFirstCycle = false;
+            cancelQueuedTimer();
             showUploading();
           } else if (status === "FILES_UPLOAD_ENDED") {
-            cancelTimer();
-            isFirstCycle = true;
+            cancelQueuedTimer();
             clearStatus();
           }
         }, this);

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -355,14 +355,31 @@ qx.Class.define("osparc.desktop.StudyEditor", {
       }
 
       if (!socket.slotExists("statePaths")) {
+        // Delay showing the "Queued" state to avoid a long 30s wait
+        // caused by rclone's --vfs-write-back interval.
+        // If uploading starts or ends before the delay, the timer is cancelled.
+        const queuedDisplayDelay = 25 * 1000;
+        let queuedTimerId = null;
         socket.on("statePaths", data => {
           if (data["project_id"] === this.getStudy().getUuid()) {
-            if (data["status"] === "FILES_UPLOAD_QUEUED") {
-              this.getStudy().setSaveFilesPending("Queued");
-            } else if (["FILES_UPLOAD_UPLOADING", "FILES_UPLOAD_QUEUED_AND_UPLOADING"].includes(data["status"])) {
-              this.getStudy().setSaveFilesPending("Uploading");
-            } else if (data["status"] === "FILES_UPLOAD_ENDED") {
-              this.getStudy().setSaveFilesPending(null);
+            const status = data["status"];
+            if (status === "FILES_UPLOAD_QUEUED") {
+              if (queuedTimerId === null) {
+                queuedTimerId = setTimeout(() => {
+                  queuedTimerId = null;
+                  this.getStudy().setSaveFilesPending("Queued");
+                }, queuedDisplayDelay);
+              }
+            } else {
+              if (queuedTimerId !== null) {
+                clearTimeout(queuedTimerId);
+                queuedTimerId = null;
+              }
+              if (["FILES_UPLOAD_UPLOADING", "FILES_UPLOAD_QUEUED_AND_UPLOADING"].includes(status)) {
+                this.getStudy().setSaveFilesPending("Uploading");
+              } else if (status === "FILES_UPLOAD_ENDED") {
+                this.getStudy().setSaveFilesPending(null);
+              }
             }
           }
         }, this);

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -358,7 +358,9 @@ qx.Class.define("osparc.desktop.StudyEditor", {
         // Delay showing the "Queued" state to avoid a long 30s wait
         // caused by rclone's --vfs-write-back interval.
         // If uploading starts or ends before the delay, the timer is cancelled.
-        const queuedDisplayDelay = 25 * 1000;
+        const rcloneQueuingTime = 30;
+        const displayMessageFor = 5;
+        const queuedDisplayDelay = (rcloneQueuingTime - displayMessageFor) * 1000;
         let queuedTimerId = null;
         socket.on("statePaths", data => {
           if (data["project_id"] === this.getStudy().getUuid()) {

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -356,7 +356,6 @@ qx.Class.define("osparc.desktop.StudyEditor", {
 
       if (!socket.slotExists("statePaths")) {
         socket.on("statePaths", data => {
-          console.log("Received statePaths update", data);
           if (data["project_id"] === this.getStudy().getUuid()) {
             if (data["status"] === "FILES_UPLOAD_QUEUED") {
               this.getStudy().setSaveFilesPending("Queued");

--- a/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/StudyEditor.js
@@ -355,16 +355,16 @@ qx.Class.define("osparc.desktop.StudyEditor", {
       }
 
       if (!socket.slotExists("statePaths")) {
-        // Delay showing the "Queued" state to avoid a long 30s wait
-        // caused by rclone's --vfs-write-back interval.
+        // Delay showing the "Queued" state to avoid showing it during
+        // rclone's --vfs-write-back interval.
         // If uploading starts or ends before the delay, the timer is cancelled.
-        const rcloneQueuingTime = 30;
         const displayMessageFor = 5;
-        const queuedDisplayDelay = (rcloneQueuingTime - displayMessageFor) * 1000;
         let queuedTimerId = null;
         socket.on("statePaths", data => {
           if (data["project_id"] === this.getStudy().getUuid()) {
             const status = data["status"];
+            const vfsWriteBackS = data["vfs_write_back_s"];
+            const queuedDisplayDelay = (vfsWriteBackS - displayMessageFor) * 1000;
             if (status === "FILES_UPLOAD_QUEUED") {
               if (queuedTimerId === null) {
                 queuedTimerId = setTimeout(() => {

--- a/services/static-webserver/client/source/class/osparc/desktop/account/MyAccountWindow.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/account/MyAccountWindow.js
@@ -30,6 +30,8 @@ qx.Class.define("osparc.desktop.account.MyAccountWindow", {
       maxHeight,
     });
 
+    osparc.utils.Utils.setIdToWidget(closeBtn, "myAccountWindow");
+
     const myAccount = this.__myAccount = new osparc.desktop.account.MyAccount();
     this._setTabbedView(myAccount);
   },

--- a/services/static-webserver/client/source/class/osparc/desktop/account/MyAccountWindow.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/account/MyAccountWindow.js
@@ -30,7 +30,7 @@ qx.Class.define("osparc.desktop.account.MyAccountWindow", {
       maxHeight,
     });
 
-    osparc.utils.Utils.setIdToWidget(closeBtn, "myAccountWindow");
+    osparc.utils.Utils.setIdToWidget(this, "myAccountWindow");
 
     const myAccount = this.__myAccount = new osparc.desktop.account.MyAccount();
     this._setTabbedView(myAccount);

--- a/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
@@ -246,6 +246,14 @@ qx.Class.define("osparc.navigation.NavigationBar", {
           osparc.utils.Utils.setIdToWidget(control, "savingStudyIcon");
           this.getChildControl("left-items").add(control);
           break;
+        case "saving-study-files-icon":
+          control = new qx.ui.basic.Atom().set({
+            font: "text-12",
+            opacity: 0.8,
+            visibility: "excluded",
+          });
+          this.getChildControl("left-items").add(control);
+          break;
         case "read-only-info": {
           control = new qx.ui.basic.Atom().set({
             label: this.tr("Read only"),
@@ -390,17 +398,42 @@ qx.Class.define("osparc.navigation.NavigationBar", {
 
     __applyStudy: function(study) {
       const savingStudyIcon = this.getChildControl("saving-study-icon");
+      const savingStudyFilesIcon = this.getChildControl("saving-study-files-icon");
       const readOnlyInfo = this.getChildControl("read-only-info");
       if (study) {
         this.getChildControl("study-title-options").setStudy(study);
         study.bind("savePending", savingStudyIcon, "visibility", {
           converter: value => value && ["workbench", "pipeline"].includes(study.getUi().getMode()) ? "visible" : "excluded"
         });
+        study.bind("saveFilesPending", savingStudyFilesIcon, "visibility", {
+          converter: value => value && ["workbench", "pipeline"].includes(study.getUi().getMode()) ? "visible" : "excluded"
+        });
+        study.bind("saveFilesPending", savingStudyFilesIcon, "label", {
+          converter: value => {
+            if (value === "Uploading") {
+              return this.tr("Uploading...");
+            } else if (value === "Queued") {
+              return this.tr("Queued...");
+            }
+            return "";
+          }
+        });
+        study.bind("saveFilesPending", savingStudyFilesIcon, "icon", {
+          converter: value => {
+            if (value === "Uploading") {
+              return "@FontAwesome5Solid/file-alt/14";
+            } else if (value === "Queued") {
+              return "@FontAwesome5Solid/file-medical/14";
+            }
+            return "";
+          }
+        });
         study.bind("readOnly", readOnlyInfo, "visibility", {
           converter: value => value ? "visible" : "excluded"
         });
       } else {
         savingStudyIcon.exclude();
+        savingStudyFilesIcon.exclude();
         readOnlyInfo.exclude();
       }
 

--- a/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
@@ -415,7 +415,7 @@ qx.Class.define("osparc.navigation.NavigationBar", {
             } else if (value === "Queued") {
               return this.tr("Queued...");
             }
-            return "";
+            return null;
           }
         });
         study.bind("saveFilesPending", savingStudyFilesIcon, "toolTipText", {
@@ -425,7 +425,7 @@ qx.Class.define("osparc.navigation.NavigationBar", {
             } else if (value === "Queued") {
               return this.tr("Files are queued for upload/syncing");
             }
-            return "";
+            return null;
           }
         });
         study.bind("saveFilesPending", savingStudyFilesIcon, "icon", {
@@ -435,7 +435,7 @@ qx.Class.define("osparc.navigation.NavigationBar", {
             } else if (value === "Queued") {
               return "@FontAwesome5Solid/file-medical/12";
             }
-            return "";
+            return null;
           }
         });
         study.bind("readOnly", readOnlyInfo, "visibility", {

--- a/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
+++ b/services/static-webserver/client/source/class/osparc/navigation/NavigationBar.js
@@ -418,12 +418,22 @@ qx.Class.define("osparc.navigation.NavigationBar", {
             return "";
           }
         });
+        study.bind("saveFilesPending", savingStudyFilesIcon, "toolTipText", {
+          converter: value => {
+            if (value === "Uploading") {
+              return this.tr("Files are being uploaded/synced");
+            } else if (value === "Queued") {
+              return this.tr("Files are queued for upload/syncing");
+            }
+            return "";
+          }
+        });
         study.bind("saveFilesPending", savingStudyFilesIcon, "icon", {
           converter: value => {
             if (value === "Uploading") {
-              return "@FontAwesome5Solid/file-alt/14";
+              return "@FontAwesome5Solid/upload/12";
             } else if (value === "Queued") {
-              return "@FontAwesome5Solid/file-medical/14";
+              return "@FontAwesome5Solid/file-medical/12";
             }
             return "";
           }

--- a/services/static-webserver/client/source/class/osparc/theme/Appearance.js
+++ b/services/static-webserver/client/source/class/osparc/theme/Appearance.js
@@ -1288,7 +1288,8 @@ qx.Theme.define("osparc.theme.Appearance", {
     */
     "tooltip": {
       style: state => ({
-        decorator: "tooltip",
+        decorator: "hint",
+        backgroundColor: "hint-background",
         padding: [5, 10],
         maxWidth: 400,
         // showTimeout is themeable so it can be tuned

--- a/services/static-webserver/client/source/class/osparc/workbench/DiskUsageIndicator.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/DiskUsageIndicator.js
@@ -104,9 +104,11 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
       // Subscribe to disk usage data for the new node
       this._subscribe(node);
 
-      node.getStatus().bind("interactive", this, "visibility", {
-        converter: state => state === "ready" ? "visible" : "excluded"
-      });
+      // Re-evaluate visibility when the interactive state changes instead of
+      // binding directly so the widget stays hidden when there is no data.
+      node.getStatus().addListener("changeInteractive", () => this.__updateDiskIndicator(), this);
+      // trigger an initial check
+      this.__updateDiskIndicator();
     },
 
     _subscribe: function(node) {
@@ -135,7 +137,6 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
     },
 
     __updateDiskIndicator: function(diskUsage) {
-      this.show();
       if (diskUsage && diskUsage["node_id"]) {
         this.__lastDiskUsage[diskUsage["node_id"]] = diskUsage;
       }
@@ -143,10 +144,9 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
       const indicator = this.getChildControl("disk-indicator");
 
       const currentNode = this.getCurrentNode();
-      if (currentNode) {
-        indicator.setVisibility("visible");
-      } else {
-        indicator.setVisibility("exclude");
+      if (!currentNode || currentNode.getStatus().getInteractive() !== "ready") {
+        indicator.setVisibility("excluded");
+        this.exclude();
         return;
       }
 
@@ -156,8 +156,12 @@ qx.Class.define("osparc.workbench.DiskUsageIndicator", {
         diskUsage = this.__lastDiskUsage[currentNodeId];
       }
       if (!diskUsage) {
+        this.exclude();
         return;
       }
+
+      indicator.setVisibility("visible");
+      this.show();
 
       const diskHostUsage = diskUsage["usage"]["HOST"]
       let color1 = this.__getIndicatorColor(diskHostUsage.free);


### PR DESCRIPTION
## What do these changes do?

Show real-time feedback in the navigation bar when the dynamic-sidecar backend is syncing/uploading files via rclone.

How it works
1. rclone detects file changes → queues them (30s write-back) and sends statePaths WebSocket events with the current status
2. Frontend receives events and shows feedback:
    - If queued, the frontend wait 25" to show the "Queded..." message for just 5"
    - Then it goes to "Uploading..."
    - When done, indicator disappears

<img width="1440" height="850" alt="Queued" src="https://github.com/user-attachments/assets/4c47057f-e94d-4e2f-a5aa-1e0bc1cc8980" />


## Related issue/s
- closes https://github.com/ITISFoundation/osparc-simcore/issues/9050
- https://github.com/ITISFoundation/private-issues/issues/8

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
