### PR TITLE
🎨  Fix misleading `NodeNotFound` error when service version or pricing plan is misconfigured

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/_filemanager_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/_filemanager_utils.py
@@ -122,7 +122,7 @@ async def resolve_location_id(
 ) -> LocationID:
     if store_name is None and store_id is None:
         msg = f"both {store_name=} and {store_id=} are None"
-        raise exceptions.NodeportsException(msg)
+        raise exceptions.NodeportsError(msg)
 
     if store_name is not None:
         store_id = await _get_location_id_from_location_name(user_id, store_name, client_session)

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/_filemanager_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/_filemanager_utils.py
@@ -39,7 +39,7 @@ async def _get_location_id_from_location_name(
         if location.name == store:
             return cast(LocationID, location.id)  # mypy wants it
     # location id not found
-    raise exceptions.S3InvalidStore(store)
+    raise exceptions.S3InvalidStoreError(store)
 
 
 def _get_https_link_if_storage_secure(url: str) -> str:

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/dbmanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/dbmanager.py
@@ -15,7 +15,7 @@ from simcore_postgres_database.utils_comp_run_snapshot_tasks import (
 from simcore_postgres_database.utils_comp_runs import get_latest_run_id_for_project
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
 
-from .exceptions import NodeNotFound, ProjectNotFoundError
+from .exceptions import NodeNotFoundError, ProjectNotFoundError
 
 _logger = logging.getLogger(__name__)
 
@@ -40,8 +40,15 @@ async def _get_node_from_db(project_id: str, node_uuid: str, connection: AsyncCo
     )
     node = result.one_or_none()
     if not node:
-        _logger.error("the node id %s was not found", node_uuid)
-        raise NodeNotFound(node_uuid)
+        _logger.error(
+            "Node %s not found in comp_tasks table for project %s. "
+            "This typically means the node's comp_tasks entry was never created, "
+            "possibly because the service version is not registered in the catalog "
+            "or has no valid pricing plan.",
+            node_uuid,
+            project_id,
+        )
+        raise NodeNotFoundError(node_uuid, project_id=project_id)
     return node
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/dbmanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/dbmanager.py
@@ -40,14 +40,6 @@ async def _get_node_from_db(project_id: str, node_uuid: str, connection: AsyncCo
     )
     node = result.one_or_none()
     if not node:
-        _logger.error(
-            "Node %s not found in comp_tasks table for project %s. "
-            "This typically means the node's comp_tasks entry was never created, "
-            "possibly because the service version is not registered in the catalog "
-            "or has no valid pricing plan.",
-            node_uuid,
-            project_id,
-        )
         raise NodeNotFoundError(node_uuid, project_id=project_id)
     return node
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/exceptions.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/exceptions.py
@@ -120,12 +120,12 @@ class PortNotFoundError(NodeportsError):
 class NodeNotFoundError(NodeportsError):
     """The given node_uuid was not found in the comp_tasks table"""
 
-    def __init__(self, node_uuid, *, project_id: str | None = None):
+    def __init__(self, node_uuid: str, *, project_id: str):
         self.node_uuid = node_uuid
         self.project_id = project_id
         msg = (
-            f"the node id {node_uuid} was not found in comp_tasks"
-            f"for project_id={project_id}'. This may indicate the "
+            f"the node id {node_uuid} was not found in comp_tasks "
+            f"for project_id={project_id}. This may indicate the "
             "service version is not registered in the catalog "
             "or has no valid pricing plan configured."
         )

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/exceptions.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/exceptions.py
@@ -120,7 +120,7 @@ class PortNotFoundError(NodeportsError):
 class NodeNotFoundError(NodeportsError):
     """The given node_uuid was not found in the comp_tasks table"""
 
-    def __init__(self, node_uuid: str, *, project_id: str):
+    def __init__(self, node_uuid: str, project_id: str):
         self.node_uuid = node_uuid
         self.project_id = project_id
         msg = (
@@ -130,6 +130,9 @@ class NodeNotFoundError(NodeportsError):
             "or has no valid pricing plan configured."
         )
         super().__init__(msg)
+
+    def __reduce__(self):
+        return (self.__class__, (self.node_uuid, self.project_id))
 
 
 class ProjectNotFoundError(NodeportsError):

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/exceptions.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/exceptions.py
@@ -6,14 +6,14 @@
 #
 
 
-class NodeportsException(Exception):
+class NodeportsError(Exception):
     """Basic exception for errors raised in nodeports"""
 
     def __init__(self, msg: str | None = None):
         super().__init__(msg or "An error occurred in simcore")
 
 
-class ReadOnlyError(NodeportsException):
+class ReadOnlyError(NodeportsError):
     """Trying to modify read-only object"""
 
     def __init__(self, obj):
@@ -21,23 +21,15 @@ class ReadOnlyError(NodeportsException):
         self.obj = obj
 
 
-class UnboundPortError(NodeportsException, IndexError):
+class UnboundPortError(NodeportsError, IndexError):
     """Accessed port is not configured"""
 
-    def __init__(self, port_index, msg: str | None = None):
+    def __init__(self, port_index):
         super().__init__(f"No port bound at index {port_index}")
         self.port_index = port_index
 
 
-class InvalidKeyError(NodeportsException):
-    """Accessed key does not exist"""
-
-    def __init__(self, item_key: str, msg: str | None = None):
-        super().__init__(f"No port bound with key {item_key}")
-        self.item_key = item_key
-
-
-class InvalidItemTypeError(NodeportsException):
+class InvalidItemTypeError(NodeportsError):
     """Item type incorrect"""
 
     def __init__(self, item_type: str, item_value: str, msg: str | None = None):
@@ -46,7 +38,7 @@ class InvalidItemTypeError(NodeportsException):
         self.item_value = item_value
 
 
-class InvalidProtocolError(NodeportsException):
+class InvalidProtocolError(NodeportsError):
     """Invalid protocol used"""
 
     def __init__(self, dct, msg: str | None = None):
@@ -54,22 +46,22 @@ class InvalidProtocolError(NodeportsException):
         self.dct = dct
 
 
-class StorageInvalidCall(NodeportsException):
+class StorageInvalidCall(NodeportsError):
     """Storage returned an error 400<=status<500"""
 
 
-class StorageServerIssue(NodeportsException):
+class StorageServerIssue(NodeportsError):
     """Storage returned an error status>=500"""
 
 
-class S3TransferError(NodeportsException):
+class S3TransferError(NodeportsError):
     """S3 transfer error"""
 
     def __init__(self, msg: str | None = None):
         super().__init__(msg or "Error while transferring to/from S3 storage")
 
 
-class AwsS3BadRequestRequestTimeoutError(NodeportsException):
+class AwsS3BadRequestRequestTimeoutError(NodeportsError):
     """Sometimes the request to S3 can time out and a 400 with a `RequestTimeout`
     reason in the body will be received. For details regarding the error
     see https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
@@ -81,7 +73,7 @@ class AwsS3BadRequestRequestTimeoutError(NodeportsException):
         super().__init__(f"S3 replied with 400 RequestTimeout: {body=}")
 
 
-class S3InvalidPathError(NodeportsException):
+class S3InvalidPathError(NodeportsError):
     """S3 transfer error"""
 
     def __init__(self, s3_object_name):
@@ -89,7 +81,7 @@ class S3InvalidPathError(NodeportsException):
         self.object_name = s3_object_name
 
 
-class S3InvalidStore(NodeportsException):
+class S3InvalidStore(NodeportsError):
     """S3 transfer error"""
 
     def __init__(self, s3_store):
@@ -97,7 +89,7 @@ class S3InvalidStore(NodeportsException):
         self.store = s3_store
 
 
-class InvalidDownloadLinkError(NodeportsException):
+class InvalidDownloadLinkError(NodeportsError):
     """Download link is invalid"""
 
     def __init__(self, link):
@@ -105,7 +97,7 @@ class InvalidDownloadLinkError(NodeportsException):
         self.link = link
 
 
-class TransferError(NodeportsException):
+class TransferError(NodeportsError):
     """Download/Upload transfer error"""
 
     def __init__(self, link):
@@ -113,7 +105,7 @@ class TransferError(NodeportsException):
         self.link = link
 
 
-class StorageConnectionError(NodeportsException):
+class StorageConnectionError(NodeportsError):
     """S3 transfer error"""
 
     def __init__(self, s3_store, additional_msg=None):
@@ -121,19 +113,26 @@ class StorageConnectionError(NodeportsException):
         self.store = s3_store
 
 
-class PortNotFound(NodeportsException):
+class PortNotFoundError(NodeportsError):
     """Accessed key does not exist"""
 
 
-class NodeNotFound(NodeportsException):
-    """The given node_uuid was not found"""
+class NodeNotFoundError(NodeportsError):
+    """The given node_uuid was not found in the comp_tasks table"""
 
-    def __init__(self, node_uuid):
+    def __init__(self, node_uuid, *, project_id: str | None = None):
         self.node_uuid = node_uuid
-        super().__init__(f"the node id {node_uuid} was not found")
+        self.project_id = project_id
+        msg = (
+            f"the node id {node_uuid} was not found in comp_tasks"
+            f"{f' for project {project_id}' if project_id else ''}. "
+            f"This may indicate the service version is not registered in the catalog "
+            f"or has no valid pricing plan configured."
+        )
+        super().__init__(msg)
 
 
-class ProjectNotFoundError(NodeportsException):
+class ProjectNotFoundError(NodeportsError):
     """The given node_uuid was not found"""
 
     def __init__(self, project_id):
@@ -141,7 +140,7 @@ class ProjectNotFoundError(NodeportsException):
         super().__init__(f"the {project_id=} was not found")
 
 
-class SymlinkToSymlinkIsNotUploadableException(NodeportsException):
+class SymlinkToSymlinkIsNotUploadableError(NodeportsError):
     """Not possible to upload a symlink to a symlink"""
 
     def __init__(self, symlink, symlink_target_path):
@@ -153,7 +152,7 @@ class SymlinkToSymlinkIsNotUploadableException(NodeportsException):
         self.symlink_target_path = symlink_target_path
 
 
-class AbsoluteSymlinkIsNotUploadableException(NodeportsException):
+class AbsoluteSymlinkIsNotUploadableError(NodeportsError):
     """absolute symlink is not uploadable"""
 
     def __init__(self, symlink, symlink_target_path):

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/exceptions.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/exceptions.py
@@ -7,14 +7,37 @@
 
 
 class NodeportsError(Exception):
-    """Basic exception for errors raised in nodeports"""
+    """Basic exception for errors raised in nodeports
+
+    Subclasses with custom __init__ parameters should define `_pickle_args`
+    as a tuple of attribute names to enable proper pickling/unpickling.
+
+    Example:
+        class MyError(NodeportsError):
+            _pickle_args = ("my_attr",)
+
+            def __init__(self, my_attr):
+                self.my_attr = my_attr
+                super().__init__(f"Error with {my_attr}")
+    """
+
+    _pickle_args: tuple[str, ...] = ()
 
     def __init__(self, msg: str | None = None):
         super().__init__(msg or "An error occurred in simcore")
 
+    def __reduce__(self):
+        if self._pickle_args:
+            args = tuple(getattr(self, attr) for attr in self._pickle_args)
+            return (self.__class__, args)
+        # Default: use self.args (the message passed to Exception)
+        return (self.__class__, self.args)
+
 
 class ReadOnlyError(NodeportsError):
     """Trying to modify read-only object"""
+
+    _pickle_args = ("obj",)
 
     def __init__(self, obj):
         super().__init__(f"Trying to modify read-only object {obj}")
@@ -24,6 +47,8 @@ class ReadOnlyError(NodeportsError):
 class UnboundPortError(NodeportsError, IndexError):
     """Accessed port is not configured"""
 
+    _pickle_args = ("port_index",)
+
     def __init__(self, port_index):
         super().__init__(f"No port bound at index {port_index}")
         self.port_index = port_index
@@ -31,6 +56,8 @@ class UnboundPortError(NodeportsError, IndexError):
 
 class InvalidItemTypeError(NodeportsError):
     """Item type incorrect"""
+
+    _pickle_args = ("item_type", "item_value")
 
     def __init__(self, item_type: str, item_value: str, msg: str | None = None):
         super().__init__(msg or f"Invalid item type, value [{item_value}] does not qualify as type [{item_type}]")
@@ -40,6 +67,8 @@ class InvalidItemTypeError(NodeportsError):
 
 class InvalidProtocolError(NodeportsError):
     """Invalid protocol used"""
+
+    _pickle_args = ("dct",)
 
     def __init__(self, dct, msg: str | None = None):
         super().__init__(f"Invalid protocol used: {dct} [{msg}]")
@@ -69,12 +98,17 @@ class AwsS3BadRequestRequestTimeoutError(NodeportsError):
     In this case the entire multipart upload needs to be abandoned and retried.
     """
 
+    _pickle_args = ("body",)
+
     def __init__(self, body: str):
         super().__init__(f"S3 replied with 400 RequestTimeout: {body=}")
+        self.body = body
 
 
 class S3InvalidPathError(NodeportsError):
     """S3 transfer error"""
+
+    _pickle_args = ("object_name",)
 
     def __init__(self, s3_object_name):
         super().__init__(f"No object in S3 storage at {s3_object_name}")
@@ -84,6 +118,8 @@ class S3InvalidPathError(NodeportsError):
 class S3InvalidStoreError(NodeportsError):
     """S3 transfer error"""
 
+    _pickle_args = ("store",)
+
     def __init__(self, s3_store):
         super().__init__(f"Invalid store used: {s3_store}")
         self.store = s3_store
@@ -91,6 +127,8 @@ class S3InvalidStoreError(NodeportsError):
 
 class InvalidDownloadLinkError(NodeportsError):
     """Download link is invalid"""
+
+    _pickle_args = ("link",)
 
     def __init__(self, link):
         super().__init__(f"Invalid link [{link}]")
@@ -100,6 +138,8 @@ class InvalidDownloadLinkError(NodeportsError):
 class TransferError(NodeportsError):
     """Download/Upload transfer error"""
 
+    _pickle_args = ("link",)
+
     def __init__(self, link):
         super().__init__(f"Error while transferring to/from [{link}]")
         self.link = link
@@ -108,9 +148,12 @@ class TransferError(NodeportsError):
 class StorageConnectionError(NodeportsError):
     """S3 transfer error"""
 
+    _pickle_args = ("store", "additional_msg")
+
     def __init__(self, s3_store, additional_msg=None):
         super().__init__(f"Connection to store {s3_store} failed: {additional_msg}")
         self.store = s3_store
+        self.additional_msg = additional_msg
 
 
 class PortNotFoundError(NodeportsError):
@@ -119,6 +162,8 @@ class PortNotFoundError(NodeportsError):
 
 class NodeNotFoundError(NodeportsError):
     """The given node_uuid was not found in the comp_tasks table"""
+
+    _pickle_args = ("node_uuid", "project_id")
 
     def __init__(self, node_uuid: str, project_id: str):
         self.node_uuid = node_uuid
@@ -131,12 +176,11 @@ class NodeNotFoundError(NodeportsError):
         )
         super().__init__(msg)
 
-    def __reduce__(self):
-        return (self.__class__, (self.node_uuid, self.project_id))
-
 
 class ProjectNotFoundError(NodeportsError):
     """The given node_uuid was not found"""
+
+    _pickle_args = ("project_id",)
 
     def __init__(self, project_id):
         self.project_id = project_id
@@ -145,6 +189,8 @@ class ProjectNotFoundError(NodeportsError):
 
 class SymlinkToSymlinkIsNotUploadableError(NodeportsError):
     """Not possible to upload a symlink to a symlink"""
+
+    _pickle_args = ("symlink", "symlink_target_path")
 
     def __init__(self, symlink, symlink_target_path):
         message = (
@@ -157,6 +203,8 @@ class SymlinkToSymlinkIsNotUploadableError(NodeportsError):
 
 class AbsoluteSymlinkIsNotUploadableError(NodeportsError):
     """absolute symlink is not uploadable"""
+
+    _pickle_args = ("symlink", "symlink_target_path")
 
     def __init__(self, symlink, symlink_target_path):
         message = (

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/exceptions.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/exceptions.py
@@ -46,11 +46,11 @@ class InvalidProtocolError(NodeportsError):
         self.dct = dct
 
 
-class StorageInvalidCall(NodeportsError):
+class StorageInvalidCallError(NodeportsError):
     """Storage returned an error 400<=status<500"""
 
 
-class StorageServerIssue(NodeportsError):
+class StorageServerIssueError(NodeportsError):
     """Storage returned an error status>=500"""
 
 
@@ -81,7 +81,7 @@ class S3InvalidPathError(NodeportsError):
         self.object_name = s3_object_name
 
 
-class S3InvalidStore(NodeportsError):
+class S3InvalidStoreError(NodeportsError):
     """S3 transfer error"""
 
     def __init__(self, s3_store):
@@ -125,9 +125,9 @@ class NodeNotFoundError(NodeportsError):
         self.project_id = project_id
         msg = (
             f"the node id {node_uuid} was not found in comp_tasks"
-            f"{f' for project {project_id}' if project_id else ''}. "
-            f"This may indicate the service version is not registered in the catalog "
-            f"or has no valid pricing plan configured."
+            f"for project_id={project_id}'. This may indicate the "
+            "service version is not registered in the catalog "
+            "or has no valid pricing plan configured."
         )
         super().__init__(msg)
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -70,7 +70,7 @@ async def get_download_link_from_s3(
     client_session: ClientSession | None = None,
 ) -> URL:
     """
-    :raises exceptions.NodeportsException
+    :raises exceptions.NodeportsError
     :raises exceptions.S3InvalidPathError
     :raises exceptions.StorageInvalidCall
     :raises exceptions.StorageServerIssue
@@ -156,7 +156,7 @@ async def download_path_from_s3(
 
     :param session: add app[APP_CLIENT_SESSION_KEY] session here otherwise default is opened/closed every call
     :type session: ClientSession, optional
-    :raises exceptions.NodeportsException
+    :raises exceptions.NodeportsError
     :raises exceptions.S3InvalidPathError
     :raises exceptions.StorageInvalidCall
     :return: path to downloaded file
@@ -304,7 +304,7 @@ async def upload_path(  # pylint: disable=too-many-arguments
     :type session: ClientSession, optional
     :raises exceptions.S3InvalidPathError
     :raises exceptions.S3TransferError
-    :raises exceptions.NodeportsException
+    :raises exceptions.NodeportsError
     :return: stored id, S3 entity_tag
     """
     async for attempt in AsyncRetrying(

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -44,6 +44,7 @@ async def complete_file_upload(
     uploaded_parts: list[UploadedPart],
     upload_completion_link: AnyUrl,
     client_session: ClientSession | None = None,
+    *,
     is_directory: bool = False,
 ) -> ETag | None:
     async with ClientSessionContextManager(client_session) as session:
@@ -179,7 +180,7 @@ async def download_path_from_s3(
 
         if file_meta_data.is_directory and not await r_clone.is_r_clone_available(r_clone_settings):
             msg = f"Requested to download directory {s3_object}, but no rclone support was detected"
-            raise exceptions.NodeportsException(msg)
+            raise exceptions.NodeportsError(msg)
 
         # get the s3 link
         download_link = await get_download_link_from_s3(
@@ -272,7 +273,7 @@ class UploadedFile:
 class UploadedFolder: ...
 
 
-async def _generate_checksum(path_to_upload: Path | UploadableFileObject, is_directory: bool) -> SHA256Str | None:
+async def _generate_checksum(path_to_upload: Path | UploadableFileObject, *, is_directory: bool) -> SHA256Str | None:
     checksum: SHA256Str | None = None
     if is_directory:
         return checksum
@@ -357,9 +358,9 @@ async def _upload_path(  # pylint: disable=too-many-arguments
     is_directory: bool = isinstance(path_to_upload, Path) and path_to_upload.is_dir()
     if is_directory and not await r_clone.is_r_clone_available(r_clone_settings):
         msg = f"Requested to upload directory {path_to_upload}, but no rclone support was detected"
-        raise exceptions.NodeportsException(msg)
+        raise exceptions.NodeportsError(msg)
 
-    checksum: SHA256Str | None = await _generate_checksum(path_to_upload, is_directory)
+    checksum: SHA256Str | None = await _generate_checksum(path_to_upload, is_directory=is_directory)
     if io_log_redirect_cb:
         await io_log_redirect_cb(f"uploading {path_to_upload}, please wait...")
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -72,8 +72,8 @@ async def get_download_link_from_s3(
     """
     :raises exceptions.NodeportsError
     :raises exceptions.S3InvalidPathError
-    :raises exceptions.StorageInvalidCall
-    :raises exceptions.StorageServerIssue
+    :raises exceptions.StorageInvalidCallError
+    :raises exceptions.StorageServerIssueError
     """
     async with ClientSessionContextManager(client_session) as session:
         store_id = await _filemanager_utils.resolve_location_id(session, user_id, store_name, store_id)
@@ -158,7 +158,7 @@ async def download_path_from_s3(
     :type session: ClientSession, optional
     :raises exceptions.NodeportsError
     :raises exceptions.S3InvalidPathError
-    :raises exceptions.StorageInvalidCall
+    :raises exceptions.StorageInvalidCallError
     :return: path to downloaded file
     """
     _logger.debug(

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/storage_client.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/storage_client.py
@@ -151,8 +151,8 @@ async def get_download_file_link(
     link_type: LinkType,
 ) -> AnyUrl:
     """
-    :raises exceptions.StorageInvalidCall
-    :raises exceptions.StorageServerIssue
+    :raises exceptions.StorageInvalidCallError
+    :raises exceptions.StorageServerIssueError
     """
     async with retry_request(
         session,
@@ -182,7 +182,7 @@ async def get_upload_file_links(
     sha256_checksum: SHA256Str | None,
 ) -> FileUploadSchema:
     """
-    :raises exceptions.StorageServerIssue: _description_
+    :raises exceptions.StorageServerIssueError: _description_
     :raises ClientResponseError
     """
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/storage_client.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/storage_client.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Callable, Coroutine
 from contextlib import asynccontextmanager
 from functools import wraps
 from json import JSONDecodeError
-from typing import Any, ParamSpec, TypeVar
+from typing import Any
 from urllib.parse import quote
 
 from aiohttp import ClientResponse, ClientSession
@@ -40,9 +40,6 @@ _logger = logging.getLogger(__name__)
 type RequestContextManager = (
     aiohttp_client_module._RequestContextManager  # pylint: disable=protected-access # noqa: SLF001
 )
-
-P = ParamSpec("P")
-R = TypeVar("R")
 
 
 def handle_client_exception[**P, R](

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/storage_client.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/storage_client.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Callable, Coroutine
 from contextlib import asynccontextmanager
 from functools import wraps
 from json import JSONDecodeError
-from typing import Any, ParamSpec, TypeAlias, TypeVar
+from typing import Any, ParamSpec, TypeVar
 from urllib.parse import quote
 
 from aiohttp import ClientResponse, ClientSession
@@ -37,7 +37,7 @@ from .storage_endpoint import get_base_url, get_basic_auth
 _logger = logging.getLogger(__name__)
 
 
-RequestContextManager: TypeAlias = (
+type RequestContextManager = (
     aiohttp_client_module._RequestContextManager  # pylint: disable=protected-access # noqa: SLF001
 )
 
@@ -45,7 +45,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def handle_client_exception(
+def handle_client_exception[**P, R](
     handler: Callable[P, Coroutine[Any, Any, R]],
 ) -> Callable[P, Coroutine[Any, Any, R]]:
     @wraps(handler)
@@ -58,17 +58,17 @@ def handle_client_exception(
                 raise exceptions.S3InvalidPathError(msg) from err
             if err.status == status.HTTP_422_UNPROCESSABLE_ENTITY:
                 msg = f"Invalid call to storage: {err.message}"
-                raise exceptions.StorageInvalidCall(msg) from err
+                raise exceptions.StorageInvalidCallError(msg) from err
             if status.HTTP_500_INTERNAL_SERVER_ERROR > err.status >= status.HTTP_400_BAD_REQUEST:
-                raise exceptions.StorageInvalidCall(err.message) from err
+                raise exceptions.StorageInvalidCallError(err.message) from err
             if err.status > status.HTTP_500_INTERNAL_SERVER_ERROR:
-                raise exceptions.StorageServerIssue(err.message) from err
+                raise exceptions.StorageServerIssueError(err.message) from err
         except ClientConnectionError as err:
             msg = f"{err}"
-            raise exceptions.StorageServerIssue(msg) from err
+            raise exceptions.StorageServerIssueError(msg) from err
         except JSONDecodeError as err:
             msg = f"{err}"
-            raise exceptions.StorageServerIssue(msg) from err
+            raise exceptions.StorageServerIssueError(msg) from err
         # satisfy mypy
         msg = "Unhandled control flow"
         raise RuntimeError(msg)
@@ -140,7 +140,7 @@ async def list_storage_locations(*, session: ClientSession, user_id: UserID) -> 
         locations_enveloped = Envelope[FileLocationArray].model_validate(await response.json())
         if locations_enveloped.data is None:
             msg = "Storage server is not responding"
-            raise exceptions.StorageServerIssue(msg)
+            raise exceptions.StorageServerIssueError(msg)
         return locations_enveloped.data
 
 
@@ -207,7 +207,7 @@ async def get_upload_file_links(
         file_upload_links_enveloped = Envelope[FileUploadSchema].model_validate(await response.json())
     if file_upload_links_enveloped.data is None:
         msg = "Storage server is not responding"
-        raise exceptions.StorageServerIssue(msg)
+        raise exceptions.StorageServerIssueError(msg)
     return file_upload_links_enveloped.data
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/nodeports_v2.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/nodeports_v2.py
@@ -18,7 +18,7 @@ from servicelib.utils import logged_gather
 from settings_library.r_clone import RCloneSettings
 
 from ..node_ports_common.dbmanager import DBManager
-from ..node_ports_common.exceptions import PortNotFound, UnboundPortError
+from ..node_ports_common.exceptions import PortNotFoundError, UnboundPortError
 from ..node_ports_common.file_io_utils import LogRedirectCB
 from ..node_ports_v2.port import SetKWargs
 from .links import ItemConcreteValue, ItemValue
@@ -150,7 +150,7 @@ class Nodeports(BaseModel):
             ):
                 await output.set(item_value)
                 return
-        raise PortNotFound(msg=f"output port for item {item_value} not found")
+        raise PortNotFoundError(msg=f"output port for item {item_value} not found")
 
     async def _node_ports_creator_cb(self, node_uuid: NodeIDStr) -> type["Nodeports"]:
         return await self.node_port_creator_cb(self.db_manager, self.user_id, self.project_id, node_uuid)

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port.py
@@ -22,9 +22,9 @@ from pydantic import (
 from servicelib.progress_bar import ProgressBarData
 
 from ..node_ports_common.exceptions import (
-    AbsoluteSymlinkIsNotUploadableException,
+    AbsoluteSymlinkIsNotUploadableError,
     InvalidItemTypeError,
-    SymlinkToSymlinkIsNotUploadableException,
+    SymlinkToSymlinkIsNotUploadableError,
 )
 from . import port_utils
 from .links import (
@@ -54,10 +54,10 @@ def _check_if_symlink_is_valid(symlink: Path) -> None:
 
     symlink_target_path = Path(os.readlink(symlink))
     if symlink_target_path.is_symlink():
-        raise SymlinkToSymlinkIsNotUploadableException(symlink, symlink_target_path)
+        raise SymlinkToSymlinkIsNotUploadableError(symlink, symlink_target_path)
 
     if symlink_target_path.is_absolute():
-        raise AbsoluteSymlinkIsNotUploadableException(symlink, symlink_target_path)
+        raise AbsoluteSymlinkIsNotUploadableError(symlink, symlink_target_path)
 
 
 def can_parse_as(v, *types) -> bool:

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
@@ -80,7 +80,7 @@ async def get_value_from_link(
 
 async def get_download_link_from_storage(user_id: UserID, value: FileLink, link_type: LinkType) -> AnyUrl:
     """
-    :raises exceptions.NodeportsException
+    :raises exceptions.NodeportsError
     :raises exceptions.S3InvalidPathError
     :raises exceptions.StorageInvalidCall
     :raises exceptions.StorageServerIssue
@@ -208,7 +208,7 @@ async def push_file_to_store(
     progress_bar: ProgressBarData,
 ) -> FileLink:
     """
-    :raises exceptions.NodeportsException
+    :raises exceptions.NodeportsError
     """
 
     log.debug("file path %s will be uploaded to s3", file)

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
@@ -18,7 +18,7 @@ from yarl import URL
 
 from ..node_ports_common import data_items_utils, filemanager
 from ..node_ports_common.constants import SIMCORE_LOCATION
-from ..node_ports_common.exceptions import NodeportsException
+from ..node_ports_common.exceptions import NodeportsError
 from ..node_ports_common.file_io_utils import LogRedirectCB
 from ..node_ports_common.filemanager import UploadedFile, UploadedFolder
 from .links import DownloadLink, FileLink, ItemConcreteValue, ItemValue, PortLink
@@ -215,7 +215,7 @@ async def push_file_to_store(
     s3_object = data_items_utils.create_simcore_file_id(file, project_id, node_id, file_base_path=file_base_path)
     if not file.is_file():
         msg = f"Expected path={file} should be a file"
-        raise NodeportsException(msg)
+        raise NodeportsError(msg)
 
     upload_result: UploadedFolder | UploadedFile = await filemanager.upload_path(
         user_id=user_id,

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_v2/port_utils.py
@@ -82,8 +82,8 @@ async def get_download_link_from_storage(user_id: UserID, value: FileLink, link_
     """
     :raises exceptions.NodeportsError
     :raises exceptions.S3InvalidPathError
-    :raises exceptions.StorageInvalidCall
-    :raises exceptions.StorageServerIssue
+    :raises exceptions.StorageInvalidCallError
+    :raises exceptions.StorageServerIssueError
     """
     log.debug("getting link to file from storage %s", value)
 

--- a/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_common_filemanager.py
@@ -358,7 +358,7 @@ async def test_errors_upon_invalid_file_identifiers(
     assert file_path.exists()
 
     store = s3_simcore_location
-    with pytest.raises(exceptions.StorageInvalidCall):  # noqa: PT012
+    with pytest.raises(exceptions.StorageInvalidCallError):  # noqa: PT012
         invalid_s3_path = ""
         await filemanager.upload_path(
             user_id=user_id,
@@ -369,7 +369,7 @@ async def test_errors_upon_invalid_file_identifiers(
             io_log_redirect_cb=None,
         )
 
-    with pytest.raises(exceptions.StorageInvalidCall):  # noqa: PT012
+    with pytest.raises(exceptions.StorageInvalidCallError):  # noqa: PT012
         invalid_file_id = "file_id"
         await filemanager.upload_path(
             user_id=user_id,
@@ -381,7 +381,7 @@ async def test_errors_upon_invalid_file_identifiers(
         )
 
     download_folder = Path(tmpdir) / "downloads"
-    with pytest.raises(exceptions.StorageInvalidCall):  # noqa: PT012
+    with pytest.raises(exceptions.StorageInvalidCallError):  # noqa: PT012
         async with ProgressBarData(num_steps=1, description=faker.pystr()) as progress_bar:
             invalid_s3_path = ""
             await filemanager.download_path_from_s3(
@@ -423,7 +423,7 @@ async def test_invalid_store(
 
     file_id = create_valid_file_uuid("", file_path)
     store = "somefunkystore"
-    with pytest.raises(exceptions.S3InvalidStore):
+    with pytest.raises(exceptions.S3InvalidStoreError):
         await filemanager.upload_path(
             user_id=user_id,
             store_id=None,
@@ -434,7 +434,7 @@ async def test_invalid_store(
         )
 
     download_folder = Path(tmpdir) / "downloads"
-    with pytest.raises(exceptions.S3InvalidStore):
+    with pytest.raises(exceptions.S3InvalidStoreError):
         async with ProgressBarData(num_steps=1, description=faker.pystr()) as progress_bar:
             await filemanager.download_path_from_s3(
                 user_id=user_id,
@@ -527,16 +527,16 @@ async def test_invalid_call_raises_exception(
     file_id = create_valid_file_uuid("", file_path)
     assert file_path.exists() is False
 
-    with pytest.raises(exceptions.StorageInvalidCall):
+    with pytest.raises(exceptions.StorageInvalidCallError):
         await fct(
             user_id=None,
             store_id=s3_simcore_location,
             s3_object=file_id,
             **extra_kwargs,  # type: ignore
         )
-    with pytest.raises(exceptions.StorageInvalidCall):
+    with pytest.raises(exceptions.StorageInvalidCallError):
         await fct(user_id=user_id, store_id=None, s3_object=file_id, **extra_kwargs)  # type: ignore
-    with pytest.raises(exceptions.StorageInvalidCall):
+    with pytest.raises(exceptions.StorageInvalidCallError):
         await fct(
             user_id=user_id,
             store_id=s3_simcore_location,

--- a/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
+++ b/packages/simcore-sdk/tests/integration/test_node_ports_v2_nodeports2.py
@@ -671,7 +671,7 @@ async def test_file_mapping(
 
     # now set
     invalid_alias = Path("invalid_alias.fjfj")
-    with pytest.raises(exceptions.PortNotFound):
+    with pytest.raises(exceptions.PortNotFoundError):
         await PORTS.set_file_by_keymap(invalid_alias)
     assert isinstance(file_path, Path)
     await PORTS.set_file_by_keymap(file_path)

--- a/packages/simcore-sdk/tests/unit/test_node_ports_v2_nodeports_v2.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_v2_nodeports_v2.py
@@ -205,7 +205,7 @@ async def test_node_ports_set_file_by_keymap(
 
     await node_ports.set_file_by_keymap(Path(__file__))
 
-    with pytest.raises(exceptions.PortNotFound):
+    with pytest.raises(exceptions.PortNotFoundError):
         await node_ports.set_file_by_keymap(Path("/whatever/file/that/is/invalid"))
 
 

--- a/services/api-server/src/simcore_service_api_server/services_http/solver_job_outputs.py
+++ b/services/api-server/src/simcore_service_api_server/services_http/solver_job_outputs.py
@@ -48,5 +48,5 @@ async def get_solver_output_results(
 
         return solver_output_results
 
-    except node_ports_v2.exceptions.NodeNotFound as err:
+    except node_ports_v2.exceptions.NodeNotFoundError as err:
         raise SolverOutputNotFoundError(project_uuid=project_uuid) from err

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -60,7 +60,7 @@ from pydantic.networks import AnyUrl
 from servicelib.logging_utils import log_context
 from servicelib.utils import limited_gather
 from settings_library.s3 import S3Settings
-from simcore_sdk.node_ports_common.exceptions import NodeportsException
+from simcore_sdk.node_ports_common.exceptions import NodeportsError
 from simcore_sdk.node_ports_v2 import FileLinkType
 from tenacity.asyncio import AsyncRetrying
 from tenacity.before_sleep import before_sleep_log
@@ -198,7 +198,8 @@ class DaskClient:
         ) -> TaskOutputData:
             """This function is serialized by the Dask client and sent over to the Dask sidecar(s)
             Therefore, (screaming here) DO NOT MOVE THAT IMPORT ANYWHERE ELSE EVER!!"""
-            from simcore_service_dask_sidecar.worker import (  # type: ignore[import-not-found] # this runs inside the dask-sidecar
+            # this runs inside the dask-sidecar
+            from simcore_service_dask_sidecar.worker import (  # type: ignore[import-not-found] # noqa: PLC0415
                 run_computational_sidecar,
             )
 
@@ -384,7 +385,7 @@ class DaskClient:
                         callback=callback,
                     )
                 )
-            except (NodeportsException, ValidationError, ClientResponseError) as exc:
+            except (NodeportsError, ValidationError, ClientResponseError) as exc:
                 raise TaskSchedulingError(project_id=project_id, node_id=node_id, msg=f"{exc}") from exc
 
         return list_of_node_id_to_job_id
@@ -471,7 +472,10 @@ class DaskClient:
                             f"Task {job_id} not found. State is UNKNOWN.",
                             error=exc,
                             error_context=log_error_context,
-                            tip="If the task is supposed to exist, the dask-schdeler has probably restarted. Check its status.",
+                            tip=(
+                                "If the task is supposed to exist, the dask-schdeler has probably restarted. "
+                                "Check its status."
+                            ),
                         ),
                     )
                     return RunningState.UNKNOWN

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -473,7 +473,7 @@ class DaskClient:
                             error=exc,
                             error_context=log_error_context,
                             tip=(
-                                "If the task is supposed to exist, the dask-schdeler has probably restarted. "
+                                "If the task is supposed to exist, the dask-scheduler has probably restarted. "
                                 "Check its status."
                             ),
                         ),

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_utils.py
@@ -319,33 +319,15 @@ async def generate_tasks_list_from_project(
         for node in project.workbench.values()
     }
 
-    key_version_to_node_infos: dict[
-        ServiceKeyVersion,
-        tuple[
-            ServiceMetaDataPublished | None,
-            ServiceExtras | None,
-            SimcoreServiceLabels | None,
-        ],
-    ] = {}
-    for key_version in unique_service_key_versions:
-        try:
-            key_version_to_node_infos[key_version] = await _get_node_infos(
-                catalog_client,
-                user_id,
-                product_name,
-                key_version,
-            )
-        except Exception:  # pylint: disable=broad-exception-caught
-            _logger.warning(
-                "Failed to get node info from catalog for service %s:%s. "
-                "Nodes using this service will be skipped and will NOT have "
-                "a comp_tasks entry. This may be caused by a manually edited "
-                "service version in the project workbench or a missing pricing plan.",
-                key_version.key,
-                key_version.version,
-                exc_info=True,
-            )
-            key_version_to_node_infos[key_version] = (None, None, None)
+    key_version_to_node_infos = {
+        key_version: await _get_node_infos(
+            catalog_client,
+            user_id,
+            product_name,
+            key_version,
+        )
+        for key_version in unique_service_key_versions
+    }
 
     for internal_id, node_id in enumerate(project.workbench, 1):
         node: Node = project.workbench[node_id]

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_utils.py
@@ -319,15 +319,33 @@ async def generate_tasks_list_from_project(
         for node in project.workbench.values()
     }
 
-    key_version_to_node_infos = {
-        key_version: await _get_node_infos(
-            catalog_client,
-            user_id,
-            product_name,
-            key_version,
-        )
-        for key_version in unique_service_key_versions
-    }
+    key_version_to_node_infos: dict[
+        ServiceKeyVersion,
+        tuple[
+            ServiceMetaDataPublished | None,
+            ServiceExtras | None,
+            SimcoreServiceLabels | None,
+        ],
+    ] = {}
+    for key_version in unique_service_key_versions:
+        try:
+            key_version_to_node_infos[key_version] = await _get_node_infos(
+                catalog_client,
+                user_id,
+                product_name,
+                key_version,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            _logger.warning(
+                "Failed to get node info from catalog for service %s:%s. "
+                "Nodes using this service will be skipped and will NOT have "
+                "a comp_tasks entry. This may be caused by a manually edited "
+                "service version in the project workbench or a missing pricing plan.",
+                key_version.key,
+                key_version.version,
+                exc_info=True,
+            )
+            key_version_to_node_infos[key_version] = (None, None, None)
 
     for internal_id, node_id in enumerate(project.workbench, 1):
         node: Node = project.workbench[node_id]
@@ -338,6 +356,14 @@ async def generate_tasks_list_from_project(
         )
 
         if not node_details:
+            _logger.warning(
+                "Skipping node %s (%s:%s) in project %s: "
+                "service not found in catalog. No comp_tasks entry will be created.",
+                node_id,
+                node.key,
+                node.version,
+                project.uuid,
+            )
             continue
 
         assert node.state is not None  # nosec

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -32,7 +32,7 @@ from models_library.wallets import WalletID
 from pydantic import AnyUrl, ByteSize, TypeAdapter, ValidationError
 from simcore_sdk import node_ports_v2
 from simcore_sdk.node_ports_common.exceptions import (
-    NodeportsException,
+    NodeportsError,
     S3InvalidPathError,
     StorageInvalidCall,
     UnboundPortError,
@@ -139,10 +139,7 @@ async def parse_output_data(
     ports_errors = []
     for port_key, port_value in data.items():
         value_to_transfer: links.ItemValue | None = None
-        if isinstance(port_value, FileUrl):
-            value_to_transfer = port_value.url
-        else:
-            value_to_transfer = port_value
+        value_to_transfer = port_value.url if isinstance(port_value, FileUrl) else port_value
 
         try:
             await (await ports.outputs)[port_key].set_value(value_to_transfer)
@@ -369,7 +366,7 @@ async def get_task_log_file(user_id: UserID, project_id: ProjectID, node_id: Nod
             user_id, project_id, node_id, file_link_type=FileLinkType.PRESIGNED
         )
 
-    except NodeportsException as err:
+    except NodeportsError as err:
         # Unexpected error: Cannot determine the cause of failure
         # to get download link and cannot handle it automatically.
         # Will treat it as "not available" and log a warning

--- a/services/director-v2/src/simcore_service_director_v2/utils/dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dask.py
@@ -34,7 +34,7 @@ from simcore_sdk import node_ports_v2
 from simcore_sdk.node_ports_common.exceptions import (
     NodeportsError,
     S3InvalidPathError,
-    StorageInvalidCall,
+    StorageInvalidCallError,
     UnboundPortError,
 )
 from simcore_sdk.node_ports_v2 import FileLinkType, Port, links, port_utils
@@ -355,7 +355,7 @@ async def _get_service_log_file_download_link(
             link_type=file_link_type,
         )
         return value_link
-    except (S3InvalidPathError, StorageInvalidCall) as err:
+    except (S3InvalidPathError, StorageInvalidCallError) as err:
         _logger.debug("Log for task %s not found: %s", f"{project_id=}/{node_id=}", err)
         return None
 

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/application.py
@@ -10,7 +10,7 @@ from servicelib.fastapi.openapi import (
     override_fastapi_openapi_method,
 )
 from servicelib.tracing import TracingConfig
-from simcore_sdk.node_ports_common.exceptions import NodeNotFound
+from simcore_sdk.node_ports_common.exceptions import NodeNotFoundError
 
 from .._meta import API_VERSION, API_VTAG, APP_NAME, SUMMARY, __version__
 from ..models.schemas.application_health import ApplicationHealth
@@ -217,7 +217,7 @@ def create_app() -> FastAPI:  # noqa: PLR0915
 
     # ERROR HANDLERS  ------------
     app.add_exception_handler(
-        NodeNotFound,
+        NodeNotFoundError,
         node_not_found_error_handler,  # type: ignore[arg-type]
     )
     app.add_exception_handler(BaseDynamicSidecarError, http_error_handler)  # type: ignore[arg-type]

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/error_handlers.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/core/error_handlers.py
@@ -1,6 +1,6 @@
 from fastapi import status
 from fastapi.encoders import jsonable_encoder
-from simcore_sdk.node_ports_common.exceptions import NodeNotFound
+from simcore_sdk.node_ports_common.exceptions import NodeNotFoundError
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
@@ -14,7 +14,7 @@ async def http_error_handler(_: Request, exception: BaseDynamicSidecarError) -> 
     )
 
 
-async def node_not_found_error_handler(_: Request, exception: NodeNotFound) -> JSONResponse:
+async def node_not_found_error_handler(_: Request, exception: NodeNotFoundError) -> JSONResponse:
     error_fields = {
         "code": "dynamic_sidecar.nodeports.node_not_found",
         "message": f"{exception}",

--- a/services/dynamic-sidecar/tests/unit/api/rest/test_containers_long_running_tasks.py
+++ b/services/dynamic-sidecar/tests/unit/api/rest/test_containers_long_running_tasks.py
@@ -47,7 +47,7 @@ from servicelib.long_running_tasks.errors import TaskExceptionError
 from servicelib.long_running_tasks.models import ProgressCallback, TaskId
 from servicelib.long_running_tasks.task import TaskRegistry
 from settings_library.rabbit import RabbitSettings
-from simcore_sdk.node_ports_common.exceptions import NodeNotFound
+from simcore_sdk.node_ports_common.exceptions import NodeNotFoundError
 from simcore_service_dynamic_sidecar._meta import API_VTAG
 from simcore_service_dynamic_sidecar.core.validation import InvalidComposeSpecError
 from simcore_service_dynamic_sidecar.models.shared_store import SharedStore
@@ -300,7 +300,7 @@ def missing_node_uuid(faker: faker.Faker) -> str:
 @pytest.fixture
 def mock_node_missing(mocker: MockerFixture, missing_node_uuid: str) -> None:
     async def _mocked(*args, **kwargs) -> None:
-        raise NodeNotFound(missing_node_uuid)
+        raise NodeNotFoundError(missing_node_uuid)
 
     mocker.patch(
         "simcore_service_dynamic_sidecar.modules.outputs._manager.upload_outputs",

--- a/services/dynamic-sidecar/tests/unit/api/rest/test_containers_long_running_tasks.py
+++ b/services/dynamic-sidecar/tests/unit/api/rest/test_containers_long_running_tasks.py
@@ -300,7 +300,7 @@ def missing_node_uuid(faker: faker.Faker) -> str:
 @pytest.fixture
 def mock_node_missing(mocker: MockerFixture, missing_node_uuid: str) -> None:
     async def _mocked(*args, **kwargs) -> None:
-        raise NodeNotFoundError(missing_node_uuid)
+        raise NodeNotFoundError(missing_node_uuid, project_id="fake-project-id")
 
     mocker.patch(
         "simcore_service_dynamic_sidecar.modules.outputs._manager.upload_outputs",

--- a/services/dynamic-sidecar/tests/unit/api/rpc/test__containers_long_running_tasks.py
+++ b/services/dynamic-sidecar/tests/unit/api/rpc/test__containers_long_running_tasks.py
@@ -46,7 +46,7 @@ from servicelib.rabbitmq.rpc_interfaces.dynamic_sidecar import (
     containers_long_running_tasks,
 )
 from settings_library.rabbit import RabbitSettings
-from simcore_sdk.node_ports_common.exceptions import NodeNotFound
+from simcore_sdk.node_ports_common.exceptions import NodeNotFoundError
 from simcore_service_dynamic_sidecar.core.validation import InvalidComposeSpecError
 from simcore_service_dynamic_sidecar.models.shared_store import SharedStore
 from simcore_service_dynamic_sidecar.modules import long_running_tasks as sidecar_lrts
@@ -255,7 +255,7 @@ def missing_node_uuid(faker: faker.Faker) -> str:
 @pytest.fixture
 def mock_node_missing(mocker: MockerFixture, missing_node_uuid: str) -> None:
     async def _mocked(*args, **kwargs) -> None:
-        raise NodeNotFound(missing_node_uuid)
+        raise NodeNotFoundError(missing_node_uuid)
 
     mocker.patch(
         "simcore_service_dynamic_sidecar.modules.outputs._manager.upload_outputs",

--- a/services/dynamic-sidecar/tests/unit/api/rpc/test__containers_long_running_tasks.py
+++ b/services/dynamic-sidecar/tests/unit/api/rpc/test__containers_long_running_tasks.py
@@ -255,7 +255,7 @@ def missing_node_uuid(faker: faker.Faker) -> str:
 @pytest.fixture
 def mock_node_missing(mocker: MockerFixture, missing_node_uuid: str) -> None:
     async def _mocked(*args, **kwargs) -> None:
-        raise NodeNotFoundError(missing_node_uuid)
+        raise NodeNotFoundError(missing_node_uuid, project_id="fake-project-id")
 
     mocker.patch(
         "simcore_service_dynamic_sidecar.modules.outputs._manager.upload_outputs",


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


A node that exists in the project workbench can fail with a confusing "node not found" error if its `comp_tasks` entry was never created — typically because someone manually edited the service version in the DB to one the catalog doesn't know, or because the pricing plan lookup failed. This PR:

- Logs actionable warnings identifying the exact service:version causing the issue
- Improves the error message to point operators toward the actual root cause (catalog/pricing misconfiguration) instead of implying the node doesn't exist
- Enhances serialisation to avoid issues when traversing the RPC bridge


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
