### PR TITLE
✨Director-v0: ensure cancelled requests are really cancelled

### DIFF
--- a/services/director/src/simcore_service_director/core/application.py
+++ b/services/director/src/simcore_service_director/core/application.py
@@ -1,6 +1,7 @@
 import logging
 
 from fastapi import FastAPI
+from servicelib.fastapi.cancellation_middleware import RequestCancellationMiddleware
 from servicelib.fastapi.http_error import set_app_default_http_error_handlers
 from servicelib.fastapi.httpx_client import setup_httpx_client
 from servicelib.fastapi.tracing import (
@@ -54,6 +55,8 @@ def create_app(settings: ApplicationSettings, tracing_config: TracingConfig) -> 
         tracing_config=tracing_config,
     )
     setup_registry(app)
+
+    app.add_middleware(RequestCancellationMiddleware)
 
     if tracing_config.tracing_enabled:
         initialize_fastapi_app_tracing(app, tracing_config=tracing_config)

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -306,25 +306,32 @@ async def _list_repositories_gen(
             app, path=path, method="GET", use_cache=not update_cache
         )  # initial call
 
-        while True:
-            if "Link" in headers:
-                next_path = str(headers["Link"]).split(";")[0].strip("<>").removeprefix("/v2/")
-                prefetch_task = asyncio.create_task(
-                    registry_request(app, path=next_path, method="GET", use_cache=not update_cache)
-                )
-            else:
-                prefetch_task = None
+        prefetch_task: asyncio.Task | None = None
+        try:
+            while True:
+                if "Link" in headers:
+                    next_path = str(headers["Link"]).split(";")[0].strip("<>").removeprefix("/v2/")
+                    prefetch_task = asyncio.create_task(
+                        registry_request(app, path=next_path, method="GET", use_cache=not update_cache)
+                    )
+                else:
+                    prefetch_task = None
 
-            yield list(
-                filter(
-                    lambda x: str(x).startswith(_SERVICE_TYPE_FILTER_MAP[service_type]),
-                    result["repositories"],
+                yield list(
+                    filter(
+                        lambda x: str(x).startswith(_SERVICE_TYPE_FILTER_MAP[service_type]),
+                        result["repositories"],
+                    )
                 )
-            )
-            if prefetch_task:
-                result, headers = await prefetch_task
-            else:
-                return
+                if prefetch_task:
+                    result, headers = await prefetch_task
+                    prefetch_task = None
+                else:
+                    return
+        finally:
+            # Handle cancellation properly
+            if prefetch_task and not prefetch_task.done():
+                await cancel_wait_task(prefetch_task)
 
 
 async def list_image_tags_gen(app: FastAPI, image_key: str, *, update_cache=False) -> AsyncGenerator[list[str]]:
@@ -333,29 +340,36 @@ async def list_image_tags_gen(app: FastAPI, image_key: str, *, update_cache=Fals
         path = f"{image_key}/tags/list?n={max_objects}"
         tags, headers = await registry_request(app, path=path, method="GET", use_cache=not update_cache)  # initial call
         assert "tags" in tags  # nosec
-        while True:
-            if "Link" in headers:
-                next_path = str(headers["Link"]).split(";")[0].strip("<>").removeprefix("/v2/")
-                prefetch_task = asyncio.create_task(
-                    registry_request(app, path=next_path, method="GET", use_cache=not update_cache)
-                )
-            else:
-                prefetch_task = None
-
-            yield (
-                list(
-                    filter(
-                        VERSION_REG.match,
-                        tags["tags"],
+        prefetch_task: asyncio.Task | None = None
+        try:
+            while True:
+                if "Link" in headers:
+                    next_path = str(headers["Link"]).split(";")[0].strip("<>").removeprefix("/v2/")
+                    prefetch_task = asyncio.create_task(
+                        registry_request(app, path=next_path, method="GET", use_cache=not update_cache)
                     )
+                else:
+                    prefetch_task = None
+
+                yield (
+                    list(
+                        filter(
+                            VERSION_REG.match,
+                            tags["tags"],
+                        )
+                    )
+                    if tags["tags"] is not None
+                    else []
                 )
-                if tags["tags"] is not None
-                else []
-            )
-            if prefetch_task:
-                tags, headers = await prefetch_task
-            else:
-                return
+                if prefetch_task:
+                    tags, headers = await prefetch_task
+                    prefetch_task = None
+                else:
+                    return
+        finally:
+            # Handle cancellation properly
+            if prefetch_task and not prefetch_task.done():
+                await cancel_wait_task(prefetch_task)
 
 
 async def list_image_tags(app: FastAPI, image_key: str) -> list[str]:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This will ensure that when a client (for example the catalog) times-out calling into the director-v0 for the list of services, that the director-v0 cancels the request (especially when this is listing 1000s of services)



<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/private-issues/issues/565

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
