### PR TITLE
 🎨 🤖 Per-instance OpenTelemetry tracing for autoscaling

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_auto_scaling_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_auto_scaling_core.py
@@ -27,6 +27,7 @@ from models_library.docker import DockerLabelKey
 from models_library.generated_models.docker_rest_api import Node
 from models_library.rabbitmq_messages import ProgressType
 from servicelib.logging_utils import log_catch, log_context
+from servicelib.tracing import traced_operation
 from servicelib.utils_formatting import timedelta_as_minute_second
 from types_aiobotocore_ec2.literals import InstanceTypeType
 
@@ -78,6 +79,7 @@ from ..ec2 import get_ec2_client
 from ..instrumentation import get_instrumentation, has_instrumentation
 from ..ssm import get_ssm_client
 from ._provider_protocol import AutoscalingProvider
+from ._tracing import emit_instance_span, get_tracing_config
 
 _logger = logging.getLogger(__name__)
 
@@ -258,7 +260,18 @@ async def _cleanup_disconnected_nodes(app: FastAPI, cluster: Cluster) -> Cluster
 async def _terminate_broken_ec2s(app: FastAPI, cluster: Cluster) -> Cluster:
     broken_instances = [i.ec2_instance for i in cluster.broken_ec2s]
     if broken_instances:
+        tracing_config = get_tracing_config(app)
         with log_context(_logger, logging.WARNING, msg="terminate broken EC2 instances"):
+            for instance in broken_instances:
+                emit_instance_span(
+                    tracing_config,
+                    instance.id,
+                    "ec2_instance_broken_terminated",
+                    {
+                        "ec2.instance.type": instance.type,
+                        "ec2.instance.state": instance.state,
+                    },
+                )
             await get_ec2_client(app).terminate_instances(broken_instances)
 
     return dataclasses.replace(
@@ -279,6 +292,7 @@ async def _try_attach_pending_ec2s(
     app_settings = get_application_settings(app)
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
     ec2_instances_to_remove_custom_label_tags: list[EC2InstanceData] = []
+    tracing_config = get_tracing_config(app)
 
     for instance_data in cluster.pending_ec2s:
         try:
@@ -307,6 +321,16 @@ async def _try_attach_pending_ec2s(
                         node=new_node,
                         ec2_instance=instance_data.ec2_instance,
                     )
+                )
+                elapsed_since_launch = datetime.datetime.now(datetime.UTC) - instance_data.ec2_instance.launch_time
+                emit_instance_span(
+                    tracing_config,
+                    instance_data.ec2_instance.id,
+                    "ec2_instance_attached_to_swarm",
+                    {
+                        "ec2.instance.type": instance_data.ec2_instance.type,
+                        "ec2.instance.time_to_attach_seconds": f"{elapsed_since_launch.total_seconds():.1f}",
+                    },
                 )
                 _logger.info(
                     "Attached new EC2 instance %s with custom placement labels: %s",
@@ -394,6 +418,15 @@ async def _activate_and_notify(
             progress_type=ProgressType.CLUSTER_UP_SCALING,
         ),
     )
+    emit_instance_span(
+        get_tracing_config(app),
+        drained_node.ec2_instance.id,
+        "ec2_node_activated",
+        {
+            "ec2.instance.type": drained_node.ec2_instance.type,
+            "task.count": str(len(drained_node.assigned_tasks)),
+        },
+    )
     return dataclasses.replace(drained_node, node=updated_node)
 
 
@@ -418,6 +451,15 @@ async def _cancel_previous_pulling_command_if_any(
             msg=f"cancelling previous pulling {command_id} on {instance.id}",
         ):
             await ssm_client.cancel_command(instance.id, command_id=command_id)
+        emit_instance_span(
+            get_tracing_config(app),
+            instance.id,
+            "ec2_prepull_cancelled",
+            {
+                "ec2.instance.type": instance.type,
+                "ssm.command.id": command_id,
+            },
+        )
         await ec2_client.remove_instances_tags(
             [instance],
             tag_keys=[
@@ -548,8 +590,18 @@ async def _try_start_warm_buffer_instances(
 
         # NOTE: first start the instance and then set the tags in case the instance cannot start
         # (e.g. InsufficientInstanceCapacity)  # noqa: ERA001
+        tracing_config = get_tracing_config(app)
         non_associated_instance_by_id = {i.ec2_instance.id: i for i in cluster.warm_buffer_ec2s}
         for instance in started_instances:
+            emit_instance_span(
+                tracing_config,
+                instance.id,
+                "ec2_warm_buffer_started",
+                {
+                    "ec2.instance.type": instance.type,
+                    "ec2.instance.state": instance.state,
+                },
+            )
             non_associated_instance = non_associated_instance_by_id[instance.id]
 
             activation_tags = get_activated_warm_buffer_ec2_tags(auto_scaling_mode.get_ec2_tags(app))
@@ -898,6 +950,7 @@ async def _launch_instances(
     # parse results
     last_issue = ""
     new_pending_instances: list[EC2InstanceData] = []
+    tracing_config = get_tracing_config(app)
     for r in results:
         if isinstance(r, EC2TooManyInstancesError):
             await post_tasks_log_message(
@@ -910,8 +963,27 @@ async def _launch_instances(
             _logger.error("Unexpected error happened when starting EC2 instance: %s", r)
             last_issue = f"{r}"
         elif isinstance(r, list):
+            for instance in r:
+                emit_instance_span(
+                    tracing_config,
+                    instance.id,
+                    "ec2_instance_launched",
+                    {
+                        "ec2.instance.type": instance.type,
+                        "ec2.instance.state": instance.state,
+                    },
+                )
             new_pending_instances.extend(r)
         else:
+            emit_instance_span(
+                tracing_config,
+                r.id,
+                "ec2_instance_launched",
+                {
+                    "ec2.instance.type": r.type,
+                    "ec2.instance.state": r.state,
+                },
+            )
             new_pending_instances.append(r)
 
     log_message = (
@@ -998,6 +1070,7 @@ async def _deactivate_empty_nodes(app: FastAPI, cluster: Cluster) -> Cluster:
                 "following nodes were deactivated: '%s'",
                 f"{[node.description.hostname for node in updated_nodes if node.description]}",
             )
+    tracing_config = get_tracing_config(app)
     newly_drained_instances = [
         AssociatedInstance(
             node=node,
@@ -1005,6 +1078,15 @@ async def _deactivate_empty_nodes(app: FastAPI, cluster: Cluster) -> Cluster:
         )
         for instance, node in zip(active_empty_instances, updated_nodes, strict=True)
     ]
+    for instance in newly_drained_instances:
+        emit_instance_span(
+            tracing_config,
+            instance.ec2_instance.id,
+            "ec2_node_deactivated",
+            {
+                "ec2.instance.type": instance.ec2_instance.type,
+            },
+        )
     return dataclasses.replace(
         cluster,
         active_nodes=[n for n in cluster.active_nodes if n not in active_empty_instances],
@@ -1065,6 +1147,14 @@ async def _try_scale_down_cluster(app: FastAPI, cluster: Cluster) -> Cluster:
             log_catch(_logger, reraise=False),
         ):
             await utils_docker.set_node_begin_termination_process(get_docker_client(app), instance.node)
+            emit_instance_span(
+                get_tracing_config(app),
+                instance.ec2_instance.id,
+                "ec2_instance_termination_started",
+                {
+                    "ec2.instance.type": instance.ec2_instance.type,
+                },
+            )
             new_terminating_instances.append(instance)
     new_terminating_instance_ids = [i.ec2_instance.id for i in new_terminating_instances]
 
@@ -1085,6 +1175,17 @@ async def _try_scale_down_cluster(app: FastAPI, cluster: Cluster) -> Cluster:
             f"'{[i.node.description.hostname for i in instances_to_terminate if i.node.description]}'",
         ):
             await get_ec2_client(app).terminate_instances([i.ec2_instance for i in instances_to_terminate])
+
+        tracing_config = get_tracing_config(app)
+        for i in instances_to_terminate:
+            emit_instance_span(
+                tracing_config,
+                i.ec2_instance.id,
+                "ec2_instance_terminated",
+                {
+                    "ec2.instance.type": i.ec2_instance.type,
+                },
+            )
 
         # since these nodes are being terminated, remove them from the swarm
         await utils_docker.remove_nodes(
@@ -1181,6 +1282,16 @@ async def _drain_retired_nodes(
         )
         for instance, node in zip(cluster.retired_nodes, updated_nodes, strict=True)
     ]
+    tracing_config = get_tracing_config(app)
+    for instance in newly_drained_instances:
+        emit_instance_span(
+            tracing_config,
+            instance.ec2_instance.id,
+            "ec2_node_retired_drained",
+            {
+                "ec2.instance.type": instance.ec2_instance.type,
+            },
+        )
     return dataclasses.replace(
         cluster,
         retired_nodes=[],
@@ -1373,6 +1484,15 @@ async def _handle_pre_pull_status(app: FastAPI, node: AssociatedInstance) -> Ass
     match ssm_command.status:
         case "Success":
             _logger.info("%s finished pre-pulling images", node.ec2_instance.id)
+            emit_instance_span(
+                get_tracing_config(app),
+                node.ec2_instance.id,
+                "ec2_prepull_completed",
+                {
+                    "ec2.instance.type": node.ec2_instance.type,
+                    "ssm.command.status": ssm_command.status,
+                },
+            )
             return await _remove_tags_and_return(
                 node,
                 [
@@ -1385,6 +1505,15 @@ async def _handle_pre_pull_status(app: FastAPI, node: AssociatedInstance) -> Ass
                 "%s failed pre-pulling images, status is %s. this will be retried later",
                 node.ec2_instance.id,
                 ssm_command.status,
+            )
+            emit_instance_span(
+                get_tracing_config(app),
+                node.ec2_instance.id,
+                "ec2_prepull_failed",
+                {
+                    "ec2.instance.type": node.ec2_instance.type,
+                    "ssm.command.status": ssm_command.status,
+                },
             )
             return await _remove_tags_and_return(
                 node,
@@ -1468,6 +1597,16 @@ async def _pre_pull_docker_images_on_idle_hot_buffers(app: FastAPI, cluster: Clu
             command=change_docker_compose_and_pull_command,
             command_name=PREPULL_COMMAND_NAME,
         )
+        emit_instance_span(
+            get_tracing_config(app),
+            node.ec2_instance.id,
+            "ec2_prepull_command_sent",
+            {
+                "ec2.instance.type": node.ec2_instance.type,
+                "ssm.command.id": ssm_command.command_id,
+                "prepull.image_count": str(len(desired_pre_pulled_images)),
+            },
+        )
         await ec2_client.set_instances_tags(
             (node.ec2_instance,),
             tags={
@@ -1483,22 +1622,26 @@ async def auto_scale_cluster(*, app: FastAPI, auto_scaling_mode: AutoscalingProv
     If there are such tasks, this method will allocate new machines in AWS to cope with
     the additional load.
     """
-    # current state
-    allowed_instance_types = await _sorted_allowed_instance_types(app, auto_scaling_mode)
+    with traced_operation(
+        "autoscaling_cycle",
+        tracing_config=get_tracing_config(app),
+    ):
+        # current state
+        allowed_instance_types = await _sorted_allowed_instance_types(app, auto_scaling_mode)
 
-    cluster = await _analyze_current_cluster(app, auto_scaling_mode, allowed_instance_types)
+        cluster = await _analyze_current_cluster(app, auto_scaling_mode, allowed_instance_types)
 
-    # cleanup
-    cluster = await _cleanup_disconnected_nodes(app, cluster)
-    cluster = await _terminate_broken_ec2s(app, cluster)
-    cluster = await _try_attach_pending_ec2s(app, cluster, auto_scaling_mode)
-    cluster = await _drain_retired_nodes(app, cluster)
+        # cleanup
+        cluster = await _cleanup_disconnected_nodes(app, cluster)
+        cluster = await _terminate_broken_ec2s(app, cluster)
+        cluster = await _try_attach_pending_ec2s(app, cluster, auto_scaling_mode)
+        cluster = await _drain_retired_nodes(app, cluster)
 
-    # desired state
-    cluster = await _autoscale_cluster(app, cluster, auto_scaling_mode, allowed_instance_types)
+        # desired state
+        cluster = await _autoscale_cluster(app, cluster, auto_scaling_mode, allowed_instance_types)
 
-    # take care of hot buffer pre-pulling
-    await _pre_pull_docker_images_on_idle_hot_buffers(app, cluster)
-    # notify
-    await _notify_machine_creation_progress(app, cluster)
-    await _notify_autoscaling_status(app, cluster, auto_scaling_mode)
+        # take care of hot buffer pre-pulling
+        await _pre_pull_docker_images_on_idle_hot_buffers(app, cluster)
+        # notify
+        await _notify_machine_creation_progress(app, cluster)
+        await _notify_autoscaling_status(app, cluster, auto_scaling_mode)

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_tracing.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_tracing.py
@@ -1,0 +1,64 @@
+"""Per-EC2-instance tracing helpers.
+
+A deterministic trace_id is derived from each EC2 instance id, so every
+lifecycle event for the same instance shares one trace in Tempo, without
+keeping any in-memory state between autoscaler ticks (or across restarts).
+"""
+
+import hashlib
+import logging
+
+from fastapi import FastAPI
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from servicelib.tracing import TracingConfig
+
+_logger = logging.getLogger(__name__)
+
+
+def get_tracing_config(app: FastAPI) -> TracingConfig:
+    return app.state.tracing_config
+
+
+def _trace_id_for_instance(instance_id: str) -> int:
+    """Deterministic 128-bit trace_id derived from EC2 instance id."""
+    return int.from_bytes(hashlib.blake2b(instance_id.encode(), digest_size=16).digest(), "big")
+
+
+def _parent_span_id_for_instance(instance_id: str) -> int:
+    """Deterministic 64-bit span_id used as the virtual parent for all lifecycle spans."""
+    return int.from_bytes(
+        hashlib.blake2b(instance_id.encode(), digest_size=8, key=b"parent").digest(),
+        "big",
+    )
+
+
+def emit_instance_span(
+    tracing_config: TracingConfig,
+    instance_id: str,
+    name: str,
+    attributes: dict[str, str] | None = None,
+) -> None:
+    """Fire-and-forget: emit a single span on the per-instance trace.
+
+    All spans for the same instance_id share a deterministic trace_id
+    so they appear as one trace in Tempo. No state is kept between calls;
+    safe across restarts.
+    """
+    try:
+        tracer = trace.get_tracer(__name__, tracer_provider=tracing_config.tracer_provider)
+        parent_ctx = SpanContext(
+            trace_id=_trace_id_for_instance(instance_id),
+            span_id=_parent_span_id_for_instance(instance_id),
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        ctx = trace.set_span_in_context(NonRecordingSpan(parent_ctx))
+        span = tracer.start_span(
+            name,
+            context=ctx,
+            attributes={"ec2.instance.id": instance_id, **(attributes or {})},
+        )
+        span.end()
+    except Exception:
+        _logger.debug("Failed to emit trace span for %s", instance_id, exc_info=True)

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_warm_buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_warm_buffer_machines_pool_core.py
@@ -16,7 +16,7 @@ Open features:
 
 import logging
 from collections import defaultdict
-from typing import TypeAlias, cast
+from typing import cast
 
 import arrow
 from aws_library.ec2 import (
@@ -57,6 +57,7 @@ from ..ec2 import get_ec2_client
 from ..instrumentation import get_instrumentation, has_instrumentation
 from ..ssm import get_ssm_client
 from ._provider_protocol import AutoscalingProvider
+from ._tracing import emit_instance_span, get_tracing_config
 
 _logger = logging.getLogger(__name__)
 
@@ -121,7 +122,9 @@ def _handle_unconnected_instance(app: FastAPI, *, buffer_pool: WarmBufferPool, i
 
     if is_broken:
         _logger.error(
-            "The machine does not connect to the SSM server after %s. It will be terminated. TIP: check the initialization phase for errors.",
+            "The machine does not connect to the SSM server after %s."
+            " It will be terminated."
+            " TIP: check the initialization phase for errors.",
             app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_MAX_START_TIME,
         )
         buffer_pool.broken_instances.add(instance)
@@ -193,6 +196,16 @@ async def _terminate_unneeded_pools(
                     buffers_manager.buffer_pools[ec2_type].all_instances()
                 )
             await ec2_client.terminate_instances(instances_to_terminate)
+            tracing_config = get_tracing_config(app)
+            for instance in instances_to_terminate:
+                emit_instance_span(
+                    tracing_config,
+                    instance.id,
+                    "ec2_warm_buffer_pool_terminated",
+                    {
+                        "ec2.instance.type": instance.type,
+                    },
+                )
             for ec2_type in terminateable_warm_pool_types:
                 buffers_manager.buffer_pools.pop(ec2_type)
     return buffers_manager
@@ -306,8 +319,8 @@ async def _add_remove_buffer_instances(
     return buffers_manager
 
 
-InstancesToStop: TypeAlias = set[EC2InstanceData]
-InstancesToTerminate: TypeAlias = set[EC2InstanceData]
+type InstancesToStop = set[EC2InstanceData]
+type InstancesToTerminate = set[EC2InstanceData]
 
 
 async def _handle_pool_image_pulling(
@@ -322,6 +335,17 @@ async def _handle_pool_image_pulling(
             command=DOCKER_PULL_COMMAND,
             command_name=PREPULL_COMMAND_NAME,
         )
+        tracing_config = get_tracing_config(app)
+        for instance in pool.waiting_to_pull_instances:
+            emit_instance_span(
+                tracing_config,
+                instance.id,
+                "ec2_warm_buffer_prepull_sent",
+                {
+                    "ec2.instance.type": instance.type,
+                    "ssm.command.id": ssm_command.command_id,
+                },
+            )
         await ec2_client.set_instances_tags(
             tuple(pool.waiting_to_pull_instances),
             tags={
@@ -398,9 +422,29 @@ async def _handle_image_pre_pulling(app: FastAPI, buffers_manager: WarmBufferPoo
                 tag_keys=tag_keys_to_remove,
             )
             await ec2_client.stop_instances(instances_to_stop)
+            tracing_config = get_tracing_config(app)
+            for instance in instances_to_stop:
+                emit_instance_span(
+                    tracing_config,
+                    instance.id,
+                    "ec2_warm_buffer_stopped",
+                    {
+                        "ec2.instance.type": instance.type,
+                    },
+                )
     if broken_instances_to_terminate:
         with log_context(_logger, logging.WARNING, "broken buffer instances, terminating them"):
             await ec2_client.terminate_instances(broken_instances_to_terminate)
+            tracing_config = get_tracing_config(app)
+            for instance in broken_instances_to_terminate:
+                emit_instance_span(
+                    tracing_config,
+                    instance.id,
+                    "ec2_warm_buffer_broken_terminated",
+                    {
+                        "ec2.instance.type": instance.type,
+                    },
+                )
 
 
 async def monitor_buffer_machines(app: FastAPI, *, auto_scaling_mode: AutoscalingProvider) -> None:


### PR DESCRIPTION
#### Disclaimer: 🤖 research by perplexity deep research and Opus4.7
#### Disclaimer: 🤖 code by Opus 4.6

<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

Adds fire-and-forget otel spans that track each EC2 instance through its full lifecycle.

Each instance gets a deterministic trace_id from `blake2b(instance_id)` (blake2b is a hash function), so all its spans land on one trace in Tempo with no in-memory state in the autoscaler. A synthetic parent span (also derived from the instance ID) groups the lifecycle spans visually under a single root. it's never actually recorded, just referenced as a parent context.

New module: `_tracing.py`

Not insisting on having this in this way, or at all, but might be a nice addition in order to monitor starting times mainly.

:kissing_cat: @sanderegg let me know what you think, what I should rework, if you prefer to take the PR over potentially, or maybe this is not good in the first place.

CC @bisgaard-itis 

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

The existing tests pass

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
