### PR TITLE
Fix function selection in mmux test 🐛

### DIFF
--- a/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
+++ b/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
@@ -571,9 +571,9 @@ def test_response_surface_modeling(  # noqa: PLR0912, PLR0915, C901  # pylint: d
 
                 input_values = sorted(
                     [
-                        j["inputs"]["Number parameter"]
+                        j["inputs"]["Number Parameter"]
                         for j in all_jobs
-                        if j.get("inputs") and "Number parameter" in j["inputs"]
+                        if j.get("inputs") and "Number Parameter" in j["inputs"]
                     ]
                 )
 

--- a/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
+++ b/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
@@ -404,10 +404,8 @@ def test_response_surface_modeling(  # noqa: PLR0912, PLR0915, C901  # pylint: d
             service_iframe.locator("body").wait_for(state="visible", timeout=_WAITING_FOR_SERVICE_TO_APPEAR)
 
         with log_context(logging.INFO, "Selected test function..."):
-            # Find the row containing our function by title, then click its Select button
-            function_row = service_iframe.locator(
-                f'div[role="row"]:has(div[role="gridcell"][data-field="title"]:has-text("{_STUDY_FUNCTION_NAME}"))'
-            )
+            # Find the exact row by function UUID (data-id attribute in the MUI DataGrid)
+            function_row = service_iframe.locator(f'div[role="row"][data-id="{function_uuid}"]')
             function_row.wait_for(state="visible", timeout=_WAITING_FOR_SERVICE_TO_APPEAR)
             select_btn = function_row.locator('[mmux-testid="select-function-btn"]')
             select_btn.wait_for(state="visible", timeout=30 * SECOND)

--- a/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
+++ b/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
@@ -404,8 +404,13 @@ def test_response_surface_modeling(  # noqa: PLR0912, PLR0915, C901  # pylint: d
             service_iframe.locator("body").wait_for(state="visible", timeout=_WAITING_FOR_SERVICE_TO_APPEAR)
 
         with log_context(logging.INFO, "Selected test function..."):
-            select_btn = service_iframe.locator('[mmux-testid="select-function-btn"]').first
-            select_btn.wait_for(state="visible", timeout=_WAITING_FOR_SERVICE_TO_APPEAR)
+            # Find the row containing our function by title, then click its Select button
+            function_row = service_iframe.locator(
+                f'div[role="row"]:has(div[role="gridcell"][data-field="title"]:has-text("{_STUDY_FUNCTION_NAME}"))'
+            )
+            function_row.wait_for(state="visible", timeout=_WAITING_FOR_SERVICE_TO_APPEAR)
+            select_btn = function_row.locator('[mmux-testid="select-function-btn"]')
+            select_btn.wait_for(state="visible", timeout=30 * SECOND)
             select_btn.click()
 
         with log_context(logging.INFO, "Filling the input parameters..."):


### PR DESCRIPTION
## What do these changes do?

After some frontend fix, the mmux e2e test was still failing. This was because the test was not specifically selecting the function it ran a test on, but could get results from previous runs. This fix now picks the function more carefully.

## Related issue/s


## How to test

run ﻿﻿test_response_surface_modeling

## Dev-ops
\
