### PR TITLE
:bug: fix(director-v2): align computation lifecycle timestamps with run state

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -73,8 +73,6 @@ from ...utils import computations as utils
 from ...utils.computations_tasks import validate_pipeline
 from ...utils.dags import (
     compute_pipeline_details,
-    compute_pipeline_started_timestamp,
-    compute_pipeline_stopped_timestamp,
     create_complete_dag,
     create_complete_dag_from_tasks,
     create_minimal_computational_graph_based_on_selection,
@@ -364,8 +362,8 @@ async def create_or_update_or_start_computation(  # noqa: PLR0913 # pylint: disa
             ),
             iteration=last_run.iteration if last_run else None,
             result=None,
-            started=compute_pipeline_started_timestamp(minimal_computational_dag, comp_tasks),
-            stopped=compute_pipeline_stopped_timestamp(minimal_computational_dag, comp_tasks),
+            started=last_run.started if last_run else None,
+            stopped=last_run.ended if last_run else None,
             submitted=last_run.created if last_run else None,
         )
 
@@ -452,8 +450,8 @@ async def get_computation(
         ),
         iteration=last_run.iteration if last_run else None,
         result=None,
-        started=compute_pipeline_started_timestamp(pipeline_dag, all_tasks),
-        stopped=compute_pipeline_stopped_timestamp(pipeline_dag, all_tasks),
+        started=last_run.started if last_run else None,
+        stopped=last_run.ended if last_run else None,
         submitted=last_run.created if last_run else None,
     )
 
@@ -505,8 +503,8 @@ async def stop_computation(
             stop_url=None,
             iteration=last_run.iteration if last_run else None,
             result=None,
-            started=compute_pipeline_started_timestamp(pipeline_dag, tasks),
-            stopped=compute_pipeline_stopped_timestamp(pipeline_dag, tasks),
+            started=last_run.started if last_run else None,
+            stopped=last_run.ended if last_run else None,
             submitted=last_run.created if last_run else None,
         )
 

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -362,8 +362,8 @@ async def create_or_update_or_start_computation(  # noqa: PLR0913 # pylint: disa
             ),
             iteration=last_run.iteration if last_run else None,
             result=None,
-            started=last_run.started if pipeline_started and last_run else None,
-            stopped=last_run.ended if pipeline_started and last_run else None,
+            started=last_run.started if last_run else None,
+            stopped=last_run.ended if last_run else None,
             submitted=last_run.created if last_run else None,
         )
 

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -362,8 +362,8 @@ async def create_or_update_or_start_computation(  # noqa: PLR0913 # pylint: disa
             ),
             iteration=last_run.iteration if last_run else None,
             result=None,
-            started=last_run.started if last_run else None,
-            stopped=last_run.ended if last_run else None,
+            started=last_run.started if last_run and pipeline_started else None,
+            stopped=last_run.ended if last_run and pipeline_started else None,
             submitted=last_run.created if last_run else None,
         )
 

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -362,8 +362,8 @@ async def create_or_update_or_start_computation(  # noqa: PLR0913 # pylint: disa
             ),
             iteration=last_run.iteration if last_run else None,
             result=None,
-            started=last_run.started if last_run else None,
-            stopped=last_run.ended if last_run else None,
+            started=last_run.started if pipeline_started and last_run else None,
+            stopped=last_run.ended if pipeline_started and last_run else None,
             submitted=last_run.created if last_run else None,
         )
 

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -72,7 +72,6 @@ from ...modules.resource_usage_tracker_client import ResourceUsageTrackerClient
 from ...utils import computations as utils
 from ...utils.computations_tasks import validate_pipeline
 from ...utils.dags import (
-    compute_pipeline_details,
     create_complete_dag,
     create_complete_dag_from_tasks,
     create_minimal_computational_graph_based_on_selection,

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -72,6 +72,7 @@ from ...modules.resource_usage_tracker_client import ResourceUsageTrackerClient
 from ...utils import computations as utils
 from ...utils.computations_tasks import validate_pipeline
 from ...utils.dags import (
+    compute_pipeline_details,
     create_complete_dag,
     create_complete_dag_from_tasks,
     create_minimal_computational_graph_based_on_selection,

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -500,15 +500,15 @@ async def test_run_partial_computation(
         ],
     )
     assert new_task_out is not None
-    # pipeline is up-to-date: nothing to run, so no stop_url, empty adjacency list,
-    # and state/timestamps reflect the last completed run
+    # pipeline is up-to-date: nothing to run, so no stop_url, no started/stopped timestamps,
+    # empty adjacency list, and state reflects the last completed run
     assert new_task_out.stop_url is None
     assert new_task_out.state is RunningState.SUCCESS
     assert new_task_out.id == task_out.id
     assert new_task_out.iteration == task_out.iteration
     assert new_task_out.pipeline_details.adjacency_list == {}
-    assert new_task_out.started == task_out.started
-    assert new_task_out.stopped == task_out.stopped
+    assert new_task_out.started is None
+    assert new_task_out.stopped is None
 
     # force run it this time.
     # the task are up-to-date but we force run them
@@ -614,15 +614,15 @@ async def test_run_computation(
         product_api_base_url=osparc_product_api_base_url,
     )
     assert new_task_out is not None
-    # pipeline is up-to-date: nothing to run, so no stop_url, empty adjacency list,
-    # and state/timestamps reflect the last completed run
+    # pipeline is up-to-date: nothing to run, so no stop_url, no started/stopped timestamps,
+    # empty adjacency list, and state reflects the last completed run
     assert new_task_out.stop_url is None
     assert new_task_out.state is RunningState.SUCCESS
     assert new_task_out.id == task_out.id
     assert new_task_out.iteration == task_out.iteration
     assert new_task_out.pipeline_details.adjacency_list == {}
-    assert new_task_out.started == task_out.started
-    assert new_task_out.stopped == task_out.stopped
+    assert new_task_out.started is None
+    assert new_task_out.stopped is None
 
     # now force run again
     # the task are up-to-date but we force run them

--- a/services/director-v2/tests/integration/01/test_computation_api.py
+++ b/services/director-v2/tests/integration/01/test_computation_api.py
@@ -500,15 +500,15 @@ async def test_run_partial_computation(
         ],
     )
     assert new_task_out is not None
-    # pipeline is up-to-date: nothing to run, so no stop_url, no started/stopped timestamps,
-    # empty adjacency list, and state reflects the last completed run
+    # pipeline is up-to-date: nothing to run, so no stop_url, empty adjacency list,
+    # and state/timestamps reflect the last completed run
     assert new_task_out.stop_url is None
     assert new_task_out.state is RunningState.SUCCESS
     assert new_task_out.id == task_out.id
     assert new_task_out.iteration == task_out.iteration
     assert new_task_out.pipeline_details.adjacency_list == {}
-    assert new_task_out.started is None
-    assert new_task_out.stopped is None
+    assert new_task_out.started == task_out.started
+    assert new_task_out.stopped == task_out.stopped
 
     # force run it this time.
     # the task are up-to-date but we force run them
@@ -614,15 +614,15 @@ async def test_run_computation(
         product_api_base_url=osparc_product_api_base_url,
     )
     assert new_task_out is not None
-    # pipeline is up-to-date: nothing to run, so no stop_url, no started/stopped timestamps,
-    # empty adjacency list, and state reflects the last completed run
+    # pipeline is up-to-date: nothing to run, so no stop_url, empty adjacency list,
+    # and state/timestamps reflect the last completed run
     assert new_task_out.stop_url is None
     assert new_task_out.state is RunningState.SUCCESS
     assert new_task_out.id == task_out.id
     assert new_task_out.iteration == task_out.iteration
     assert new_task_out.pipeline_details.adjacency_list == {}
-    assert new_task_out.started is None
-    assert new_task_out.stopped is None
+    assert new_task_out.started == task_out.started
+    assert new_task_out.stopped == task_out.stopped
 
     # now force run again
     # the task are up-to-date but we force run them

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/conftest.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/conftest.py
@@ -108,12 +108,17 @@ def minimal_configuration(
     with_disabled_scheduler_publisher: mock.Mock,
     with_product: dict[str, Any],
 ) -> None:
-    monkeypatch.setenv("DIRECTOR_V2_DYNAMIC_SIDECAR_ENABLED", "false")
-    monkeypatch.setenv("COMPUTATIONAL_BACKEND_DASK_CLIENT_ENABLED", "1")
-    monkeypatch.setenv("COMPUTATIONAL_BACKEND_ENABLED", "1")
-    monkeypatch.setenv("R_CLONE_PROVIDER", "MINIO")
-    monkeypatch.setenv("S3_ENDPOINT", faker.url())
-    monkeypatch.setenv("S3_ACCESS_KEY", faker.pystr())
-    monkeypatch.setenv("S3_REGION", faker.pystr())
-    monkeypatch.setenv("S3_SECRET_KEY", faker.pystr())
-    monkeypatch.setenv("S3_BUCKET_NAME", faker.pystr())
+    setenvs_from_dict(
+        monkeypatch,
+        {
+            "DIRECTOR_V2_DYNAMIC_SIDECAR_ENABLED": "false",
+            "COMPUTATIONAL_BACKEND_DASK_CLIENT_ENABLED": "1",
+            "COMPUTATIONAL_BACKEND_ENABLED": "1",
+            "R_CLONE_PROVIDER": "MINIO",
+            "S3_ENDPOINT": faker.url(),
+            "S3_ACCESS_KEY": faker.pystr(),
+            "S3_REGION": faker.pystr(),
+            "S3_SECRET_KEY": faker.pystr(),
+            "S3_BUCKET_NAME": faker.pystr(),
+        },
+    )

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/conftest.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/conftest.py
@@ -9,10 +9,12 @@
 
 
 import datetime
+from typing import Any
 from unittest import mock
 
 import pytest
 import sqlalchemy as sa
+from faker import Faker
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
@@ -92,3 +94,26 @@ def with_short_max_wait_for_retrieving_results(
         {"COMPUTATIONAL_BACKEND_MAX_WAITING_FOR_RETRIEVING_RESULTS": f"{short_time}"},
     )
     return short_time
+
+
+@pytest.fixture()
+def minimal_configuration(
+    mock_env: EnvVarsDict,
+    postgres_host_config: dict[str, str],
+    rabbit_service: RabbitSettings,
+    redis_service: RedisSettings,
+    monkeypatch: pytest.MonkeyPatch,
+    faker: Faker,
+    with_disabled_auto_scheduling: mock.Mock,
+    with_disabled_scheduler_publisher: mock.Mock,
+    with_product: dict[str, Any],
+):
+    monkeypatch.setenv("DIRECTOR_V2_DYNAMIC_SIDECAR_ENABLED", "false")
+    monkeypatch.setenv("COMPUTATIONAL_BACKEND_DASK_CLIENT_ENABLED", "1")
+    monkeypatch.setenv("COMPUTATIONAL_BACKEND_ENABLED", "1")
+    monkeypatch.setenv("R_CLONE_PROVIDER", "MINIO")
+    monkeypatch.setenv("S3_ENDPOINT", faker.url())
+    monkeypatch.setenv("S3_ACCESS_KEY", faker.pystr())
+    monkeypatch.setenv("S3_REGION", faker.pystr())
+    monkeypatch.setenv("S3_SECRET_KEY", faker.pystr())
+    monkeypatch.setenv("S3_BUCKET_NAME", faker.pystr())

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/conftest.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/conftest.py
@@ -107,7 +107,7 @@ def minimal_configuration(
     with_disabled_auto_scheduling: mock.Mock,
     with_disabled_scheduler_publisher: mock.Mock,
     with_product: dict[str, Any],
-):
+) -> None:
     monkeypatch.setenv("DIRECTOR_V2_DYNAMIC_SIDECAR_ENABLED", "false")
     monkeypatch.setenv("COMPUTATIONAL_BACKEND_DASK_CLIENT_ENABLED", "1")
     monkeypatch.setenv("COMPUTATIONAL_BACKEND_ENABLED", "1")

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations.py
@@ -49,9 +49,6 @@ from models_library.utils.fastapi_encoders import jsonable_encoder
 from models_library.wallets import WalletInfo
 from pydantic import AnyHttpUrl, ByteSize, PositiveInt, TypeAdapter
 from pytest_mock.plugin import MockerFixture
-from pytest_simcore.helpers.typing_env import EnvVarsDict
-from settings_library.rabbit import RabbitSettings
-from settings_library.redis import RedisSettings
 from simcore_postgres_database.models.comp_pipeline import StateType
 from simcore_postgres_database.models.comp_tasks import NodeClass
 from simcore_postgres_database.utils_projects_nodes import ProjectNodesRepo
@@ -77,29 +74,6 @@ def mocked_rabbit_mq_client(mocker: MockerFixture):
         "simcore_service_director_v2.core.application.rabbitmq.RabbitMQClient",
         autospec=True,
     )
-
-
-@pytest.fixture()
-def minimal_configuration(
-    mock_env: EnvVarsDict,
-    postgres_host_config: dict[str, str],
-    rabbit_service: RabbitSettings,
-    redis_service: RedisSettings,
-    monkeypatch: pytest.MonkeyPatch,
-    faker: Faker,
-    with_disabled_auto_scheduling: mock.Mock,
-    with_disabled_scheduler_publisher: mock.Mock,
-    with_product: dict[str, Any],
-):
-    monkeypatch.setenv("DIRECTOR_V2_DYNAMIC_SIDECAR_ENABLED", "false")
-    monkeypatch.setenv("COMPUTATIONAL_BACKEND_DASK_CLIENT_ENABLED", "1")
-    monkeypatch.setenv("COMPUTATIONAL_BACKEND_ENABLED", "1")
-    monkeypatch.setenv("R_CLONE_PROVIDER", "MINIO")
-    monkeypatch.setenv("S3_ENDPOINT", faker.url())
-    monkeypatch.setenv("S3_ACCESS_KEY", faker.pystr())
-    monkeypatch.setenv("S3_REGION", faker.pystr())
-    monkeypatch.setenv("S3_SECRET_KEY", faker.pystr())
-    monkeypatch.setenv("S3_BUCKET_NAME", faker.pystr())
 
 
 @pytest.fixture(scope="session")
@@ -969,102 +943,3 @@ async def test_get_computation_from_published_computation_task(
     assert returned_computation.model_dump(include=_CHANGED_FIELDS) != expected_computation.model_dump(
         include=_CHANGED_FIELDS
     )
-
-
-async def test_get_computation_does_not_expose_stopped_timestamp_until_run_is_completed(
-    minimal_configuration: None,
-    fake_workbench_without_outputs: dict[str, Any],
-    fake_workbench_adjacency: dict[str, Any],
-    create_registered_user: Callable[..., dict[str, Any]],
-    create_project: Callable[..., Awaitable[ProjectAtDB]],
-    create_pipeline: Callable[..., Awaitable[CompPipelineAtDB]],
-    create_tasks_from_project: Callable[..., Awaitable[list[CompTaskAtDB]]],
-    create_comp_run: Callable[..., Awaitable[CompRunsAtDB]],
-    async_client: httpx.AsyncClient,
-):
-    user = create_registered_user()
-    proj = await create_project(user, workbench=fake_workbench_without_outputs)
-    started_at = dt.datetime.now(tz=dt.UTC)
-    stopped_at = started_at + dt.timedelta(seconds=1)
-
-    await create_pipeline(
-        project_id=f"{proj.uuid}",
-        dag_adjacency_list=fake_workbench_adjacency,
-    )
-    await create_tasks_from_project(
-        user=user,
-        project=proj,
-        state=StateType.SUCCESS,
-        progress=1,
-        start=started_at,
-        end=stopped_at,
-    )
-    await create_comp_run(
-        user=user,
-        project=proj,
-        result=StateType.RUNNING,
-        started=started_at,
-        dag_adjacency_list=fake_workbench_adjacency,
-    )
-
-    get_computation_url = httpx.URL(f"/v2/computations/{proj.uuid}?user_id={user['id']}")
-    response = await async_client.get(get_computation_url)
-
-    assert response.status_code == status.HTTP_200_OK, response.text
-    returned_computation = ComputationGet.model_validate(response.json())
-    assert returned_computation.state == RunningState.STARTED
-    assert returned_computation.started == started_at
-    assert returned_computation.pipeline_details.progress == 1
-    assert {node_state.current_status for node_state in returned_computation.pipeline_details.node_states.values()} == {
-        RunningState.SUCCESS
-    }
-    assert returned_computation.stopped is None
-
-
-async def test_get_computation_uses_comp_run_timestamps_for_top_level_lifecycle(
-    minimal_configuration: None,
-    fake_workbench_without_outputs: dict[str, Any],
-    fake_workbench_adjacency: dict[str, Any],
-    create_registered_user: Callable[..., dict[str, Any]],
-    create_project: Callable[..., Awaitable[ProjectAtDB]],
-    create_pipeline: Callable[..., Awaitable[CompPipelineAtDB]],
-    create_tasks_from_project: Callable[..., Awaitable[list[CompTaskAtDB]]],
-    create_comp_run: Callable[..., Awaitable[CompRunsAtDB]],
-    async_client: httpx.AsyncClient,
-):
-    user = create_registered_user()
-    proj = await create_project(user, workbench=fake_workbench_without_outputs)
-    started_at = dt.datetime.now(tz=dt.UTC)
-    task_stopped_at = started_at + dt.timedelta(seconds=1)
-    run_stopped_at = started_at + dt.timedelta(seconds=2)
-
-    await create_pipeline(
-        project_id=f"{proj.uuid}",
-        dag_adjacency_list=fake_workbench_adjacency,
-    )
-    await create_tasks_from_project(
-        user=user,
-        project=proj,
-        state=StateType.SUCCESS,
-        progress=1,
-        start=started_at,
-        end=task_stopped_at,
-    )
-    await create_comp_run(
-        user=user,
-        project=proj,
-        result=StateType.SUCCESS,
-        started=started_at,
-        ended=run_stopped_at,
-        dag_adjacency_list=fake_workbench_adjacency,
-    )
-
-    get_computation_url = httpx.URL(f"/v2/computations/{proj.uuid}?user_id={user['id']}")
-    response = await async_client.get(get_computation_url)
-
-    assert response.status_code == status.HTTP_200_OK, response.text
-    returned_computation = ComputationGet.model_validate(response.json())
-    assert returned_computation.state == RunningState.SUCCESS
-    assert returned_computation.started == started_at
-    assert returned_computation.stopped == run_stopped_at
-    assert returned_computation.stopped != task_stopped_at

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations.py
@@ -969,3 +969,102 @@ async def test_get_computation_from_published_computation_task(
     assert returned_computation.model_dump(include=_CHANGED_FIELDS) != expected_computation.model_dump(
         include=_CHANGED_FIELDS
     )
+
+
+async def test_get_computation_does_not_expose_stopped_timestamp_until_run_is_completed(
+    minimal_configuration: None,
+    fake_workbench_without_outputs: dict[str, Any],
+    fake_workbench_adjacency: dict[str, Any],
+    create_registered_user: Callable[..., dict[str, Any]],
+    create_project: Callable[..., Awaitable[ProjectAtDB]],
+    create_pipeline: Callable[..., Awaitable[CompPipelineAtDB]],
+    create_tasks_from_project: Callable[..., Awaitable[list[CompTaskAtDB]]],
+    create_comp_run: Callable[..., Awaitable[CompRunsAtDB]],
+    async_client: httpx.AsyncClient,
+):
+    user = create_registered_user()
+    proj = await create_project(user, workbench=fake_workbench_without_outputs)
+    started_at = dt.datetime.now(tz=dt.UTC)
+    stopped_at = started_at + dt.timedelta(seconds=1)
+
+    await create_pipeline(
+        project_id=f"{proj.uuid}",
+        dag_adjacency_list=fake_workbench_adjacency,
+    )
+    await create_tasks_from_project(
+        user=user,
+        project=proj,
+        state=StateType.SUCCESS,
+        progress=1,
+        start=started_at,
+        end=stopped_at,
+    )
+    await create_comp_run(
+        user=user,
+        project=proj,
+        result=StateType.RUNNING,
+        started=started_at,
+        dag_adjacency_list=fake_workbench_adjacency,
+    )
+
+    get_computation_url = httpx.URL(f"/v2/computations/{proj.uuid}?user_id={user['id']}")
+    response = await async_client.get(get_computation_url)
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    returned_computation = ComputationGet.model_validate(response.json())
+    assert returned_computation.state == RunningState.STARTED
+    assert returned_computation.started == started_at
+    assert returned_computation.pipeline_details.progress == 1
+    assert {node_state.current_status for node_state in returned_computation.pipeline_details.node_states.values()} == {
+        RunningState.SUCCESS
+    }
+    assert returned_computation.stopped is None
+
+
+async def test_get_computation_uses_comp_run_timestamps_for_top_level_lifecycle(
+    minimal_configuration: None,
+    fake_workbench_without_outputs: dict[str, Any],
+    fake_workbench_adjacency: dict[str, Any],
+    create_registered_user: Callable[..., dict[str, Any]],
+    create_project: Callable[..., Awaitable[ProjectAtDB]],
+    create_pipeline: Callable[..., Awaitable[CompPipelineAtDB]],
+    create_tasks_from_project: Callable[..., Awaitable[list[CompTaskAtDB]]],
+    create_comp_run: Callable[..., Awaitable[CompRunsAtDB]],
+    async_client: httpx.AsyncClient,
+):
+    user = create_registered_user()
+    proj = await create_project(user, workbench=fake_workbench_without_outputs)
+    started_at = dt.datetime.now(tz=dt.UTC)
+    task_stopped_at = started_at + dt.timedelta(seconds=1)
+    run_stopped_at = started_at + dt.timedelta(seconds=2)
+
+    await create_pipeline(
+        project_id=f"{proj.uuid}",
+        dag_adjacency_list=fake_workbench_adjacency,
+    )
+    await create_tasks_from_project(
+        user=user,
+        project=proj,
+        state=StateType.SUCCESS,
+        progress=1,
+        start=started_at,
+        end=task_stopped_at,
+    )
+    await create_comp_run(
+        user=user,
+        project=proj,
+        result=StateType.SUCCESS,
+        started=started_at,
+        ended=run_stopped_at,
+        dag_adjacency_list=fake_workbench_adjacency,
+    )
+
+    get_computation_url = httpx.URL(f"/v2/computations/{proj.uuid}?user_id={user['id']}")
+    response = await async_client.get(get_computation_url)
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    returned_computation = ComputationGet.model_validate(response.json())
+    assert returned_computation.state == RunningState.SUCCESS
+    assert returned_computation.started == started_at
+    assert returned_computation.stopped == run_stopped_at
+    assert returned_computation.stopped != task_stopped_at

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations_lifecycle.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations_lifecycle.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
 
 import datetime as dt
 from collections.abc import Awaitable, Callable

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations_lifecycle.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations_lifecycle.py
@@ -1,0 +1,120 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=too-many-arguments
+
+import datetime as dt
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import httpx
+from fastapi import status
+from models_library.api_schemas_directorv2.computations import ComputationGet
+from models_library.projects import ProjectAtDB
+from models_library.projects_state import RunningState
+from simcore_postgres_database.models.comp_pipeline import StateType
+from simcore_service_director_v2.models.comp_pipelines import CompPipelineAtDB
+from simcore_service_director_v2.models.comp_runs import CompRunsAtDB
+from simcore_service_director_v2.models.comp_tasks import CompTaskAtDB
+
+pytest_simcore_core_services_selection = ["postgres", "rabbit", "redis"]
+pytest_simcore_ops_services_selection = [
+    "adminer",
+]
+
+
+async def test_get_computation_does_not_expose_stopped_timestamp_until_run_is_completed(
+    minimal_configuration: None,
+    fake_workbench_without_outputs: dict[str, Any],
+    fake_workbench_adjacency: dict[str, Any],
+    create_registered_user: Callable[..., dict[str, Any]],
+    create_project: Callable[..., Awaitable[ProjectAtDB]],
+    create_pipeline: Callable[..., Awaitable[CompPipelineAtDB]],
+    create_tasks_from_project: Callable[..., Awaitable[list[CompTaskAtDB]]],
+    create_comp_run: Callable[..., Awaitable[CompRunsAtDB]],
+    async_client: httpx.AsyncClient,
+):
+    user = create_registered_user()
+    proj = await create_project(user, workbench=fake_workbench_without_outputs)
+    started_at = dt.datetime.now(tz=dt.UTC)
+    stopped_at = started_at + dt.timedelta(seconds=1)
+
+    await create_pipeline(
+        project_id=f"{proj.uuid}",
+        dag_adjacency_list=fake_workbench_adjacency,
+    )
+    await create_tasks_from_project(
+        user=user,
+        project=proj,
+        state=StateType.SUCCESS,
+        progress=1,
+        start=started_at,
+        end=stopped_at,
+    )
+    await create_comp_run(
+        user=user,
+        project=proj,
+        result=StateType.RUNNING,
+        started=started_at,
+        dag_adjacency_list=fake_workbench_adjacency,
+    )
+
+    get_computation_url = httpx.URL(f"/v2/computations/{proj.uuid}?user_id={user['id']}")
+    response = await async_client.get(get_computation_url)
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    returned_computation = ComputationGet.model_validate(response.json())
+    assert returned_computation.state == RunningState.STARTED
+    assert returned_computation.started == started_at
+    assert returned_computation.pipeline_details.progress == 1
+    assert {node_state.current_status for node_state in returned_computation.pipeline_details.node_states.values()} == {
+        RunningState.SUCCESS
+    }
+    assert returned_computation.stopped is None
+
+
+async def test_get_computation_uses_comp_run_timestamps_for_top_level_lifecycle(
+    minimal_configuration: None,
+    fake_workbench_without_outputs: dict[str, Any],
+    fake_workbench_adjacency: dict[str, Any],
+    create_registered_user: Callable[..., dict[str, Any]],
+    create_project: Callable[..., Awaitable[ProjectAtDB]],
+    create_pipeline: Callable[..., Awaitable[CompPipelineAtDB]],
+    create_tasks_from_project: Callable[..., Awaitable[list[CompTaskAtDB]]],
+    create_comp_run: Callable[..., Awaitable[CompRunsAtDB]],
+    async_client: httpx.AsyncClient,
+):
+    user = create_registered_user()
+    proj = await create_project(user, workbench=fake_workbench_without_outputs)
+    started_at = dt.datetime.now(tz=dt.UTC)
+    task_stopped_at = started_at + dt.timedelta(seconds=1)
+    run_stopped_at = started_at + dt.timedelta(seconds=2)
+
+    await create_pipeline(
+        project_id=f"{proj.uuid}",
+        dag_adjacency_list=fake_workbench_adjacency,
+    )
+    await create_tasks_from_project(
+        user=user,
+        project=proj,
+        state=StateType.SUCCESS,
+        progress=1,
+        start=started_at,
+        end=task_stopped_at,
+    )
+    await create_comp_run(
+        user=user,
+        project=proj,
+        result=StateType.SUCCESS,
+        started=started_at,
+        ended=run_stopped_at,
+        dag_adjacency_list=fake_workbench_adjacency,
+    )
+
+    get_computation_url = httpx.URL(f"/v2/computations/{proj.uuid}?user_id={user['id']}")
+    response = await async_client.get(get_computation_url)
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    returned_computation = ComputationGet.model_validate(response.json())
+    assert returned_computation.state == RunningState.SUCCESS
+    assert returned_computation.started == started_at
+    assert returned_computation.stopped == run_stopped_at
+    assert returned_computation.stopped != task_stopped_at

--- a/tests/public-api/test_solvers_jobs_api.py
+++ b/tests/public-api/test_solvers_jobs_api.py
@@ -20,7 +20,7 @@ from zipfile import ZipFile
 import osparc
 import pytest
 from pytest_simcore.helpers.typing_public_api import ServiceInfoDict, ServiceNameStr
-from tenacity import Retrying, TryAgain, stop_after_delay, wait_fixed
+from tenacity import Retrying, TryAgain, retry_if_exception_type, stop_after_delay, wait_fixed
 
 osparc_VERSION = tuple(map(int, osparc.__version__.split(".")))
 assert osparc_VERSION >= (0, 4, 3)
@@ -217,6 +217,7 @@ def test_run_job(
     for attempt in Retrying(
         stop=stop_after_delay(_JOB_COMPLETION_TIMEOUT),
         wait=wait_fixed(0.5),
+        retry=retry_if_exception_type(TryAgain),
         reraise=True,
     ):
         with attempt:

--- a/tests/public-api/test_solvers_jobs_api.py
+++ b/tests/public-api/test_solvers_jobs_api.py
@@ -14,6 +14,7 @@ import logging
 import time
 from operator import attrgetter
 from pathlib import Path
+from typing import Final
 from urllib.parse import quote_plus
 from zipfile import ZipFile
 
@@ -26,6 +27,8 @@ assert osparc_VERSION >= (0, 4, 3)
 
 
 logger = logging.getLogger(__name__)
+
+_JOB_COMPLETION_TIMEOUT: Final = 120
 
 
 @pytest.fixture(scope="module")
@@ -211,8 +214,9 @@ def test_run_job(
     #    job.created_at < status.submitted_at < (job.created_at + timedelta(seconds=2))
     # )
 
-    # poll stop time-stamp
+    deadline = time.monotonic() + _JOB_COMPLETION_TIMEOUT
     while not status.stopped_at:
+        assert time.monotonic() < deadline, f"Timed out waiting for job {job.id}: {status=}"
         time.sleep(0.5)
         status: osparc.JobStatus = solvers_api.inspect_job(solver.id, solver.version, job.id)
         assert isinstance(status, osparc.JobStatus)
@@ -224,6 +228,7 @@ def test_run_job(
     # done, either successfully or with failures!
     assert status.progress == 100
     assert status.state == expected_outcome
+    assert status.stopped_at is not None
     # FIXME: assert status.submitted_at < status.started_at
     # FIXME: assert status.started_at < status.stopped_at
     assert status.submitted_at < status.stopped_at

--- a/tests/public-api/test_solvers_jobs_api.py
+++ b/tests/public-api/test_solvers_jobs_api.py
@@ -11,7 +11,6 @@ might affect the others. E.g. files uploaded in one test can be listed in rext
 # pylint: disable=unused-variable
 
 import logging
-import time
 from operator import attrgetter
 from pathlib import Path
 from typing import Final
@@ -21,6 +20,7 @@ from zipfile import ZipFile
 import osparc
 import pytest
 from pytest_simcore.helpers.typing_public_api import ServiceInfoDict, ServiceNameStr
+from tenacity import Retrying, TryAgain, stop_after_delay, wait_fixed
 
 osparc_VERSION = tuple(map(int, osparc.__version__.split(".")))
 assert osparc_VERSION >= (0, 4, 3)
@@ -214,16 +214,20 @@ def test_run_job(
     #    job.created_at < status.submitted_at < (job.created_at + timedelta(seconds=2))
     # )
 
-    deadline = time.monotonic() + _JOB_COMPLETION_TIMEOUT
-    while not status.stopped_at:
-        assert time.monotonic() < deadline, f"Timed out waiting for job {job.id}: {status=}"
-        time.sleep(0.5)
-        status: osparc.JobStatus = solvers_api.inspect_job(solver.id, solver.version, job.id)
-        assert isinstance(status, osparc.JobStatus)
+    for attempt in Retrying(
+        stop=stop_after_delay(_JOB_COMPLETION_TIMEOUT),
+        wait=wait_fixed(0.5),
+        reraise=True,
+    ):
+        with attempt:
+            status = solvers_api.inspect_job(solver.id, solver.version, job.id)
+            assert isinstance(status, osparc.JobStatus)
+            assert 0 <= status.progress <= 100
 
-        assert 0 <= status.progress <= 100
+            print("Solver progress", f"{status.progress}/100", flush=True)
 
-        print("Solver progress", f"{status.progress}/100", flush=True)
+            if not status.stopped_at:
+                raise TryAgain
 
     # done, either successfully or with failures!
     assert status.progress == 100


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request refactors how computation run timestamps are determined and exposed in the director-v2 service. Instead of inferring the `started` and `stopped` timestamps from task-level data, the code now consistently uses the top-level computation run (`CompRunsAtDB`) timestamps. This ensures more accurate and consistent reporting of computation lifecycle events. Additionally, new tests were added to verify this behavior, and a minor improvement was made to a public API test to make job completion polling more robust.

> [!NOTE]
> 🐛 found while analyzing a [flaky test](https://github.com/ITISFoundation/osparc-simcore/actions/runs/25763738965/job/75672260910?pr=9120). 

## Related issue/s

## How to test
```sh
cd service/director-v2
make install-dev
pytest -vv --pdb tests/unit/with_dbs/comp_scheduler/test_api_route_computations.py
```

## Dev-ops
No changes.