### PR TITLE
e2e: Support https://sarvalidation.site

### DIFF
--- a/tests/e2e/publications/SarValidation.js
+++ b/tests/e2e/publications/SarValidation.js
@@ -1,7 +1,8 @@
 // node SarValidation.js [url_prefix] [template_uuid] [timeout] [--demo]
+// node SarValidation.js --url [full_url] [timeout] [--demo]
 
 // master https://osparc-master.speag.com/study/2b7b88be-ea51-11ed-ade4-02420a000d13
-// prod https://osparc.io/study/ff72c36a-df81-11ed-9c9e-02420a0b755a
+// prod https://sarvalidation.site (redirects to https://osparc.io/study/ff72c36a-df81-11ed-9c9e-02420a0b755a)
 
 const tutorialBase = require('../tutorials/tutorialBase');
 const utils = require('../utils/utils');
@@ -16,7 +17,14 @@ const {
   enableDemoMode
 } = utils.parseCommandLineArgumentsAnonymous(args);
 
-const anonURL = urlPrefix + templateUuid;
+const urlIdx = args.indexOf('--url');
+let anonURL;
+if (urlIdx > -1) {
+  anonURL = args[urlIdx + 1];
+} else {
+  anonURL = urlPrefix + templateUuid;
+}
+
 const screenshotPrefix = "SarValidation";
 
 

--- a/tests/e2e/publications/SarValidation.js
+++ b/tests/e2e/publications/SarValidation.js
@@ -8,21 +8,23 @@ const tutorialBase = require('../tutorials/tutorialBase');
 const utils = require('../utils/utils');
 
 const args = process.argv.slice(2);
-const {
-  urlPrefix,
-  templateUuid,
-  startTimeout,
-  basicauthUsername,
-  basicauthPassword,
-  enableDemoMode
-} = utils.parseCommandLineArgumentsAnonymous(args);
+const urlIdx = args.indexOf('--url'); // used in production only
 
-const urlIdx = args.indexOf('--url');
-let anonURL;
+let anonURL, startTimeout, basicauthUsername, basicauthPassword, enableDemoMode;
+
 if (urlIdx > -1) {
   anonURL = args[urlIdx + 1];
+  startTimeout = args[urlIdx + 2];
+  basicauthUsername = "";
+  basicauthPassword = "";
+  enableDemoMode = args.includes("--demo");
 } else {
-  anonURL = urlPrefix + templateUuid;
+  const parsed = utils.parseCommandLineArgumentsAnonymous(args);
+  anonURL = parsed.urlPrefix + parsed.templateUuid;
+  startTimeout = parsed.startTimeout;
+  basicauthUsername = parsed.basicauthUsername;
+  basicauthPassword = parsed.basicauthPassword;
+  enableDemoMode = parsed.enableDemoMode;
 }
 
 const screenshotPrefix = "SarValidation";

--- a/tests/e2e/publications/SarValidation.js
+++ b/tests/e2e/publications/SarValidation.js
@@ -10,20 +10,16 @@ const utils = require('../utils/utils');
 const args = process.argv.slice(2);
 const urlIdx = args.indexOf('--url'); // used in production only
 
-let anonURL, startTimeout, basicauthUsername, basicauthPassword, enableDemoMode;
+let anonURL, startTimeout, enableDemoMode;
 
 if (urlIdx > -1) {
   anonURL = args[urlIdx + 1];
   startTimeout = args[urlIdx + 2];
-  basicauthUsername = "";
-  basicauthPassword = "";
   enableDemoMode = args.includes("--demo");
 } else {
   const parsed = utils.parseCommandLineArgumentsAnonymous(args);
   anonURL = parsed.urlPrefix + parsed.templateUuid;
   startTimeout = parsed.startTimeout;
-  basicauthUsername = parsed.basicauthUsername;
-  basicauthPassword = parsed.basicauthPassword;
   enableDemoMode = parsed.enableDemoMode;
 }
 
@@ -31,7 +27,7 @@ const screenshotPrefix = "SarValidation";
 
 
 async function runTutorial () {
-  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, basicauthUsername, basicauthPassword, enableDemoMode);
+  const tutorial = new tutorialBase.TutorialBase(anonURL, screenshotPrefix, null, null, null, "", "", enableDemoMode);
 
   try {
     await tutorial.beforeScript();


### PR DESCRIPTION
## What do these changes do?

In production, http://sarvalidation.site (not https yet) redirects to https://osparc.io/study/ff72c36a-df81-11ed-9c9e-02420a0b755a, and this is where the e2e was tested. This PR adapts the SarValidation.js test to also support the full_url argument, this way we also test that the redirection works.

## Related issue/s
- related to https://github.com/ITISFoundation/osparc-issues/issues/2024


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
