### PR TITLE
🐛 More resilience for mmux e2e test on dalco master

### DIFF
--- a/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
+++ b/tests/e2e-playwright/tests/metamodeling/test_response_surface_modeling.py
@@ -438,11 +438,27 @@ def test_response_surface_modeling(  # noqa: PLR0912, PLR0915, C901  # pylint: d
                     # Wait for MUI DataGrid loading overlay to disappear before clicking
                     overlay = service_iframe.locator(".MuiDataGrid-overlay")
                     try:
-                        overlay.wait_for(state="hidden", timeout=10 * SECOND)
+                        overlay.wait_for(state="hidden", timeout=30 * SECOND)
                         select_btn.click(timeout=30 * SECOND)
                     except PlaywrightTimeoutError:
                         logging.warning("Overlay still present, clicking with force=True")
                         select_btn.click(force=True, timeout=30 * SECOND)
+
+                    # Verify the click actually navigated to the input step
+                    min_test_id = "Mean" if "uq" in local_service_key.lower() else "Min"
+                    input_locator = service_iframe.locator(
+                        f'[mmux-testid="input-block-{min_test_id}"] input[type="number"]'
+                    )
+                    try:
+                        input_locator.first.wait_for(state="visible", timeout=10 * SECOND)
+                    except PlaywrightTimeoutError:
+                        if attempt == 2:
+                            raise
+                        logging.warning(
+                            "Select click did not navigate to input step (attempt %d/3), retrying...",
+                            attempt + 1,
+                        )
+                        continue
                     break
                 except PlaywrightTimeoutError:
                     if attempt == 2:


### PR DESCRIPTION


## What do these changes do?
Improved mmux test resilience on dalco master:

After clicking the select button, verify the input fields appear within 10s. If they don't, retry the selection attempt instead of proceeding to the fill step where it would time out.

Also increases overlay wait timeout from 10s to 30s.

## Related issue/s


## How to test

Run mmux e2e against dalco master

## Dev-ops
N/A
