### PR TITLE
🎨ARM: ensure tagging of staging/production/hotfix images is done in place, preserving multi-arch images

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-24.04]
       fail-fast: false
     env:
-      TO_TAG_PREFIX: release-github
+      TO_DOCKER_TAG_PREFIX: release-github
     steps:
       - uses: actions/checkout@v6
         with:
@@ -44,9 +44,9 @@ jobs:
         if: github.event_name == 'push'
         run: ./ci/helpers/show_system_versions.bash
       - name: source image is staging
-        run: echo "FROM_TAG_PREFIX=staging-github" >> $GITHUB_ENV
+        run: echo "FROM_DOCKER_TAG_PREFIX=staging-github" >> $GITHUB_ENV
       - if: contains(env.BRANCH_NAME, 'remotes/origin/hotfix_v')
         name: source image is hotfix (instead of staging)
-        run: echo "FROM_TAG_PREFIX=hotfix-github" >> $GITHUB_ENV
+        run: echo "FROM_DOCKER_TAG_PREFIX=hotfix-github" >> $GITHUB_ENV
       - name: deploy
         run: ./ci/deploy/dockerhub-tag-version.bash

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -25,7 +25,7 @@ jobs:
         os: [ubuntu-24.04]
       fail-fast: false
     env:
-      TO_TAG_PREFIX: staging-github
+      TO_DOCKER_TAG_PREFIX: staging-github
     steps:
       - uses: actions/checkout@v6
         with:
@@ -44,9 +44,9 @@ jobs:
         if: github.event_name == 'push'
         run: ./ci/helpers/show_system_versions.bash
       - name: source image is master
-        run: echo "FROM_TAG_PREFIX=master-github" >> $GITHUB_ENV
+        run: echo "FROM_DOCKER_TAG_PREFIX=master-github" >> $GITHUB_ENV
       - if: contains(env.BRANCH_NAME, 'remotes/origin/hotfix_staging_')
         name: source image is hotfix-staging (instead of master)
-        run: echo "FROM_TAG_PREFIX=hotfix-staging-github" >> $GITHUB_ENV
+        run: echo "FROM_DOCKER_TAG_PREFIX=hotfix-staging-github" >> $GITHUB_ENV
       - name: deploy
         run: ./ci/deploy/dockerhub-tag-version.bash

--- a/Makefile
+++ b/Makefile
@@ -590,6 +590,12 @@ pull-externals: ## pulls non-simcore external images defined in docker-compose.y
 		xargs -r -n 1 docker pull
 
 
+.PHONY: promote-version
+promote-version: guard-FROM_DOCKER_TAG_PREFIX guard-TO_DOCKER_TAG_PREFIX guard-GIT_TAG ## Promotes registry images from one docker tag family to another without loading images locally
+	# Delegates implementation to ci/deploy/dockerhub-tag-version.bash
+	@bash ci/deploy/dockerhub-tag-version.bash
+
+
 ## ENVIRONMENT -------------------------------
 
 .PHONY: devenv devenv-all node-env

--- a/Makefile
+++ b/Makefile
@@ -591,7 +591,7 @@ pull-externals: ## pulls non-simcore external images defined in docker-compose.y
 
 
 .PHONY: promote-version
-promote-version: guard-FROM_DOCKER_TAG_PREFIX guard-TO_DOCKER_TAG_PREFIX guard-GIT_TAG ## Promotes registry images from one docker tag family to another without loading images locally
+promote-version: guard-FROM_DOCKER_TAG_PREFIX guard-TO_DOCKER_TAG_PREFIX guard-GIT_TAG guard-DOCKER_USERNAME guard-DOCKER_PASSWORD guard-DOCKER_REGISTRY guard-OWNER ## Promotes registry images from one docker tag family to another without loading images locally
 	# Delegates implementation to ci/deploy/dockerhub-tag-version.bash
 	@bash ci/deploy/dockerhub-tag-version.bash
 

--- a/ci/deploy/dockerhub-tag-version.bash
+++ b/ci/deploy/dockerhub-tag-version.bash
@@ -5,7 +5,7 @@ set -o nounset   # abort on unbound variable
 set -o pipefail  # don't hide errors within pipes
 IFS=$'\n\t'
 
-repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+repo_root="$(git rev-parse --show-toplevel)"
 
 # shellcheck source=/dev/null
 source "$repo_root/scripts/helpers/logger.bash"

--- a/ci/deploy/dockerhub-tag-version.bash
+++ b/ci/deploy/dockerhub-tag-version.bash
@@ -5,70 +5,58 @@ set -o nounset   # abort on unbound variable
 set -o pipefail  # don't hide errors within pipes
 IFS=$'\n\t'
 
-my_dir="$(dirname "$0")"
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+
 # shellcheck source=/dev/null
-source "$my_dir/../../scripts/helpers/logger.bash"
+source "$repo_root/scripts/helpers/logger.bash"
 
 # check script needed variables
-if [ ! -v FROM_TAG_PREFIX ] || [ ! -v TO_TAG_PREFIX ] || [ ! -v GIT_TAG ]; then
-    error_exit "$LINENO" "incorrect use of script. FROM_TAG_PREFIX/TO_TAG_PREFIX (e.g. master, staging), and/or GIT_TAG not defined!"
+if [ ! -v FROM_DOCKER_TAG_PREFIX ] || [ ! -v TO_DOCKER_TAG_PREFIX ] || [ ! -v GIT_TAG ]; then
+    error_exit "$LINENO" "incorrect use of script. FROM_DOCKER_TAG_PREFIX/TO_DOCKER_TAG_PREFIX (e.g. master-github, staging-github), and/or GIT_TAG not defined!"
 fi
+
+cd "$repo_root"
 
 log_info "logging in dockerhub..."
 bash ci/helpers/dockerhub_login.bash
 
-log_info "finding the version in the docker hub registry..."
-# find and pull the tagged build
-# find the docker image tag
-export ORG=${DOCKER_REGISTRY}
+log_info "finding the source image tag in the registry..."
+export ORG="${DOCKER_REGISTRY}"
 export REPO="webserver"
-# FROM_TAG_PREFIX-DATE.GIT_SHA
-export TAG_PATTERN="^${FROM_TAG_PREFIX}-.+\..+"
-DOCKER_IMAGE_TAG=$(./ci/helpers/find_docker_image_tag_from_git_sha.bash | awk 'END{print}') || exit $?
-log_info "found image ${DOCKER_IMAGE_TAG}"
-export DOCKER_IMAGE_TAG
-log_info "pulling images ${DOCKER_IMAGE_TAG} from ${DOCKER_REGISTRY}"
-make pull-version tag-local
+# FROM_DOCKER_TAG_PREFIX-DATE.GIT_SHA
+export TAG_PATTERN="^${FROM_DOCKER_TAG_PREFIX}-.+\..+"
+source_tag="$(./ci/helpers/find_docker_image_tag_from_git_sha.bash | awk 'END{print}')" || exit $?
+log_info "found source image tag ${source_tag}"
 
-# show current images on system
-log_info "Before push"
-make info-images
+promote_registry_tag() {
+    local source_image="$1"
+    local destination_image="$2"
 
-# re-tag images to ${TO_TAG_PREFIX}-{GIT_TAG}-DATE.GIT_SHA
-readonly GIT_COMMIT_SHA=$(git show-ref -s "${GIT_TAG}")
-DOCKER_IMAGE_TAG="${TO_TAG_PREFIX}-${GIT_TAG}"-$(date --utc +"%Y-%m-%d--%H-%M")."${GIT_COMMIT_SHA}"
-export DOCKER_IMAGE_TAG
-log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"
-make push-version
+    log_info "promoting ${source_image} -> ${destination_image}"
+    docker buildx imagetools create --tag "${destination_image}" "${source_image}"
+}
 
-# push latest image ${TO_TAG_PREFIX}-latest
-DOCKER_IMAGE_TAG="${TO_TAG_PREFIX}-latest"
-export DOCKER_IMAGE_TAG
-log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"
-make push-version
+services="$(docker compose --file services/docker-compose-deploy.yml config --services)"
+readonly git_commit_sha="$(git show-ref -s "${GIT_TAG}")"
+versioned_image_tag="${TO_DOCKER_TAG_PREFIX}-${GIT_TAG}-$(date --utc +"%Y-%m-%d--%H-%M").${git_commit_sha}"
+latest_image_tag="${TO_DOCKER_TAG_PREFIX}-latest"
 
-# push latest image to matching git tag if on git tag
-#
-# Explanation on how checking if a variable is set works with `set -o nounset`:
-#
-# - `${MY_ENV_VAR}`   : This would normally return the value of `MY_ENV_VAR`.
-#                       If `MY_ENV_VAR` is not set and `set -o nounset` is active, using this causes an error and the script would exit.
-# - `${MY_ENV_VAR+x}` : This is a form of parameter expansion. If `MY_ENV_VAR` is unset or null, this expands to nothing (i.e., it's an empty string).
-#                       If `MY_ENV_VAR` is set, this expands to `x`. Importantly, even if `MY_ENV_VAR` is unset, this will not cause an error even with `set -o nounset` active,
-#                       because you're not actually trying to use the value of an unset variable - you're just checking if it is set or not.
-# The `if [ ! -z ${MY_ENV_VAR+x} ]` line checks if `${MY_ENV_VAR+x}` is not an empty string (`! -z` checks for a non-empty string).
-# If `MY_ENV_VAR` is set, `${MY_ENV_VAR+x}` will be `x`, and the condition will be true. If `MY_ENV_VAR` is unset, `${MY_ENV_VAR+x}` will be an empty string, and the condition will be false.
-# `MY_ENV_VAR` is unset, this will not cause an error even with `set -o nounset` active.
+for service in ${services}; do
+    source_image="${DOCKER_REGISTRY}/${service}:${source_tag}"
 
-if [ ! -z ${GIT_TAG+x} ]; then
-    echo "GIT_TAG is '$GIT_TAG'"
-    DOCKER_IMAGE_TAG=${GIT_TAG}
-    export DOCKER_IMAGE_TAG
-    log_info "pushing images ${DOCKER_IMAGE_TAG} to ${DOCKER_REGISTRY}"
-    make push-version
-else
-    echo "GIT_TAG is not set, we assume we are on the master branch."
-fi
+    promote_registry_tag "${source_image}" "${DOCKER_REGISTRY}/${service}:${versioned_image_tag}"
+done
 
+for service in ${services}; do
+    source_image="${DOCKER_REGISTRY}/${service}:${source_tag}"
+
+    promote_registry_tag "${source_image}" "${DOCKER_REGISTRY}/${service}:${latest_image_tag}"
+done
+
+for service in ${services}; do
+    source_image="${DOCKER_REGISTRY}/${service}:${source_tag}"
+
+    promote_registry_tag "${source_image}" "${DOCKER_REGISTRY}/${service}:${GIT_TAG}"
+done
 
 log_info "complete!"

--- a/ci/deploy/dockerhub-tag-version.bash
+++ b/ci/deploy/dockerhub-tag-version.bash
@@ -15,6 +15,10 @@ if [ ! -v FROM_DOCKER_TAG_PREFIX ] || [ ! -v TO_DOCKER_TAG_PREFIX ] || [ ! -v GI
     error_exit "$LINENO" "incorrect use of script. FROM_DOCKER_TAG_PREFIX/TO_DOCKER_TAG_PREFIX (e.g. master-github, staging-github), and/or GIT_TAG not defined!"
 fi
 
+if [ -z "${FROM_DOCKER_TAG_PREFIX:-}" ] || [ -z "${TO_DOCKER_TAG_PREFIX:-}" ] || [ -z "${GIT_TAG:-}" ]; then
+    error_exit "$LINENO" "incorrect use of script. FROM_DOCKER_TAG_PREFIX/TO_DOCKER_TAG_PREFIX/GIT_TAG must be non-empty!"
+fi
+
 cd "$repo_root"
 
 log_info "logging in dockerhub..."

--- a/ci/deploy/dockerhub-tag-version.bash
+++ b/ci/deploy/dockerhub-tag-version.bash
@@ -28,14 +28,6 @@ export TAG_PATTERN="^${FROM_DOCKER_TAG_PREFIX}-.+\..+"
 source_tag="$(./ci/helpers/find_docker_image_tag_from_git_sha.bash | awk 'END{print}')" || exit $?
 log_info "found source image tag ${source_tag}"
 
-promote_registry_tag() {
-    local source_image="$1"
-    local destination_image="$2"
-
-    log_info "promoting ${source_image} -> ${destination_image}"
-    docker buildx imagetools create --tag "${destination_image}" "${source_image}"
-}
-
 services="$(docker compose --file services/docker-compose-deploy.yml config --services)"
 readonly git_commit_sha="$(git show-ref -s "${GIT_TAG}")"
 versioned_image_tag="${TO_DOCKER_TAG_PREFIX}-${GIT_TAG}-$(date --utc +"%Y-%m-%d--%H-%M").${git_commit_sha}"
@@ -43,20 +35,16 @@ latest_image_tag="${TO_DOCKER_TAG_PREFIX}-latest"
 
 for service in ${services}; do
     source_image="${DOCKER_REGISTRY}/${service}:${source_tag}"
+    service_versioned_tag="${DOCKER_REGISTRY}/${service}:${versioned_image_tag}"
+    service_latest_tag="${DOCKER_REGISTRY}/${service}:${latest_image_tag}"
+    service_git_tag="${DOCKER_REGISTRY}/${service}:${GIT_TAG}"
 
-    promote_registry_tag "${source_image}" "${DOCKER_REGISTRY}/${service}:${versioned_image_tag}"
-done
-
-for service in ${services}; do
-    source_image="${DOCKER_REGISTRY}/${service}:${source_tag}"
-
-    promote_registry_tag "${source_image}" "${DOCKER_REGISTRY}/${service}:${latest_image_tag}"
-done
-
-for service in ${services}; do
-    source_image="${DOCKER_REGISTRY}/${service}:${source_tag}"
-
-    promote_registry_tag "${source_image}" "${DOCKER_REGISTRY}/${service}:${GIT_TAG}"
+    log_info "promoting ${source_image} -> ${service_versioned_tag} ${service_latest_tag} ${service_git_tag}"
+    docker buildx imagetools create \
+        --tag "${service_versioned_tag}" \
+        --tag "${service_latest_tag}" \
+        --tag "${service_git_tag}" \
+        "${source_image}"
 done
 
 log_info "complete!"

--- a/ci/deploy/dockerhub-tag-version.bash
+++ b/ci/deploy/dockerhub-tag-version.bash
@@ -26,12 +26,17 @@ export REPO="webserver"
 # FROM_DOCKER_TAG_PREFIX-DATE.GIT_SHA
 export TAG_PATTERN="^${FROM_DOCKER_TAG_PREFIX}-.+\..+"
 source_tag="$(./ci/helpers/find_docker_image_tag_from_git_sha.bash | awk 'END{print}')" || exit $?
+readonly source_tag
 log_info "found source image tag ${source_tag}"
 
 services="$(docker compose --file services/docker-compose-deploy.yml config --services)"
-readonly git_commit_sha="$(git show-ref -s "${GIT_TAG}")"
+readonly services
+git_commit_sha="$(git show-ref -s "${GIT_TAG}")" || exit $?
+readonly git_commit_sha
 versioned_image_tag="${TO_DOCKER_TAG_PREFIX}-${GIT_TAG}-$(date --utc +"%Y-%m-%d--%H-%M").${git_commit_sha}"
+readonly versioned_image_tag
 latest_image_tag="${TO_DOCKER_TAG_PREFIX}-latest"
+readonly latest_image_tag
 
 for service in ${services}; do
     source_image="${DOCKER_REGISTRY}/${service}:${source_tag}"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request refactors the Docker image promotion process in our CI/CD pipeline to use more explicit environment variable names and a safer, registry-based image retagging approach. The main changes are the renaming of tag-related environment variables to clarify their purpose, and a significant rewrite of the promotion script to avoid pulling images locally and instead use Docker registry tools for retagging. This should prevent losing multi-architecture when retagging master images to staging/production.

**CI/CD variable renaming and workflow updates:**

* Renamed environment variables from `FROM_TAG_PREFIX`/`TO_TAG_PREFIX` to `FROM_DOCKER_TAG_PREFIX`/`TO_DOCKER_TAG_PREFIX` in both `.github/workflows/ci-release.yml` and `.github/workflows/ci-staging.yml` for improved clarity and consistency.

**Promotion process improvements:**

* Added a new `promote-version` target to the `Makefile` that delegates Docker image promotion to the `ci/deploy/dockerhub-tag-version.bash` script, enforcing the use of the new environment variables. Mostly for testing.
* Refactored `ci/deploy/dockerhub-tag-version.bash` to:
  - Use the new variable names throughout.
  - Avoid pulling images locally which only pulls local machine architecture; instead, it uses `docker buildx imagetools create` to retag images directly in the registry.
  - Loop over all services defined in `services/docker-compose-deploy.yml`, promoting each service image with versioned, latest, and Git tag-based tags.
  - Improve script robustness by setting the working directory explicitly and sourcing helper scripts from the repository root. :robot: 
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/9175

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
