### PR TITLE
🐛 fix(web-server): prevent `functions` repositories pool exhaustion

### DIFF
--- a/services/web/server/src/simcore_service_webserver/functions/_controller/_functions_rpc.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_controller/_functions_rpc.py
@@ -59,9 +59,6 @@ from servicelib.rabbitmq import RPCRouter
 from ...application_settings import get_application_settings
 from ...rabbitmq import get_rabbitmq_rpc_client
 from .. import (
-    _function_job_collections_repository,
-    _function_jobs_repository,
-    _functions_repository,
     _functions_service,
 )
 
@@ -377,7 +374,7 @@ async def delete_function(
     product_name: ProductName,
     function_id: FunctionID,
 ) -> None:
-    return await _functions_repository.delete_function(
+    return await _functions_service.delete_function(
         app=app,
         user_id=user_id,
         product_name=product_name,
@@ -400,7 +397,7 @@ async def delete_function_job(
     product_name: ProductName,
     function_job_id: FunctionJobID,
 ) -> None:
-    return await _function_jobs_repository.delete_function_job(
+    return await _functions_service.delete_function_job(
         app=app,
         user_id=user_id,
         product_name=product_name,
@@ -423,7 +420,7 @@ async def delete_function_job_collection(
     product_name: ProductName,
     function_job_collection_id: FunctionJobID,
 ) -> None:
-    return await _function_job_collections_repository.delete_function_job_collection(
+    return await _functions_service.delete_function_job_collection(
         app=app,
         user_id=user_id,
         product_name=product_name,

--- a/services/web/server/src/simcore_service_webserver/functions/_controller/_functions_rpc.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_controller/_functions_rpc.py
@@ -418,7 +418,7 @@ async def delete_function_job_collection(
     *,
     user_id: UserID,
     product_name: ProductName,
-    function_job_collection_id: FunctionJobID,
+    function_job_collection_id: FunctionJobCollectionID,
 ) -> None:
     return await _functions_service.delete_function_job_collection(
         app=app,

--- a/services/web/server/src/simcore_service_webserver/functions/_controller/_functions_rpc.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_controller/_functions_rpc.py
@@ -235,7 +235,7 @@ async def get_function_job_collection(
     *,
     user_id: UserID,
     product_name: ProductName,
-    function_job_collection_id: FunctionJobID,
+    function_job_collection_id: FunctionJobCollectionID,
 ) -> RegisteredFunctionJobCollection:
     return await _functions_service.get_function_job_collection(
         app=app,

--- a/services/web/server/src/simcore_service_webserver/functions/_function_job_collections_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_function_job_collections_repository.py
@@ -8,6 +8,7 @@ from models_library.functions import (
     RegisteredFunctionJobCollectionDB,
 )
 from models_library.functions_errors import FunctionJobCollectionIDNotFoundError
+from models_library.groups import GroupID
 from models_library.products import ProductName
 from models_library.rest_pagination import PageMetaInfoLimitOffset
 from models_library.users import UserID
@@ -33,7 +34,6 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.sql import func
 
 from ..db.plugin import get_asyncpg_engine
-from ..groups.api import list_all_user_groups_ids
 from ..users import users_service
 from ._functions_permissions_repository import (
     _internal_set_group_permissions,
@@ -50,6 +50,7 @@ async def create_function_job_collection(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     title: str,
     description: str,
@@ -60,6 +61,7 @@ async def create_function_job_collection(
             app,
             connection=transaction,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             api_access_rights=[
                 FunctionsApiAccessRights.WRITE_FUNCTION_JOB_COLLECTIONS,
@@ -70,6 +72,7 @@ async def create_function_job_collection(
                 app,
                 connection=transaction,
                 user_id=user_id,
+                user_groups=user_groups,
                 product_name=product_name,
                 object_type="function_job",
                 object_id=job_id,
@@ -134,6 +137,7 @@ async def list_function_job_collections(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     pagination_limit: int,
     pagination_offset: int,
@@ -152,6 +156,7 @@ async def list_function_job_collections(
             app,
             connection=conn,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             api_access_rights=[
                 FunctionsApiAccessRights.READ_FUNCTION_JOB_COLLECTIONS,
@@ -174,7 +179,6 @@ async def list_function_job_collections(
                 .where(function_jobs_table.c.function_uuid == function_id)
             )
             filter_condition = function_job_collections_table.c.uuid.in_(subquery)
-        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
 
         access_subquery = (
             function_job_collections_access_rights_table.select()
@@ -227,6 +231,7 @@ async def get_function_job_collection(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_job_collection_id: FunctionID,
 ) -> tuple[RegisteredFunctionJobCollectionDB, list[FunctionJobID]]:
@@ -235,6 +240,7 @@ async def get_function_job_collection(
             app,
             connection=conn,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             object_id=function_job_collection_id,
             object_type="function_job_collection",
@@ -274,6 +280,7 @@ async def delete_function_job_collection(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_job_collection_id: FunctionID,
 ) -> None:
@@ -282,6 +289,7 @@ async def delete_function_job_collection(
             app,
             connection=transaction,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             object_id=function_job_collection_id,
             object_type="function_job_collection",

--- a/services/web/server/src/simcore_service_webserver/functions/_function_job_collections_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_function_job_collections_repository.py
@@ -144,7 +144,8 @@ async def list_function_job_collections(
 ]:
     """
     Returns a list of function job collections and their associated job ids.
-    Filters the collections to include only those that have function jobs with the specified function id if filters.has_function_id is provided.
+    Filters the collections to include only those that have function jobs with the specified function id
+    if filters.has_function_id is provided.
     """
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
         await check_user_api_access_rights(
@@ -173,7 +174,7 @@ async def list_function_job_collections(
                 .where(function_jobs_table.c.function_uuid == function_id)
             )
             filter_condition = function_job_collections_table.c.uuid.in_(subquery)
-        user_groups = await list_all_user_groups_ids(app, user_id=user_id)
+        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
 
         access_subquery = (
             function_job_collections_access_rights_table.select()

--- a/services/web/server/src/simcore_service_webserver/functions/_function_job_collections_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_function_job_collections_repository.py
@@ -2,6 +2,7 @@ import sqlalchemy
 from aiohttp import web
 from models_library.functions import (
     FunctionID,
+    FunctionJobCollectionID,
     FunctionJobCollectionsListFilters,
     FunctionJobID,
     FunctionsApiAccessRights,
@@ -34,7 +35,6 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.sql import func
 
 from ..db.plugin import get_asyncpg_engine
-from ..users import users_service
 from ._functions_permissions_repository import (
     _internal_set_group_permissions,
     check_user_api_access_rights,
@@ -51,6 +51,7 @@ async def create_function_job_collection(
     *,
     user_id: UserID,
     user_groups: list[GroupID],
+    user_primary_group_id: GroupID,
     product_name: ProductName,
     title: str,
     description: str,
@@ -116,7 +117,6 @@ async def create_function_job_collection(
             )  # nosec
             job_collection_entries.append(entry)
 
-        user_primary_group_id = await users_service.get_user_primary_group_id(app, user_id=user_id)
         await _internal_set_group_permissions(
             app,
             connection=transaction,
@@ -233,7 +233,7 @@ async def get_function_job_collection(
     user_id: UserID,
     user_groups: list[GroupID],
     product_name: ProductName,
-    function_job_collection_id: FunctionID,
+    function_job_collection_id: FunctionJobCollectionID,
 ) -> tuple[RegisteredFunctionJobCollectionDB, list[FunctionJobID]]:
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
         await check_user_permissions(
@@ -282,7 +282,7 @@ async def delete_function_job_collection(
     user_id: UserID,
     user_groups: list[GroupID],
     product_name: ProductName,
-    function_job_collection_id: FunctionID,
+    function_job_collection_id: FunctionJobCollectionID,
 ) -> None:
     async with transaction_context(get_asyncpg_engine(app), connection) as transaction:
         await check_user_permissions(

--- a/services/web/server/src/simcore_service_webserver/functions/_function_jobs_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_function_jobs_repository.py
@@ -28,6 +28,7 @@ from models_library.functions_errors import (
     FunctionJobPatchModelIncompatibleError,
     UnsupportedFunctionJobClassError,
 )
+from models_library.groups import GroupID
 from models_library.products import ProductName
 from models_library.rest_pagination import PageMetaInfoLimitOffset
 from models_library.users import UserID
@@ -42,7 +43,6 @@ from sqlalchemy import Text, cast, func
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from ..db.plugin import get_asyncpg_engine
-from ..groups.api import list_all_user_groups_ids
 from ..users import users_service
 from ._functions_permissions_repository import (
     _internal_set_group_permissions,
@@ -59,6 +59,7 @@ async def create_function_jobs(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_jobs: list[FunctionJobDB],
 ) -> BatchCreateRegisteredFunctionJobsDB:
@@ -69,6 +70,7 @@ async def create_function_jobs(
             app,
             connection=transaction,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             api_access_rights=[
                 FunctionsApiAccessRights.WRITE_FUNCTION_JOBS,
@@ -122,6 +124,7 @@ async def patch_function_jobs(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_job_patch_requests: list[FunctionJobPatchRequest],
 ) -> BatchUpdateRegisteredFunctionJobsDB:
@@ -130,6 +133,7 @@ async def patch_function_jobs(
             app,
             connection=transaction,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             api_access_rights=[
                 FunctionsApiAccessRights.WRITE_FUNCTION_JOBS,
@@ -141,6 +145,7 @@ async def patch_function_jobs(
                 app,
                 connection=transaction,
                 user_id=user_id,
+                user_groups=user_groups,
                 product_name=product_name,
                 function_job_id=patch_request.uid,
             )
@@ -174,6 +179,7 @@ async def list_function_jobs_with_status(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     pagination_limit: int,
     pagination_offset: int,
@@ -186,10 +192,10 @@ async def list_function_jobs_with_status(
             app,
             connection=conn,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             api_access_rights=[FunctionsApiAccessRights.READ_FUNCTION_JOBS],
         )
-        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
 
         access_subquery = (
             function_jobs_access_rights_table.select()
@@ -258,6 +264,7 @@ async def delete_function_job(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_job_id: FunctionID,
 ) -> None:
@@ -266,6 +273,7 @@ async def delete_function_job(
             app,
             connection=transaction,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             object_id=function_job_id,
             object_type="function_job",
@@ -288,16 +296,13 @@ async def find_cached_function_jobs(
     app: web.Application,
     connection: AsyncConnection | None = None,
     *,
-    user_id: UserID,
+    user_groups: list[GroupID],
     function_id: FunctionID,
     product_name: ProductName,
     inputs: FunctionInputsList,
     cached_job_statuses: list[FunctionJobStatus] | None = None,
 ) -> list[RegisteredFunctionJobDB | None]:
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
-        # Get user groups for access check
-        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
-
         # Create access subquery
         access_subquery = (
             function_jobs_access_rights_table.select()
@@ -351,6 +356,7 @@ async def get_function_job_status(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_job_id: FunctionJobID,
 ) -> FunctionJobStatus:
@@ -359,6 +365,7 @@ async def get_function_job_status(
             app,
             connection=conn,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             object_type="function_job",
             object_id=function_job_id,
@@ -379,6 +386,7 @@ async def get_function_job_outputs(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_job_id: FunctionJobID,
 ) -> FunctionOutputs:
@@ -387,6 +395,7 @@ async def get_function_job_outputs(
             app,
             connection=conn,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             object_type="function_job",
             object_id=function_job_id,
@@ -407,6 +416,7 @@ async def get_function_job(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_job_id: FunctionID,
 ) -> RegisteredFunctionJobDB:
@@ -415,6 +425,7 @@ async def get_function_job(
             app,
             connection=conn,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             object_id=function_job_id,
             object_type="function_job",

--- a/services/web/server/src/simcore_service_webserver/functions/_function_jobs_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_function_jobs_repository.py
@@ -43,7 +43,6 @@ from sqlalchemy import Text, cast, func
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from ..db.plugin import get_asyncpg_engine
-from ..users import users_service
 from ._functions_permissions_repository import (
     _internal_set_group_permissions,
     check_user_api_access_rights,
@@ -60,6 +59,7 @@ async def create_function_jobs(
     *,
     user_id: UserID,
     user_groups: list[GroupID],
+    user_primary_group_id: GroupID,
     product_name: ProductName,
     function_jobs: list[FunctionJobDB],
 ) -> BatchCreateRegisteredFunctionJobsDB:
@@ -100,8 +100,7 @@ async def create_function_jobs(
         # Get all created jobs
         created_jobs = TypeAdapter(list[RegisteredFunctionJobDB]).validate_python(list(result))
 
-        # Get user primary group and set permissions for all jobs
-        user_primary_group_id = await users_service.get_user_primary_group_id(app, user_id=user_id)
+        # Set permissions for all jobs
         job_uuids = [job.uuid for job in created_jobs]
 
         await _internal_set_group_permissions(

--- a/services/web/server/src/simcore_service_webserver/functions/_function_jobs_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_function_jobs_repository.py
@@ -189,7 +189,7 @@ async def list_function_jobs_with_status(
             product_name=product_name,
             api_access_rights=[FunctionsApiAccessRights.READ_FUNCTION_JOBS],
         )
-        user_groups = await list_all_user_groups_ids(app, user_id=user_id)
+        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
 
         access_subquery = (
             function_jobs_access_rights_table.select()
@@ -296,7 +296,7 @@ async def find_cached_function_jobs(
 ) -> list[RegisteredFunctionJobDB | None]:
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
         # Get user groups for access check
-        user_groups = await list_all_user_groups_ids(app, user_id=user_id)
+        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
 
         # Create access subquery
         access_subquery = (

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
@@ -306,7 +306,7 @@ async def _internal_set_group_permissions(
         return access_rights_list
 
 
-async def set_group_permissions(  # noqa: PLR0913
+async def set_group_permissions(  # pylint: disable=too-many-arguments # noqa: PLR0913
     app: web.Application,
     connection: AsyncConnection | None = None,
     *,

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
@@ -54,7 +54,6 @@ from simcore_postgres_database.utils_repos import (
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from ..db.plugin import get_asyncpg_engine
-from ..groups.api import list_all_user_groups_ids
 from ._functions_exceptions import _ERRORS_MAP
 from ._functions_table_cols import (
     _FUNCTION_JOB_COLLECTIONS_ACCESS_RIGHTS_TABLE_COLS,
@@ -122,6 +121,7 @@ async def check_user_permissions(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     object_id: UUID,
     object_type: Literal["function", "function_job", "function_job_collection"],
@@ -134,6 +134,7 @@ async def check_user_permissions(
         app,
         connection=connection,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         api_access_rights=api_access_rights,
     )
@@ -141,7 +142,7 @@ async def check_user_permissions(
     user_permissions = await get_user_permissions(
         app,
         connection=connection,
-        user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         object_id=object_id,
         object_type=object_type,
@@ -190,6 +191,7 @@ async def get_group_permissions(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     object_type: Literal["function", "function_job", "function_job_collection"],
     object_ids: list[UUID],
@@ -200,6 +202,7 @@ async def get_group_permissions(
                 app,
                 connection=conn,
                 user_id=user_id,
+                user_groups=user_groups,
                 product_name=product_name,
                 object_id=object_id,
                 object_type=object_type,
@@ -303,11 +306,12 @@ async def _internal_set_group_permissions(
         return access_rights_list
 
 
-async def set_group_permissions(
+async def set_group_permissions(  # noqa: PLR0913
     app: web.Application,
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     permission_group_id: GroupID,
     product_name: ProductName,
     object_type: Literal["function", "function_job", "function_job_collection"],
@@ -322,6 +326,7 @@ async def set_group_permissions(
                 app,
                 connection=conn,
                 user_id=user_id,
+                user_groups=user_groups,
                 product_name=product_name,
                 object_id=object_id,
                 object_type=object_type,
@@ -382,6 +387,7 @@ async def remove_group_permissions(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     permission_group_id: GroupID,
     product_name: ProductName,
     object_type: Literal["function", "function_job", "function_job_collection"],
@@ -393,6 +399,7 @@ async def remove_group_permissions(
                 app,
                 connection=conn,
                 user_id=user_id,
+                user_groups=user_groups,
                 product_name=product_name,
                 object_id=object_id,
                 object_type=object_type,
@@ -414,11 +421,10 @@ async def get_user_api_access_rights(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
 ) -> FunctionUserApiAccessRights:
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
-        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
-
         # Initialize combined permissions with False values
         combined_permissions = FunctionUserApiAccessRights(
             user_id=user_id,
@@ -490,7 +496,7 @@ async def get_user_permissions(
     app: web.Application,
     connection: AsyncConnection | None = None,
     *,
-    user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     object_id: UUID,
     object_type: Literal["function", "function_job", "function_job_collection"],
@@ -515,8 +521,6 @@ async def get_user_permissions(
             access_rights_table = function_job_collections_access_rights_table
             cols = _FUNCTION_JOB_COLLECTIONS_ACCESS_RIGHTS_TABLE_COLS
         assert access_rights_table is not None  # nosec
-
-        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
 
         # Initialize combined permissions with False values
         combined_permissions = FunctionAccessRightsDB(read=False, write=False, execute=False)
@@ -543,11 +547,12 @@ async def check_user_api_access_rights(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     api_access_rights: list[FunctionsApiAccessRights],
 ) -> bool:
     user_api_access_rights = await get_user_api_access_rights(
-        app, connection=connection, user_id=user_id, product_name=product_name
+        app, connection=connection, user_id=user_id, user_groups=user_groups, product_name=product_name
     )
 
     for api_access_right in api_access_rights:

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
@@ -417,7 +417,7 @@ async def get_user_api_access_rights(
     product_name: ProductName,
 ) -> FunctionUserApiAccessRights:
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
-        user_groups = await list_all_user_groups_ids(app, user_id=user_id)
+        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
 
         # Initialize combined permissions with False values
         combined_permissions = FunctionUserApiAccessRights(
@@ -516,7 +516,7 @@ async def get_user_permissions(
             cols = _FUNCTION_JOB_COLLECTIONS_ACCESS_RIGHTS_TABLE_COLS
         assert access_rights_table is not None  # nosec
 
-        user_groups = await list_all_user_groups_ids(app, user_id=user_id)
+        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
 
         # Initialize combined permissions with False values
         combined_permissions = FunctionAccessRightsDB(read=False, write=False, execute=False)

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
@@ -18,6 +18,7 @@ from models_library.functions_errors import (
     FunctionHasJobsCannotDeleteError,
     FunctionIDNotFoundError,
 )
+from models_library.groups import GroupID
 from models_library.products import ProductName
 from models_library.rest_ordering import OrderBy, OrderDirection
 from models_library.rest_pagination import PageMetaInfoLimitOffset
@@ -38,7 +39,6 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.sql import ColumnElement, func
 
 from ..db.plugin import get_asyncpg_engine
-from ..groups.api import list_all_user_groups_ids
 from ..users import users_service
 from ._functions_permissions_repository import (
     _internal_set_group_permissions,
@@ -57,6 +57,7 @@ async def create_function(  # noqa: PLR0913
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_class: FunctionClass,
     class_specific_data: dict,
@@ -71,6 +72,7 @@ async def create_function(  # noqa: PLR0913
             app,
             connection=transaction,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             api_access_rights=[FunctionsApiAccessRights.WRITE_FUNCTIONS],
         )
@@ -113,6 +115,7 @@ async def get_function(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_id: FunctionID,
 ) -> RegisteredFunctionDB:
@@ -121,6 +124,7 @@ async def get_function(
             app,
             connection=conn,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             object_id=function_id,
             object_type="function",
@@ -159,11 +163,12 @@ def _create_list_functions_attributes_filters(
     return attributes_filters
 
 
-async def list_functions(
+async def list_functions(  # noqa: PLR0913
     app: web.Application,
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     pagination_limit: int,
     pagination_offset: int,
@@ -177,10 +182,10 @@ async def list_functions(
             app,
             connection=conn,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             api_access_rights=[FunctionsApiAccessRights.READ_FUNCTIONS],
         )
-        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
         attributes_filters = _create_list_functions_attributes_filters(
             filter_by_function_class=filter_by_function_class,
             search_by_multi_columns=search_by_multi_columns,
@@ -240,6 +245,7 @@ async def delete_function(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_id: FunctionID,
     force: bool = False,
@@ -249,6 +255,7 @@ async def delete_function(
             app,
             connection=transaction,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             object_id=function_id,
             object_type="function",
@@ -283,6 +290,7 @@ async def update_function(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    user_groups: list[GroupID],
     product_name: ProductName,
     function_id: FunctionID,
     function: FunctionUpdate,
@@ -292,6 +300,7 @@ async def update_function(
             app,
             transaction,
             user_id=user_id,
+            user_groups=user_groups,
             product_name=product_name,
             object_id=function_id,
             object_type="function",

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
@@ -39,7 +39,6 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.sql import ColumnElement, func
 
 from ..db.plugin import get_asyncpg_engine
-from ..users import users_service
 from ._functions_permissions_repository import (
     _internal_set_group_permissions,
     check_user_api_access_rights,
@@ -58,6 +57,7 @@ async def create_function(  # noqa: PLR0913
     *,
     user_id: UserID,
     user_groups: list[GroupID],
+    user_primary_group_id: GroupID,
     product_name: ProductName,
     function_class: FunctionClass,
     class_specific_data: dict,
@@ -94,7 +94,6 @@ async def create_function(  # noqa: PLR0913
 
         registered_function = RegisteredFunctionDB.model_validate(row)
 
-        user_primary_group_id = await users_service.get_user_primary_group_id(app, user_id=user_id)
         await _internal_set_group_permissions(
             app,
             connection=transaction,

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
@@ -180,7 +180,7 @@ async def list_functions(
             product_name=product_name,
             api_access_rights=[FunctionsApiAccessRights.READ_FUNCTIONS],
         )
-        user_groups = await list_all_user_groups_ids(app, user_id=user_id)
+        user_groups = await list_all_user_groups_ids(app, conn, user_id=user_id)
         attributes_filters = _create_list_functions_attributes_filters(
             filter_by_function_class=filter_by_function_class,
             search_by_multi_columns=search_by_multi_columns,

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_service.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_service.py
@@ -53,6 +53,7 @@ from pydantic import TypeAdapter
 from servicelib.rabbitmq import RPCRouter
 
 from ..groups.api import list_all_user_groups_ids
+from ..users import users_service
 from . import (
     _function_job_collections_repository,
     _function_jobs_repository,
@@ -72,6 +73,7 @@ async def register_function(
     function: Function,
 ) -> RegisteredFunction:
     user_groups = await list_all_user_groups_ids(app, user_id=user_id)
+    user_primary_group_id = await users_service.get_user_primary_group_id(app, user_id=user_id)
     encoded_function = _encode_function(function)
     saved_function = await _functions_repository.create_function(
         app=app,
@@ -84,6 +86,7 @@ async def register_function(
         class_specific_data=encoded_function.class_specific_data,
         user_id=user_id,
         user_groups=user_groups,
+        user_primary_group_id=user_primary_group_id,
         product_name=product_name,
     )
     return _decode_function(saved_function)
@@ -97,11 +100,13 @@ async def register_function_job(
     function_job: FunctionJob,
 ) -> RegisteredFunctionJob:
     user_groups = await list_all_user_groups_ids(app, user_id=user_id)
+    user_primary_group_id = await users_service.get_user_primary_group_id(app, user_id=user_id)
     encoded_function_jobs = _encode_functionjob(function_job)
     created_function_jobs_db = await _function_jobs_repository.create_function_jobs(
         app=app,
         user_id=user_id,
         user_groups=user_groups,
+        user_primary_group_id=user_primary_group_id,
         product_name=product_name,
         function_jobs=[encoded_function_jobs],
     )
@@ -118,12 +123,14 @@ async def batch_register_function_jobs(
     function_jobs: FunctionJobList,
 ) -> BatchCreateRegisteredFunctionJobs:
     user_groups = await list_all_user_groups_ids(app, user_id=user_id)
+    user_primary_group_id = await users_service.get_user_primary_group_id(app, user_id=user_id)
     function_jobs = TypeAdapter(FunctionJobList).validate_python(function_jobs)
     encoded_function_jobs = [_encode_functionjob(job) for job in function_jobs]
     created_function_jobs_db = await _function_jobs_repository.create_function_jobs(
         app=app,
         user_id=user_id,
         user_groups=user_groups,
+        user_primary_group_id=user_primary_group_id,
         product_name=product_name,
         function_jobs=encoded_function_jobs,
     )
@@ -179,6 +186,7 @@ async def register_function_job_collection(
     function_job_collection: FunctionJobCollection,
 ) -> RegisteredFunctionJobCollection:
     user_groups = await list_all_user_groups_ids(app, user_id=user_id)
+    user_primary_group_id = await users_service.get_user_primary_group_id(app, user_id=user_id)
     (
         registered_function_job_collection,
         registered_job_ids,
@@ -186,6 +194,7 @@ async def register_function_job_collection(
         app=app,
         user_id=user_id,
         user_groups=user_groups,
+        user_primary_group_id=user_primary_group_id,
         product_name=product_name,
         title=function_job_collection.title,
         description=function_job_collection.description,
@@ -431,7 +440,7 @@ async def delete_function_job_collection(
     *,
     user_id: UserID,
     product_name: ProductName,
-    function_job_collection_id: FunctionJobID,
+    function_job_collection_id: FunctionJobCollectionID,
 ) -> None:
     user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     await _function_job_collections_repository.delete_function_job_collection(

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_service.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_service.py
@@ -245,7 +245,7 @@ async def get_function_job_collection(
     *,
     user_id: UserID,
     product_name: ProductName,
-    function_job_collection_id: FunctionJobID,
+    function_job_collection_id: FunctionJobCollectionID,
 ) -> RegisteredFunctionJobCollection:
     user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     (

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_service.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_service.py
@@ -561,7 +561,6 @@ async def get_function_user_permissions(
     user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     user_permissions = await _functions_permissions_repository.get_user_permissions(
         app=app,
-        user_id=user_id,
         user_groups=user_groups,
         product_name=product_name,
         object_id=function_id,

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_service.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_service.py
@@ -52,6 +52,7 @@ from models_library.users import UserID
 from pydantic import TypeAdapter
 from servicelib.rabbitmq import RPCRouter
 
+from ..groups.api import list_all_user_groups_ids
 from . import (
     _function_job_collections_repository,
     _function_jobs_repository,
@@ -70,6 +71,7 @@ async def register_function(
     product_name: ProductName,
     function: Function,
 ) -> RegisteredFunction:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     encoded_function = _encode_function(function)
     saved_function = await _functions_repository.create_function(
         app=app,
@@ -81,6 +83,7 @@ async def register_function(
         default_inputs=encoded_function.default_inputs,
         class_specific_data=encoded_function.class_specific_data,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
     )
     return _decode_function(saved_function)
@@ -93,10 +96,12 @@ async def register_function_job(
     product_name: ProductName,
     function_job: FunctionJob,
 ) -> RegisteredFunctionJob:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     encoded_function_jobs = _encode_functionjob(function_job)
     created_function_jobs_db = await _function_jobs_repository.create_function_jobs(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_jobs=[encoded_function_jobs],
     )
@@ -112,11 +117,13 @@ async def batch_register_function_jobs(
     product_name: ProductName,
     function_jobs: FunctionJobList,
 ) -> BatchCreateRegisteredFunctionJobs:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     function_jobs = TypeAdapter(FunctionJobList).validate_python(function_jobs)
     encoded_function_jobs = [_encode_functionjob(job) for job in function_jobs]
     created_function_jobs_db = await _function_jobs_repository.create_function_jobs(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_jobs=encoded_function_jobs,
     )
@@ -132,9 +139,11 @@ async def patch_registered_function_job(
     product_name: ProductName,
     function_job_patch_request: FunctionJobPatchRequest,
 ) -> RegisteredFunctionJob:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     result = await _function_jobs_repository.patch_function_jobs(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_job_patch_requests=[function_job_patch_request],
     )
@@ -149,11 +158,13 @@ async def batch_patch_registered_function_jobs(
     product_name: ProductName,
     function_job_patch_requests: FunctionJobPatchRequestList,
 ) -> BatchUpdateRegisteredFunctionJobs:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     TypeAdapter(FunctionJobPatchRequestList).validate_python(function_job_patch_requests)
 
     result = await _function_jobs_repository.patch_function_jobs(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_job_patch_requests=function_job_patch_requests,
     )
@@ -167,12 +178,14 @@ async def register_function_job_collection(
     product_name: ProductName,
     function_job_collection: FunctionJobCollection,
 ) -> RegisteredFunctionJobCollection:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     (
         registered_function_job_collection,
         registered_job_ids,
     ) = await _function_job_collections_repository.create_function_job_collection(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         title=function_job_collection.title,
         description=function_job_collection.description,
@@ -194,9 +207,11 @@ async def get_function(
     product_name: ProductName,
     function_id: FunctionID,
 ) -> RegisteredFunction:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     returned_function = await _functions_repository.get_function(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_id=function_id,
     )
@@ -212,9 +227,11 @@ async def get_function_job(
     product_name: ProductName,
     function_job_id: FunctionJobID,
 ) -> RegisteredFunctionJob:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     returned_function_job = await _function_jobs_repository.get_function_job(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_job_id=function_job_id,
     )
@@ -230,12 +247,14 @@ async def get_function_job_collection(
     product_name: ProductName,
     function_job_collection_id: FunctionJobID,
 ) -> RegisteredFunctionJobCollection:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     (
         returned_function_job_collection,
         returned_job_ids,
     ) = await _function_job_collections_repository.get_function_job_collection(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_job_collection_id=function_job_collection_id,
     )
@@ -260,9 +279,11 @@ async def list_functions(
     search_by_function_title: str | None = None,
     search_by_multi_columns: str | None = None,
 ) -> tuple[list[RegisteredFunction], PageMetaInfoLimitOffset]:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     returned_functions, page = await _functions_repository.list_functions(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         pagination_limit=pagination_limit,
         pagination_offset=pagination_offset,
@@ -292,9 +313,11 @@ async def list_function_jobs(
     filter_by_function_job_ids: list[FunctionJobID] | None = None,
     filter_by_function_job_collection_id: FunctionJobCollectionID | None = None,
 ) -> tuple[list[RegisteredFunctionJob], PageMetaInfoLimitOffset]:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     returned_function_jobs, page = await _function_jobs_repository.list_function_jobs_with_status(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         pagination_limit=pagination_limit,
         pagination_offset=pagination_offset,
@@ -319,9 +342,11 @@ async def list_function_jobs_with_status(
     list[RegisteredFunctionJobWithStatus],
     PageMetaInfoLimitOffset,
 ]:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     returned_function_jobs_wso, page = await _function_jobs_repository.list_function_jobs_with_status(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         pagination_limit=pagination_limit,
         pagination_offset=pagination_offset,
@@ -343,9 +368,11 @@ async def list_function_job_collections(
     pagination_offset: int,
     filters: FunctionJobCollectionsListFilters | None = None,
 ) -> tuple[list[RegisteredFunctionJobCollection], PageMetaInfoLimitOffset]:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     returned_function_job_collections, page = await _function_job_collections_repository.list_function_job_collections(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         pagination_limit=pagination_limit,
         pagination_offset=pagination_offset,
@@ -371,9 +398,11 @@ async def delete_function(
     function_id: FunctionID,
     force: bool = False,
 ) -> None:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     await _functions_repository.delete_function(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_id=function_id,
         force=force,
@@ -387,9 +416,11 @@ async def delete_function_job(
     product_name: ProductName,
     function_job_id: FunctionJobID,
 ) -> None:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     await _function_jobs_repository.delete_function_job(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_job_id=function_job_id,
     )
@@ -402,9 +433,11 @@ async def delete_function_job_collection(
     product_name: ProductName,
     function_job_collection_id: FunctionJobID,
 ) -> None:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     await _function_job_collections_repository.delete_function_job_collection(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_job_collection_id=function_job_collection_id,
     )
@@ -418,9 +451,11 @@ async def update_function(
     function_id: FunctionID,
     function: FunctionUpdate,
 ) -> RegisteredFunction:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     updated_function = await _functions_repository.update_function(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_id=function_id,
         function=function,
@@ -437,9 +472,10 @@ async def find_cached_function_jobs(
     inputs: FunctionInputsList,
     cached_job_statuses: list[FunctionJobStatus] | None = None,
 ) -> list[RegisteredFunctionJob | None]:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     returned_function_jobs = await _function_jobs_repository.find_cached_function_jobs(
         app=app,
-        user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_id=function_id,
         inputs=inputs,
@@ -491,6 +527,7 @@ async def get_function_input_schema(
     returned_function = await _functions_repository.get_function(
         app=app,
         user_id=user_id,
+        user_groups=await list_all_user_groups_ids(app, user_id=user_id),
         product_name=product_name,
         function_id=function_id,
     )
@@ -507,6 +544,7 @@ async def get_function_output_schema(
     returned_function = await _functions_repository.get_function(
         app=app,
         user_id=user_id,
+        user_groups=await list_all_user_groups_ids(app, user_id=user_id),
         product_name=product_name,
         function_id=function_id,
     )
@@ -520,9 +558,11 @@ async def get_function_user_permissions(
     product_name: ProductName,
     function_id: FunctionID,
 ) -> FunctionUserAccessRights:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     user_permissions = await _functions_permissions_repository.get_user_permissions(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         object_id=function_id,
         object_type="function",
@@ -551,9 +591,11 @@ async def list_function_group_permissions(
     product_name: ProductName,
     function_id: FunctionID,
 ) -> list[FunctionGroupAccessRights]:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     access_rights_list = await _functions_permissions_repository.get_group_permissions(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         object_ids=[function_id],
         object_type="function",
@@ -577,9 +619,11 @@ async def set_function_group_permissions(
     function_id: FunctionID,
     permissions: FunctionGroupAccessRights,
 ) -> FunctionGroupAccessRights:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     access_rights_list = await _functions_permissions_repository.set_group_permissions(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         object_ids=[function_id],
         object_type="function",
@@ -606,9 +650,11 @@ async def remove_function_group_permissions(
     function_id: FunctionID,
     permission_group_id: GroupID,
 ) -> None:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     await _functions_permissions_repository.remove_group_permissions(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         object_ids=[function_id],
         object_type="function",
@@ -628,9 +674,11 @@ async def set_group_permissions(
     write: bool | None = None,
     execute: bool | None = None,
 ) -> list[tuple[FunctionID | FunctionJobID | FunctionJobCollectionID, FunctionGroupAccessRights]]:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     return await _functions_permissions_repository.set_group_permissions(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         object_type=object_type,
         object_ids=object_ids,
@@ -648,9 +696,11 @@ async def get_function_job_status(
     product_name: ProductName,
     function_job_id: FunctionJobID,
 ) -> FunctionJobStatus:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     return await _function_jobs_repository.get_function_job_status(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_job_id=function_job_id,
     )
@@ -663,9 +713,11 @@ async def get_function_job_outputs(
     product_name: ProductName,
     function_job_id: FunctionJobID,
 ) -> FunctionOutputs:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     return await _function_jobs_repository.get_function_job_outputs(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         function_job_id=function_job_id,
     )
@@ -680,12 +732,14 @@ async def update_function_job_outputs(
     outputs: FunctionOutputs,
     check_write_permissions: bool = True,
 ) -> FunctionOutputs:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     checked_permissions: list[Literal["read", "write", "execute"]] = ["read"]
     if check_write_permissions:
         checked_permissions.append("write")
     await _functions_permissions_repository.check_user_permissions(
         app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         object_type="function_job",
         object_id=function_job_id,
@@ -708,6 +762,7 @@ async def update_function_job_status(
     job_status: FunctionJobStatus,
     check_write_permissions: bool = True,
 ) -> FunctionJobStatus:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     checked_permissions: list[Literal["read", "write", "execute"]] = ["read"]
 
     if check_write_permissions:
@@ -715,6 +770,7 @@ async def update_function_job_status(
     await _functions_permissions_repository.check_user_permissions(
         app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
         object_type="function_job",
         object_id=function_job_id,
@@ -733,9 +789,11 @@ async def get_functions_user_api_access_rights(
     user_id: UserID,
     product_name: ProductName,
 ) -> FunctionUserApiAccessRights:
+    user_groups = await list_all_user_groups_ids(app, user_id=user_id)
     return await _functions_permissions_repository.get_user_api_access_rights(
         app=app,
         user_id=user_id,
+        user_groups=user_groups,
         product_name=product_name,
     )
 

--- a/services/web/server/src/simcore_service_webserver/groups/_groups_service.py
+++ b/services/web/server/src/simcore_service_webserver/groups/_groups_service.py
@@ -14,6 +14,7 @@ from models_library.groups import (
 from models_library.products import ProductName
 from models_library.users import UserID, UserNameID
 from pydantic import EmailStr
+from sqlalchemy.ext.asyncio import AsyncConnection
 
 from ..products.models import Product
 from ..users import _users_service
@@ -52,8 +53,10 @@ async def list_user_groups_ids_with_read_access(app: web.Application, *, user_id
     return await _groups_repository.get_ids_of_all_user_groups_with_read_access(app, user_id=user_id)
 
 
-async def list_all_user_groups_ids(app: web.Application, *, user_id: UserID) -> list[GroupID]:
-    return await _groups_repository.get_ids_of_all_user_groups(app, user_id=user_id)
+async def list_all_user_groups_ids(
+    app: web.Application, connection: AsyncConnection | None = None, *, user_id: UserID
+) -> list[GroupID]:
+    return await _groups_repository.get_ids_of_all_user_groups(app, connection=connection, user_id=user_id)
 
 
 async def get_product_group_for_user(

--- a/services/web/server/src/simcore_service_webserver/groups/_groups_service.py
+++ b/services/web/server/src/simcore_service_webserver/groups/_groups_service.py
@@ -14,7 +14,6 @@ from models_library.groups import (
 from models_library.products import ProductName
 from models_library.users import UserID, UserNameID
 from pydantic import EmailStr
-from sqlalchemy.ext.asyncio import AsyncConnection
 
 from ..products.models import Product
 from ..users import _users_service
@@ -53,10 +52,8 @@ async def list_user_groups_ids_with_read_access(app: web.Application, *, user_id
     return await _groups_repository.get_ids_of_all_user_groups_with_read_access(app, user_id=user_id)
 
 
-async def list_all_user_groups_ids(
-    app: web.Application, connection: AsyncConnection | None = None, *, user_id: UserID
-) -> list[GroupID]:
-    return await _groups_repository.get_ids_of_all_user_groups(app, connection=connection, user_id=user_id)
+async def list_all_user_groups_ids(app: web.Application, *, user_id: UserID) -> list[GroupID]:
+    return await _groups_repository.get_ids_of_all_user_groups(app, user_id=user_id)
 
 
 async def get_product_group_for_user(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request refactors the handling of user group information and permissions in the functions service, making permission checks more explicit and improving type safety. The main changes involve passing user group data directly to repository functions, updating function signatures, and consistently using the correct ID types for function job collections.

> [!NOTE]
> Spotted looking at e2e in `master`. 

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
No changes.