### PR TITLE
🎨 [Frontend] UX: Pop up windows closer to context

### DIFF
--- a/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
@@ -200,13 +200,22 @@ qx.Class.define("osparc.conversation.MessageUI", {
       });
       addMessage.getChildControl("notify-user-button").exclude();
       const title = this.tr("Edit message");
-      const win = osparc.ui.window.Window.popUpInWindow(addMessage, title, 570, 120).set({
+      // check if support center is open to decide where to open the edit message window
+      const width = this.__studyData ? 570 : osparc.support.SupportCenter.WINDOW_WIDTH - 10;
+      const win = osparc.ui.window.Window.popUpInWindow(addMessage, title, width, 120).set({
         clickAwayClose: false,
         resizable: true,
         showClose: true,
       });
+      if (!this.__studyData) {
+        // only if the message belong to the support center
+        const supportCenter = osparc.ui.window.SingletonWindow.getWindowById("support-center");
+        win.setCenterOnElement(supportCenter);
+        win.center();
+      }
       addMessage.addListener("updateMessage", e => {
         const content = e.getData();
+        let promise = null;
         if (this.__studyData) {
           promise = osparc.store.ConversationsProject.getInstance().editMessage(message, content, this.__studyData["uuid"]);
         } else {

--- a/services/static-webserver/client/source/class/osparc/support/ConversationOptionsMenu.js
+++ b/services/static-webserver/client/source/class/osparc/support/ConversationOptionsMenu.js
@@ -146,7 +146,10 @@ qx.Class.define("osparc.support.ConversationOptionsMenu", {
         oldName = "";
       }
       const title = this.tr("Rename Conversation");
-      const renamer = new osparc.widget.Renamer(oldName, null, title).set({
+      const supportCenter = qx.core.Init.getApplication().getRoot()
+        .getChildren()
+        .find(child => child.classname === "osparc.support.SupportCenter");
+      const renamer = new osparc.widget.Renamer(oldName, null, title, supportCenter).set({
         maxChars: osparc.data.model.Conversation.MAX_TITLE_LENGTH,
       });
       renamer.addListener("labelChanged", e => {

--- a/services/static-webserver/client/source/class/osparc/support/ConversationOptionsMenu.js
+++ b/services/static-webserver/client/source/class/osparc/support/ConversationOptionsMenu.js
@@ -146,9 +146,7 @@ qx.Class.define("osparc.support.ConversationOptionsMenu", {
         oldName = "";
       }
       const title = this.tr("Rename Conversation");
-      const supportCenter = qx.core.Init.getApplication().getRoot()
-        .getChildren()
-        .find(child => child.classname === "osparc.support.SupportCenter");
+      const supportCenter = osparc.ui.window.SingletonWindow.getWindowById("support-center");
       const renamer = new osparc.widget.Renamer(oldName, null, title, supportCenter).set({
         maxChars: osparc.data.model.Conversation.MAX_TITLE_LENGTH,
       });

--- a/services/static-webserver/client/source/class/osparc/ui/window/SingletonWindow.js
+++ b/services/static-webserver/client/source/class/osparc/ui/window/SingletonWindow.js
@@ -23,6 +23,14 @@ qx.Class.define("osparc.ui.window.SingletonWindow", {
     this.base(arguments, caption, icon);
   },
 
+  statics: {
+    getWindowById: function(id) {
+      return qx.core.Init.getApplication().getRoot()
+        .getChildren()
+        .find(child => child instanceof osparc.ui.window.SingletonWindow && child.getId() === id) || null;
+    },
+  },
+
   properties: {
     id: {
       check: "String",

--- a/services/static-webserver/client/source/class/osparc/widget/NodesTree.js
+++ b/services/static-webserver/client/source/class/osparc/widget/NodesTree.js
@@ -197,7 +197,7 @@ qx.Class.define("osparc.widget.NodesTree", {
           const nodeTreeItem = new osparc.widget.NodeTreeItem();
           this.bind("simpleNodes", nodeTreeItem, "simpleNode");
           nodeTreeItem.addListener("fullscreenNode", e => this.__openFullscreen(e.getData()));
-          nodeTreeItem.addListener("renameNode", e => this._openItemRenamer(e.getData()));
+          nodeTreeItem.addListener("renameNode", e => this._openItemRenamer(e.getData(), nodeTreeItem));
           nodeTreeItem.addListener("infoNode", e => this.__openNodeInfo(e.getData()));
           nodeTreeItem.addListener("deleteNode", e => this.__deleteNode(e.getData()));
           return nodeTreeItem;
@@ -264,7 +264,7 @@ qx.Class.define("osparc.widget.NodesTree", {
       }
     },
 
-    _openItemRenamer: function(nodeId) {
+    _openItemRenamer: function(nodeId, treeItem) {
       if (nodeId === undefined && this.__getSelection()) {
         nodeId = this.__getSelection().getId();
       }
@@ -285,8 +285,8 @@ qx.Class.define("osparc.widget.NodesTree", {
           }
           treeItemRenamer.close();
         }, this);
-        const bounds = this.getLayoutParent().getContentLocation();
-        treeItemRenamer.moveTo(bounds.left + 100, bounds.top + 150);
+        const bounds = treeItem ? treeItem.getLayoutParent().getContentLocation() : this.getLayoutParent().getContentLocation();
+        treeItemRenamer.moveTo(bounds.left + 200, bounds.top - 20);
         treeItemRenamer.open();
       }
     },

--- a/services/static-webserver/client/source/class/osparc/widget/NodesTree.js
+++ b/services/static-webserver/client/source/class/osparc/widget/NodesTree.js
@@ -285,7 +285,7 @@ qx.Class.define("osparc.widget.NodesTree", {
           }
           treeItemRenamer.close();
         }, this);
-        const bounds = treeItem ? treeItem.getLayoutParent().getContentLocation() : this.getLayoutParent().getContentLocation();
+        const bounds = treeItem ? treeItem.getContentLocation() : this.getLayoutParent().getContentLocation();
         treeItemRenamer.moveTo(bounds.left + 200, bounds.top - 20);
         treeItemRenamer.open();
       }

--- a/services/static-webserver/client/source/class/osparc/widget/Renamer.js
+++ b/services/static-webserver/client/source/class/osparc/widget/Renamer.js
@@ -37,7 +37,7 @@
 qx.Class.define("osparc.widget.Renamer", {
   extend: osparc.ui.window.Window,
 
-  construct: function(oldLabel = "", subtitle = "", winTitle) {
+  construct: function(oldLabel = "", subtitle = "", winTitle, targetWidget) {
     this.base(arguments, winTitle || this.tr("Rename"));
 
     const maxWidth = 400;
@@ -53,6 +53,10 @@ qx.Class.define("osparc.widget.Renamer", {
       width: labelWidth,
       clickAwayClose: true
     });
+
+    if (targetWidget) {
+      this.setCenterOnElement(targetWidget);
+    }
 
     this.__populateNodeLabelEditor(oldLabel, labelWidth);
     this.__addSubtitle(subtitle);

--- a/services/static-webserver/client/source/class/osparc/widget/StudyTitleOnlyTree.js
+++ b/services/static-webserver/client/source/class/osparc/widget/StudyTitleOnlyTree.js
@@ -36,7 +36,7 @@ qx.Class.define("osparc.widget.StudyTitleOnlyTree", {
         ...this._getDelegate(study),
         createItem: () => {
           const studyTreeItem = new osparc.widget.NodeTreeItem();
-          studyTreeItem.addListener("renameNode", e => this._openItemRenamer(e.getData()));
+          studyTreeItem.addListener("renameNode", e => this._openItemRenamer(e.getData(), studyTreeItem));
           studyTreeItem.addListener("infoNode", () => this.__openStudyInfo());
           return studyTreeItem;
         }


### PR DESCRIPTION
## What do these changes do?

Improves frontend UX by positioning rename/edit popup windows closer to the UI element that triggered them (notably within the Support Center.

Pop up window position improved for:
- Edit Support Message
- Rename Support Conversation 
- Rename Node from tree

Rename Conversation:
<img width="1440" height="850" alt="RenamePosition" src="https://github.com/user-attachments/assets/05ccb500-5fa2-4ef2-9f4d-56675e6e16d1" />


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
