### PR TITLE
Support `AND` filtering when listing jobs in api-server

### DIFF
--- a/packages/models-library/src/models_library/rpc/webserver/projects.py
+++ b/packages/models-library/src/models_library/rpc/webserver/projects.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Self
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -35,7 +35,7 @@ class ListProjectsMarkedAsJobRpcFilters(BaseModel):
     ] = None
 
     @model_validator(mode="after")
-    def _check_any_and_all_are_mutually_exclusive(self) -> "ListProjectsMarkedAsJobRpcFilters":
+    def _check_any_and_all_are_mutually_exclusive(self) -> Self:
         if self.any_custom_metadata and self.all_custom_metadata:
             msg = "any_custom_metadata and all_custom_metadata are mutually exclusive"
             raise ValueError(msg)

--- a/packages/models-library/src/models_library/rpc/webserver/projects.py
+++ b/packages/models-library/src/models_library/rpc/webserver/projects.py
@@ -151,7 +151,7 @@ class ProjectJobRpcGet(BaseModel):
     )
 
 
-PageRpcProjectJobRpcGet = PageRpc[
+type PageRpcProjectJobRpcGet = PageRpc[
     # WARNING: keep this definition in models_library and not in the RPC interface
     # otherwise the metaclass PageRpc[*] will create *different* classes in server/client side
     # and will fail to serialize/deserialize these parameters when transmitted/received

--- a/packages/models-library/src/models_library/rpc/webserver/projects.py
+++ b/packages/models-library/src/models_library/rpc/webserver/projects.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from typing import Annotated, TypeAlias
+from typing import Annotated
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic.config import JsonDict
 
 from ...projects import NodesDict, ProjectID
@@ -26,8 +26,20 @@ class ListProjectsMarkedAsJobRpcFilters(BaseModel):
 
     any_custom_metadata: Annotated[
         list[MetadataFilterItem] | None,
-        Field(description="Searchs for matches of any of the custom metadata fields"),
+        Field(description="Searches for matches of any of the custom metadata fields"),
     ] = None
+
+    all_custom_metadata: Annotated[
+        list[MetadataFilterItem] | None,
+        Field(description="Searches for matches of all of the custom metadata fields"),
+    ] = None
+
+    @model_validator(mode="after")
+    def _check_any_and_all_are_mutually_exclusive(self) -> "ListProjectsMarkedAsJobRpcFilters":
+        if self.any_custom_metadata and self.all_custom_metadata:
+            msg = "any_custom_metadata and all_custom_metadata are mutually exclusive"
+            raise ValueError(msg)
+        return self
 
     @staticmethod
     def _update_json_schema_extra(schema: JsonDict) -> None:
@@ -67,7 +79,7 @@ class ListProjectsMarkedAsJobRpcFilters(BaseModel):
 
 class ProjectJobRpcGet(BaseModel):
     """
-    Minimal information about a project that (for now) will fullfill
+    Minimal information about a project that (for now) will fulfill
     the needs of the api-server. Specifically, the fields needed in
     project to call create_job_from_project
     """
@@ -139,7 +151,7 @@ class ProjectJobRpcGet(BaseModel):
     )
 
 
-PageRpcProjectJobRpcGet: TypeAlias = PageRpc[
+type PageRpcProjectJobRpcGet = PageRpc[
     # WARNING: keep this definition in models_library and not in the RPC interface
     # otherwise the metaclass PageRpc[*] will create *different* classes in server/client side
     # and will fail to serialize/deserialize these parameters when transmitted/received

--- a/packages/models-library/src/models_library/rpc/webserver/projects.py
+++ b/packages/models-library/src/models_library/rpc/webserver/projects.py
@@ -151,7 +151,7 @@ class ProjectJobRpcGet(BaseModel):
     )
 
 
-type PageRpcProjectJobRpcGet = PageRpc[
+PageRpcProjectJobRpcGet = PageRpc[
     # WARNING: keep this definition in models_library and not in the RPC interface
     # otherwise the metaclass PageRpc[*] will create *different* classes in server/client side
     # and will fail to serialize/deserialize these parameters when transmitted/received

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_rpc.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_rpc.py
@@ -10,12 +10,12 @@ from models_library.projects import ProjectID
 from models_library.rest_pagination import PageOffsetInt
 from models_library.rpc.webserver.projects import (
     ListProjectsMarkedAsJobRpcFilters,
+    PageRpcProjectJobRpcGet,
     ProjectJobRpcGet,
 )
 from models_library.rpc_pagination import (
     DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
     PageLimitInt,
-    PageRpc,
 )
 from models_library.users import UserID
 from pydantic import TypeAdapter, validate_call
@@ -63,7 +63,7 @@ class WebserverRpcSideEffects:
         offset: PageOffsetInt = 0,
         limit: PageLimitInt = DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
         filters: ListProjectsMarkedAsJobRpcFilters | None = None,
-    ) -> PageRpc[ProjectJobRpcGet]:
+    ) -> PageRpcProjectJobRpcGet:
         assert rpc_client
         assert product_name
         assert user_id
@@ -81,7 +81,7 @@ class WebserverRpcSideEffects:
             or item.get("job_parent_resource_name").startswith(filters.job_parent_resource_name_prefix)
         ]
 
-        return PageRpc[ProjectJobRpcGet].create(
+        return PageRpcProjectJobRpcGet.create(
             items[offset : offset + limit],
             total=len(items),
             limit=limit,

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_rpc.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_rpc.py
@@ -10,12 +10,12 @@ from models_library.projects import ProjectID
 from models_library.rest_pagination import PageOffsetInt
 from models_library.rpc.webserver.projects import (
     ListProjectsMarkedAsJobRpcFilters,
-    PageRpcProjectJobRpcGet,
     ProjectJobRpcGet,
 )
 from models_library.rpc_pagination import (
     DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
     PageLimitInt,
+    PageRpc,
 )
 from models_library.users import UserID
 from pydantic import TypeAdapter, validate_call
@@ -63,7 +63,7 @@ class WebserverRpcSideEffects:
         offset: PageOffsetInt = 0,
         limit: PageLimitInt = DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
         filters: ListProjectsMarkedAsJobRpcFilters | None = None,
-    ) -> PageRpcProjectJobRpcGet:
+    ) -> PageRpc[ProjectJobRpcGet]:
         assert rpc_client
         assert product_name
         assert user_id
@@ -81,7 +81,7 @@ class WebserverRpcSideEffects:
             or item.get("job_parent_resource_name").startswith(filters.job_parent_resource_name_prefix)
         ]
 
-        return PageRpcProjectJobRpcGet.create(
+        return PageRpc[ProjectJobRpcGet].create(
             items[offset : offset + limit],
             total=len(items),
             limit=limit,

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_rpc.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/webserver_rpc.py
@@ -16,6 +16,7 @@ from models_library.rpc.webserver.projects import (
 from models_library.rpc_pagination import (
     DEFAULT_NUMBER_OF_ITEMS_PER_PAGE,
     PageLimitInt,
+    PageRpc,
 )
 from models_library.users import UserID
 from pydantic import TypeAdapter, validate_call
@@ -81,7 +82,7 @@ class WebserverRpcSideEffects:
             or item.get("job_parent_resource_name").startswith(filters.job_parent_resource_name_prefix)
         ]
 
-        return PageRpcProjectJobRpcGet.create(
+        return PageRpc[ProjectJobRpcGet].create(
             items[offset : offset + limit],
             total=len(items),
             limit=limit,

--- a/services/api-server/openapi.json
+++ b/services/api-server/openapi.json
@@ -3991,6 +3991,27 @@
               "title": "Metadata.Any"
             },
             "description": "\nFilters jobs based on **any** of the matches on custom metadata fields.\n\n*Format*: `key:pattern` where pattern can contain glob wildcards\n"
+          },
+          {
+            "name": "metadata.all",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "\nFilters jobs based on **all** of the matches on custom metadata fields.\n\n*Format*: `key:pattern` where pattern can contain glob wildcards\n",
+              "title": "Metadata.All"
+            },
+            "description": "\nFilters jobs based on **all** of the matches on custom metadata fields.\n\n*Format*: `key:pattern` where pattern can contain glob wildcards\n"
           }
         ],
         "responses": {

--- a/services/api-server/src/simcore_service_api_server/_service_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/_service_jobs.py
@@ -112,10 +112,10 @@ class JobService:
         self,
         job_parent_resource_name: str,
         *,
-        filter_any_custom_metadata: list[NameValueTuple] | None = None,
-        filter_all_custom_metadata: list[NameValueTuple] | None = None,
-        pagination_offset: PageOffsetInt | None = None,
-        pagination_limit: PageLimitInt | None = None,
+        filter_any_custom_metadata: list[NameValueTuple] | None,
+        filter_all_custom_metadata: list[NameValueTuple] | None,
+        pagination_offset: PageOffsetInt | None,
+        pagination_limit: PageLimitInt | None,
     ) -> tuple[list[Job], PageMetaInfoLimitOffset]:
         """Lists all jobs for a user with pagination based on resource name prefix"""
 

--- a/services/api-server/src/simcore_service_api_server/_service_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/_service_jobs.py
@@ -113,6 +113,7 @@ class JobService:
         job_parent_resource_name: str,
         *,
         filter_any_custom_metadata: list[NameValueTuple] | None = None,
+        filter_all_custom_metadata: list[NameValueTuple] | None = None,
         pagination_offset: PageOffsetInt | None = None,
         pagination_limit: PageLimitInt | None = None,
     ) -> tuple[list[Job], PageMetaInfoLimitOffset]:
@@ -126,6 +127,7 @@ class JobService:
             user_id=self.user_id,
             filter_by_job_parent_resource_name_prefix=job_parent_resource_name,
             filter_any_custom_metadata=filter_any_custom_metadata,
+            filter_all_custom_metadata=filter_all_custom_metadata,
             **pagination_kwargs,
         )
 
@@ -163,6 +165,7 @@ class JobService:
         filter_by_solver_key: SolverKeyId | None = None,
         filter_by_solver_version: VersionStr | None = None,
         filter_any_custom_metadata: list[NameValueTuple] | None = None,
+        filter_all_custom_metadata: list[NameValueTuple] | None = None,
     ) -> tuple[list[Job], PageMetaInfoLimitOffset]:
         """Lists all solver jobs for a user with pagination"""
 
@@ -184,6 +187,7 @@ class JobService:
         return await self._list_jobs(
             job_parent_resource_name=job_parent_resource_name,
             filter_any_custom_metadata=filter_any_custom_metadata,
+            filter_all_custom_metadata=filter_all_custom_metadata,
             pagination_offset=pagination_offset,
             pagination_limit=pagination_limit,
         )

--- a/services/api-server/src/simcore_service_api_server/_service_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/_service_jobs.py
@@ -213,6 +213,8 @@ class JobService:
         # 2. list jobs under job_parent_resource_name
         return await self._list_jobs(
             job_parent_resource_name=job_parent_resource_name,
+            filter_any_custom_metadata=None,
+            filter_all_custom_metadata=None,
             pagination_offset=pagination_offset,
             pagination_limit=pagination_limit,
         )

--- a/services/api-server/src/simcore_service_api_server/api/dependencies/models_schemas_jobs_filters.py
+++ b/services/api-server/src/simcore_service_api_server/api/dependencies/models_schemas_jobs_filters.py
@@ -10,10 +10,12 @@ from ...models.schemas.jobs_filters import JobMetadataFilter, MetadataFilterItem
 def _parse_metadata_items(raw: list[str]) -> list[MetadataFilterItem]:
     items = []
     for item in raw:
-        try:
-            name, pattern = item.split(":", 1)
-        except ValueError:
-            continue
+        if ":" not in item:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid metadata filter format: '{item}'. Expected 'key:pattern'.",
+            )
+        name, pattern = item.split(":", 1)
         items.append(MetadataFilterItem(name=name, pattern=pattern))
     return items
 

--- a/services/api-server/src/simcore_service_api_server/api/dependencies/models_schemas_jobs_filters.py
+++ b/services/api-server/src/simcore_service_api_server/api/dependencies/models_schemas_jobs_filters.py
@@ -1,9 +1,21 @@
 import textwrap
 from typing import Annotated
 
-from fastapi import Query
+from fastapi import HTTPException, Query, status
+from pydantic import ValidationError
 
 from ...models.schemas.jobs_filters import JobMetadataFilter, MetadataFilterItem
+
+
+def _parse_metadata_items(raw: list[str]) -> list[MetadataFilterItem]:
+    items = []
+    for item in raw:
+        try:
+            name, pattern = item.split(":", 1)
+        except ValueError:
+            continue
+        items.append(MetadataFilterItem(name=name, pattern=pattern))
+    return items
 
 
 def get_job_metadata_filter(
@@ -23,31 +35,33 @@ def get_job_metadata_filter(
             ],
         ),
     ] = None,
+    all_: Annotated[
+        list[str] | None,
+        Query(
+            alias="metadata.all",
+            description=textwrap.dedent(
+                """
+            Filters jobs based on **all** of the matches on custom metadata fields.
+
+            *Format*: `key:pattern` where pattern can contain glob wildcards
+            """
+            ),
+            examples=[
+                ["solver_type:FEM", "mesh_cells:1*"],
+            ],
+        ),
+    ] = None,
 ) -> JobMetadataFilter | None:
-    """
-    Example input:
-
-        /solvers/-/releases/-/jobs?metadata.any=key1:val*&metadata.any=key2:exactval
-
-    This will be converted to:
-        JobMetadataFilter(
-            any=[
-                MetadataFilterItem(name="key1", pattern="val*"),
-                MetadataFilterItem(name="key2", pattern="exactval"),
-            ]
-        )
-
-    This is used to filter jobs based on custom metadata fields.
-
-    """
-    if not any_:
+    if not any_ and not all_:
         return None
 
-    items = []
-    for item in any_:
-        try:
-            name, pattern = item.split(":", 1)
-        except ValueError:
-            continue  # or raise HTTPException
-        items.append(MetadataFilterItem(name=name, pattern=pattern))
-    return JobMetadataFilter(any=items)
+    try:
+        return JobMetadataFilter(
+            any=_parse_metadata_items(any_) if any_ else None,
+            all=_parse_metadata_items(all_) if all_ else None,
+        )
+    except ValidationError as err:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=err.errors(include_context=False),
+        ) from err

--- a/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs_read.py
+++ b/services/api-server/src/simcore_service_api_server/api/routes/solvers_jobs_read.py
@@ -132,7 +132,15 @@ async def list_all_solvers_jobs(
                 NameValueTuple(filter_metadata.name, filter_metadata.pattern)
                 for filter_metadata in filter_job_metadata_params.any
             ]
-            if filter_job_metadata_params
+            if filter_job_metadata_params and filter_job_metadata_params.any
+            else None
+        ),
+        filter_all_custom_metadata=(
+            [
+                NameValueTuple(filter_metadata.name, filter_metadata.pattern)
+                for filter_metadata in filter_job_metadata_params.all
+            ]
+            if filter_job_metadata_params and filter_job_metadata_params.all
             else None
         ),
         pagination_offset=page_params.offset,

--- a/services/api-server/src/simcore_service_api_server/models/schemas/jobs_filters.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/jobs_filters.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Self
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
 from pydantic.config import JsonDict
@@ -28,7 +28,7 @@ class JobMetadataFilter(BaseModel):
     ] = None
 
     @model_validator(mode="after")
-    def _check_any_and_all_are_mutually_exclusive(self) -> "JobMetadataFilter":
+    def _check_any_and_all_are_mutually_exclusive(self) -> Self:
         if self.any and self.all:
             msg = "metadata.any and metadata.all are mutually exclusive"
             raise ValueError(msg)

--- a/services/api-server/src/simcore_service_api_server/models/schemas/jobs_filters.py
+++ b/services/api-server/src/simcore_service_api_server/models/schemas/jobs_filters.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
 from pydantic.config import JsonDict
 
 
@@ -8,7 +8,7 @@ class MetadataFilterItem(BaseModel):
     name: Annotated[
         str,
         StringConstraints(min_length=1, max_length=255),
-        Field(description="Name fo the metadata field"),
+        Field(description="Name of the metadata field"),
     ]
     pattern: Annotated[
         str,
@@ -19,10 +19,23 @@ class MetadataFilterItem(BaseModel):
 
 class JobMetadataFilter(BaseModel):
     any: Annotated[
-        list[MetadataFilterItem],
+        list[MetadataFilterItem] | None,
         Field(description="Matches any custom metadata field (OR logic)"),
-    ]
-    # NOTE: AND logic shall be implemented as `all: list[MetadataFilterItem] | None = None`
+    ] = None
+    all: Annotated[
+        list[MetadataFilterItem] | None,
+        Field(description="Matches all custom metadata fields (AND logic)"),
+    ] = None
+
+    @model_validator(mode="after")
+    def _check_any_and_all_are_mutually_exclusive(self) -> "JobMetadataFilter":
+        if self.any and self.all:
+            msg = "metadata.any and metadata.all are mutually exclusive"
+            raise ValueError(msg)
+        if not self.any and not self.all:
+            msg = "Either metadata.any or metadata.all must be provided"
+            raise ValueError(msg)
+        return self
 
     @staticmethod
     def _update_json_schema_extra(schema: JsonDict) -> None:

--- a/services/api-server/src/simcore_service_api_server/services_rpc/wb_api_server.py
+++ b/services/api-server/src/simcore_service_api_server/services_rpc/wb_api_server.py
@@ -269,6 +269,7 @@ class WbApiRpcClient(SingletonInAppStateMixin):
         pagination_limit: int = 50,
         filter_by_job_parent_resource_name_prefix: str | None,
         filter_any_custom_metadata: list[NameValueTuple] | None,
+        filter_all_custom_metadata: list[NameValueTuple] | None = None,
     ):
         pagination_kwargs = as_dict_exclude_none(offset=pagination_offset, limit=pagination_limit)
 
@@ -277,6 +278,11 @@ class WbApiRpcClient(SingletonInAppStateMixin):
             any_custom_metadata=(
                 [MetadataFilterItem(name=name, pattern=pattern) for name, pattern in filter_any_custom_metadata]
                 if filter_any_custom_metadata
+                else None
+            ),
+            all_custom_metadata=(
+                [MetadataFilterItem(name=name, pattern=pattern) for name, pattern in filter_all_custom_metadata]
+                if filter_all_custom_metadata
                 else None
             ),
         )

--- a/services/api-server/src/simcore_service_api_server/services_rpc/wb_api_server.py
+++ b/services/api-server/src/simcore_service_api_server/services_rpc/wb_api_server.py
@@ -269,7 +269,7 @@ class WbApiRpcClient(SingletonInAppStateMixin):
         pagination_limit: int = 50,
         filter_by_job_parent_resource_name_prefix: str | None,
         filter_any_custom_metadata: list[NameValueTuple] | None,
-        filter_all_custom_metadata: list[NameValueTuple] | None = None,
+        filter_all_custom_metadata: list[NameValueTuple] | None,
     ):
         pagination_kwargs = as_dict_exclude_none(offset=pagination_offset, limit=pagination_limit)
 

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_read.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_read.py
@@ -187,3 +187,71 @@ async def test_list_all_solvers_jobs_with_metadata_filter(
     assert call_args.kwargs["filters"].any_custom_metadata[0].pattern == "val*"
     assert call_args.kwargs["filters"].any_custom_metadata[1].name == "key2"
     assert call_args.kwargs["filters"].any_custom_metadata[1].pattern == "exactval"
+
+
+async def test_list_all_solvers_jobs_with_all_metadata_filter(
+    auth: httpx.BasicAuth,
+    client: httpx.AsyncClient,
+    mocked_backend: MockBackendRouters,
+    user_id: UserID,
+    mock_dependency_get_celery_task_manager: MockType,
+):
+    """Tests AND metadata filtering: all conditions must match."""
+
+    metadata_filters = ["solver_type:FEM", "mesh_cells:1*"]
+
+    params = {
+        "limit": 10,
+        "offset": 0,
+        "metadata.all": metadata_filters,
+    }
+
+    resp = await client.get(
+        f"/{API_VTAG}/solvers/-/releases/-/jobs",
+        auth=auth,
+        params=params,
+    )
+
+    assert resp.status_code == status.HTTP_200_OK
+
+    jobs_page = TypeAdapter(Page[Job]).validate_python(resp.json())
+    assert isinstance(jobs_page.items, list)
+
+    # Verify RPC was called with all_custom_metadata
+    call_args = mocked_backend.webserver_rpc["mocked_rabbit_rpc_client"].request.call_args
+    assert call_args.args == (
+        "wb-api-server",
+        "list_projects_marked_as_jobs",
+    )
+    assert call_args.kwargs["product_name"] == "osparc"
+    assert call_args.kwargs["user_id"] == user_id
+    assert call_args.kwargs["filters"].all_custom_metadata[0].name == "solver_type"
+    assert call_args.kwargs["filters"].all_custom_metadata[0].pattern == "FEM"
+    assert call_args.kwargs["filters"].all_custom_metadata[1].name == "mesh_cells"
+    assert call_args.kwargs["filters"].all_custom_metadata[1].pattern == "1*"
+    # any_custom_metadata should be None when all is used
+    assert call_args.kwargs["filters"].any_custom_metadata is None
+
+
+async def test_list_all_solvers_jobs_metadata_any_and_all_mutually_exclusive(
+    auth: httpx.BasicAuth,
+    client: httpx.AsyncClient,
+    mocked_backend: MockBackendRouters,
+    mock_dependency_get_celery_task_manager: MockType,
+):
+    """Tests that using both metadata.any and metadata.all returns 422."""
+
+    params = {
+        "limit": 10,
+        "offset": 0,
+        "metadata.any": ["key1:val*"],
+        "metadata.all": ["key2:val2"],
+    }
+
+    resp = await client.get(
+        f"/{API_VTAG}/solvers/-/releases/-/jobs",
+        auth=auth,
+        params=params,
+    )
+
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_read.py
+++ b/services/api-server/tests/unit/api_solvers/test_api_routers_solvers_jobs_read.py
@@ -233,6 +233,45 @@ async def test_list_all_solvers_jobs_with_all_metadata_filter(
     assert call_args.kwargs["filters"].any_custom_metadata is None
 
 
+async def test_list_all_solvers_jobs_with_all_metadata_filter_pagination(
+    auth: httpx.BasicAuth,
+    client: httpx.AsyncClient,
+    mocked_backend: MockBackendRouters,
+    user_id: UserID,
+    mock_dependency_get_celery_task_manager: MockType,
+):
+    """Tests that pagination works correctly with metadata.all filter."""
+
+    metadata_filters = ["solver_type:FEM", "mesh_cells:1*"]
+
+    # First request to get the total count
+    resp = await client.get(
+        f"/{API_VTAG}/solvers/-/releases/-/jobs",
+        auth=auth,
+        params={"limit": 10, "offset": 0, "metadata.all": metadata_filters},
+    )
+    assert resp.status_code == status.HTTP_200_OK
+    first_page = TypeAdapter(Page[Job]).validate_python(resp.json())
+    assert first_page.total > 0
+
+    # Request with offset = total - 1 should return exactly 1 item
+    resp = await client.get(
+        f"/{API_VTAG}/solvers/-/releases/-/jobs",
+        auth=auth,
+        params={
+            "limit": 10,
+            "offset": first_page.total - 1,
+            "metadata.all": metadata_filters,
+        },
+    )
+    assert resp.status_code == status.HTTP_200_OK
+
+    last_page = TypeAdapter(Page[Job]).validate_python(resp.json())
+    assert last_page.total == first_page.total
+    assert last_page.offset == first_page.total - 1
+    assert len(last_page.items) == 1
+
+
 async def test_list_all_solvers_jobs_metadata_any_and_all_mutually_exclusive(
     auth: httpx.BasicAuth,
     client: httpx.AsyncClient,

--- a/services/api-server/tests/unit/service/test_service_jobs.py
+++ b/services/api-server/tests/unit/service/test_service_jobs.py
@@ -19,7 +19,13 @@ async def test_list_jobs_by_resource_prefix(
     job_service: JobService,
 ):
     # Test with default pagination parameters
-    jobs, page_meta = await job_service._list_jobs(job_parent_resource_name="solvers/some-solver")
+    jobs, page_meta = await job_service._list_jobs(  # noqa: SLF001
+        job_parent_resource_name="solvers/some-solver",
+        filter_any_custom_metadata=None,
+        filter_all_custom_metadata=None,
+        pagination_offset=0,
+        pagination_limit=10,
+    )
 
     assert isinstance(jobs, list)
 

--- a/services/api-server/tests/unit/test_api_dependencies.py
+++ b/services/api-server/tests/unit/test_api_dependencies.py
@@ -1,9 +1,8 @@
 from typing import Annotated
 
 import pytest
-from fastapi import Depends, FastAPI, status
+from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
-from pydantic import ValidationError
 from simcore_service_api_server.api.dependencies.models_schemas_jobs_filters import (
     get_job_metadata_filter,
 )
@@ -32,6 +31,7 @@ def test_get_metadata_filter():
     )
 
     assert result is not None
+    assert result.any is not None
     assert len(result.any) == 2
     assert result.any[0].name == "key1"
     assert result.any[0].pattern == "val*"
@@ -39,21 +39,17 @@ def test_get_metadata_filter():
     assert result.any[1].pattern == "exactval"
     assert result == expected
 
-    # Test with invalid input (missing colon)
+    # Test with invalid input (missing colon) - now raises HTTPException
     input_data = ["key1val", "key2:exactval"]
-    result = get_job_metadata_filter(input_data)
-
-    assert result is not None
-    assert len(result.any) == 1
-    assert result.any[0].name == "key2"
-    assert result.any[0].pattern == "exactval"
+    with pytest.raises(HTTPException) as exc_info:
+        get_job_metadata_filter(input_data)
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # Test with empty pattern not allowed
     input_data = ["key1:", "key2:exactval"]
-    with pytest.raises(ValidationError) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         get_job_metadata_filter(input_data)
-
-    assert exc_info.value.errors()[0]["type"] == "string_too_short"
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 def test_metadata_filter_in_api_route():
@@ -69,7 +65,13 @@ def test_metadata_filter_in_api_route():
             return {"filters": None}
 
         # Convert to dict for easier comparison in test
-        return {"filters": {"any": [{"name": item.name, "pattern": item.pattern} for item in metadata_filter.any]}}
+        return {
+            "filters": {
+                "any": [{"name": item.name, "pattern": item.pattern} for item in metadata_filter.any]
+                if metadata_filter.any
+                else None
+            }
+        }
 
     # Create a test client
     client = TestClient(app)
@@ -96,10 +98,9 @@ def test_metadata_filter_in_api_route():
         }
     }
 
-    # Test with invalid filter (should skip the invalid one)
+    # Test with invalid filter (should return 422)
     response = client.get("/test-filter?metadata.any=invalid&metadata.any=key2:exactval")
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {"filters": {"any": [{"name": "key2", "pattern": "exactval"}]}}
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # Test with URL-encoded characters
     # Use special characters that need encoding: space, &, =, +, /, ?
@@ -118,7 +119,7 @@ def test_metadata_filter_in_api_route():
     }
 
     # Test with Unicode characters
-    unicode_query = "/test-filter?metadata.any=emoji:%F0%9F%98%8A&metadata.any=international:caf%C3%A9"
+    unicode_query = "/test-filter?metadata.any=emoji:%F0%9F%98%8A&metadata.any=international:calf%C3%A9"
     response = client.get(unicode_query)
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {

--- a/services/api-server/tests/unit/test_api_dependencies.py
+++ b/services/api-server/tests/unit/test_api_dependencies.py
@@ -1,3 +1,4 @@
+# pylint: disable=unsubscriptable-object
 from typing import Annotated
 
 import pytest

--- a/services/api-server/tests/unit/test_api_dependencies.py
+++ b/services/api-server/tests/unit/test_api_dependencies.py
@@ -120,7 +120,9 @@ def test_metadata_filter_in_api_route():
     }
 
     # Test with Unicode characters
-    unicode_query = "/test-filter?metadata.any=emoji:%F0%9F%98%8A&metadata.any=international:calf%C3%A9"
+    unicode_query = (
+        "/test-filter?metadata.any=emoji:%F0%9F%98%8A&metadata.any=international:caf%C3%A9"  # spellchecker:disable-line
+    )
     response = client.get(unicode_query)
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {

--- a/services/web/server/src/simcore_service_webserver/projects/_controller/projects_rpc.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_controller/projects_rpc.py
@@ -7,6 +7,7 @@ from models_library.rpc.webserver.projects import (
     PageRpcProjectJobRpcGet,
     ProjectJobRpcGet,
 )
+from models_library.rpc_pagination import PageRpc
 from models_library.users import UserID
 from pydantic import ValidationError, validate_call
 from servicelib.rabbitmq import RPCRouter
@@ -101,7 +102,7 @@ async def list_projects_marked_as_jobs(
         for project in projects
     ]
 
-    page: PageRpcProjectJobRpcGet = PageRpcProjectJobRpcGet.create(
+    page: PageRpcProjectJobRpcGet = PageRpc[ProjectJobRpcGet].create(
         job_projects,
         total=total,
         limit=limit,

--- a/services/web/server/src/simcore_service_webserver/projects/_controller/projects_rpc.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_controller/projects_rpc.py
@@ -7,7 +7,6 @@ from models_library.rpc.webserver.projects import (
     PageRpcProjectJobRpcGet,
     ProjectJobRpcGet,
 )
-from models_library.rpc_pagination import PageRpc
 from models_library.users import UserID
 from pydantic import ValidationError, validate_call
 from servicelib.rabbitmq import RPCRouter
@@ -102,7 +101,7 @@ async def list_projects_marked_as_jobs(
         for project in projects
     ]
 
-    page: PageRpcProjectJobRpcGet = PageRpc[ProjectJobRpcGet].create(
+    page: PageRpcProjectJobRpcGet = PageRpcProjectJobRpcGet.create(
         job_projects,
         total=total,
         limit=limit,

--- a/services/web/server/src/simcore_service_webserver/projects/_controller/projects_rpc.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_controller/projects_rpc.py
@@ -80,6 +80,11 @@ async def list_projects_marked_as_jobs(
             if filters and filters.any_custom_metadata
             else None
         ),
+        filter_all_custom_metadata=(
+            [(custom_metadata.name, custom_metadata.pattern) for custom_metadata in filters.all_custom_metadata]
+            if filters and filters.all_custom_metadata
+            else None
+        ),
     )
 
     job_projects = [

--- a/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
@@ -52,6 +52,23 @@ def _apply_custom_metadata_filter(query: sa.sql.Select, any_metadata_fields: lis
     return query.where(sa.or_(*metadata_fields_ilike))
 
 
+def _apply_custom_metadata_all_filter(
+    query: sa.sql.Select, all_metadata_fields: list[tuple[str, str]]
+) -> sa.sql.Select:
+    """Apply metadata filters to query using AND logic.
+
+    All conditions must match for a project to be included.
+    """
+    assert all_metadata_fields  # nosec
+
+    metadata_fields_ilike = []
+    for key, pattern in all_metadata_fields:
+        sql_pattern = pattern.replace("*", "%")
+        metadata_fields_ilike.append(projects_metadata.c.custom[key].astext.ilike(sql_pattern))
+
+    return query.where(sa.and_(*metadata_fields_ilike))
+
+
 class ProjectJobsRepository(BaseRepository):
     async def set_project_as_job(
         self,
@@ -90,6 +107,7 @@ class ProjectJobsRepository(BaseRepository):
         pagination_limit: int,
         filter_by_job_parent_resource_name_prefix: str | None = None,
         filter_any_custom_metadata: list[tuple[str, str]] | None = None,
+        filter_all_custom_metadata: list[tuple[str, str]] | None = None,
     ) -> tuple[int, list[ProjectJobDBGet]]:
         """Lists projects marked as jobs for a specific user and product
 
@@ -148,6 +166,9 @@ class ProjectJobsRepository(BaseRepository):
 
         if filter_any_custom_metadata:
             access_query = _apply_custom_metadata_filter(access_query, filter_any_custom_metadata)
+
+        if filter_all_custom_metadata:
+            access_query = _apply_custom_metadata_all_filter(access_query, filter_all_custom_metadata)
 
         # Step 4. Convert access_query to a subquery
         base_query = access_query.subquery()

--- a/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
@@ -34,39 +34,28 @@ def _apply_job_parent_resource_name_filter(query: sa.sql.Select, prefix: str) ->
     return query.where(projects_to_jobs.c.job_parent_resource_name.like(f"{prefix}%"))
 
 
-def _apply_custom_metadata_filter(query: sa.sql.Select, any_metadata_fields: list[tuple[str, str]]) -> sa.sql.Select:
+def _apply_custom_metadata_filter(
+    query: sa.sql.Select,
+    metadata_fields: list[tuple[str, str]],
+    *,
+    match_all: bool = False,
+) -> sa.sql.Select:
     """Apply metadata filters to query.
 
-    For PostgreSQL JSONB fields, we need to extract the text value using ->> operator
+    For PostgreSQL JSONB fields, we extract the text value using ->> operator
     before applying string comparison operators like ILIKE.
+
+    When match_all=False (default), uses OR logic. When match_all=True, uses AND logic.
     """
-    assert any_metadata_fields  # nosec
+    assert metadata_fields  # nosec
 
     metadata_fields_ilike = []
-    for key, pattern in any_metadata_fields:
-        # Use ->> operator to extract the text value from JSONB
-        # Then apply ILIKE for case-insensitive pattern matching
+    for key, pattern in metadata_fields:
         sql_pattern = pattern.replace("*", "%")  # Convert glob-like pattern to SQL LIKE
         metadata_fields_ilike.append(projects_metadata.c.custom[key].astext.ilike(sql_pattern))
 
-    return query.where(sa.or_(*metadata_fields_ilike))
-
-
-def _apply_custom_metadata_all_filter(
-    query: sa.sql.Select, all_metadata_fields: list[tuple[str, str]]
-) -> sa.sql.Select:
-    """Apply metadata filters to query using AND logic.
-
-    All conditions must match for a project to be included.
-    """
-    assert all_metadata_fields  # nosec
-
-    metadata_fields_ilike = []
-    for key, pattern in all_metadata_fields:
-        sql_pattern = pattern.replace("*", "%")
-        metadata_fields_ilike.append(projects_metadata.c.custom[key].astext.ilike(sql_pattern))
-
-    return query.where(sa.and_(*metadata_fields_ilike))
+    combine = sa.and_ if match_all else sa.or_
+    return query.where(combine(*metadata_fields_ilike))
 
 
 class ProjectJobsRepository(BaseRepository):
@@ -168,7 +157,7 @@ class ProjectJobsRepository(BaseRepository):
             access_query = _apply_custom_metadata_filter(access_query, filter_any_custom_metadata)
 
         if filter_all_custom_metadata:
-            access_query = _apply_custom_metadata_all_filter(access_query, filter_all_custom_metadata)
+            access_query = _apply_custom_metadata_filter(access_query, filter_all_custom_metadata, match_all=True)
 
         # Step 4. Convert access_query to a subquery
         base_query = access_query.subquery()

--- a/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_jobs_repository.py
@@ -94,9 +94,9 @@ class ProjectJobsRepository(BaseRepository):
         user_id: UserID,
         pagination_offset: int,
         pagination_limit: int,
-        filter_by_job_parent_resource_name_prefix: str | None = None,
-        filter_any_custom_metadata: list[tuple[str, str]] | None = None,
-        filter_all_custom_metadata: list[tuple[str, str]] | None = None,
+        filter_by_job_parent_resource_name_prefix: str | None,
+        filter_any_custom_metadata: list[tuple[str, str]] | None,
+        filter_all_custom_metadata: list[tuple[str, str]] | None,
     ) -> tuple[int, list[ProjectJobDBGet]]:
         """Lists projects marked as jobs for a specific user and product
 

--- a/services/web/server/src/simcore_service_webserver/projects/_jobs_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_jobs_service.py
@@ -59,13 +59,18 @@ async def list_my_projects_marked_as_jobs(
     pagination_limit: int = 10,
     filter_by_job_parent_resource_name_prefix: str | None = None,
     filter_any_custom_metadata: list[tuple[str, str]] | None = None,
+    filter_all_custom_metadata: list[tuple[str, str]] | None = None,
 ) -> tuple[int, list[ProjectJobDBGet]]:
     """
     Lists paginated projects marked as jobs for the given user and product.
 
     Keyword Arguments:
-        filter_by_job_parent_resource_name_prefix -- Optionally filters by job_parent_resource_name using SQL-like wildcard patterns. (default: {None})
-        filter_any_custom_metadata -- is a list of dictionaries with key-pattern pairs for custom metadata fields (OR logic). (default: {None})
+        filter_by_job_parent_resource_name_prefix -- Optionally filters by
+            job_parent_resource_name using SQL-like wildcard patterns. (default: {None})
+        filter_any_custom_metadata -- is a list of key-pattern pairs
+            for custom metadata fields (OR logic). (default: {None})
+        filter_all_custom_metadata -- is a list of key-pattern pairs
+            for custom metadata fields (AND logic). (default: {None})
 
     Returns:
         A tuple containing the total number of projects and a list of ProjectJobDBGet objects for this page.
@@ -78,6 +83,7 @@ async def list_my_projects_marked_as_jobs(
         pagination_limit=pagination_limit,
         filter_by_job_parent_resource_name_prefix=filter_by_job_parent_resource_name_prefix,
         filter_any_custom_metadata=filter_any_custom_metadata,
+        filter_all_custom_metadata=filter_all_custom_metadata,
     )
 
 

--- a/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
@@ -4,6 +4,7 @@
 # pylint: disable=too-many-arguments
 
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 from aiohttp.test_utils import TestClient
@@ -11,7 +12,13 @@ from common_library.users_enums import UserRole
 from models_library.api_schemas_webserver.projects_metadata import MetadataDict
 from models_library.products import ProductName
 from models_library.projects import ProjectID
+from models_library.rpc.webserver.projects import (
+    ListProjectsMarkedAsJobRpcFilters,
+    MetadataFilterItem,
+)
 from models_library.users import UserID
+from pydantic import ValidationError
+from pytest_simcore.helpers.webserver_projects import NewProject
 from pytest_simcore.helpers.webserver_users import UserInfoDict
 from simcore_service_webserver.projects._jobs_service import (
     list_my_projects_marked_as_jobs,
@@ -320,3 +327,143 @@ async def test_filter_projects_by_metadata(
     )
     assert total_count == 0
     assert len(result) == 0
+
+
+async def test_filter_projects_by_metadata_all(
+    client: TestClient,
+    logged_user: UserInfoDict,
+    osparc_product_name: ProductName,
+    tests_data_dir: Path,
+):
+    """Test that list_my_projects_marked_as_jobs can filter projects using AND logic on custom metadata.
+
+    Creates 3 projects with different metadata combinations and verifies that
+    filter_all_custom_metadata requires ALL conditions to match (AND logic).
+    """
+    assert client.app
+
+    user_id = logged_user["id"]
+
+    # Create 3 projects with distinct metadata
+    projects_metadata_map: dict[str, MetadataDict] = {
+        "solvers/fem-solver/v1": {
+            "solver_type": "FEM",
+            "mesh_cells": "1000",
+            "status": "completed",
+        },
+        "solvers/fem-solver/v2": {
+            "solver_type": "FEM",
+            "mesh_cells": "500",
+            "status": "pending",
+        },
+        "solvers/cfd-solver/v1": {
+            "solver_type": "CFD",
+            "mesh_cells": "1000",
+            "status": "completed",
+        },
+    }
+
+    project_uuids: dict[str, ProjectID] = {}
+
+    for job_parent_resource_name, custom_metadata in projects_metadata_map.items():
+        async with NewProject(
+            {"name": f"project-{job_parent_resource_name}"},
+            client.app,
+            user_id=user_id,
+            product_name=osparc_product_name,
+            tests_data_dir=tests_data_dir,
+        ) as project:
+            project_uuid = ProjectID(project["uuid"])
+            project_uuids[job_parent_resource_name] = project_uuid
+
+            await set_project_as_job(
+                app=client.app,
+                product_name=osparc_product_name,
+                user_id=user_id,
+                project_uuid=project_uuid,
+                job_parent_resource_name=job_parent_resource_name,
+                storage_assets_deleted=False,
+            )
+
+            await set_project_custom_metadata(
+                app=client.app,
+                user_id=user_id,
+                project_uuid=project_uuid,
+                value=custom_metadata,
+            )
+
+    uuid_a = project_uuids["solvers/fem-solver/v1"]
+    uuid_b = project_uuids["solvers/fem-solver/v2"]
+    uuid_c = project_uuids["solvers/cfd-solver/v1"]
+
+    # --- AND filter: solver_type=FEM AND mesh_cells=1000 -> only Project A
+    total_count, result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        filter_all_custom_metadata=[("solver_type", "FEM"), ("mesh_cells", "1000")],
+    )
+    assert total_count == 1
+    assert result[0].uuid == uuid_a
+
+    # --- AND filter: solver_type=FEM -> Projects A and B
+    total_count, result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        filter_all_custom_metadata=[("solver_type", "FEM")],
+    )
+    assert total_count == 2
+    result_uuids = {r.uuid for r in result}
+    assert result_uuids == {uuid_a, uuid_b}
+
+    # --- AND filter: status=completed AND mesh_cells=1000 -> Projects A and C
+    total_count, result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        filter_all_custom_metadata=[("status", "completed"), ("mesh_cells", "1000")],
+    )
+    assert total_count == 2
+    result_uuids = {r.uuid for r in result}
+    assert result_uuids == {uuid_a, uuid_c}
+
+    # --- AND filter: all 3 conditions that no single project matches -> empty
+    total_count, result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        filter_all_custom_metadata=[("solver_type", "FEM"), ("status", "pending"), ("mesh_cells", "999")],
+    )
+    assert total_count == 0
+    assert result == []
+
+    # --- AND filter with wildcards: solver_type=FEM AND mesh_cells=1* -> Project A only
+    total_count, result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        filter_all_custom_metadata=[("solver_type", "FEM"), ("mesh_cells", "1*")],
+    )
+    assert total_count == 1
+    assert result[0].uuid == uuid_a
+
+    # --- Combining AND filter with job_parent_resource_name_prefix
+    total_count, result = await list_my_projects_marked_as_jobs(
+        app=client.app,
+        product_name=osparc_product_name,
+        user_id=user_id,
+        filter_by_job_parent_resource_name_prefix="solvers/fem-solver",
+        filter_all_custom_metadata=[("status", "completed")],
+    )
+    assert total_count == 1
+    assert result[0].uuid == uuid_a
+
+
+async def test_filter_all_and_any_custom_metadata_are_mutually_exclusive():
+    """Test that setting both any_custom_metadata and all_custom_metadata raises a validation error."""
+    with pytest.raises(ValidationError):
+        ListProjectsMarkedAsJobRpcFilters(
+            any_custom_metadata=[MetadataFilterItem(name="key", pattern="val")],
+            all_custom_metadata=[MetadataFilterItem(name="key2", pattern="val2")],
+        )

--- a/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects__jobs_service.py
@@ -3,6 +3,7 @@
 # pylint: disable=unused-variable
 # pylint: disable=too-many-arguments
 
+from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -365,14 +366,17 @@ async def test_filter_projects_by_metadata_all(
 
     project_uuids: dict[str, ProjectID] = {}
 
-    for job_parent_resource_name, custom_metadata in projects_metadata_map.items():
-        async with NewProject(
-            {"name": f"project-{job_parent_resource_name}"},
-            client.app,
-            user_id=user_id,
-            product_name=osparc_product_name,
-            tests_data_dir=tests_data_dir,
-        ) as project:
+    async with AsyncExitStack() as stack:
+        for job_parent_resource_name, custom_metadata in projects_metadata_map.items():
+            project = await stack.enter_async_context(
+                NewProject(
+                    {"name": f"project-{job_parent_resource_name}"},
+                    client.app,
+                    user_id=user_id,
+                    product_name=osparc_product_name,
+                    tests_data_dir=tests_data_dir,
+                )
+            )
             project_uuid = ProjectID(project["uuid"])
             project_uuids[job_parent_resource_name] = project_uuid
 
@@ -392,72 +396,72 @@ async def test_filter_projects_by_metadata_all(
                 value=custom_metadata,
             )
 
-    uuid_a = project_uuids["solvers/fem-solver/v1"]
-    uuid_b = project_uuids["solvers/fem-solver/v2"]
-    uuid_c = project_uuids["solvers/cfd-solver/v1"]
+        uuid_a = project_uuids["solvers/fem-solver/v1"]
+        uuid_b = project_uuids["solvers/fem-solver/v2"]
+        uuid_c = project_uuids["solvers/cfd-solver/v1"]
 
-    # --- AND filter: solver_type=FEM AND mesh_cells=1000 -> only Project A
-    total_count, result = await list_my_projects_marked_as_jobs(
-        app=client.app,
-        product_name=osparc_product_name,
-        user_id=user_id,
-        filter_all_custom_metadata=[("solver_type", "FEM"), ("mesh_cells", "1000")],
-    )
-    assert total_count == 1
-    assert result[0].uuid == uuid_a
+        # --- AND filter: solver_type=FEM AND mesh_cells=1000 -> only Project A
+        total_count, result = await list_my_projects_marked_as_jobs(
+            app=client.app,
+            product_name=osparc_product_name,
+            user_id=user_id,
+            filter_all_custom_metadata=[("solver_type", "FEM"), ("mesh_cells", "1000")],
+        )
+        assert total_count == 1
+        assert result[0].uuid == uuid_a
 
-    # --- AND filter: solver_type=FEM -> Projects A and B
-    total_count, result = await list_my_projects_marked_as_jobs(
-        app=client.app,
-        product_name=osparc_product_name,
-        user_id=user_id,
-        filter_all_custom_metadata=[("solver_type", "FEM")],
-    )
-    assert total_count == 2
-    result_uuids = {r.uuid for r in result}
-    assert result_uuids == {uuid_a, uuid_b}
+        # --- AND filter: solver_type=FEM -> Projects A and B
+        total_count, result = await list_my_projects_marked_as_jobs(
+            app=client.app,
+            product_name=osparc_product_name,
+            user_id=user_id,
+            filter_all_custom_metadata=[("solver_type", "FEM")],
+        )
+        assert total_count == 2
+        result_uuids = {r.uuid for r in result}
+        assert result_uuids == {uuid_a, uuid_b}
 
-    # --- AND filter: status=completed AND mesh_cells=1000 -> Projects A and C
-    total_count, result = await list_my_projects_marked_as_jobs(
-        app=client.app,
-        product_name=osparc_product_name,
-        user_id=user_id,
-        filter_all_custom_metadata=[("status", "completed"), ("mesh_cells", "1000")],
-    )
-    assert total_count == 2
-    result_uuids = {r.uuid for r in result}
-    assert result_uuids == {uuid_a, uuid_c}
+        # --- AND filter: status=completed AND mesh_cells=1000 -> Projects A and C
+        total_count, result = await list_my_projects_marked_as_jobs(
+            app=client.app,
+            product_name=osparc_product_name,
+            user_id=user_id,
+            filter_all_custom_metadata=[("status", "completed"), ("mesh_cells", "1000")],
+        )
+        assert total_count == 2
+        result_uuids = {r.uuid for r in result}
+        assert result_uuids == {uuid_a, uuid_c}
 
-    # --- AND filter: all 3 conditions that no single project matches -> empty
-    total_count, result = await list_my_projects_marked_as_jobs(
-        app=client.app,
-        product_name=osparc_product_name,
-        user_id=user_id,
-        filter_all_custom_metadata=[("solver_type", "FEM"), ("status", "pending"), ("mesh_cells", "999")],
-    )
-    assert total_count == 0
-    assert result == []
+        # --- AND filter: all 3 conditions that no single project matches -> empty
+        total_count, result = await list_my_projects_marked_as_jobs(
+            app=client.app,
+            product_name=osparc_product_name,
+            user_id=user_id,
+            filter_all_custom_metadata=[("solver_type", "FEM"), ("status", "pending"), ("mesh_cells", "999")],
+        )
+        assert total_count == 0
+        assert result == []
 
-    # --- AND filter with wildcards: solver_type=FEM AND mesh_cells=1* -> Project A only
-    total_count, result = await list_my_projects_marked_as_jobs(
-        app=client.app,
-        product_name=osparc_product_name,
-        user_id=user_id,
-        filter_all_custom_metadata=[("solver_type", "FEM"), ("mesh_cells", "1*")],
-    )
-    assert total_count == 1
-    assert result[0].uuid == uuid_a
+        # --- AND filter with wildcards: solver_type=FEM AND mesh_cells=1* -> Project A only
+        total_count, result = await list_my_projects_marked_as_jobs(
+            app=client.app,
+            product_name=osparc_product_name,
+            user_id=user_id,
+            filter_all_custom_metadata=[("solver_type", "FEM"), ("mesh_cells", "1*")],
+        )
+        assert total_count == 1
+        assert result[0].uuid == uuid_a
 
-    # --- Combining AND filter with job_parent_resource_name_prefix
-    total_count, result = await list_my_projects_marked_as_jobs(
-        app=client.app,
-        product_name=osparc_product_name,
-        user_id=user_id,
-        filter_by_job_parent_resource_name_prefix="solvers/fem-solver",
-        filter_all_custom_metadata=[("status", "completed")],
-    )
-    assert total_count == 1
-    assert result[0].uuid == uuid_a
+        # --- Combining AND filter with job_parent_resource_name_prefix
+        total_count, result = await list_my_projects_marked_as_jobs(
+            app=client.app,
+            product_name=osparc_product_name,
+            user_id=user_id,
+            filter_by_job_parent_resource_name_prefix="solvers/fem-solver",
+            filter_all_custom_metadata=[("status", "completed")],
+        )
+        assert total_count == 1
+        assert result[0].uuid == uuid_a
 
 
 async def test_filter_all_and_any_custom_metadata_are_mutually_exclusive():

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_rpc.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_rpc.py
@@ -32,6 +32,7 @@ from settings_library.rabbit import RabbitSettings
 from simcore_service_webserver.application_settings import (
     ApplicationSettings,
 )
+from simcore_service_webserver.projects import _metadata_service
 from simcore_service_webserver.projects.models import ProjectDict
 
 pytest_simcore_core_services_selection = [
@@ -202,8 +203,6 @@ async def test_rpc_client_list_projects_marked_as_jobs_with_metadata_filter(
     user_project: ProjectDict,
     client: TestClient,
 ):
-    from simcore_service_webserver.projects import _metadata_service
-
     project_uuid = ProjectID(user_project["uuid"])
     user_id = logged_user["id"]
 
@@ -434,3 +433,92 @@ async def test_mark_and_get_project_job_storage_assets_deleted(
         job_parent_resource_name=job_parent_resource_name,
     )
     assert project_job.storage_assets_deleted is False
+
+
+async def test_rpc_client_list_projects_marked_as_jobs_with_all_metadata_filter(
+    webserver_rpc_client: WebServerRpcClient,
+    product_name: ProductName,
+    logged_user: UserInfoDict,
+    user_project: ProjectDict,
+    client: TestClient,
+):
+    """Test that list_projects_marked_as_jobs with all_custom_metadata uses AND logic via RPC."""
+
+    project_uuid = ProjectID(user_project["uuid"])
+    user_id = logged_user["id"]
+
+    # Mark the project as a job
+    await webserver_rpc_client.projects.mark_project_as_job(
+        product_name=product_name,
+        user_id=user_id,
+        project_uuid=project_uuid,
+        job_parent_resource_name="solvers/solver123/version/1.2.3",
+        storage_assets_deleted=False,
+    )
+
+    # Set custom metadata on the project
+    custom_metadata: MetadataDict = {
+        "solver_type": "FEM",
+        "mesh_cells": "10000",
+        "domain": "biomedical",
+    }
+
+    await _metadata_service.set_project_custom_metadata(
+        app=client.app,
+        user_id=user_id,
+        project_uuid=project_uuid,
+        value=custom_metadata,
+    )
+
+    # Test AND filter: all conditions match -> found
+    page: PageRpcProjectJobRpcGet = await webserver_rpc_client.projects.list_projects_marked_as_jobs(
+        product_name=product_name,
+        user_id=user_id,
+        filters=ListProjectsMarkedAsJobRpcFilters(
+            all_custom_metadata=[
+                MetadataFilterItem(name="solver_type", pattern="FEM"),
+                MetadataFilterItem(name="domain", pattern="biomedical"),
+            ],
+        ),
+    )
+
+    assert page.meta.total == 1
+    assert len(page.data) == 1
+    assert page.data[0].uuid == project_uuid
+
+    # Test AND filter: one condition doesn't match -> not found
+    page = await webserver_rpc_client.projects.list_projects_marked_as_jobs(
+        product_name=product_name,
+        user_id=user_id,
+        filters=ListProjectsMarkedAsJobRpcFilters(
+            all_custom_metadata=[
+                MetadataFilterItem(name="solver_type", pattern="FEM"),
+                MetadataFilterItem(name="domain", pattern="aerospace"),  # No match
+            ],
+        ),
+    )
+
+    assert page.meta.total == 0
+    assert len(page.data) == 0
+
+    # Test AND filter with wildcard: both match -> found
+    page = await webserver_rpc_client.projects.list_projects_marked_as_jobs(
+        product_name=product_name,
+        user_id=user_id,
+        filters=ListProjectsMarkedAsJobRpcFilters(
+            all_custom_metadata=[
+                MetadataFilterItem(name="solver_type", pattern="F*"),
+                MetadataFilterItem(name="mesh_cells", pattern="1*"),
+            ],
+        ),
+    )
+
+    assert page.meta.total == 1
+    assert page.data[0].uuid == project_uuid
+
+    # Test mutual exclusivity: both any and all raises validation error
+    with pytest.raises(ValidationError):
+        ListProjectsMarkedAsJobRpcFilters(
+            any_custom_metadata=[MetadataFilterItem(name="solver_type", pattern="FEM")],
+            all_custom_metadata=[MetadataFilterItem(name="domain", pattern="biomedical")],
+        )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request introduces support for filtering jobs based on custom metadata fields using both "any" (OR logic) and "all" (AND logic) conditions. It ensures that these two filters are mutually exclusive and updates the API, backend, and tests accordingly. The changes include schema updates, validation logic, backend query enhancements, and new tests for the AND logic and exclusivity constraint.

**API and Schema Enhancements:**

- Added `metadata.all` query parameter to the API, allowing users to filter jobs that match all specified metadata fields (AND logic), in addition to the existing `metadata.any` (OR logic). Both filters are now mutually exclusive. [[1]](diffhunk://#diff-d7e1065e286c7d0a19aa5093a24b5c6de81183f1b2abd0362e6fb3836cdc3d4dL29-R43) [[2]](diffhunk://#diff-df5227866c9e7c1120057638e75a1343f913d00906a6b00a6c14e0c08ce361cdL22-R38) [[3]](diffhunk://#diff-b58ec3249497b46bfab4edae275971b7554e3d3829f5017cd64caa0ec47cc46fL26-R67) [[4]](diffhunk://#diff-1abe543c001191b3afe3c09d6ed70bf515a338bc79dc292dd4b379534dd8aa35R3994-R4014)

**Backend Filtering Logic:**

- Implemented backend support for AND logic filtering by adding new parameters and SQL query logic to handle `filter_all_custom_metadata`, ensuring that all specified metadata conditions must match. [[1]](diffhunk://#diff-952369d3e183ae59dc02f098abe3cadf905978f51779259efd6be80b6776cbb5R55-R71) [[2]](diffhunk://#diff-952369d3e183ae59dc02f098abe3cadf905978f51779259efd6be80b6776cbb5R110) [[3]](diffhunk://#diff-952369d3e183ae59dc02f098abe3cadf905978f51779259efd6be80b6776cbb5R170-R172) [[4]](diffhunk://#diff-a81b24719407aed4bab7c745611625f1fed3990504e72eb48523ff2b6909eb5bR83-R87) [[5]](diffhunk://#diff-db0c958586be07890f843572e522c77b4277cf8885cd45af2c710a5a3dfc7913R272) [[6]](diffhunk://#diff-db0c958586be07890f843572e522c77b4277cf8885cd45af2c710a5a3dfc7913R283-R287) [[7]](diffhunk://#diff-c50cfebb0a4bff4f71cff0f39912df15a9c56cf42f7fd7e32ca08d300c79e42aR116) [[8]](diffhunk://#diff-c50cfebb0a4bff4f71cff0f39912df15a9c56cf42f7fd7e32ca08d300c79e42aR130) [[9]](diffhunk://#diff-c50cfebb0a4bff4f71cff0f39912df15a9c56cf42f7fd7e32ca08d300c79e42aR168) [[10]](diffhunk://#diff-c50cfebb0a4bff4f71cff0f39912df15a9c56cf42f7fd7e32ca08d300c79e42aR190)

**Validation and Error Handling:**

- Added model validators to ensure that both "any" and "all" metadata filters cannot be used simultaneously and that at least one is provided, returning appropriate errors if the constraint is violated. [[1]](diffhunk://#diff-d7e1065e286c7d0a19aa5093a24b5c6de81183f1b2abd0362e6fb3836cdc3d4dL29-R43) [[2]](diffhunk://#diff-df5227866c9e7c1120057638e75a1343f913d00906a6b00a6c14e0c08ce361cdL22-R38) [[3]](diffhunk://#diff-b58ec3249497b46bfab4edae275971b7554e3d3829f5017cd64caa0ec47cc46fL26-R67)

**Testing Improvements:**

- Added unit tests to verify the new AND logic, the mutual exclusivity of filters, and correct backend invocation with the new parameters.

**Minor Fixes and Typing Updates:**

- Fixed typos in docstrings and improved type annotations for pagination and filter models to align with the new logic. [[1]](diffhunk://#diff-d7e1065e286c7d0a19aa5093a24b5c6de81183f1b2abd0362e6fb3836cdc3d4dL2-R5) [[2]](diffhunk://#diff-d7e1065e286c7d0a19aa5093a24b5c6de81183f1b2abd0362e6fb3836cdc3d4dL70-R82) [[3]](diffhunk://#diff-d7e1065e286c7d0a19aa5093a24b5c6de81183f1b2abd0362e6fb3836cdc3d4dL142-R154) [[4]](diffhunk://#diff-cda3ae6f5fe0e182270b152e578dddd69154aca6a7ddde2e3efc7ee62d3ecb38L13-R18) [[5]](diffhunk://#diff-cda3ae6f5fe0e182270b152e578dddd69154aca6a7ddde2e3efc7ee62d3ecb38L66-R66) [[6]](diffhunk://#diff-cda3ae6f5fe0e182270b152e578dddd69154aca6a7ddde2e3efc7ee62d3ecb38L84-R84) [[7]](diffhunk://#diff-df5227866c9e7c1120057638e75a1343f913d00906a6b00a6c14e0c08ce361cdL3-R11)

These changes collectively enable more flexible and precise job filtering based on custom metadata, while maintaining robust validation and clear API behavior.
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- https://github.com/ITISFoundation/private-issues/issues/551

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
