### PR TITLE
♻️ Add xfail to pact tests

### DIFF
--- a/services/api-server/tests/unit/pact_broker/test_pact_checkout_release.py
+++ b/services/api-server/tests/unit/pact_broker/test_pact_checkout_release.py
@@ -88,7 +88,9 @@ def mock_rut_server_rpc(app: FastAPI, mocker: MockerFixture) -> Iterable[None]:
     app.dependency_overrides.pop(get_resource_usage_tracker_client, None)
 
 
-@pytest.mark.xfail(reason="PACT broker server pending migration to AWS ZMT account")
+@pytest.mark.xfail(
+    reason="PACT broker server pending migration to AWS ZMT account (https://github.com/ITISFoundation/osparc-simcore/issues/9118)"
+)
 def test_osparc_api_server_checkout_release_pact(
     pact_broker_credentials: tuple[str, str, str],
     mock_wb_api_server_rpc: None,

--- a/services/api-server/tests/unit/pact_broker/test_pact_checkout_release.py
+++ b/services/api-server/tests/unit/pact_broker/test_pact_checkout_release.py
@@ -88,6 +88,7 @@ def mock_rut_server_rpc(app: FastAPI, mocker: MockerFixture) -> Iterable[None]:
     app.dependency_overrides.pop(get_resource_usage_tracker_client, None)
 
 
+@pytest.mark.xfail(reason="PACT broker server pending migration to AWS ZMT account")
 def test_osparc_api_server_checkout_release_pact(
     pact_broker_credentials: tuple[str, str, str],
     mock_wb_api_server_rpc: None,

--- a/services/api-server/tests/unit/pact_broker/test_pact_licensed_items.py
+++ b/services/api-server/tests/unit/pact_broker/test_pact_licensed_items.py
@@ -142,7 +142,9 @@ async def mock_wb_api_server_rpc(
     mock_handler_in_licenses_rpc_interface("get_licensed_items", return_value=EXPECTED_LICENSED_ITEMS_PAGE)
 
 
-@pytest.mark.xfail(reason="PACT broker server pending migration to AWS ZMT account")
+@pytest.mark.xfail(
+    reason="PACT broker server pending migration to AWS ZMT account (https://github.com/ITISFoundation/osparc-simcore/issues/9118)"
+)
 def test_osparc_api_server_licensed_items_pact(
     pact_broker_credentials: tuple[str, str, str],
     mock_wb_api_server_rpc: None,

--- a/services/api-server/tests/unit/pact_broker/test_pact_licensed_items.py
+++ b/services/api-server/tests/unit/pact_broker/test_pact_licensed_items.py
@@ -142,6 +142,7 @@ async def mock_wb_api_server_rpc(
     mock_handler_in_licenses_rpc_interface("get_licensed_items", return_value=EXPECTED_LICENSED_ITEMS_PAGE)
 
 
+@pytest.mark.xfail(reason="PACT broker server pending migration to AWS ZMT account")
 def test_osparc_api_server_licensed_items_pact(
     pact_broker_credentials: tuple[str, str, str],
     mock_wb_api_server_rpc: None,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
- ♻️ Add xfail to pact tests
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
