### PR TITLE
e2e: Update Classic TI tests

### DIFF
--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -277,15 +277,6 @@ def test_classic_ti_plan(
         # click to open and expand
         page.get_by_test_id("userMenuBtn").click()
 
-        params = _ServiceStepParams(
-            page=page,
-            websocket=log_in_and_out,
-            is_autoscaled=is_autoscaled,
-            product_url=product_url,
-            is_service_legacy=is_service_legacy,
-            is_product_lite=is_product_lite,
-        )
-
         if is_product_lite:
             page.get_by_test_id("userMenuAccessTIPBtn").click()
             assert page.get_by_test_id("tipTeaserWindow").is_visible()

--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -10,6 +10,7 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Final
 
 from playwright.sync_api import Page, WebSocket
@@ -62,6 +63,67 @@ class _JLabWaitForWebSocket:
             return bool(re.search("/api/kernels/[^/]+/channels", new_websocket.url))
 
 
+@dataclass(frozen=True)
+class _ServiceStepParams:
+    page: Page
+    websocket: RobustWebSocket
+    is_autoscaled: bool
+    product_url: AnyUrl
+    is_service_legacy: bool
+    is_product_lite: bool
+
+
+def _run_electrode_selector_step(
+    params: _ServiceStepParams,
+    node_id: str,
+    log_ctx: SimpleNamespace,
+) -> None:
+    electrode_selector_iframe = wait_for_service_running(
+        page=params.page,
+        node_id=node_id,
+        websocket=params.websocket,
+        timeout=(
+            _ELECTRODE_SELECTOR_AUTOSCALED_MAX_STARTUP_TIME
+            if params.is_autoscaled
+            else _ELECTRODE_SELECTOR_MAX_STARTUP_TIME
+        ),
+        press_start_button=False,
+        product_url=params.product_url,
+        is_service_legacy=params.is_service_legacy,
+    )
+    # NOTE: Sometimes this iframe flicks and shows a white page. This wait will avoid it
+    params.page.wait_for_timeout(_ELECTRODE_SELECTOR_FLICKERING_WAIT_TIME)
+
+    with log_context(logging.INFO, "Configure selector", logger=log_ctx.logger):
+        assert params.page.get_by_test_id("settingsForm_" + node_id).count() == 0, (
+            "service settings should not be visible"
+        )
+
+        electrode_selector_iframe.get_by_test_id("TargetStructure_Selector").click()
+        electrode_selector_iframe.get_by_test_id("TargetStructure_Target_(Targets_combined) Hypothalamus").click()
+        electrode_selections = [
+            ["E1+", "FT9"],
+            ["E1-", "FT7"],
+            ["E2+", "T9"],
+            ["E2-", "T7"],
+        ]
+        for selection in electrode_selections:
+            group_id = "ElectrodeGroup_" + selection[0] + "_Start"
+            electrode_id = "Electrode_" + selection[1]
+            electrode_selector_iframe.get_by_test_id(group_id).click()
+            electrode_selector_iframe.get_by_test_id(electrode_id).click()
+    # configuration done, push and wait for the 1 output
+    with log_context(logging.INFO, "Check outputs", logger=log_ctx.logger):
+        waiter = SocketIOWaitNodeForOutputs(expected_number_of_outputs=1, node_id=node_id)
+        with params.websocket.expect_event("framereceived", waiter) as frame_received_event:
+            electrode_selector_iframe.get_by_test_id("FinishSetUp").click()
+        socket_io_message = decode_socketio_42_message(frame_received_event.value)
+        log_ctx.logger.info(
+            "the following output was generated: %s",
+            socket_io_message.obj["data"]["outputs"]["output_1"]["path"],
+        )
+
+
 @retry(
     stop=stop_after_delay(_JLAB_RUN_OPTIMIZATION_MAX_TIME / 1000),  # seconds
     wait=wait_fixed(2),
@@ -74,7 +136,134 @@ def _wait_for_optimization_complete(run_button):
         raise ValueError(msg)
 
 
-def test_classic_ti_plan(  # noqa: PLR0915
+def _run_classic_ti_step(
+    params: _ServiceStepParams,
+    node_id: str,
+    log_ctx: SimpleNamespace,
+) -> RobustWebSocket:
+    with params.page.expect_websocket(
+        _JLabWaitForWebSocket(),
+        timeout=_OUTER_EXPECT_TIMEOUT_RATIO
+        * (_JLAB_AUTOSCALED_MAX_STARTUP_TIME if params.is_autoscaled else _JLAB_MAX_STARTUP_MAX_TIME),
+    ) as ws_info:
+        with expected_service_running(
+            page=params.page,
+            node_id=node_id,
+            websocket=params.websocket,
+            timeout=(_JLAB_AUTOSCALED_MAX_STARTUP_TIME if params.is_autoscaled else _JLAB_MAX_STARTUP_MAX_TIME),
+            press_start_button=False,
+            product_url=params.product_url,
+            is_service_legacy=params.is_service_legacy,
+        ) as service_running:
+            app_mode_trigger_next_app(params.page)
+        ti_iframe = service_running.iframe_locator
+        assert ti_iframe
+
+    assert not ws_info.value.is_closed()
+    restartable_jlab_websocket = RobustWebSocket(params.page, ws_info.value)
+
+    with log_context(logging.INFO, "Run optimization", logger=log_ctx.logger) as ctx2:
+        run_button = ti_iframe.get_by_role("button", name="Run Optimization")
+        run_button.click(timeout=_JLAB_RUN_OPTIMIZATION_APPEARANCE_TIME)
+        try:
+            _wait_for_optimization_complete(run_button)
+            ctx2.logger.info("Optimization finished!")
+        except RetryError as e:
+            last_exc = e.last_attempt.exception()
+            ctx2.logger.warning("Optimization did not finish in time: %s", f"{last_exc}")
+
+    with log_context(logging.INFO, "Create report", logger=log_ctx.logger):
+        with log_context(
+            logging.INFO,
+            f"Click button - `Load Analysis` and wait for {_JLAB_REPORTING_MAX_TIME}",
+        ):
+            ti_iframe.get_by_role("button", name="Load Analysis").click()
+            params.page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
+        with log_context(
+            logging.INFO,
+            f"Click button - `Load` and wait for {_JLAB_REPORTING_MAX_TIME}",
+        ):
+            ti_iframe.get_by_role("button", name="Load").nth(1).click()
+            params.page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
+
+        if params.is_product_lite:
+            assert (
+                ti_iframe.get_by_role("button", name="Add to Report (0)").nth(0).get_attribute("disabled") is not None
+            ), "Add to Report button should be disabled in lite product"
+            assert ti_iframe.get_by_role("button", name="Export to S4L").get_attribute("disabled") is not None, (
+                "Export to S4L button should be disabled in lite product"
+            )
+            assert ti_iframe.get_by_role("button", name="Export Report").get_attribute("disabled") is not None, (
+                "Export Report button should be disabled in lite product"
+            )
+
+        else:
+            with log_context(
+                logging.INFO,
+                f"Click button - `Add to Report (0)` and wait for {_JLAB_REPORTING_MAX_TIME}",
+            ):
+                ti_iframe.get_by_role("button", name="Add to Report (0)").nth(0).click()
+                params.page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
+            with log_context(
+                logging.INFO,
+                f"Click button - `Export to S4L` and wait for {_JLAB_REPORTING_MAX_TIME}",
+            ):
+                ti_iframe.get_by_role("button", name="Export to S4L").click()
+                params.page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
+            with log_context(
+                logging.INFO,
+                f"Click button - `Add to Report (1)` and wait for {_JLAB_REPORTING_MAX_TIME}",
+            ):
+                ti_iframe.get_by_role("button", name="Add to Report (1)").nth(1).click()
+                params.page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
+            with log_context(
+                logging.INFO,
+                f"Click button - `Export Report` and wait for {_JLAB_REPORTING_MAX_TIME}",
+            ):
+                ti_iframe.get_by_role("button", name="Export Report").click()
+                params.page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
+
+    with log_context(logging.INFO, "Check outputs", logger=log_ctx.logger):
+        if params.is_product_lite:
+            expected_outputs = ["results.csv"]
+            text_on_output_button = f"Outputs ({len(expected_outputs)})"
+            params.page.get_by_test_id("outputsBtn").get_by_text(text_on_output_button).click()
+
+        else:
+            expected_outputs = ["output_1.zip", "TIP_report.pdf", "results.csv"]
+            text_on_output_button = f"Outputs ({len(expected_outputs)})"
+            params.page.get_by_test_id("outputsBtn").get_by_text(text_on_output_button).click()
+
+    return restartable_jlab_websocket
+
+
+def _run_exposure_analysis_step(
+    params: _ServiceStepParams,
+    node_id: str,
+    log_ctx: SimpleNamespace,
+) -> None:
+    with expected_service_running(
+        page=params.page,
+        node_id=node_id,
+        websocket=params.websocket,
+        timeout=(_POST_PRO_AUTOSCALED_MAX_STARTUP_TIME if params.is_autoscaled else _POST_PRO_MAX_STARTUP_TIME),
+        press_start_button=False,
+        product_url=params.product_url,
+        is_service_legacy=params.is_service_legacy,
+    ) as service_running:
+        app_mode_trigger_next_app(params.page)
+    s4l_postpro_iframe = service_running.iframe_locator
+    assert s4l_postpro_iframe
+
+    with log_context(logging.INFO, "Post process", logger=log_ctx.logger):
+        # click on the postpro mode button
+        s4l_postpro_iframe.get_by_test_id("mode-button-postro").click()
+        # click on the surface viewer
+        s4l_postpro_iframe.get_by_test_id("tree-item-ti_field.cache").click()
+        s4l_postpro_iframe.get_by_test_id("tree-item-SurfaceViewer").nth(0).click()
+
+
+def test_classic_ti_plan(
     page: Page,
     log_in_and_out: RobustWebSocket,
     is_autoscaled: bool,
@@ -87,6 +276,15 @@ def test_classic_ti_plan(  # noqa: PLR0915
     with log_context(logging.INFO, "Checking 'Access TIP' teaser"):
         # click to open and expand
         page.get_by_test_id("userMenuBtn").click()
+
+        params = _ServiceStepParams(
+            page=page,
+            websocket=log_in_and_out,
+            is_autoscaled=is_autoscaled,
+            product_url=product_url,
+            is_service_legacy=is_service_legacy,
+            is_product_lite=is_product_lite,
+        )
 
         if is_product_lite:
             page.get_by_test_id("userMenuAccessTIPBtn").click()
@@ -103,179 +301,28 @@ def test_classic_ti_plan(  # noqa: PLR0915
     assert isinstance(project_data["workbench"], dict), "Expected workbench to be a dict!"
     node_ids: list[str] = list(project_data["workbench"])
 
-    if is_product_lite:
-        expected_number_of_steps = 2
-        assert len(node_ids) == expected_number_of_steps, f"Expected {expected_number_of_steps=} in the app-mode"
-    else:
-        expected_number_of_steps = 3
-        assert len(node_ids) >= expected_number_of_steps, (
-            f"Expected at least {expected_number_of_steps} nodes in the workbench"
-        )
+    # count the number of elements with test id matching the pattern
+    # 1. Classic TI (ti-postpro)
+    # 2. Exposure Analysis (sim4life-postpro) - only in full product
+    expected_number_of_steps = 2 if not is_product_lite else 1
+    assert len(node_ids) == expected_number_of_steps, f"Expected {expected_number_of_steps=} in the app-mode"
 
-    with log_context(logging.INFO, "Electrode Selector step (1/%s)", expected_number_of_steps) as ctx:
-        # NOTE: creating the plan auto-triggers the first service to start, which might already triggers socket events
-        electrode_selector_iframe = wait_for_service_running(
-            page=page,
-            node_id=node_ids[0],
-            websocket=log_in_and_out,
-            timeout=(
-                _ELECTRODE_SELECTOR_AUTOSCALED_MAX_STARTUP_TIME
-                if is_autoscaled
-                else _ELECTRODE_SELECTOR_MAX_STARTUP_TIME
-            ),
-            press_start_button=False,
-            product_url=product_url,
-            is_service_legacy=is_service_legacy,
-        )
-        # NOTE: Sometimes this iframe flicks and shows a white page. This wait will avoid it
-        page.wait_for_timeout(_ELECTRODE_SELECTOR_FLICKERING_WAIT_TIME)
+    params = _ServiceStepParams(
+        page=page,
+        websocket=log_in_and_out,
+        is_autoscaled=is_autoscaled,
+        product_url=product_url,
+        is_service_legacy=is_service_legacy,
+        is_product_lite=is_product_lite,
+    )
 
-        with log_context(logging.INFO, "Configure selector", logger=ctx.logger):
-            assert page.get_by_test_id("settingsForm_" + node_ids[0]).count() == 0, (
-                "service settings should not be visible"
-            )
-
-            electrode_selector_iframe.get_by_test_id("TargetStructure_Selector").click()
-            electrode_selector_iframe.get_by_test_id("TargetStructure_Target_(Targets_combined) Hypothalamus").click()
-            electrode_selections = [
-                ["E1+", "FT9"],
-                ["E1-", "FT7"],
-                ["E2+", "T9"],
-                ["E2-", "T7"],
-            ]
-            for selection in electrode_selections:
-                group_id = "ElectrodeGroup_" + selection[0] + "_Start"
-                electrode_id = "Electrode_" + selection[1]
-                electrode_selector_iframe.get_by_test_id(group_id).click()
-                electrode_selector_iframe.get_by_test_id(electrode_id).click()
-        # configuration done, push and wait for the 1 output
-        with log_context(logging.INFO, "Check outputs", logger=ctx.logger):
-            waiter = SocketIOWaitNodeForOutputs(expected_number_of_outputs=1, node_id=node_ids[0])
-            with log_in_and_out.expect_event("framereceived", waiter) as frame_received_event:
-                electrode_selector_iframe.get_by_test_id("FinishSetUp").click()
-            socket_io_message = decode_socketio_42_message(frame_received_event.value)
-            ctx.logger.info(
-                "the following output was generated: %s",
-                socket_io_message.obj["data"]["outputs"]["output_1"]["path"],
-            )
-
-    with log_context(logging.INFO, "Classic TI step (2/%s)", expected_number_of_steps) as ctx:
-        with page.expect_websocket(
-            _JLabWaitForWebSocket(),
-            timeout=_OUTER_EXPECT_TIMEOUT_RATIO
-            * (_JLAB_AUTOSCALED_MAX_STARTUP_TIME if is_autoscaled else _JLAB_MAX_STARTUP_MAX_TIME),
-        ) as ws_info:
-            with expected_service_running(
-                page=page,
-                node_id=node_ids[1],
-                websocket=log_in_and_out,
-                timeout=(_JLAB_AUTOSCALED_MAX_STARTUP_TIME if is_autoscaled else _JLAB_MAX_STARTUP_MAX_TIME),
-                press_start_button=False,
-                product_url=product_url,
-                is_service_legacy=is_service_legacy,
-            ) as service_running:
-                app_mode_trigger_next_app(page)
-            ti_iframe = service_running.iframe_locator
-            assert ti_iframe
-
-        assert not ws_info.value.is_closed()
-        restartable_jlab_websocket = RobustWebSocket(page, ws_info.value)
-
-        with log_context(logging.INFO, "Run optimization") as ctx2:
-            run_button = ti_iframe.get_by_role("button", name="Run Optimization")
-            run_button.click(timeout=_JLAB_RUN_OPTIMIZATION_APPEARANCE_TIME)
-            try:
-                _wait_for_optimization_complete(run_button)
-                ctx2.logger.info("Optimization finished!")
-            except RetryError as e:
-                last_exc = e.last_attempt.exception()
-                ctx2.logger.warning("Optimization did not finish in time: %s", f"{last_exc}")
-
-        with log_context(logging.INFO, "Create report"):
-            with log_context(
-                logging.INFO,
-                f"Click button - `Load Analysis` and wait for {_JLAB_REPORTING_MAX_TIME}",
-            ):
-                ti_iframe.get_by_role("button", name="Load Analysis").click()
-                page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
-            with log_context(
-                logging.INFO,
-                f"Click button - `Load` and wait for {_JLAB_REPORTING_MAX_TIME}",
-            ):
-                ti_iframe.get_by_role("button", name="Load").nth(1).click()
-                page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
-
-            if is_product_lite:
-                assert (
-                    ti_iframe.get_by_role("button", name="Add to Report (0)").nth(0).get_attribute("disabled")
-                    is not None
-                ), "Add to Report button should be disabled in lite product"
-                assert ti_iframe.get_by_role("button", name="Export to S4L").get_attribute("disabled") is not None, (
-                    "Export to S4L button should be disabled in lite product"
-                )
-                assert ti_iframe.get_by_role("button", name="Export Report").get_attribute("disabled") is not None, (
-                    "Export Report button should be disabled in lite product"
-                )
-
-            else:
-                with log_context(
-                    logging.INFO,
-                    f"Click button - `Add to Report (0)` and wait for {_JLAB_REPORTING_MAX_TIME}",
-                ):
-                    ti_iframe.get_by_role("button", name="Add to Report (0)").nth(0).click()
-                    page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
-                with log_context(
-                    logging.INFO,
-                    f"Click button - `Export to S4L` and wait for {_JLAB_REPORTING_MAX_TIME}",
-                ):
-                    ti_iframe.get_by_role("button", name="Export to S4L").click()
-                    page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
-                with log_context(
-                    logging.INFO,
-                    f"Click button - `Add to Report (1)` and wait for {_JLAB_REPORTING_MAX_TIME}",
-                ):
-                    ti_iframe.get_by_role("button", name="Add to Report (1)").nth(1).click()
-                    page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
-                with log_context(
-                    logging.INFO,
-                    f"Click button - `Export Report` and wait for {_JLAB_REPORTING_MAX_TIME}",
-                ):
-                    ti_iframe.get_by_role("button", name="Export Report").click()
-                    page.wait_for_timeout(_JLAB_REPORTING_MAX_TIME)
-
-        with log_context(logging.INFO, "Check outputs"):
-            if is_product_lite:
-                expected_outputs = ["results.csv"]
-                text_on_output_button = f"Outputs ({len(expected_outputs)})"
-                page.get_by_test_id("outputsBtn").get_by_text(text_on_output_button).click()
-
-            else:
-                expected_outputs = ["output_1.zip", "TIP_report.pdf", "results.csv"]
-                text_on_output_button = f"Outputs ({len(expected_outputs)})"
-                page.get_by_test_id("outputsBtn").get_by_text(text_on_output_button).click()
+    with log_context(logging.INFO, "Classic TI step (1/%s)", expected_number_of_steps) as log_ctx:
+        restartable_jlab_websocket = _run_classic_ti_step(params, node_ids[0], log_ctx)
 
     if is_product_lite:
-        assert expected_number_of_steps == 2
+        assert expected_number_of_steps == 1
     else:
-        with log_context(logging.INFO, "Exposure Analysis step (3/%s)", expected_number_of_steps):
-            with expected_service_running(
-                page=page,
-                node_id=node_ids[2],
-                websocket=log_in_and_out,
-                timeout=(_POST_PRO_AUTOSCALED_MAX_STARTUP_TIME if is_autoscaled else _POST_PRO_MAX_STARTUP_TIME),
-                press_start_button=False,
-                product_url=product_url,
-                is_service_legacy=is_service_legacy,
-            ) as service_running:
-                app_mode_trigger_next_app(page)
-            s4l_postpro_iframe = service_running.iframe_locator
-            assert s4l_postpro_iframe
-
-            with log_context(logging.INFO, "Post process"):
-                # click on the postpro mode button
-                s4l_postpro_iframe.get_by_test_id("mode-button-postro").click()
-                # click on the surface viewer
-                s4l_postpro_iframe.get_by_test_id("tree-item-ti_field.cache").click()
-                s4l_postpro_iframe.get_by_test_id("tree-item-SurfaceViewer").nth(0).click()
+        with log_context(logging.INFO, "Exposure Analysis step (2/%s)", expected_number_of_steps) as log_ctx:
+            _run_exposure_analysis_step(params, node_ids[1], log_ctx)
 
     restartable_jlab_websocket.auto_reconnect = False

--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -136,7 +136,7 @@ def _wait_for_optimization_complete(run_button):
         raise ValueError(msg)
 
 
-def _run_classic_ti_step(
+def _run_classic_ti_step(  # noqa: PLR0915
     params: _ServiceStepParams,
     node_id: str,
     log_ctx: SimpleNamespace,
@@ -161,6 +161,15 @@ def _run_classic_ti_step(
 
     assert not ws_info.value.is_closed()
     restartable_jlab_websocket = RobustWebSocket(params.page, ws_info.value)
+
+    if params.is_product_lite:
+        with log_context(logging.INFO, "Check species selector has only 2 options", logger=log_ctx.logger):
+            species_selector = ti_iframe.locator("select").first
+            options = species_selector.locator("option")
+            assert options.count() == 2, f"Expected 2 species options in lite product, got {options.count()}"
+            option_texts = [options.nth(i).inner_text() for i in range(options.count())]
+            assert "Human - MIDA anisotropic" in option_texts
+            assert "Mouse" in option_texts
 
     with log_context(logging.INFO, "Run optimization", logger=log_ctx.logger) as ctx2:
         run_button = ti_iframe.get_by_role("button", name="Run Optimization")

--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -91,7 +91,6 @@ def _run_electrode_selector_step(
         product_url=params.product_url,
         is_service_legacy=params.is_service_legacy,
     )
-    # NOTE: Sometimes this iframe flicks and shows a white page. This wait will avoid it
     params.page.wait_for_timeout(_ELECTRODE_SELECTOR_FLICKERING_WAIT_TIME)
 
     with log_context(logging.INFO, "Configure selector", logger=log_ctx.logger):

--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -306,6 +306,10 @@ def test_classic_ti_plan(
     # 2. Exposure Analysis (sim4life-postpro) - only in full product
     expected_number_of_steps = 2 if not is_product_lite else 1
     assert len(node_ids) == expected_number_of_steps, f"Expected {expected_number_of_steps=} in the app-mode"
+    step_buttons_count = page.locator("[osparc-test-id^='AppMode_StepBtn_']").count()
+    assert step_buttons_count == expected_number_of_steps, (
+        f"Expected {expected_number_of_steps=} visible in the app-mode, got {step_buttons_count=}"
+    )
 
     params = _ServiceStepParams(
         page=page,


### PR DESCRIPTION
## What do these changes do?

This PR updates the TI Classic e2e test to only check the ``ti-postpro`` and ``sim4life-ui`` (full only) pipelines.

The Templates in master were also updated.


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
