### PR TITLE
🐛E2E: Improvements on Classic TI tests

### DIFF
--- a/tests/e2e-playwright/.gitignore
+++ b/tests/e2e-playwright/.gitignore
@@ -3,3 +3,4 @@ assets
 report.html
 report.xml
 test-results
+debug-logs.txt

--- a/tests/e2e-playwright/requirements/_test.txt
+++ b/tests/e2e-playwright/requirements/_test.txt
@@ -2,19 +2,19 @@ annotated-types==0.7.0
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   pydantic
-anyio==4.12.1
+anyio==4.13.0
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   httpx
 arrow==1.4.0
     # via -r requirements/_test_wo_playwright.txt
-certifi==2026.2.25
+certifi==2026.5.20
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
 dnspython==2.8.0
     # via
@@ -22,9 +22,9 @@ dnspython==2.8.0
     #   email-validator
 email-validator==2.3.0
     # via -r requirements/_test_wo_playwright.txt
-faker==40.11.0
+faker==40.19.1
     # via -r requirements/_test_wo_playwright.txt
-greenlet==3.3.2
+greenlet==3.5.1
     # via playwright
 h11==0.16.0
     # via
@@ -36,7 +36,7 @@ httpcore==1.0.9
     #   httpx
 httpx==0.28.1
     # via -r requirements/_test_wo_playwright.txt
-idna==3.11
+idna==3.16
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   anyio
@@ -55,29 +55,29 @@ markupsafe==3.0.3
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   jinja2
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   pytest
-playwright==1.58.0
+playwright==1.60.0
     # via pytest-playwright
 pluggy==1.6.0
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   pytest
-pydantic==2.12.5
+pydantic==2.13.4
     # via -r requirements/_test_wo_playwright.txt
-pydantic-core==2.41.5
+pydantic-core==2.46.4
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   pydantic
 pyee==13.0.1
     # via playwright
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   pytest
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   pytest-base-url
@@ -96,7 +96,7 @@ pytest-metadata==3.1.1
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   pytest-html
-pytest-playwright==0.7.2
+pytest-playwright==0.8.0
     # via -r requirements/_test.in
 pytest-runner==6.0.1
     # via -r requirements/_test_wo_playwright.txt
@@ -110,7 +110,7 @@ python-slugify==8.0.4
     # via pytest-playwright
 pyyaml==6.0.3
     # via -r requirements/_test_wo_playwright.txt
-requests==2.32.5
+requests==2.34.2
     # via pytest-base-url
 six==1.17.0
     # via
@@ -135,7 +135,7 @@ typing-inspection==0.4.2
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   pydantic
-tzdata==2025.3
+tzdata==2026.2
     # via
     #   -r requirements/_test_wo_playwright.txt
     #   arrow

--- a/tests/e2e-playwright/requirements/_test_wo_playwright.txt
+++ b/tests/e2e-playwright/requirements/_test_wo_playwright.txt
@@ -1,10 +1,10 @@
 annotated-types==0.7.0
     # via pydantic
-anyio==4.12.1
+anyio==4.13.0
     # via httpx
 arrow==1.4.0
     # via -r requirements/_test_wo_playwright.in
-certifi==2026.2.25
+certifi==2026.5.20
     # via
     #   httpcore
     #   httpx
@@ -12,7 +12,7 @@ dnspython==2.8.0
     # via email-validator
 email-validator==2.3.0
     # via pydantic
-faker==40.11.0
+faker==40.19.1
     # via -r requirements/_test_wo_playwright.in
 h11==0.16.0
     # via httpcore
@@ -20,7 +20,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via -r requirements/_test_wo_playwright.in
-idna==3.11
+idna==3.16
     # via
     #   anyio
     #   email-validator
@@ -31,17 +31,17 @@ jinja2==3.1.6
     # via pytest-html
 markupsafe==3.0.3
     # via jinja2
-packaging==26.0
+packaging==26.2
     # via pytest
 pluggy==1.6.0
     # via pytest
-pydantic==2.12.5
+pydantic==2.13.4
     # via -r requirements/_test_wo_playwright.in
-pydantic-core==2.41.5
+pydantic-core==2.46.4
     # via pydantic
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   pytest-html
     #   pytest-instafail
@@ -74,5 +74,5 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-tzdata==2025.3
+tzdata==2026.2
     # via arrow

--- a/tests/e2e-playwright/requirements/_tools.txt
+++ b/tests/e2e-playwright/requirements/_tools.txt
@@ -1,32 +1,34 @@
+ast-serialize==0.5.0
+    # via mypy
 astroid==4.0.4
     # via pylint
-black==26.3.1
+black==26.5.1
     # via -r requirements/../../../requirements/devenv.txt
 bump2version==1.0.1
     # via -r requirements/../../../requirements/devenv.txt
 cfgv==3.5.0
     # via pre-commit
-click==8.3.1
+click==8.4.1
     # via black
 dill==0.4.1
     # via pylint
 distlib==0.4.0
     # via virtualenv
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   python-discovery
     #   virtualenv
-identify==2.6.18
+identify==2.6.19
     # via pre-commit
 isort==8.0.1
     # via
     #   -r requirements/../../../requirements/devenv.txt
     #   pylint
-librt==0.8.1
+librt==0.11.0
     # via mypy
 mccabe==0.7.0
     # via pylint
-mypy==1.19.1
+mypy==2.1.0
     # via -r requirements/../../../requirements/devenv.txt
 mypy-extensions==1.1.0
     # via
@@ -34,25 +36,25 @@ mypy-extensions==1.1.0
     #   mypy
 nodeenv==1.10.0
     # via pre-commit
-packaging==26.0
+packaging==26.2
     # via
     #   -c requirements/_test.txt
     #   black
-pathspec==1.0.4
+pathspec==1.1.1
     # via
     #   black
     #   mypy
-platformdirs==4.9.4
+platformdirs==4.10.0
     # via
     #   black
     #   pylint
     #   python-discovery
     #   virtualenv
-pre-commit==4.5.1
+pre-commit==4.6.0
     # via -r requirements/../../../requirements/devenv.txt
 pylint==4.0.5
     # via -r requirements/../../../requirements/devenv.txt
-python-discovery==1.1.3
+python-discovery==1.4.0
     # via virtualenv
 pytokens==0.4.1
     # via black
@@ -61,13 +63,13 @@ pyyaml==6.0.3
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_test.txt
     #   pre-commit
-ruff==0.15.6
+ruff==0.15.14
     # via -r requirements/../../../requirements/devenv.txt
-tomlkit==0.14.0
+tomlkit==0.15.0
     # via pylint
 typing-extensions==4.15.0
     # via
     #   -c requirements/_test.txt
     #   mypy
-virtualenv==21.2.0
+virtualenv==21.4.1
     # via pre-commit

--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Final
 
-from playwright.sync_api import Page, WebSocket
+from playwright.sync_api import Page, WebSocket, expect
 from pydantic import AnyUrl
 from pytest_simcore.helpers.logging_tools import log_context
 from pytest_simcore.helpers.playwright import (
@@ -45,7 +45,7 @@ _JLAB_AUTOSCALED_MAX_STARTUP_TIME: Final[int] = (
     _EC2_STARTUP_MAX_WAIT_TIME + _JLAB_DOCKER_PULLING_MAX_TIME + _JLAB_MAX_STARTUP_MAX_TIME
 )
 _JLAB_RUN_OPTIMIZATION_APPEARANCE_TIME: Final[int] = 2 * MINUTE
-_JLAB_RUN_OPTIMIZATION_MAX_TIME: Final[int] = 4 * MINUTE
+_JLAB_RUN_OPTIMIZATION_MAX_TIME: Final[int] = 20 * MINUTE
 _JLAB_REPORTING_MAX_TIME: Final[int] = 60 * SECOND
 
 
@@ -125,13 +125,12 @@ def _run_electrode_selector_step(
 
 @retry(
     stop=stop_after_delay(_JLAB_RUN_OPTIMIZATION_MAX_TIME / 1000),  # seconds
-    wait=wait_fixed(2),
+    wait=wait_fixed(10),
     reraise=True,
 )
-def _wait_for_optimization_complete(run_button):
-    bg_color = run_button.evaluate("el => getComputedStyle(el).backgroundColor")
-    if bg_color != "rgb(0, 128, 0)":
-        msg = "Optimization not finished yet: {bg_color=}, {run_button=}"
+def _wait_for_optimization_complete(run_button) -> None:
+    if not run_button.is_enabled():
+        msg = f"Optimization not finished yet: {run_button=}"
         raise ValueError(msg)
 
 
@@ -159,6 +158,25 @@ def _run_classic_ti_step(  # noqa: PLR0915
     assert not ws_info.value.is_closed()
     restartable_jlab_websocket = RobustWebSocket(params.page, ws_info.value)
 
+    with log_context(logging.INFO, "Wait for UI to load"):
+        target_tissue_label = ti_iframe.get_by_text("Target tissue:")
+        expect(target_tissue_label).to_be_visible(timeout=_JLAB_RUN_OPTIMIZATION_APPEARANCE_TIME)
+
+    with log_context(logging.INFO, "Select Target tissue"):
+        target_tissue_select = ti_iframe.get_by_label("Target tissue")
+        expect(target_tissue_select).to_be_visible()
+        # Pick the first non-empty option
+        options = target_tissue_select.locator("option").all()
+        selected = False
+        for option in options:
+            value = option.get_attribute("value") or ""
+            if value.strip():
+                target_tissue_select.select_option(value=value)
+                logging.info("Selected target tissue: %s", option.inner_text())
+                selected = True
+                break
+        assert selected, "No non-empty target tissue option found"
+
     if params.is_product_lite:
         with log_context(logging.INFO, "Check species selector has only 2 options", logger=log_ctx.logger):
             species_selector = ti_iframe.locator("select").first
@@ -170,8 +188,9 @@ def _run_classic_ti_step(  # noqa: PLR0915
 
     with log_context(logging.INFO, "Run optimization", logger=log_ctx.logger) as ctx2:
         run_button = ti_iframe.get_by_role("button", name="Run Optimization")
-        run_button.click(timeout=_JLAB_RUN_OPTIMIZATION_APPEARANCE_TIME)
+        run_button.click()
         try:
+            expect(run_button).to_be_disabled(timeout=_JLAB_RUN_OPTIMIZATION_APPEARANCE_TIME)
             _wait_for_optimization_complete(run_button)
             ctx2.logger.info("Optimization finished!")
         except RetryError as e:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

This is a trial to improve the reliability of the Classic TI tests.

- Classic TI was missing the step to select a Target tissue
- Classic TI `Run Computation` step was not waiting long enough (increased from 4 minutes to 20 minutes)

Running the Classic TI E2E takes > 30 minutes

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 28
- #packages after ~ 29

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | anyio                     | 4.12.1          | 4.13.0     | *minor*    | 2 | e2e-playwright🧪🧪 |
|   2 | black                     | 26.3.1          | 26.5.1     | *minor*    | 1 | e2e-playwright🧪 |
|   3 | certifi                   | 2026.2.25       | 2026.5.20  | *minor*    | 2 | e2e-playwright🧪🧪 |
|   4 | charset-normalizer        | 3.4.6           | 3.4.7      |            | 1 | e2e-playwright🧪 |
|   5 | click                     | 8.3.1           | 8.4.1      | *minor*    | 1 | e2e-playwright🧪 |
|   6 | faker                     | 40.11.0         | 40.19.1    | *minor*    | 2 | e2e-playwright🧪🧪 |
|   7 | filelock                  | 3.25.2          | 3.29.0     | *minor*    | 1 | e2e-playwright🧪 |
|   8 | greenlet                  | 3.3.2           | 3.5.1      | *minor*    | 1 | e2e-playwright🧪 |
|   9 | identify                  | 2.6.18          | 2.6.19     |            | 1 | e2e-playwright🧪 |
|  10 | idna                      | 3.11            | 3.16       | *minor*    | 2 | e2e-playwright🧪🧪 |
|  11 | librt                     | 0.8.1           | 0.11.0     | *minor*    | 1 | e2e-playwright🧪 |
|  12 | mypy                      | 1.19.1          | 2.1.0      | **MAJOR**  | 1 | e2e-playwright🧪 |
|  13 | packaging                 | 26.0            | 26.2       | *minor*    | 3 | e2e-playwright🧪🧪🧪 |
|  14 | pathspec                  | 1.0.4           | 1.1.1      | *minor*    | 1 | e2e-playwright🧪 |
|  15 | platformdirs              | 4.9.4           | 4.10.0     | *minor*    | 1 | e2e-playwright🧪 |
|  16 | playwright                | 1.58.0          | 1.60.0     | *minor*    | 1 | e2e-playwright🧪 |
|  17 | pre-commit                | 4.5.1           | 4.6.0      | *minor*    | 1 | e2e-playwright🧪 |
|  18 | pydantic                  | 2.12.5          | 2.13.4     | *minor*    | 2 | e2e-playwright🧪🧪 |
|  19 | pydantic-core             | 2.41.5          | 2.46.4     | *minor*    | 2 | e2e-playwright🧪🧪 |
|  20 | pygments                  | 2.19.2          | 2.20.0     | *minor*    | 2 | e2e-playwright🧪🧪 |
|  21 | pytest                    | 9.0.2           | 9.0.3      |            | 2 | e2e-playwright🧪🧪 |
|  22 | pytest-playwright         | 0.7.2           | 0.8.0      | *minor*    | 1 | e2e-playwright🧪 |
|  23 | python-discovery          | 1.1.3           | 1.4.0      | *minor*    | 1 | e2e-playwright🧪 |
|  24 | requests                  | 2.32.5          | 2.34.2     | *minor*    | 1 | e2e-playwright🧪 |
|  25 | ruff                      | 0.15.6          | 0.15.14    |            | 1 | e2e-playwright🧪 |
|  26 | tomlkit                   | 0.14.0          | 0.15.0     | *minor*    | 1 | e2e-playwright🧪 |
|  27 | tzdata                    | 2025.3          | 2026.2     | **MAJOR**  | 2 | e2e-playwright🧪🧪 |
|  28 | virtualenv                | 21.2.0          | 21.4.1     | *minor*    | 1 | e2e-playwright🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency


<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
