### PR TITLE
🎨 Link status page in footer

### DIFF
--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -7,6 +7,7 @@
 
 from typing import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
     Literal,
+    NotRequired,
     TypedDict,
 )
 
@@ -31,51 +32,48 @@ from .users import users
 #
 
 
-class VendorUI(TypedDict, total=True):
-    logo_url: str  # vendor logo url
-    strong_color: str  # vendor main color
+class VendorUI(TypedDict):
+    logo_url: str
+    strong_color: str
 
 
-class Vendor(TypedDict, total=False):
+class Vendor(TypedDict):
     """
-        Brand information about the vendor
+    Brand information about the vendor
     E.g. company name, address, copyright, etc.
     """
 
-    name: str  # e.g. IT'IS Foundation
-    address: str  # e.g. Zeughausstrasse 43, 8004 Zurich, Switzerland
-    copyright: str  # copyright message
+    name: NotRequired[str]  # e.g. IT'IS Foundation
+    address: NotRequired[str]  # e.g. Zeughausstrasse 43, 8004 Zurich, Switzerland
+    copyright: NotRequired[str]  # copyright message
 
-    url: str  # vendor website
-    license_url: str  # Which are the license terms? (if applies)
+    url: NotRequired[str]  # vendor website
+    license_url: NotRequired[str]  # Which are the license terms? (if applies)
 
-    invitation_url: str  # How to request a trial invitation? (if applies)
-    invitation_form: (
-        bool  # If True, it takes precedence over invitation_url and asks the FE to show the form (if defined)
-    )
+    invitation_url: NotRequired[str]  # How to request a trial invitation? (if applies)
+    invitation_form: NotRequired[bool]  # If True, takes precedence over invitation_url; asks FE to show the form
 
     # a template url where `{vtag}` will be replaced, eg: "https://example.com/{vtag}.md"
     # (used for the platform's release notes)
-    release_notes_url_template: str
+    release_notes_url_template: NotRequired[str]
 
-    ui: VendorUI
+    ui: NotRequired[VendorUI]
 
-    footer_social_links: list[tuple[str, str]]  # list of (social_media_name (youtube, linkedin), social_media_url)
-    footer_share_links: list[tuple[str, str, str]]  # list of (share_name, share_label, share_url)
-    company_name: str
-    company_address: str
-    company_links: list[tuple[str, str]]  # list of (link_name, link_url)
-    status_page_url: str
+    footer_social_links: NotRequired[list[tuple[str, str]]]  # list of (social_media_name, social_media_url)
+    footer_share_links: NotRequired[list[tuple[str, str, str]]]  # list of (share_name, share_label, share_url)
+    company_name: NotRequired[str]
+    company_address: NotRequired[str]
+    company_links: NotRequired[list[tuple[str, str]]]  # list of (link_name, link_url)
+    status_page_url: NotRequired[str]
 
-    marketing_fallback_products_on_wrong_password: (
-        list[str]  # list of product names to check (in order); on wrong password, if the user has an account
-        # in any of these products, suggest using the password from the first matching product
-        # (accounts were merged/unified across platforms)
-    )
+    # list of product names to check (in order); on wrong password, if the user has an account
+    # in any of these products, suggest using the password from the first matching product
+    # (accounts were merged/unified across platforms)
+    marketing_fallback_products_on_wrong_password: NotRequired[list[str]]
 
 
-class IssueTracker(TypedDict, total=True):
-    """Link to actions in an online issue tracker (e.g. in fogbugz, github, gitlab ...)
+class IssueTracker(TypedDict):
+    """Link to actions in an online issue tracker (e.g. fogbugz, github, gitlab ...)
 
     e.g. URL to create a new issue for this product
 
@@ -87,12 +85,12 @@ class IssueTracker(TypedDict, total=True):
     new_url: str
 
 
-class Manual(TypedDict, total=True):
+class Manual(TypedDict):
     label: str
     url: str
 
 
-class WebFeedback(TypedDict, total=True):
+class WebFeedback(TypedDict):
     """URL to a feedback form (e.g. google forms etc)"""
 
     kind: Literal["web"]
@@ -100,7 +98,7 @@ class WebFeedback(TypedDict, total=True):
     url: str
 
 
-class EmailFeedback(TypedDict, total=True):
+class EmailFeedback(TypedDict):
     """Give feedback via email"""
 
     kind: Literal["email"]
@@ -108,7 +106,7 @@ class EmailFeedback(TypedDict, total=True):
     email: str
 
 
-class Forum(TypedDict, total=True):
+class Forum(TypedDict):
     """Link to a forum"""
 
     kind: Literal["forum"]
@@ -116,7 +114,7 @@ class Forum(TypedDict, total=True):
     url: str
 
 
-class ProductLoginSettingsDict(TypedDict, total=False):
+class ProductLoginSettingsDict(TypedDict):
     """Login plugin settings customized for this product
 
     Overrides simcore_service_webserver.login.settings.LoginSettings
@@ -125,9 +123,9 @@ class ProductLoginSettingsDict(TypedDict, total=False):
     NOTE: These attributes need to match those of LoginSettings
     """
 
-    LOGIN_REGISTRATION_CONFIRMATION_REQUIRED: bool
-    LOGIN_REGISTRATION_INVITATION_REQUIRED: bool
-    LOGIN_2FA_REQUIRED: bool  # previously 'two_factor_enabled'
+    LOGIN_REGISTRATION_CONFIRMATION_REQUIRED: NotRequired[bool]
+    LOGIN_REGISTRATION_INVITATION_REQUIRED: NotRequired[bool]
+    LOGIN_2FA_REQUIRED: NotRequired[bool]  # previously 'two_factor_enabled'
 
 
 # NOTE: defaults affects migration!!

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -65,6 +65,8 @@ class Vendor(TypedDict, total=False):
     company_name: str
     company_address: str
     company_links: list[tuple[str, str]]  # list of (link_name, link_url)
+    status_page_url: str
+
     marketing_fallback_products_on_wrong_password: (
         list[str]  # list of product names to check (in order); on wrong password, if the user has an account
         # in any of these products, suggest using the password from the first matching product

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/faker_factories.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/faker_factories.py
@@ -316,6 +316,7 @@ def random_product(
                 logo_url="https://raw.githubusercontent.com/ITISFoundation/osparc-simcore/refs/heads/master/services/static-webserver/client/source/resource/osparc/osparc-black.svg",
                 strong_color=fake.color(),
             ),
+            status_page_url=fake.url(),
         ),
         "registration_email_template": registration_email_template,
         "created": fake.date_time_this_decade(),

--- a/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
+++ b/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
@@ -319,7 +319,7 @@ qx.Class.define("osparc.auth.LoginWithDecorators", {
         margin: [10, 0]
       });
 
-      const createReleaseNotesLink = osparc.utils.Utils.createReleaseNotesLink();
+      const createReleaseNotesLink = osparc.utils.Utils.createReleaseNotesLink(this.tr("Platform"));
       let toolTipText = "";
       if (!osparc.product.Utils.isProduct("osparc")) {
         const displayName = osparc.store.StaticInfo.getDisplayName();

--- a/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
+++ b/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
@@ -319,9 +319,10 @@ qx.Class.define("osparc.auth.LoginWithDecorators", {
         margin: [10, 0]
       });
 
-      const createReleaseNotesLink = osparc.utils.Utils.createReleaseNotesLink(this.tr("Platform"));
+      const isOsparc = osparc.product.Utils.isProduct("osparc");
+      const createReleaseNotesLink = osparc.utils.Utils.createReleaseNotesLink(isOsparc ? "osparc" : this.tr("Platform"));
       let toolTipText = "";
-      if (!osparc.product.Utils.isProduct("osparc")) {
+      if (!isOsparc) {
         const displayName = osparc.store.StaticInfo.getDisplayName();
         toolTipText = displayName + this.tr(" is powered by osparc.<br>");
       }

--- a/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
+++ b/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
@@ -329,17 +329,27 @@ qx.Class.define("osparc.auth.LoginWithDecorators", {
       });
       versionLinkLayout.add(createReleaseNotesLink);
 
+      const vendor = osparc.store.VendorInfo.getVendor();
+
       const organizationLink = new osparc.ui.basic.LinkLabel().set({
         textColor: "text-darker"
       });
-      const vendor = osparc.store.VendorInfo.getVendor();
-      if (vendor && "url" in vendor && "copyright" in vendor) {
+      if (vendor && "url" in vendor && "name" in vendor) {
         organizationLink.set({
-          value: vendor.copyright,
+          value: vendor.name,
           url: vendor.url
         });
       }
       versionLinkLayout.add(organizationLink);
+
+      if (vendor && "status_page_url" in vendor) {
+        const statusPageLink = new osparc.ui.basic.LinkLabel().set({
+          value: "Status",
+          url: vendor.status_page_url,
+          textColor: "text-darker"
+        });
+        versionLinkLayout.add(statusPageLink);
+      }
 
       versionLinkLayout.add(new qx.ui.core.Spacer(), {
         flex: 1

--- a/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
+++ b/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
@@ -320,6 +320,15 @@ qx.Class.define("osparc.auth.LoginWithDecorators", {
       });
 
       const createReleaseNotesLink = osparc.utils.Utils.createReleaseNotesLink();
+      let toolTipText = "";
+      if (!osparc.product.Utils.isProduct("osparc")) {
+        const displayName = osparc.store.StaticInfo.getDisplayName();
+        toolTipText = displayName + this.tr(" is powered by osparc.<br>");
+      }
+      toolTipText += this.tr("Click to see what's new in this release.");
+      createReleaseNotesLink.set({
+        toolTipText,
+      });
       createReleaseNotesLink.set({
         textColor: "text-darker"
       });

--- a/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
+++ b/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
@@ -313,14 +313,10 @@ qx.Class.define("osparc.auth.LoginWithDecorators", {
     },
 
     __getVersionLink: function() {
-      const versionLinkLayout = new qx.ui.container.Composite(new qx.ui.layout.HBox(10).set({
+      const versionLinkLayout = new qx.ui.container.Composite(new qx.ui.layout.HBox(4).set({
         alignX: "center"
       })).set({
         margin: [10, 0]
-      });
-
-      versionLinkLayout.add(new qx.ui.core.Spacer(), {
-        flex: 1
       });
 
       const createReleaseNotesLink = osparc.utils.Utils.createReleaseNotesLink();
@@ -331,18 +327,22 @@ qx.Class.define("osparc.auth.LoginWithDecorators", {
 
       const vendor = osparc.store.VendorInfo.getVendor();
 
-      const organizationLink = new osparc.ui.basic.LinkLabel().set({
-        textColor: "text-darker"
-      });
       if (vendor && "url" in vendor && "name" in vendor) {
-        organizationLink.set({
+        versionLinkLayout.add(new qx.ui.basic.Label("·").set({
+          textColor: "text-darker"
+        }));
+        const organizationLink = new osparc.ui.basic.LinkLabel().set({
           value: vendor.name,
-          url: vendor.url
+          url: vendor.url,
+          textColor: "text-darker"
         });
+        versionLinkLayout.add(organizationLink);
       }
-      versionLinkLayout.add(organizationLink);
 
       if (vendor && "status_page_url" in vendor) {
+        versionLinkLayout.add(new qx.ui.basic.Label("·").set({
+          textColor: "text-darker"
+        }));
         const statusPageLink = new osparc.ui.basic.LinkLabel().set({
           value: "Status",
           url: vendor.status_page_url,
@@ -350,10 +350,6 @@ qx.Class.define("osparc.auth.LoginWithDecorators", {
         });
         versionLinkLayout.add(statusPageLink);
       }
-
-      versionLinkLayout.add(new qx.ui.core.Spacer(), {
-        flex: 1
-      });
 
       return versionLinkLayout;
     },

--- a/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
+++ b/services/static-webserver/client/source/class/osparc/auth/LoginWithDecorators.js
@@ -336,18 +336,6 @@ qx.Class.define("osparc.auth.LoginWithDecorators", {
 
       const vendor = osparc.store.VendorInfo.getVendor();
 
-      if (vendor && "url" in vendor && "name" in vendor) {
-        versionLinkLayout.add(new qx.ui.basic.Label("·").set({
-          textColor: "text-darker"
-        }));
-        const organizationLink = new osparc.ui.basic.LinkLabel().set({
-          value: vendor.name,
-          url: vendor.url,
-          textColor: "text-darker"
-        });
-        versionLinkLayout.add(organizationLink);
-      }
-
       if (vendor && "status_page_url" in vendor) {
         versionLinkLayout.add(new qx.ui.basic.Label("·").set({
           textColor: "text-darker"
@@ -358,6 +346,18 @@ qx.Class.define("osparc.auth.LoginWithDecorators", {
           textColor: "text-darker"
         });
         versionLinkLayout.add(statusPageLink);
+      }
+
+      if (vendor && "url" in vendor && "name" in vendor) {
+        versionLinkLayout.add(new qx.ui.basic.Label("·").set({
+          textColor: "text-darker"
+        }));
+        const organizationLink = new osparc.ui.basic.LinkLabel().set({
+          value: vendor.name,
+          url: vendor.url,
+          textColor: "text-darker"
+        });
+        versionLinkLayout.add(organizationLink);
       }
 
       return versionLinkLayout;

--- a/services/static-webserver/client/source/class/osparc/store/VendorInfo.js
+++ b/services/static-webserver/client/source/class/osparc/store/VendorInfo.js
@@ -35,9 +35,10 @@ qx.Class.define("osparc.store.VendorInfo", {
       /*
       {
         "name": "ACME",
-        "copyright": "\u00a9 ACME correcaminos",
         "url": "https://acme.com",
-        "license_url": "http://docs.osparc.io/#/docs/support/license"
+        "copyright": "\u00a9 ACME correcaminos",
+        "license_url": "http://docs.osparc.io/#/docs/support/license",
+        "status_page_url": "https://status.acme.com"
       }
       */
       return this.__getFromStaticInfo("vendor", {});

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -740,7 +740,7 @@ qx.Class.define("osparc.utils.Utils", {
     },
 
     createReleaseNotesLink: function() {
-      let text = "osparc-simcore " + this.getReleaseTag();
+      let text = "osparc " + this.getReleaseTag();
       const platformName = osparc.store.StaticInfo.getPlatformName();
       text += platformName.length ? ` (${platformName})` : "";
       const url = this.self().getReleaseNotesLink();

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -739,8 +739,8 @@ qx.Class.define("osparc.utils.Utils", {
       return rData["url"] || osparc.utils.LibVersions.getVcsRefUrl();
     },
 
-    createReleaseNotesLink: function() {
-      let text = "osparc " + this.getReleaseTag();
+    createReleaseNotesLink: function(prefix = "osparc") {
+      let text = prefix + " " + this.getReleaseTag();
       const platformName = osparc.store.StaticInfo.getPlatformName();
       text += platformName.length ? ` (${platformName})` : "";
       const url = this.self().getReleaseNotesLink();

--- a/services/web/server/src/simcore_service_webserver/products/_models.py
+++ b/services/web/server/src/simcore_service_webserver/products/_models.py
@@ -271,6 +271,7 @@ class Product(BaseModel):
                                 "logo_url": "https://acme.com/logo",
                                 "strong_color": "#123456",
                             },
+                            "status_page_url": "https://status.acme.com",
                         },
                         "issues": [
                             {

--- a/services/web/server/tests/unit/isolated/products/test_products_model.py
+++ b/services/web/server/tests/unit/isolated/products/test_products_model.py
@@ -67,6 +67,7 @@ def test_product_to_static():
                 "logo_url": "https://acme.com/logo",
                 "strong_color": "#123456",
             },
+            "status_page_url": "https://status.acme.com",
         },
         "issues": [
             {

--- a/services/web/server/tests/unit/with_dbs/04/products/test_products_repository.py
+++ b/services/web/server/tests/unit/with_dbs/04/products/test_products_repository.py
@@ -55,6 +55,7 @@ def products_raw_data() -> dict[ProductName, dict[str, Any]]:
             url="https://acme.com",
             license_url="http://docs.acme.app/#/license-terms",
             invitation_url="http://docs.acme.app/#/how-to-request-invitation",
+            status_page_url="https://status.acme.com",
         ),
         "issues": [
             IssueTracker(


### PR DESCRIPTION
## What do these changes do?

Requested by @eofli 

Updates product/vendor metadata and the login footer to better match the oSPARC branding and provide a quick link to the vendor’s status page.

- Instead of saying "osparc-simcore v1.92.0", say "Platform v1.92.0" and add a tooltip explaining that it's powered by osparc
- Link "Status" page in login page footer (if this is set in the DB)
- Replace the copyright text with the vendor name

Before:
<img width="1421" height="840" alt="image" src="https://github.com/user-attachments/assets/9da4d210-9a81-4b1f-9a74-8e73558e3b8d" />

After:
<img width="1440" height="850" alt="FooterLogin" src="https://github.com/user-attachments/assets/a52071af-7b9c-4707-97d2-0b50bbfc9a1c" />



## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
