### PR TITLE
🐛 [Frontend] Conversations: Fix support filter fast switching

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/ConversationSupport.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/ConversationSupport.js
@@ -183,13 +183,14 @@ qx.Class.define("osparc.data.model.ConversationSupport", {
 
     // overridden
     _addMessage: function(messageData, markAsUnread = true) {
-      const message = this.base(arguments, messageData);
-      this.__evalFirstAndLastMessage();
-
       // mark conversation as unread if the message is from the other party
-      if (markAsUnread && !osparc.data.model.Message.isMyMessage(message)) {
+      // This must be done before this.base() which fires "messageAdded" event
+      if (markAsUnread && !osparc.data.model.Message.isMyMessage(messageData)) {
         this.setReadBy(false);
       }
+
+      const message = this.base(arguments, messageData);
+      this.__evalFirstAndLastMessage();
       return message;
     },
 

--- a/services/static-webserver/client/source/class/osparc/data/model/Message.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Message.js
@@ -97,7 +97,11 @@ qx.Class.define("osparc.data.model.Message", {
       return message.getUserGroupId() === osparc.data.model.Message.SYSTEM_MESSAGE_ID;
     },
 
-    isMyMessage: function(message) {
+    isMyMessage: function(messageOrData) {
+      let message = messageOrData;
+      if (!(messageOrData instanceof osparc.data.model.Message)) {
+        message = new osparc.data.model.Message(messageOrData);
+      }
       if (osparc.data.model.Message.isSupportMessage(message)) {
         return false;
       }

--- a/services/static-webserver/client/source/class/osparc/support/Conversation.js
+++ b/services/static-webserver/client/source/class/osparc/support/Conversation.js
@@ -323,7 +323,7 @@ qx.Class.define("osparc.support.Conversation", {
       type = type || osparc.support.Conversation.SYSTEM_MESSAGE_TYPE.ASK_A_QUESTION;
 
       let msg = null;
-      const greet = "Hi " + osparc.auth.Data.getInstance().getUserName() + ",\n";
+      const greet = "Hi " + osparc.auth.Data.getInstance().getFriendlyUserName() + ",\n";
       switch (type) {
         case osparc.support.Conversation.SYSTEM_MESSAGE_TYPE.ASK_A_QUESTION:
           msg = greet + "Have a question or feedback?\nWe are happy to assist!";

--- a/services/static-webserver/client/source/class/osparc/support/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/support/Conversations.js
@@ -118,7 +118,10 @@ qx.Class.define("osparc.support.Conversations", {
           this.getChildControl("filters-layout").add(control);
           break;
         case "loading-button":
-          control = new osparc.ui.form.FetchButton();
+          control = new osparc.ui.form.FetchButton().set({
+            backgroundColor: "transparent",
+            iconSize: 24,
+          });
           this._addAt(control, 1);
           break;
         case "no-messages-label":
@@ -240,6 +243,7 @@ qx.Class.define("osparc.support.Conversations", {
     __fetchConversations: function(filter) {
       const loadMoreButton = this.getChildControl("loading-button");
       loadMoreButton.setFetching(true);
+      loadMoreButton.show();
 
       const requestId = ++this.__fetchRequestId;
       osparc.store.ConversationsSupport.getInstance().fetchConversations(filter)

--- a/services/static-webserver/client/source/class/osparc/support/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/support/Conversations.js
@@ -276,10 +276,14 @@ qx.Class.define("osparc.support.Conversations", {
       this.__isFetchingMore = true;
       this.__showLoadingSpinner(true);
 
+      const requestId = this.__fetchRequestId;
       const filter = this.getCurrentFilter();
       const offset = this.__conversationListItems.length;
       osparc.store.ConversationsSupport.getInstance().fetchConversations(filter, offset)
         .then(resp => {
+          if (requestId !== this.__fetchRequestId) {
+            return;
+          }
           if (resp && resp.conversations && resp.conversations.length) {
             resp.conversations.forEach(conversation => this.__addConversation(conversation));
           }

--- a/services/static-webserver/client/source/class/osparc/support/Conversations.js
+++ b/services/static-webserver/client/source/class/osparc/support/Conversations.js
@@ -71,6 +71,7 @@ qx.Class.define("osparc.support.Conversations", {
     __conversationListItems: null,
     __totalConversations: null,
     __isFetchingMore: false,
+    __fetchRequestId: 0,
 
     _createChildControlImpl: function(id) {
       let control;
@@ -240,8 +241,12 @@ qx.Class.define("osparc.support.Conversations", {
       const loadMoreButton = this.getChildControl("loading-button");
       loadMoreButton.setFetching(true);
 
+      const requestId = ++this.__fetchRequestId;
       osparc.store.ConversationsSupport.getInstance().fetchConversations(filter)
         .then(resp => {
+          if (requestId !== this.__fetchRequestId) {
+            return;
+          }
           if (resp && resp.conversations && resp.conversations.length) {
             resp.conversations.forEach(conversation => this.__addConversation(conversation));
           }
@@ -251,6 +256,9 @@ qx.Class.define("osparc.support.Conversations", {
           this.__updateLoadingSpinner();
         })
         .finally(() => {
+          if (requestId !== this.__fetchRequestId) {
+            return;
+          }
           loadMoreButton.setFetching(false);
           loadMoreButton.exclude();
           this.__showNoMessagesLabelIfNeeded(filter);


### PR DESCRIPTION
## What do these changes do?

reported by @matusdrobuliak66 

This PR adds a request-id guard to prevent stale pagination results when switching fast support conversation filters

Bonus:
- Show the loading button when switching filters
- Fix conversation incorrectly marked as unread when a chatbot/support reply arrives while the user has the conversation open

<img width="1440" height="850" alt="SiwtchFilters" src="https://github.com/user-attachments/assets/b655f399-4ff6-4d77-87a5-3b813156a1ff" />


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
