### PR TITLE
🔒️ fix(service-library): redact Redis password from logs and task names

### DIFF
--- a/packages/service-library/src/servicelib/redis/_client.py
+++ b/packages/service-library/src/servicelib/redis/_client.py
@@ -88,15 +88,14 @@ class RedisClientSDK:
 
         self._task_health_check = asyncio.create_task(
             _periodic_check_health(),
-            name=f"redis_service_health_check_{self.redis_dsn}__{uuid4()}",
+            name=f"redis_service_health_check_{redact_url(self.redis_dsn)}__{uuid4()}",
         )
 
         await wait_till_redis_is_responsive(self._client)
 
         _logger.info(
-            "Connection to %s succeeded with %s",
+            "Connection to %s succeeded",
             f"Redis at dsn={redact_url(self.redis_dsn)}",
-            f"{self._client=}",
         )
 
     async def shutdown(self) -> None:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request makes minor improvements to the Redis client logging and task naming for better security and clarity.

## What happened

🚨 The Redis client's `repr()` leaks the plain password through SSLConnection's representation!

<img width="932" height="147" alt="image" src="https://github.com/user-attachments/assets/32538da7-08e9-4a56-948e-a3886e0a2235" />

## What changed
- The Redis connection health check task now uses a redacted version of the Redis DSN in its name, preventing sensitive information from appearing in logs or task lists.
- The log message for a successful Redis connection no longer includes the client object, reducing unnecessary log details and exposure of sensitive data.

## Dev-ops
No changes.