### PR TITLE
⬆️ upgrade opentelemetry- libraries to latest

### DIFF
--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -1,4 +1,4 @@
-aiohappyeyeballs==2.6.2
+aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.13.5
     # via
@@ -11,7 +11,13 @@ attrs==26.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
-coverage==7.14.0
+certifi==2026.2.25
+    # via
+    #   -c ../../requirements/constraints.txt
+    #   requests
+charset-normalizer==3.4.6
+    # via requests
+coverage==7.13.5
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -19,18 +25,20 @@ frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.16
-    # via yarl
+idna==3.11
+    # via
+    #   requests
+    #   yarl
 iniconfig==2.3.0
     # via pytest
 isodate==0.7.2
     # via openapi-core
-jsonschema==4.24.1
+jsonschema==4.26.0
     # via
     #   openapi-core
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.4.6
+jsonschema-path==0.3.4
     # via
     #   openapi-core
     #   openapi-spec-validator
@@ -42,35 +50,35 @@ lazy-object-proxy==1.12.0
     # via openapi-spec-validator
 markupsafe==3.0.3
     # via werkzeug
-more-itertools==11.0.2
+more-itertools==10.8.0
     # via openapi-core
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-openapi-core==0.23.1
+openapi-core==0.22.0
     # via -r requirements.in
-openapi-schema-validator==0.7.1
+openapi-schema-validator==0.6.3
     # via
     #   openapi-core
     #   openapi-spec-validator
-openapi-spec-validator==0.8.1
+openapi-spec-validator==0.7.2
     # via openapi-core
-packaging==26.2
+packaging==26.0
     # via pytest
-pathable==0.5.0
+pathable==0.4.4
     # via jsonschema-path
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-propcache==0.5.2
+propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
-pygments==2.20.0
+pygments==2.19.2
     # via pytest
-pytest==9.0.3
+pytest==9.0.2
     # via
     #   -r requirements.in
     #   pytest-asyncio
@@ -79,7 +87,7 @@ pytest==9.0.3
     #   pytest-sugar
 pytest-asyncio==1.3.0
     # via -r requirements.in
-pytest-cov==7.1.0
+pytest-cov==7.0.0
     # via -r requirements.in
 pytest-instafail==0.5.0
     # via -r requirements.in
@@ -95,6 +103,8 @@ referencing==0.35.1
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
+requests==2.32.5
+    # via jsonschema-path
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rpds-py==0.30.0
@@ -107,7 +117,11 @@ termcolor==3.3.0
     # via pytest-sugar
 typing-extensions==4.15.0
     # via openapi-core
-werkzeug==3.1.8
+urllib3==2.7.0
+    # via
+    #   -c ../../requirements/constraints.txt
+    #   requests
+werkzeug==3.1.6
     # via openapi-core
-yarl==1.24.2
+yarl==1.23.0
     # via aiohttp

--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -1,4 +1,4 @@
-aiohappyeyeballs==2.6.1
+aiohappyeyeballs==2.6.2
     # via aiohttp
 aiohttp==3.13.5
     # via
@@ -11,13 +11,7 @@ attrs==26.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
-certifi==2026.2.25
-    # via
-    #   -c ../../requirements/constraints.txt
-    #   requests
-charset-normalizer==3.4.6
-    # via requests
-coverage==7.13.5
+coverage==7.14.0
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -25,20 +19,18 @@ frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.11
-    # via
-    #   requests
-    #   yarl
+idna==3.16
+    # via yarl
 iniconfig==2.3.0
     # via pytest
 isodate==0.7.2
     # via openapi-core
-jsonschema==4.26.0
+jsonschema==4.24.1
     # via
     #   openapi-core
     #   openapi-schema-validator
     #   openapi-spec-validator
-jsonschema-path==0.3.4
+jsonschema-path==0.4.6
     # via
     #   openapi-core
     #   openapi-spec-validator
@@ -50,35 +42,35 @@ lazy-object-proxy==1.12.0
     # via openapi-spec-validator
 markupsafe==3.0.3
     # via werkzeug
-more-itertools==10.8.0
+more-itertools==11.0.2
     # via openapi-core
 multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-openapi-core==0.22.0
+openapi-core==0.23.1
     # via -r requirements.in
-openapi-schema-validator==0.6.3
+openapi-schema-validator==0.7.1
     # via
     #   openapi-core
     #   openapi-spec-validator
-openapi-spec-validator==0.7.2
+openapi-spec-validator==0.8.1
     # via openapi-core
-packaging==26.0
+packaging==26.2
     # via pytest
-pathable==0.4.4
+pathable==0.5.0
     # via jsonschema-path
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-propcache==0.4.1
+propcache==0.5.2
     # via
     #   aiohttp
     #   yarl
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements.in
     #   pytest-asyncio
@@ -87,7 +79,7 @@ pytest==9.0.2
     #   pytest-sugar
 pytest-asyncio==1.3.0
     # via -r requirements.in
-pytest-cov==7.0.0
+pytest-cov==7.1.0
     # via -r requirements.in
 pytest-instafail==0.5.0
     # via -r requirements.in
@@ -103,8 +95,6 @@ referencing==0.35.1
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-requests==2.32.5
-    # via jsonschema-path
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rpds-py==0.30.0
@@ -117,11 +107,7 @@ termcolor==3.3.0
     # via pytest-sugar
 typing-extensions==4.15.0
     # via openapi-core
-urllib3==2.7.0
-    # via
-    #   -c ../../requirements/constraints.txt
-    #   requests
-werkzeug==3.1.6
+werkzeug==3.1.8
     # via openapi-core
-yarl==1.23.0
+yarl==1.24.2
     # via aiohttp

--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -177,6 +177,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -199,6 +200,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.63b1
@@ -212,6 +214,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
@@ -490,6 +494,7 @@ wrapt==1.17.3
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.23.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -140,8 +140,6 @@ idna==3.11
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 jmespath==1.1.0
     # via
     #   aiobotocore
@@ -166,7 +164,7 @@ multidict==6.7.1
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -182,17 +180,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -201,42 +199,44 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.61b0
+opentelemetry-instrumentation-botocore==0.63b1
     # via -r requirements/_base.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
@@ -487,6 +487,7 @@ wrapt==1.17.3
     #   aiobotocore
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 yarl==1.23.0
@@ -495,5 +496,3 @@ yarl==1.23.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.23.0
-    # via importlib-metadata

--- a/packages/celery-library/requirements/_base.txt
+++ b/packages/celery-library/requirements/_base.txt
@@ -136,8 +136,6 @@ idna==3.11
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 jsonref==1.1.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -158,7 +156,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -172,17 +170,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -190,37 +188,39 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
@@ -477,5 +477,3 @@ yarl==1.23.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.23.0
-    # via importlib-metadata

--- a/packages/celery-library/requirements/_base.txt
+++ b/packages/celery-library/requirements/_base.txt
@@ -168,6 +168,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -188,6 +189,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.63b1
@@ -199,6 +201,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -471,6 +475,7 @@ wrapt==1.17.3
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.23.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/packages/service-library/requirements/_aiohttp.txt
+++ b/packages/service-library/requirements/_aiohttp.txt
@@ -18,8 +18,6 @@ frozenlist==1.8.0
     #   aiosignal
 idna==3.11
     # via yarl
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 jsonschema==4.26.0
     # via -r requirements/_aiohttp.in
 jsonschema-specifications==2025.9.1
@@ -30,26 +28,26 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
-opentelemetry-instrumentation-aiohttp-client==0.61b0
+opentelemetry-instrumentation-aiohttp-client==0.63b1
     # via -r requirements/_aiohttp.in
-opentelemetry-instrumentation-aiohttp-server==0.61b0
+opentelemetry-instrumentation-aiohttp-server==0.63b1
     # via -r requirements/_aiohttp.in
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
@@ -83,5 +81,3 @@ wrapt==1.17.3
     #   opentelemetry-instrumentation-aiohttp-server
 yarl==1.23.0
     # via aiohttp
-zipp==3.23.0
-    # via importlib-metadata

--- a/packages/service-library/requirements/_base.in
+++ b/packages/service-library/requirements/_base.in
@@ -25,6 +25,7 @@ opentelemetry-instrumentation-httpx
 opentelemetry-instrumentation-logging
 opentelemetry-instrumentation-redis
 opentelemetry-instrumentation-requests
+opentelemetry-instrumentation-threading
 opentelemetry-sdk
 psutil
 pydantic

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -100,8 +100,6 @@ idna==3.11
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 jsonref==1.1.0
     # via -r requirements/../../../packages/models-library/requirements/_base.in
 jsonschema==4.26.0
@@ -116,7 +114,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -130,17 +128,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -148,37 +146,39 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/_base.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
@@ -351,5 +351,3 @@ yarl==1.23.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.23.0
-    # via importlib-metadata

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -126,6 +126,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -146,6 +147,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.63b1
@@ -157,6 +159,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -345,6 +349,7 @@ wrapt==1.17.3
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.23.0
     # via
     #   -r requirements/_base.in

--- a/packages/service-library/requirements/_fastapi.txt
+++ b/packages/service-library/requirements/_fastapi.txt
@@ -60,8 +60,6 @@ idna==3.11
     #   anyio
     #   email-validator
     #   httpx
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -72,26 +70,26 @@ markupsafe==3.0.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/_fastapi.in
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -181,5 +179,3 @@ websockets==16.0
     # via uvicorn
 wrapt==1.17.3
     # via opentelemetry-instrumentation
-zipp==3.23.0
-    # via importlib-metadata

--- a/packages/service-library/src/servicelib/aiohttp/tracing.py
+++ b/packages/service-library/src/servicelib/aiohttp/tracing.py
@@ -33,6 +33,14 @@ try:
     HAS_BOTOCORE = True
 except ImportError:
     HAS_BOTOCORE = False
+
+try:
+    from opentelemetry.instrumentation.threading import ThreadingInstrumentor
+
+    HAS_THREADING = True
+except ImportError:
+    HAS_THREADING = False
+
 try:
     from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
 
@@ -142,6 +150,14 @@ def _startup(
             msg="Attempting to add asyncpg opentelemetry autoinstrumentation...",
         ):
             AsyncPGInstrumentor().instrument(tracer_provider=tracer_provider)
+    if HAS_THREADING:
+        with log_context(
+            _logger,
+            logging.INFO,
+            msg="Attempting to add threading opentelemetry autoinstrumentation...",
+        ):
+            ThreadingInstrumentor().instrument(tracer_provider=tracer_provider)
+
     if HAS_BOTOCORE:
         with log_context(
             _logger,
@@ -201,6 +217,9 @@ def _shutdown() -> None:
     if HAS_BOTOCORE:
         with log_catch(_logger, reraise=False):
             BotocoreInstrumentor().uninstrument()
+    if HAS_THREADING:
+        with log_catch(_logger, reraise=False):
+            ThreadingInstrumentor().uninstrument()
     if HAS_REQUESTS:
         with log_catch(_logger, reraise=False):
             RequestsInstrumentor().uninstrument()

--- a/packages/service-library/src/servicelib/aiohttp/tracing.py
+++ b/packages/service-library/src/servicelib/aiohttp/tracing.py
@@ -27,6 +27,7 @@ TRACING_CONFIG_KEY: Final[str] = "tracing_config"
 
 try:
     from opentelemetry.instrumentation.botocore import (  # type: ignore[import-not-found]
+        AiobotocoreInstrumentor,
         BotocoreInstrumentor,
     )
 
@@ -165,6 +166,7 @@ def _startup(
             msg="Attempting to add botocore opentelemetry autoinstrumentation...",
         ):
             BotocoreInstrumentor().instrument(tracer_provider=tracer_provider)
+            AiobotocoreInstrumentor().instrument(tracer_provider=tracer_provider)
     if HAS_REQUESTS:
         with log_context(
             _logger,
@@ -217,6 +219,7 @@ def _shutdown() -> None:
     if HAS_BOTOCORE:
         with log_catch(_logger, reraise=False):
             BotocoreInstrumentor().uninstrument()
+            AiobotocoreInstrumentor().uninstrument()
     if HAS_THREADING:
         with log_catch(_logger, reraise=False):
             ThreadingInstrumentor().uninstrument()

--- a/packages/service-library/src/servicelib/fastapi/tracing.py
+++ b/packages/service-library/src/servicelib/fastapi/tracing.py
@@ -37,13 +37,21 @@ except ImportError:
     HAS_REDIS = False
 
 try:
-    from opentelemetry.instrumentation.botocore import (  # type: ignore[import-not-found]
+    from opentelemetry.instrumentation.botocore import (
+        AioBotocoreInstrumentor,
         BotocoreInstrumentor,
     )
 
     HAS_BOTOCORE = True
 except ImportError:
     HAS_BOTOCORE = False
+
+try:
+    from opentelemetry.instrumentation.threading import ThreadingInstrumentor
+
+    HAS_THREADING = True
+except ImportError:
+    HAS_THREADING = False
 
 try:
     from opentelemetry.instrumentation.requests import RequestsInstrumentor
@@ -123,6 +131,15 @@ def _startup(
             msg="Attempting to add redis opentelemetry autoinstrumentation...",
         ):
             RedisInstrumentor().instrument(tracer_provider=tracer_provider)
+
+    if HAS_THREADING:
+        with log_context(
+            _logger,
+            logging.INFO,
+            msg="Attempting to add threading opentelemetry autoinstrumentation...",
+        ):
+            ThreadingInstrumentor().instrument(tracer_provider=tracer_provider)
+
     if HAS_BOTOCORE:
         with log_context(
             _logger,
@@ -130,6 +147,7 @@ def _startup(
             msg="Attempting to add botocore opentelemetry autoinstrumentation...",
         ):
             BotocoreInstrumentor().instrument(tracer_provider=tracer_provider)
+            AioBotocoreInstrumentor().instrument(tracer_provider=tracer_provider)
     if HAS_REQUESTS:
         with log_context(
             _logger,
@@ -163,6 +181,10 @@ def _shutdown() -> None:
     if HAS_BOTOCORE:
         with log_catch(_logger, reraise=False):
             BotocoreInstrumentor().uninstrument()
+            AioBotocoreInstrumentor().uninstrument()
+    if HAS_THREADING:
+        with log_catch(_logger, reraise=False):
+            ThreadingInstrumentor().uninstrument()
     if HAS_REQUESTS:
         with log_catch(_logger, reraise=False):
             RequestsInstrumentor().uninstrument()

--- a/packages/service-library/src/servicelib/fastapi/tracing.py
+++ b/packages/service-library/src/servicelib/fastapi/tracing.py
@@ -38,7 +38,7 @@ except ImportError:
 
 try:
     from opentelemetry.instrumentation.botocore import (  # type: ignore[import-not-found]
-        AioBotocoreInstrumentor,
+        AiobotocoreInstrumentor,
         BotocoreInstrumentor,
     )
 
@@ -147,7 +147,7 @@ def _startup(
             msg="Attempting to add botocore opentelemetry autoinstrumentation...",
         ):
             BotocoreInstrumentor().instrument(tracer_provider=tracer_provider)
-            AioBotocoreInstrumentor().instrument(tracer_provider=tracer_provider)
+            AiobotocoreInstrumentor().instrument(tracer_provider=tracer_provider)
     if HAS_REQUESTS:
         with log_context(
             _logger,
@@ -181,7 +181,7 @@ def _shutdown() -> None:
     if HAS_BOTOCORE:
         with log_catch(_logger, reraise=False):
             BotocoreInstrumentor().uninstrument()
-            AioBotocoreInstrumentor().uninstrument()
+            AiobotocoreInstrumentor().uninstrument()
     if HAS_THREADING:
         with log_catch(_logger, reraise=False):
             ThreadingInstrumentor().uninstrument()

--- a/packages/service-library/src/servicelib/fastapi/tracing.py
+++ b/packages/service-library/src/servicelib/fastapi/tracing.py
@@ -37,7 +37,7 @@ except ImportError:
     HAS_REDIS = False
 
 try:
-    from opentelemetry.instrumentation.botocore import (
+    from opentelemetry.instrumentation.botocore import (  # type: ignore[import-not-found]
         AioBotocoreInstrumentor,
         BotocoreInstrumentor,
     )

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -141,8 +141,6 @@ idna==3.11
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 jsonref==1.1.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
@@ -180,7 +178,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -194,17 +192,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -212,37 +210,39 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
@@ -538,5 +538,3 @@ yarl==1.23.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.23.0
-    # via importlib-metadata

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -190,6 +190,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -210,6 +211,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.63b1
@@ -221,6 +223,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -531,6 +535,7 @@ wrapt==1.17.3
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.23.0
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in

--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -198,6 +198,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -220,6 +221,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.63b1
@@ -235,6 +237,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -549,6 +553,7 @@ wrapt==1.17.2
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.18.3
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -149,8 +149,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.5.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -186,7 +184,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -202,17 +200,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -222,43 +220,45 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -555,5 +555,3 @@ yarl==1.18.3
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.21.0
-    # via importlib-metadata

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -470,6 +470,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -495,6 +496,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -525,6 +527,11 @@ opentelemetry-instrumentation-redis==0.63b1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via
+    #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -1241,6 +1248,7 @@ wrapt==1.17.0
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.18.3
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -337,8 +337,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.5.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/celery-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -456,7 +454,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -474,20 +472,20 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -497,63 +495,65 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -1251,5 +1251,3 @@ yarl==1.18.3
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.21.0
-    # via importlib-metadata

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -327,6 +327,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -353,6 +354,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -380,6 +382,10 @@ opentelemetry-instrumentation-redis==0.63b1
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -908,6 +914,7 @@ wrapt==1.17.3
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.22.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -241,8 +241,6 @@ idna==3.11
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -313,7 +311,7 @@ multidict==6.7.0
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -332,19 +330,19 @@ opentelemetry-api==1.40.0
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -355,61 +353,63 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.61b0
+opentelemetry-instrumentation-botocore==0.63b1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -905,6 +905,7 @@ wrapt==1.17.3
     #   aiobotocore
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 yarl==1.22.0
@@ -918,5 +919,3 @@ zict==3.0.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-zipp==3.23.0
-    # via importlib-metadata

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -233,6 +233,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -255,6 +256,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.63b1
@@ -270,6 +272,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -631,6 +635,7 @@ wrapt==1.17.2
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.18.3
     # via
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -161,8 +161,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.6.1
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -221,7 +219,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -237,17 +235,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -257,43 +255,45 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -638,5 +638,3 @@ yarl==1.18.3
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.21.0
-    # via importlib-metadata

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -325,6 +325,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -351,6 +352,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -378,6 +380,10 @@ opentelemetry-instrumentation-redis==0.63b1
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -906,6 +912,7 @@ wrapt==1.17.3
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.22.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -239,8 +239,6 @@ idna==3.11
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -311,7 +309,7 @@ multidict==6.7.0
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -330,19 +328,19 @@ opentelemetry-api==1.40.0
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -353,61 +351,63 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.61b0
+opentelemetry-instrumentation-botocore==0.63b1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -903,6 +903,7 @@ wrapt==1.17.3
     #   aiobotocore
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 yarl==1.22.0
@@ -916,5 +917,3 @@ zict==3.0.0
     # via
     #   -c requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-zipp==3.23.0
-    # via importlib-metadata

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -175,8 +175,6 @@ idna==3.11
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -242,7 +240,7 @@ numpy==2.3.5
     #   bokeh
     #   contourpy
     #   pandas
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -256,17 +254,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -274,37 +272,39 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
@@ -661,5 +661,3 @@ yarl==1.22.0
     #   aiormq
 zict==3.0.0
     # via distributed
-zipp==3.23.0
-    # via importlib-metadata

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -252,6 +252,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -272,6 +273,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.63b1
@@ -283,6 +285,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -651,6 +655,7 @@ wrapt==1.17.3
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 xyzservices==2025.10.0
     # via bokeh
 yarl==1.22.0

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -158,8 +158,6 @@ idna==3.6
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.0.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -199,7 +197,7 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -215,17 +213,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -235,43 +233,45 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -577,5 +577,3 @@ yarl==1.20.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.20.1
-    # via importlib-metadata

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -211,6 +211,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -233,6 +234,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.63b1
@@ -248,6 +250,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -571,6 +575,7 @@ wrapt==1.16.0
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.20.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -275,8 +275,6 @@ idna==3.11
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -398,7 +396,7 @@ networkx==3.5
     # via -r requirements/_base.in
 numpy==2.3.5
     # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -416,19 +414,19 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-aiohttp-client
@@ -439,59 +437,61 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-aiohttp-client==0.61b0
+opentelemetry-instrumentation-aiohttp-client==0.63b1
     # via -r requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-asgi
@@ -1169,5 +1169,3 @@ zict==3.0.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-zipp==3.23.0
-    # via importlib-metadata

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -412,6 +412,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -437,6 +438,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -464,6 +466,10 @@ opentelemetry-instrumentation-redis==0.63b1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -1154,6 +1160,7 @@ wrapt==1.17.3
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 wsproto==1.3.1
     # via simple-websocket
 yarl==1.22.0

--- a/services/director/requirements/_base.txt
+++ b/services/director/requirements/_base.txt
@@ -150,8 +150,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.5.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -187,7 +185,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -203,17 +201,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -223,43 +221,45 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -558,5 +558,3 @@ yarl==1.17.1
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.21.0
-    # via importlib-metadata

--- a/services/director/requirements/_base.txt
+++ b/services/director/requirements/_base.txt
@@ -199,6 +199,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -221,6 +222,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.63b1
@@ -236,6 +238,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -552,6 +556,7 @@ wrapt==1.16.0
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.17.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/docker-api-proxy/requirements/_test.txt
+++ b/services/docker-api-proxy/requirements/_test.txt
@@ -141,8 +141,6 @@ idna==3.11
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.1
-    # via opentelemetry-api
 iniconfig==2.3.0
     # via pytest
 jsonref==1.1.0
@@ -163,7 +161,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -177,17 +175,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -195,37 +193,39 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests
@@ -513,5 +513,3 @@ yarl==1.23.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.23.0
-    # via importlib-metadata

--- a/services/docker-api-proxy/requirements/_test.txt
+++ b/services/docker-api-proxy/requirements/_test.txt
@@ -173,6 +173,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -193,6 +194,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asyncpg==0.63b1
@@ -204,6 +206,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -507,6 +511,7 @@ wrapt==1.17.3
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.23.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -249,6 +249,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -271,6 +272,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.63b1
@@ -286,6 +288,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -669,6 +673,7 @@ wrapt==1.17.2
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 wsproto==1.2.0
     # via simple-websocket
 yarl==1.18.3

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -172,8 +172,6 @@ idna==3.10
     #   yarl
 ifaddr==0.2.0
     # via nicegui
-importlib-metadata==8.5.0
-    # via opentelemetry-api
 itsdangerous==2.2.0
     # via nicegui
 jinja2==3.1.6
@@ -237,7 +235,7 @@ multidict==6.1.0
     #   yarl
 nicegui==2.23.3
     # via -r requirements/_base.in
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -253,17 +251,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -273,43 +271,45 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -678,5 +678,3 @@ yarl==1.18.3
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.21.0
-    # via importlib-metadata

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -336,6 +336,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -360,6 +361,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -385,6 +387,10 @@ opentelemetry-instrumentation-redis==0.63b1
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -964,6 +970,7 @@ wrapt==1.17.2
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 wsproto==1.2.0
     # via simple-websocket
 yarl==1.18.3

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -233,8 +233,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.5.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -323,7 +321,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
@@ -340,19 +338,19 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -362,56 +360,58 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -975,5 +975,3 @@ yarl==1.18.3
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.21.0
-    # via importlib-metadata

--- a/services/efs-guardian/requirements/_base.txt
+++ b/services/efs-guardian/requirements/_base.txt
@@ -334,6 +334,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -360,6 +361,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -387,6 +389,10 @@ opentelemetry-instrumentation-redis==0.63b1
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -939,6 +945,7 @@ wrapt==1.17.2
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.20.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/efs-guardian/requirements/_base.txt
+++ b/services/efs-guardian/requirements/_base.txt
@@ -228,8 +228,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -320,7 +318,7 @@ multidict==6.6.2
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -339,19 +337,19 @@ opentelemetry-api==1.40.0
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -362,61 +360,63 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.61b0
+opentelemetry-instrumentation-botocore==0.63b1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -936,6 +936,7 @@ wrapt==1.17.2
     #   aiobotocore
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 yarl==1.20.1
@@ -946,5 +947,3 @@ yarl==1.20.1
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.23.0
-    # via importlib-metadata

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -211,6 +211,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -233,6 +234,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.63b1
@@ -248,6 +250,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -564,6 +568,7 @@ wrapt==1.17.2
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.18.3
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -162,8 +162,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.6.1
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -199,7 +197,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -215,17 +213,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -235,43 +233,45 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -570,5 +570,3 @@ yarl==1.18.3
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.21.0
-    # via importlib-metadata

--- a/services/notifications/requirements/_base.txt
+++ b/services/notifications/requirements/_base.txt
@@ -255,8 +255,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.6.1
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/celery-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -362,7 +360,7 @@ multidict==6.2.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -379,19 +377,19 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -401,56 +399,58 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -1081,5 +1081,3 @@ yarl==1.18.3
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.21.0
-    # via importlib-metadata

--- a/services/notifications/requirements/_base.txt
+++ b/services/notifications/requirements/_base.txt
@@ -375,6 +375,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -399,6 +400,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -424,6 +426,10 @@ opentelemetry-instrumentation-redis==0.63b1
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via
+    #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -1072,6 +1078,7 @@ wrapt==1.17.2
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.18.3
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -251,6 +251,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -273,6 +274,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-asgi==0.63b1
@@ -288,6 +290,8 @@ opentelemetry-instrumentation-logging==0.63b1
 opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-proto==1.42.1
     # via
@@ -680,6 +684,7 @@ wrapt==1.17.0
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 wsproto==1.2.0
     # via simple-websocket
 yarl==1.18.0

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -181,8 +181,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.5.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -239,7 +237,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -255,17 +253,17 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -275,43 +273,45 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -689,5 +689,3 @@ yarl==1.18.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.21.0
-    # via importlib-metadata

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -357,6 +357,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -383,6 +384,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -410,6 +412,10 @@ opentelemetry-instrumentation-redis==0.63b1
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -992,6 +998,7 @@ wrapt==1.16.0
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.20.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -239,8 +239,6 @@ idna==3.6
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.0.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -343,7 +341,7 @@ numpy==2.3.4
     #   matplotlib
     #   pandas
     #   prometheus-api-client
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
@@ -362,19 +360,19 @@ opentelemetry-api==1.40.0
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -385,61 +383,63 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.61b0
+opentelemetry-instrumentation-botocore==0.63b1
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -989,6 +989,7 @@ wrapt==1.16.0
     #   aiobotocore
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 yarl==1.20.0
@@ -999,5 +1000,3 @@ yarl==1.20.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.20.1
-    # via importlib-metadata

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -441,6 +441,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
@@ -469,6 +470,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -505,6 +507,11 @@ opentelemetry-instrumentation-redis==0.63b1
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via
+    #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -1249,6 +1256,7 @@ wrapt==1.17.2
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 yarl==1.18.3
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -303,8 +303,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.5.0
-    # via opentelemetry-api
 jinja2==3.1.6
     # via
     #   -c requirements/../../../packages/aws-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
@@ -425,7 +423,7 @@ multidict==6.1.0
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -446,20 +444,20 @@ opentelemetry-api==1.40.0
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -471,73 +469,75 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.61b0
+opentelemetry-instrumentation-asgi==0.63b1
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.61b0
+opentelemetry-instrumentation-botocore==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/_base.in
     #   -r requirements/_base.in
-opentelemetry-instrumentation-celery==0.61b0
+opentelemetry-instrumentation-celery==0.63b1
     # via -r requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.61b0
+opentelemetry-instrumentation-fastapi==0.63b1
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-celery
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
@@ -1246,6 +1246,7 @@ wrapt==1.17.2
     #   aiobotocore
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
+    #   opentelemetry-instrumentation-botocore
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
 yarl==1.18.3
@@ -1257,5 +1258,3 @@ yarl==1.18.3
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.21.0
-    # via importlib-metadata

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -377,8 +377,6 @@ idna==3.3
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.0.0
-    # via opentelemetry-api
 jinja-app-loader==1.0.2
     # via -r requirements/_base.in
 jinja2==3.1.6
@@ -526,7 +524,7 @@ multidict==6.1.0
     #   yarl
 openpyxl==3.0.9
     # via -r requirements/_base.in
-opentelemetry-api==1.40.0
+opentelemetry-api==1.42.1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
@@ -544,20 +542,20 @@ opentelemetry-api==1.40.0
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.40.0
+opentelemetry-exporter-otlp==1.42.1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.40.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.40.0
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.61b0
+opentelemetry-instrumentation==0.63b1
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-aiohttp-client
@@ -567,63 +565,65 @@ opentelemetry-instrumentation==0.61b0
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
-opentelemetry-instrumentation-aio-pika==0.61b0
+opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-aiohttp-client==0.61b0
+opentelemetry-instrumentation-aiohttp-client==0.63b1
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-opentelemetry-instrumentation-aiohttp-server==0.61b0
+opentelemetry-instrumentation-aiohttp-server==0.63b1
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-opentelemetry-instrumentation-asyncpg==0.61b0
+opentelemetry-instrumentation-asyncpg==0.63b1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-httpx==0.61b0
+opentelemetry-instrumentation-httpx==0.63b1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.61b0
+opentelemetry-instrumentation-logging==0.63b1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.61b0
+opentelemetry-instrumentation-redis==0.63b1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.61b0
+opentelemetry-instrumentation-requests==0.63b1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.40.0
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.40.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
     #   opentelemetry-instrumentation-asyncpg
     #   opentelemetry-instrumentation-httpx
+    #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-sdk
-opentelemetry-util-http==0.61b0
+opentelemetry-util-http==0.63b1
     # via
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
@@ -1423,5 +1423,3 @@ yarl==1.20.0
     #   aio-pika
     #   aiohttp
     #   aiormq
-zipp==3.20.1
-    # via importlib-metadata

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -540,6 +540,7 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp==1.42.1
@@ -565,6 +566,7 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-logging
     #   opentelemetry-instrumentation-redis
     #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-threading
 opentelemetry-instrumentation-aio-pika==0.63b1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
@@ -595,6 +597,11 @@ opentelemetry-instrumentation-redis==0.63b1
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-instrumentation-requests==0.63b1
+    # via
+    #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../../packages/service-library/requirements/_base.in
+    #   -r requirements/../../../../packages/simcore-sdk/requirements/../../../packages/service-library/requirements/_base.in
+opentelemetry-instrumentation-threading==0.63b1
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/../../../../packages/service-library/requirements/_base.in
@@ -1409,6 +1416,7 @@ wrapt==1.16.0
     #   opentelemetry-instrumentation-aiohttp-server
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
 wsproto==1.2.0
     # via simple-websocket
 yarl==1.20.0


### PR DESCRIPTION
###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 24
- #packages after ~ 23

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | importlib-metadata        | 8.7.1, 8.7.0, 8.6.1, 8.0.0, 8.5.0 | 🗑️ removed |  | 25 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   2 | opentelemetry-api         | 1.40.0          | 1.42.1     | *minor*    | 25 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   3 | opentelemetry-exporter-otlp | 1.40.0          | 1.42.1     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   4 | opentelemetry-exporter-otlp-proto-common | 1.40.0          | 1.42.1     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   5 | opentelemetry-exporter-otlp-proto-grpc | 1.40.0          | 1.42.1     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   6 | opentelemetry-exporter-otlp-proto-http | 1.40.0          | 1.42.1     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   7 | opentelemetry-instrumentation | 0.61            | 0.63       | *minor*    | 25 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   8 | opentelemetry-instrumentation-aio-pika | 0.61            | 0.63       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   9 | opentelemetry-instrumentation-aiohttp-client | 0.61            | 0.63       | *minor*    | 3 | director-v2⬆️</br>service-library🧪</br>web⬆️ |
|  10 | opentelemetry-instrumentation-aiohttp-server | 0.61            | 0.63       | *minor*    | 2 | service-library🧪</br>web⬆️ |
|  11 | opentelemetry-instrumentation-asgi | 0.61            | 0.63       | *minor*    | 17 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>catalog⬆️</br>clusters-keeper⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>storage⬆️ |
|  12 | opentelemetry-instrumentation-asyncpg | 0.61            | 0.63       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  13 | opentelemetry-instrumentation-botocore | 0.61            | 0.63       | *minor*    | 6 | autoscaling⬆️</br>aws-library🧪</br>clusters-keeper⬆️</br>efs-guardian⬆️</br>resource-usage-tracker⬆️</br>storage⬆️ |
|  14 | opentelemetry-instrumentation-celery | 0.61            | 0.63       | *minor*    | 1 | storage⬆️ |
|  15 | opentelemetry-instrumentation-fastapi | 0.61            | 0.63       | *minor*    | 17 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>catalog⬆️</br>clusters-keeper⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>storage⬆️ |
|  16 | opentelemetry-instrumentation-httpx | 0.61            | 0.63       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  17 | opentelemetry-instrumentation-logging | 0.61            | 0.63       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  18 | opentelemetry-instrumentation-redis | 0.61            | 0.63       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  19 | opentelemetry-instrumentation-requests | 0.61            | 0.63       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  20 | opentelemetry-proto       | 1.40.0          | 1.42.1     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  21 | opentelemetry-sdk         | 1.40.0          | 1.42.1     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  22 | opentelemetry-semantic-conventions | 0.61            | 0.63       | *minor*    | 25 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  23 | opentelemetry-util-http   | 0.61            | 0.63       | *minor*    | 25 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  24 | zipp                      | 3.20.1, 3.23.0, 3.21.0 | 🗑️ removed |  | 25 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency