### PR TITLE
🐛 Clusters-keeper: do not terminate clusters that are still busy after a long shutdown time

### DIFF
--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_core.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_core.py
@@ -124,7 +124,7 @@ async def _find_terminateable_instances(app: FastAPI, instances: Iterable[EC2Ins
 async def _heartbeat_connected_clusters(
     app: FastAPI, connected_instances: set[EC2InstanceData]
 ) -> set[EC2InstanceData]:
-    """Update heartbeat for all connected clusters. Log busy ones.
+    """Check connected clusters and heartbeat the busy ones.
 
     Returns the set of instances that are currently busy (and were heartbeated).
     """

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_core.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_core.py
@@ -121,8 +121,14 @@ async def _find_terminateable_instances(app: FastAPI, instances: Iterable[EC2Ins
     return terminateable_instances.union(worker_instances)
 
 
-async def _heartbeat_connected_clusters(app: FastAPI, connected_instances: set[EC2InstanceData]) -> None:
-    """Update heartbeat for all connected clusters. Log busy ones."""
+async def _heartbeat_connected_clusters(
+    app: FastAPI, connected_instances: set[EC2InstanceData]
+) -> set[EC2InstanceData]:
+    """Update heartbeat for all connected clusters. Log busy ones.
+
+    Returns the set of instances that are currently busy (and were heartbeated).
+    """
+    busy_instances: set[EC2InstanceData] = set()
     for instance in connected_instances:
         with log_catch(_logger, reraise=False):
             # NOTE: a connected instance could break between these 2 calls;
@@ -130,6 +136,8 @@ async def _heartbeat_connected_clusters(app: FastAPI, connected_instances: set[E
             if await is_scheduler_busy(get_scheduler_url(instance), get_scheduler_auth(app)):
                 _logger.info("%s is running tasks", _log_instance(instance))
                 await set_instance_heartbeat(app, instance=instance)
+                busy_instances.add(instance)
+    return busy_instances
 
 
 async def _terminate_idle_clusters(app: FastAPI, connected_instances: set[EC2InstanceData]) -> None:
@@ -247,8 +255,8 @@ async def check_clusters(app: FastAPI) -> None:
     connected = {i for i in primary_instances if await ping_scheduler(get_scheduler_url(i), get_scheduler_auth(app))}
     disconnected = primary_instances - connected
 
-    await _heartbeat_connected_clusters(app, connected)
-    await _terminate_idle_clusters(app, connected)
+    busy_instances = await _heartbeat_connected_clusters(app, connected)
+    await _terminate_idle_clusters(app, connected - busy_instances)
 
     starting = {i for i in disconnected if _get_instance_last_heartbeat(i) is None}
     await _handle_starting_clusters(app, starting)

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_core.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_core.py
@@ -135,8 +135,9 @@ async def _heartbeat_connected_clusters(
             # silenced and handled next cycle
             if await is_scheduler_busy(get_scheduler_url(instance), get_scheduler_auth(app)):
                 _logger.info("%s is running tasks", _log_instance(instance))
-                await set_instance_heartbeat(app, instance=instance)
                 busy_instances.add(instance)
+                await set_instance_heartbeat(app, instance=instance)
+
     return busy_instances
 
 

--- a/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
+++ b/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
@@ -152,8 +152,9 @@ async def test_cluster_management_core_properly_removes_unused_instances(
     mocked_dask_ping_scheduler.is_scheduler_busy.assert_called_once()
     mocked_dask_ping_scheduler.is_scheduler_busy.reset_mock()
 
-    # after waiting the termination time, running the task shall remove the cluster
+    # after waiting the termination time, the cluster is now idle (not busy anymore)
     await asyncio.sleep(_FAST_TIME_BEFORE_TERMINATION_SECONDS.total_seconds() + 1)
+    mocked_dask_ping_scheduler.is_scheduler_busy.return_value = False
     await check_clusters(initialized_app)
     await _assert_cluster_exist_and_state(ec2_client, instances=created_clusters, state="terminated")
     mocked_dask_ping_scheduler.ping_scheduler.assert_called_once()
@@ -184,8 +185,9 @@ async def test_cluster_management_core_properly_removes_workers_on_shutdown(
     # create some workers
     worker_instance_ids = await create_ec2_workers(10)
     await _assert_instances_state(ec2_client, instance_ids=worker_instance_ids, state="running")
-    # after waiting the termination time, running the task shall remove the cluster
+    # after waiting the termination time, the cluster is now idle
     await asyncio.sleep(_FAST_TIME_BEFORE_TERMINATION_SECONDS.total_seconds() + 1)
+    mocked_dask_ping_scheduler.is_scheduler_busy.return_value = False
     await check_clusters(initialized_app)
     await _assert_cluster_exist_and_state(ec2_client, instances=created_clusters, state="terminated")
     mocked_dask_ping_scheduler.ping_scheduler.assert_called_once()

--- a/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
+++ b/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
@@ -244,6 +244,50 @@ async def test_cluster_management_core_removes_long_starting_clusters_after_some
     mocked_dask_ping_scheduler.is_scheduler_busy.assert_not_called()
 
 
+@pytest.mark.acceptance_test("https://github.com/ITISFoundation/osparc-simcore/issues/9138")
+async def test_cluster_management_core_does_not_terminate_busy_cluster_with_stale_heartbeat(
+    disable_clusters_management_background_task: None,
+    _base_configuration: None,
+    ec2_client: EC2Client,
+    user_id: UserID,
+    wallet_id: WalletID | None,
+    initialized_app: FastAPI,
+    mocked_dask_ping_scheduler: MockedDaskModule,
+):
+    """Regression test: when clusters-keeper restarts and the heartbeat tag is stale,
+    a busy cluster should NOT be terminated. The heartbeat written by
+    _heartbeat_connected_clusters must protect the instance from termination within
+    the same check_clusters cycle.
+
+    Reproduces the scenario:
+    1. Cluster exists and was previously heartbeated
+    2. clusters-keeper goes down for a while (heartbeat becomes stale)
+    3. clusters-keeper starts back up and runs check_clusters
+    4. The scheduler IS busy (is_scheduler_busy returns True)
+    5. BUG: the cluster is terminated despite being busy because the in-memory
+       instance data has a stale heartbeat tag
+    """
+    created_clusters = await create_cluster(initialized_app, user_id=user_id, wallet_id=wallet_id)
+    assert len(created_clusters) == 1
+
+    # Give the cluster an initial heartbeat so it is considered "connected" (has heartbeat tag)
+    await cluster_heartbeat(initialized_app, user_id=user_id, wallet_id=wallet_id)
+
+    # Simulate clusters-keeper being down: wait longer than the termination threshold
+    # so the heartbeat tag becomes stale
+    await asyncio.sleep(_FAST_TIME_BEFORE_TERMINATION_SECONDS.total_seconds() + 1)
+
+    # The scheduler is still busy (processing tasks)
+    mocked_dask_ping_scheduler.ping_scheduler.return_value = True
+    mocked_dask_ping_scheduler.is_scheduler_busy.return_value = True
+
+    # Run check_clusters — this simulates what happens right after clusters-keeper restarts
+    await check_clusters(initialized_app)
+
+    # The cluster MUST NOT be terminated because it is busy
+    await _assert_cluster_exist_and_state(ec2_client, instances=created_clusters, state="running")
+
+
 async def test_cluster_management_core_removes_broken_clusters_after_some_delay(
     disable_clusters_management_background_task: None,
     _base_configuration: None,

--- a/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
+++ b/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
@@ -246,7 +246,6 @@ async def test_cluster_management_core_removes_long_starting_clusters_after_some
     mocked_dask_ping_scheduler.is_scheduler_busy.assert_not_called()
 
 
-@pytest.mark.acceptance_test("https://github.com/ITISFoundation/osparc-simcore/issues/9138")
 async def test_cluster_management_core_does_not_terminate_busy_cluster_with_stale_heartbeat(
     disable_clusters_management_background_task: None,
     _base_configuration: None,
@@ -255,8 +254,11 @@ async def test_cluster_management_core_does_not_terminate_busy_cluster_with_stal
     wallet_id: WalletID | None,
     initialized_app: FastAPI,
     mocked_dask_ping_scheduler: MockedDaskModule,
+    app_settings: ApplicationSettings,
+    mocker: MockerFixture,
 ):
-    """Regression test: when clusters-keeper restarts and the heartbeat tag is stale,
+    """Regression test (https://github.com/ITISFoundation/osparc-simcore/issues/9138):
+    when clusters-keeper restarts and the heartbeat tag is stale,
     a busy cluster should NOT be terminated. The heartbeat written by
     _heartbeat_connected_clusters must protect the instance from termination within
     the same check_clusters cycle.
@@ -275,9 +277,22 @@ async def test_cluster_management_core_does_not_terminate_busy_cluster_with_stal
     # Give the cluster an initial heartbeat so it is considered "connected" (has heartbeat tag)
     await cluster_heartbeat(initialized_app, user_id=user_id, wallet_id=wallet_id)
 
-    # Simulate clusters-keeper being down: wait longer than the termination threshold
-    # so the heartbeat tag becomes stale
-    await asyncio.sleep(_FAST_TIME_BEFORE_TERMINATION_SECONDS.total_seconds() + 1)
+    # Simulate a stale heartbeat (clusters-keeper was down) by mocking get_all_clusters
+    # to return an instance with an old heartbeat tag — avoids real-time sleep
+    the_cluster = created_clusters[0]
+    stale_heartbeat_time = (
+        arrow.utcnow().shift(seconds=-(_FAST_TIME_BEFORE_TERMINATION_SECONDS.total_seconds() + 1)).datetime.isoformat()
+    )
+    mocked_get_all_clusters = mocker.patch(
+        "simcore_service_clusters_keeper.modules.clusters_management_core.get_all_clusters",
+        autospec=True,
+        return_value={
+            dataclasses.replace(
+                the_cluster,
+                tags=the_cluster.tags | {"last_heartbeat": stale_heartbeat_time},
+            )
+        },
+    )
 
     # The scheduler is still busy (processing tasks)
     mocked_dask_ping_scheduler.ping_scheduler.return_value = True
@@ -287,6 +302,7 @@ async def test_cluster_management_core_does_not_terminate_busy_cluster_with_stal
     await check_clusters(initialized_app)
 
     # The cluster MUST NOT be terminated because it is busy
+    mocked_get_all_clusters.assert_called_once()
     await _assert_cluster_exist_and_state(ec2_client, instances=created_clusters, state="running")
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request enhances the cluster termination logic to ensure that busy clusters are not mistakenly terminated due to stale heartbeat tags, particularly after a service restart. It also adds a regression test to prevent this issue from recurring and updates existing tests to reflect the improved logic.

**Cluster management logic improvements:**

* The `_heartbeat_connected_clusters` function now returns the set of busy instances it heartbeats, allowing the main logic to distinguish between busy and idle clusters. Busy clusters are no longer considered for termination within the same cycle, even if their heartbeat tag is stale. 

**Testing and regression prevention:**

* Adds a regression test (`test_cluster_management_core_does_not_terminate_busy_cluster_with_stale_heartbeat`) to ensure that a busy cluster with a stale heartbeat tag is not terminated after a service restart. This addresses a scenario where clusters could be incorrectly terminated if their in-memory heartbeat data was outdated.
* Updates existing tests to explicitly set clusters as idle before checking for termination, aligning them with the new logic that prevents termination of busy clusters. 

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/9138

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
