### PR TITLE
🐛E2E: classic tip do not test s4l, tip-lite adjust test code

### DIFF
--- a/tests/e2e-playwright/tests/tip/test_ti_personalized_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_personalized_plan.py
@@ -24,7 +24,7 @@ from pytest_simcore.helpers.playwright import (
     app_mode_trigger_next_app,
     expected_service_running,
 )
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import retry, stop_after_attempt, stop_after_delay, wait_fixed
 
 _OPEN_PROJECT_WAIT_TIME: Final[int] = 20 * SECOND
 
@@ -150,7 +150,7 @@ def _log_simulation_progress(simulator_iframe: FrameLocator) -> None:
 
 
 @retry(
-    stop=stop_after_attempt(_SIMULATION_MAX_TIME // (60 * SECOND)),
+    stop=stop_after_delay(_SIMULATION_MAX_TIME / 1000),  # seconds
     wait=wait_fixed(60),  # wait 1 minute between retries to avoid spamming the page with checks
     reraise=True,
 )
@@ -167,7 +167,7 @@ def _wait_for_simulation_complete(setup_button: Locator, simulator_iframe: Frame
 
 
 @retry(
-    stop=stop_after_attempt(_SIMULATION_EXPORT_MAX_TIME // (60 * SECOND)),
+    stop=stop_after_delay(_SIMULATION_EXPORT_MAX_TIME / 1000),  # seconds
     wait=wait_fixed(60),
     reraise=True,
 )
@@ -220,7 +220,7 @@ def _run_simulations(simulator_iframe: FrameLocator, page: Page) -> None:
 
 
 @retry(
-    stop=stop_after_attempt(_POST_PRO_RUN_OPTIMIZATION_MAX_TIME // (60 * SECOND)),
+    stop=stop_after_delay(_POST_PRO_RUN_OPTIMIZATION_MAX_TIME / 1000),  # seconds
     wait=wait_fixed(60),
     reraise=True,
 )
@@ -236,7 +236,7 @@ def _wait_for_postpro_optimization_complete(run_optimization_button: Locator) ->
 
 
 @retry(
-    stop=stop_after_attempt(_POST_PRO_LOAD_ANALYSIS_MAX_TIME // (60 * SECOND)),
+    stop=stop_after_delay(_POST_PRO_LOAD_ANALYSIS_MAX_TIME / 1000),  # seconds
     wait=wait_fixed(60),
     reraise=True,
 )
@@ -252,7 +252,7 @@ def _wait_for_postpro_analysis_load(run_optimization_button: Locator) -> None:
 
 
 @retry(
-    stop=stop_after_attempt(_POST_PRO_LOAD_RESULT_MAX_TIME // (10 * SECOND)),
+    stop=stop_after_delay(_POST_PRO_LOAD_RESULT_MAX_TIME / 1000),  # seconds
     wait=wait_fixed(10),
     reraise=True,
 )
@@ -486,6 +486,7 @@ def test_personalized_classic_ti_plan(
         # press + button
         project_data = create_tip_plan_from_dashboard("newPTIPlanButton")
 
+    assert project_data
     assert "workbench" in project_data, "Expected workbench to be in project data!"
     assert isinstance(project_data["workbench"], dict), "Expected workbench to be a dict!"
     node_ids: list[str] = list(project_data["workbench"])

--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -280,13 +280,6 @@ def _run_exposure_analysis_step(
     s4l_postpro_iframe = service_running.iframe_locator
     assert s4l_postpro_iframe
 
-    with log_context(logging.INFO, "Post process", logger=log_ctx.logger):
-        # click on the postpro mode button
-        s4l_postpro_iframe.get_by_test_id("mode-button-postro").click()
-        # click on the surface viewer
-        s4l_postpro_iframe.get_by_test_id("tree-item-ti_field.cache").click()
-        s4l_postpro_iframe.get_by_test_id("tree-item-SurfaceViewer").nth(0).click()
-
 
 def test_classic_ti_plan(
     page: Page,

--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -182,9 +182,7 @@ def _run_classic_ti_step(  # noqa: PLR0915
             species_selector = ti_iframe.locator("select").first
             options = species_selector.locator("option")
             assert options.count() == 2, f"Expected 2 species options in lite product, got {options.count()}"
-            option_texts = [options.nth(i).inner_text() for i in range(options.count())]
-            assert "Human - MIDA anisotropic" in option_texts
-            assert "Mouse" in option_texts
+            expect(options).to_have_values(["Human - MIDA anisotropic", "Mouse"])
 
     with log_context(logging.INFO, "Run optimization", logger=log_ctx.logger) as ctx2:
         run_button = ti_iframe.get_by_role("button", name="Run Optimization")


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
2nd attempt at fixing Classic TIP E2e.

- the second step is failing currently and it is trying to do things that are not available anymore --> removed
- the tip-lite was comparing html rendered text with text, attempt to change this

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```bash
cd tests/e2e-playwright
make install-dev
make test-tip-anywhere
```

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
