### PR TITLE
✨ [Frontend] PO Center: registered users

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_webserver/users.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/users.py
@@ -326,7 +326,7 @@ type UserAccountSortableField = Literal[
     "name",
     "email",
     "status",
-    "accountRequestedReviewedAt",
+    "accountRequestReviewedAt",
     "preRegistrationCreated",
 ]
 
@@ -337,7 +337,7 @@ class UsersAccountListOrderParams(
     _default_order_by: ClassVar[str] = "email"
     _field_name_map: ClassVar[dict[str, str]] = {
         "name": "first_name",
-        "accountRequestedReviewedAt": "account_request_reviewed_at",
+        "accountRequestReviewedAt": "account_request_reviewed_at",
         "preRegistrationCreated": "created",
     }
 

--- a/packages/models-library/tests/test_rest_ordering.py
+++ b/packages/models-library/tests/test_rest_ordering.py
@@ -526,12 +526,12 @@ def test_ordering_query_params_equivalence_folders_pattern():
 
 def test_ordering_query_params_equivalence_users_accounts_pattern():
     """Equivalent to users accounts ordering with multiple API-to-column mappings."""
-    UserField = Literal["name", "email", "status", "accountRequestedReviewedAt", "preRegistrationCreated"]
+    UserField = Literal["name", "email", "status", "accountRequestReviewedAt", "preRegistrationCreated"]
 
     class UserOrdering(OrderingQueryParams[UserField]):
         _field_name_map: ClassVar[dict[str, str]] = {
             "name": "first_name",
-            "accountRequestedReviewedAt": "account_request_reviewed_at",
+            "accountRequestReviewedAt": "account_request_reviewed_at",
             "preRegistrationCreated": "created",
         }
         _default_order_by: ClassVar[str] = "email"

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -1147,6 +1147,10 @@ qx.Class.define("osparc.data.Resources", {
             method: "GET",
             url: statics.API + "/admin/user-accounts?review_status=REVIEWED&offset={offset}&limit={limit}&registered={registered}"
           },
+          getRegisteredUsers: {
+            method: "GET",
+            url: statics.API + "/admin/user-accounts?registered=true&offset={offset}&limit={limit}"
+          },
           previewApproval: {
             method: "POST",
             url: statics.API + "/admin/user-accounts:preview-approval"

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -1149,7 +1149,7 @@ qx.Class.define("osparc.data.Resources", {
           },
           getRegisteredUsers: {
             method: "GET",
-            url: statics.API + "/admin/user-accounts?registered=true&offset={offset}&limit={limit}"
+            url: statics.API + "/admin/user-accounts?registered=true&offset={offset}&limit={limit}&order_by={orderBy}"
           },
           previewApproval: {
             method: "POST",

--- a/services/static-webserver/client/source/class/osparc/data/Resources.js
+++ b/services/static-webserver/client/source/class/osparc/data/Resources.js
@@ -1789,7 +1789,7 @@ qx.Class.define("osparc.data.Resources", {
           params["url"] = {};
         }
         params["url"]["offset"] = offset;
-        params["url"]["limit"] = 10;
+        params["url"]["limit"] = params["url"]["limit"] || 10;
         const options = {
           resolveWResponse: true
         };

--- a/services/static-webserver/client/source/class/osparc/po/POCenter.js
+++ b/services/static-webserver/client/source/class/osparc/po/POCenter.js
@@ -27,6 +27,7 @@ qx.Class.define("osparc.po.POCenter", {
     this.addWidgetToTabs(miniProfile);
 
     this.__addReviewUsersPage();
+    this.__addRegisteredUsersPage();
     this.__addActiveUsersPage();
     this.__addPreRegistrationPage();
     this.__addInvitationsPage();
@@ -52,6 +53,13 @@ qx.Class.define("osparc.po.POCenter", {
       const iconSrc = "@FontAwesome5Solid/user/22";
       const users = new osparc.po.Users();
       this.addTab(title, iconSrc, users);
+    },
+
+    __addRegisteredUsersPage: function() {
+      const title = this.tr("Registered Users");
+      const iconSrc = "@FontAwesome5Solid/user/22";
+      const usersRegistered = new osparc.po.UsersRegistered();
+      this.addTab(title, iconSrc, usersRegistered);
     },
 
     __addPreRegistrationPage: function() {

--- a/services/static-webserver/client/source/class/osparc/po/POCenter.js
+++ b/services/static-webserver/client/source/class/osparc/po/POCenter.js
@@ -50,7 +50,7 @@ qx.Class.define("osparc.po.POCenter", {
 
     __addRegisteredUsersPage: function() {
       const title = this.tr("Active Users");
-      const iconSrc = "@FontAwesome5Solid/user/22";
+      const iconSrc = "@MaterialIcons/how_to_reg/34";
       const usersRegistered = new osparc.po.UsersRegistered();
       this.addTab(title, iconSrc, usersRegistered);
     },

--- a/services/static-webserver/client/source/class/osparc/po/POCenter.js
+++ b/services/static-webserver/client/source/class/osparc/po/POCenter.js
@@ -28,7 +28,7 @@ qx.Class.define("osparc.po.POCenter", {
 
     this.__addReviewUsersPage();
     this.__addRegisteredUsersPage();
-    this.__addActiveUsersPage();
+    this.__addSearchUsersPage();
     this.__addPreRegistrationPage();
     this.__addInvitationsPage();
     this.__addProductPage();
@@ -48,18 +48,18 @@ qx.Class.define("osparc.po.POCenter", {
       page.pageId = "reviewUsers";
     },
 
-    __addActiveUsersPage: function() {
-      const title = this.tr("Active Users");
-      const iconSrc = "@FontAwesome5Solid/user/22";
-      const users = new osparc.po.Users();
-      this.addTab(title, iconSrc, users);
-    },
-
     __addRegisteredUsersPage: function() {
-      const title = this.tr("Registered Users");
+      const title = this.tr("Active Users");
       const iconSrc = "@FontAwesome5Solid/user/22";
       const usersRegistered = new osparc.po.UsersRegistered();
       this.addTab(title, iconSrc, usersRegistered);
+    },
+
+    __addSearchUsersPage: function() {
+      const title = this.tr("Search Users");
+      const iconSrc = "@FontAwesome5Solid/search/22";
+      const users = new osparc.po.UsersSearch();
+      this.addTab(title, iconSrc, users);
     },
 
     __addPreRegistrationPage: function() {

--- a/services/static-webserver/client/source/class/osparc/po/ProductInfo.js
+++ b/services/static-webserver/client/source/class/osparc/po/ProductInfo.js
@@ -20,6 +20,10 @@ qx.Class.define("osparc.po.ProductInfo", {
 
   members: {
     _buildLayout: function() {
+      this.addListenerOnce("appear", () => this.__fetchProductInfo());
+    },
+
+    __fetchProductInfo: function() {
       const params = {
         url: {
           productName: osparc.product.Utils.getProductName()

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -128,7 +128,7 @@ qx.Class.define("osparc.po.UsersPending", {
           this.getChildControl("header-layout").add(control);
           break;
         case "intro-text":
-          control = new qx.ui.basic.Label(this.tr("List of pending users or reviewed but not yet registered:")).set({
+          control = new qx.ui.basic.Label(this.tr("List of pending or reviewed users but not yet registered:")).set({
             font: "text-14",
             textColor: "text",
             allowGrowX: true

--- a/services/static-webserver/client/source/class/osparc/po/UsersPending.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersPending.js
@@ -173,7 +173,7 @@ qx.Class.define("osparc.po.UsersPending", {
       this.getChildControl("reload-button");
       this.getChildControl("intro-text");
       this.getChildControl("loading-spinner");
-      this.__populatePendingUsersLayout();
+      this.addListenerOnce("appear", () => this.__populatePendingUsersLayout());
     },
 
     __addHeader: function() {

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -31,7 +31,6 @@ qx.Class.define("osparc.po.UsersRegistered", {
   },
 
   members: {
-    __currentFilterText: "",
     __currentOrderBy: null,
     __registeredUsers: null,
     __currentOffset: 0,
@@ -61,17 +60,6 @@ qx.Class.define("osparc.po.UsersRegistered", {
           control.getContentElement().addClass("rotate");
           this._add(control);
           break;
-        case "filter-users": {
-          const filterGroupId = "registeredUsersLayout";
-          control = new osparc.filter.TextFilter("text", filterGroupId).set({
-            minWidth: 300,
-          });
-          control.getChildControl("textfield").setPlaceholder(this.tr("Filter by Name, Username or Email"));
-          const msgName = osparc.utils.Utils.capitalize(filterGroupId, "filter");
-          qx.event.message.Bus.getInstance().subscribe(msgName, this.__onFilterChange, this);
-          this._add(control);
-          break;
-        }
         case "registered-users-container":
           control = new qx.ui.container.Scroll();
           this._add(control);
@@ -128,7 +116,6 @@ qx.Class.define("osparc.po.UsersRegistered", {
 
     _buildLayout: function() {
       this.getChildControl("intro-text");
-      this.getChildControl("filter-users").exclude();
       this.getChildControl("loading-spinner");
       this.getChildControl("registered-users-container");
       this.getChildControl("pagination-layout");
@@ -257,7 +244,6 @@ qx.Class.define("osparc.po.UsersRegistered", {
 
     __fetchPage: function() {
       this.getChildControl("loading-spinner").show();
-      this.getChildControl("filter-users").exclude();
 
       const params = {
         url: {
@@ -275,7 +261,6 @@ qx.Class.define("osparc.po.UsersRegistered", {
           const data = ("_meta" in resp["data"]) ? resp["data"]["data"] : resp["data"];
           this.__totalUsers = meta.total;
           this.__registeredUsers = data;
-          this.getChildControl("filter-users").show();
           this.__updatePaginationControls();
           this.__renderRegisteredUsers();
         })
@@ -299,36 +284,11 @@ qx.Class.define("osparc.po.UsersRegistered", {
       this.__fetchPage();
     },
 
-    __onFilterChange: function(msg) {
-      const data = msg ? msg.getData() : null;
-      this.__currentFilterText = data && data.text ? data.text : "";
-      this.__renderRegisteredUsers();
-    },
-
-    __filterRegisteredUsers: function() {
-      if (!this.__registeredUsers) {
-        return [];
-      }
-
-      const text = this.__currentFilterText.trim();
-      if (!text || text.length < 2) {
-        return this.__registeredUsers;
-      }
-
-      const query = text.toLowerCase();
-      return this.__registeredUsers.filter(user => {
-        const fullName = `${user.firstName || ""} ${user.lastName || ""}`.trim().toLowerCase();
-        const email = (user.email || "").toLowerCase();
-        const username = (user.userName || "").toLowerCase();
-        return [fullName, email, username].some(value => value.includes(query));
-      });
-    },
-
     __renderRegisteredUsers: function() {
       const layout = this.getChildControl("registered-users-layout");
       layout.removeAll();
       this.__addHeader();
-      this.__addRows(this.__filterRegisteredUsers());
+      this.__addRows(this.__registeredUsers || []);
     },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -30,6 +30,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
 
   members: {
     __currentFilterText: "",
+    __currentOrderBy: null,
     __registeredUsers: null,
 
     _createChildControlImpl: function(id) {
@@ -94,7 +95,44 @@ qx.Class.define("osparc.po.UsersRegistered", {
       this.getChildControl("reload-button");
       this.getChildControl("intro-text");
       this.getChildControl("loading-spinner");
+      this.__currentOrderBy = "-accountRequestedReviewedAt";
       this.__populateRegisteredUsersLayout();
+    },
+
+    __createSortableHeader: function(label, fieldName) {
+      const container = new qx.ui.container.Composite(new qx.ui.layout.HBox(4).set({
+        alignY: "middle"
+      }));
+      container.set({
+        cursor: "pointer",
+      });
+      const textLabel = new qx.ui.basic.Label(label).set({
+        font: "text-14",
+      });
+      container.add(textLabel);
+      const sortIcon = new qx.ui.basic.Label("").set({
+        font: "text-12",
+      });
+      container.add(sortIcon);
+      // Update icon based on current sort
+      const currentField = this.__currentOrderBy.replace(/^-/, "");
+      const isDesc = this.__currentOrderBy.startsWith("-");
+      if (currentField === fieldName) {
+        sortIcon.setValue(isDesc ? "\u25BC" : "\u25B2");
+      }
+      container.addListener("tap", () => {
+        const curField = this.__currentOrderBy.replace(/^-/, "");
+        const curDesc = this.__currentOrderBy.startsWith("-");
+        if (curField === fieldName) {
+          // Toggle direction
+          this.__currentOrderBy = curDesc ? fieldName : "-" + fieldName;
+        } else {
+          // Default to ascending for new field
+          this.__currentOrderBy = fieldName;
+        }
+        this.__reload();
+      });
+      return container;
     },
 
     __addHeader: function() {
@@ -107,23 +145,17 @@ qx.Class.define("osparc.po.UsersRegistered", {
         column: this.self().COLUMNS.NAME,
       });
 
-      layout.add(new qx.ui.basic.Label(this.tr("Username")).set({
-        font: "text-14"
-      }), {
+      layout.add(this.__createSortableHeader(this.tr("Username"), "name"), {
         row: 0,
         column: this.self().COLUMNS.USERNAME,
       });
 
-      layout.add(new qx.ui.basic.Label(this.tr("Email")).set({
-        font: "text-14"
-      }), {
+      layout.add(this.__createSortableHeader(this.tr("Email"), "email"), {
         row: 0,
         column: this.self().COLUMNS.EMAIL,
       });
 
-      layout.add(new qx.ui.basic.Label(this.tr("Reviewed At")).set({
-        font: "text-14"
-      }), {
+      layout.add(this.__createSortableHeader(this.tr("Reviewed At"), "accountRequestedReviewedAt"), {
         row: 0,
         column: this.self().COLUMNS.DATE,
       });
@@ -192,18 +224,12 @@ qx.Class.define("osparc.po.UsersRegistered", {
 
       const params = {
         url: {
-          registered: "true",
+          orderBy: this.__currentOrderBy,
         }
       };
       osparc.data.Resources.getInstance().getAllPages("poUsers", params, "getRegisteredUsers")
         .then(users => {
           this.getChildControl("filter-users").show();
-          const sortByDate = (a, b) => {
-            const dateA = a.accountRequestReviewedAt ? new Date(a.accountRequestReviewedAt) : new Date(0);
-            const dateB = b.accountRequestReviewedAt ? new Date(b.accountRequestReviewedAt) : new Date(0);
-            return dateB - dateA;
-          };
-          users.sort(sortByDate);
           this.__registeredUsers = users;
           this.__renderRegisteredUsers();
         })

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -122,7 +122,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
       this.getChildControl("registered-users-container");
       this.getChildControl("pagination-layout");
       this.__currentOrderBy = "-accountRequestedReviewedAt";
-      this.__fetchPage();
+      this.addListenerOnce("appear", () => this.__fetchPage());
     },
 
     __createSortableHeader: function(label, fieldName) {

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -32,6 +32,9 @@ qx.Class.define("osparc.po.UsersRegistered", {
     __currentFilterText: "",
     __currentOrderBy: null,
     __registeredUsers: null,
+    __currentOffset: 0,
+    __pageLimit: 5,
+    __totalUsers: 0,
 
     _createChildControlImpl: function(id) {
       let control;
@@ -87,6 +90,40 @@ qx.Class.define("osparc.po.UsersRegistered", {
           this.getChildControl("registered-users-container").add(control);
           break;
         }
+        case "pagination-layout":
+          control = new qx.ui.container.Composite(new qx.ui.layout.HBox(10).set({
+            alignY: "middle"
+          }));
+          this._add(control);
+          break;
+        case "prev-page-button":
+          control = new qx.ui.form.Button(this.tr("Previous")).set({
+            allowGrowX: false,
+            enabled: false,
+          });
+          control.addListener("execute", () => {
+            this.__currentOffset = Math.max(0, this.__currentOffset - this.__pageLimit);
+            this.__fetchPage();
+          });
+          this.getChildControl("pagination-layout").add(control);
+          break;
+        case "page-info-label":
+          control = new qx.ui.basic.Label("").set({
+            font: "text-14",
+          });
+          this.getChildControl("pagination-layout").add(control);
+          break;
+        case "next-page-button":
+          control = new qx.ui.form.Button(this.tr("Next")).set({
+            allowGrowX: false,
+            enabled: false,
+          });
+          control.addListener("execute", () => {
+            this.__currentOffset += this.__pageLimit;
+            this.__fetchPage();
+          });
+          this.getChildControl("pagination-layout").add(control);
+          break;
       }
       return control || this.base(arguments, id);
     },
@@ -95,8 +132,11 @@ qx.Class.define("osparc.po.UsersRegistered", {
       this.getChildControl("reload-button");
       this.getChildControl("intro-text");
       this.getChildControl("loading-spinner");
+      this.getChildControl("prev-page-button");
+      this.getChildControl("page-info-label");
+      this.getChildControl("next-page-button");
       this.__currentOrderBy = "-accountRequestedReviewedAt";
-      this.__populateRegisteredUsersLayout();
+      this.__fetchPage();
     },
 
     __createSortableHeader: function(label, fieldName) {
@@ -218,28 +258,48 @@ qx.Class.define("osparc.po.UsersRegistered", {
       });
     },
 
-    __populateRegisteredUsersLayout: function() {
+    __fetchPage: function() {
       this.getChildControl("loading-spinner").show();
       this.getChildControl("filter-users").exclude();
 
       const params = {
         url: {
+          offset: this.__currentOffset,
+          limit: this.__pageLimit,
           orderBy: this.__currentOrderBy,
         }
       };
-      osparc.data.Resources.getInstance().getAllPages("poUsers", params, "getRegisteredUsers")
-        .then(users => {
+      const options = {
+        resolveWResponse: true,
+      };
+      osparc.data.Resources.fetch("poUsers", "getRegisteredUsers", params, options)
+        .then(resp => {
+          const meta = ("_meta" in resp["data"]) ? resp["data"]["_meta"] : resp["_meta"];
+          const data = ("_meta" in resp["data"]) ? resp["data"]["data"] : resp["data"];
+          this.__totalUsers = meta.total;
+          this.__registeredUsers = data;
           this.getChildControl("filter-users").show();
-          this.__registeredUsers = users;
+          this.__updatePaginationControls();
           this.__renderRegisteredUsers();
         })
         .catch(err => osparc.FlashMessenger.logError(err))
         .finally(() => this.getChildControl("loading-spinner").exclude());
     },
 
+    __updatePaginationControls: function() {
+      const currentPage = Math.floor(this.__currentOffset / this.__pageLimit) + 1;
+      const totalPages = Math.ceil(this.__totalUsers / this.__pageLimit) || 1;
+      this.getChildControl("page-info-label").setValue(
+        this.tr("Page %1 of %2 (%3 users)", currentPage, totalPages, this.__totalUsers)
+      );
+      this.getChildControl("prev-page-button").setEnabled(this.__currentOffset > 0);
+      this.getChildControl("next-page-button").setEnabled(this.__currentOffset + this.__pageLimit < this.__totalUsers);
+    },
+
     __reload: function() {
+      this.__currentOffset = 0;
       this.getChildControl("registered-users-layout").removeAll();
-      this.__populateRegisteredUsersLayout();
+      this.__fetchPage();
     },
 
     __onFilterChange: function(msg) {

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -26,6 +26,8 @@ qx.Class.define("osparc.po.UsersRegistered", {
       DATE: 3,
       INFO: 4,
     },
+
+    PAGE_LIMIT: 10,
   },
 
   members: {
@@ -33,7 +35,6 @@ qx.Class.define("osparc.po.UsersRegistered", {
     __currentOrderBy: null,
     __registeredUsers: null,
     __currentOffset: 0,
-    __pageLimit: 5,
     __totalUsers: 0,
 
     _createChildControlImpl: function(id) {
@@ -97,7 +98,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
             toolTipText: this.tr("Previous page"),
           });
           control.addListener("execute", () => {
-            this.__currentOffset = Math.max(0, this.__currentOffset - this.__pageLimit);
+            this.__currentOffset = Math.max(0, this.__currentOffset - this.self().PAGE_LIMIT);
             this.__fetchPage();
           });
           this.getChildControl("pagination-layout").add(control);
@@ -116,7 +117,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
             toolTipText: this.tr("Next page"),
           });
           control.addListener("execute", () => {
-            this.__currentOffset += this.__pageLimit;
+            this.__currentOffset += this.self().PAGE_LIMIT;
             this.__fetchPage();
           });
           this.getChildControl("pagination-layout").add(control);
@@ -261,7 +262,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
       const params = {
         url: {
           offset: this.__currentOffset,
-          limit: this.__pageLimit,
+          limit: this.self().PAGE_LIMIT,
           orderBy: this.__currentOrderBy,
         }
       };
@@ -283,13 +284,13 @@ qx.Class.define("osparc.po.UsersRegistered", {
     },
 
     __updatePaginationControls: function() {
-      const currentPage = Math.floor(this.__currentOffset / this.__pageLimit) + 1;
-      const totalPages = Math.ceil(this.__totalUsers / this.__pageLimit) || 1;
-      this.getChildControl("page-info-label").setValue(
-        this.tr("Page %1 of %2 (%3 users)", currentPage, totalPages, this.__totalUsers)
-      );
       this.getChildControl("prev-page-button").setEnabled(this.__currentOffset > 0);
-      this.getChildControl("next-page-button").setEnabled(this.__currentOffset + this.__pageLimit < this.__totalUsers);
+      const currentPage = Math.floor(this.__currentOffset / this.self().PAGE_LIMIT) + 1;
+      const totalPages = Math.ceil(this.__totalUsers / this.self().PAGE_LIMIT) || 1;
+      this.getChildControl("page-info-label").setValue(
+        this.tr("Page %1/%2 (%3 users)", currentPage, totalPages, this.__totalUsers)
+      );
+      this.getChildControl("next-page-button").setEnabled(this.__currentOffset + this.self().PAGE_LIMIT < this.__totalUsers);
     },
 
     __reload: function() {

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -93,6 +93,34 @@ qx.Class.define("osparc.po.UsersRegistered", {
           });
           this.getChildControl("pagination-layout").add(control);
           break;
+        case "first-page-button":
+          control = new qx.ui.form.Button(null, "@MaterialIcons/first_page/16").set({
+            allowGrowX: false,
+            enabled: false,
+            toolTipText: this.tr("First page"),
+          });
+          control.addListener("execute", () => {
+            this.__currentOffset = 0;
+            this.__fetchPage();
+          });
+          this.getChildControl("pagination-layout").add(control);
+          break;
+        case "page-spinner": {
+          control = new qx.ui.form.Spinner(1, 1, 1).set({
+            width: 60,
+            allowGrowX: false,
+          });
+          control.addListener("changeValue", e => {
+            const page = e.getData();
+            const newOffset = (page - 1) * this.self().PAGE_LIMIT;
+            if (newOffset !== this.__currentOffset) {
+              this.__currentOffset = newOffset;
+              this.__fetchPage();
+            }
+          });
+          this.getChildControl("pagination-layout").add(control);
+          break;
+        }
         case "page-info-label":
           control = new qx.ui.basic.Label("").set({
             font: "text-13",
@@ -112,6 +140,19 @@ qx.Class.define("osparc.po.UsersRegistered", {
           });
           this.getChildControl("pagination-layout").add(control);
           break;
+        case "last-page-button":
+          control = new qx.ui.form.Button(null, "@MaterialIcons/last_page/16").set({
+            allowGrowX: false,
+            enabled: false,
+            toolTipText: this.tr("Last page"),
+          });
+          control.addListener("execute", () => {
+            const totalPages = Math.ceil(this.__totalUsers / this.self().PAGE_LIMIT) || 1;
+            this.__currentOffset = (totalPages - 1) * this.self().PAGE_LIMIT;
+            this.__fetchPage();
+          });
+          this.getChildControl("pagination-layout").add(control);
+          break;
       }
       return control || this.base(arguments, id);
     },
@@ -120,7 +161,12 @@ qx.Class.define("osparc.po.UsersRegistered", {
       this.getChildControl("intro-text");
       this.getChildControl("loading-spinner");
       this.getChildControl("registered-users-container");
-      this.getChildControl("pagination-layout");
+      this.getChildControl("first-page-button");
+      this.getChildControl("prev-page-button");
+      this.getChildControl("page-spinner");
+      this.getChildControl("page-info-label");
+      this.getChildControl("next-page-button");
+      this.getChildControl("last-page-button");
       this.__currentOrderBy = "-accountRequestReviewedAt";
       this.addListenerOnce("appear", () => this.__fetchPage());
     },
@@ -269,13 +315,23 @@ qx.Class.define("osparc.po.UsersRegistered", {
     },
 
     __updatePaginationControls: function() {
-      this.getChildControl("prev-page-button").setEnabled(this.__currentOffset > 0);
       const currentPage = Math.floor(this.__currentOffset / this.self().PAGE_LIMIT) + 1;
       const totalPages = Math.ceil(this.__totalUsers / this.self().PAGE_LIMIT) || 1;
+
+      this.getChildControl("first-page-button").setEnabled(currentPage > 1);
+      this.getChildControl("prev-page-button").setEnabled(currentPage > 1);
+      this.getChildControl("next-page-button").setEnabled(currentPage < totalPages);
+      this.getChildControl("last-page-button").setEnabled(currentPage < totalPages);
+
+      const spinner = this.getChildControl("page-spinner");
+      spinner.set({
+        maximum: totalPages,
+        value: currentPage,
+      });
+
       this.getChildControl("page-info-label").setValue(
-        this.tr("Page %1/%2 (%3 users)", currentPage, totalPages, this.__totalUsers)
+        this.tr("of %1 (%2 users)", totalPages, this.__totalUsers)
       );
-      this.getChildControl("next-page-button").setEnabled(this.__currentOffset + this.self().PAGE_LIMIT < this.__totalUsers);
     },
 
     __reload: function() {

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -121,7 +121,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
       this.getChildControl("loading-spinner");
       this.getChildControl("registered-users-container");
       this.getChildControl("pagination-layout");
-      this.__currentOrderBy = "-accountRequestedReviewedAt";
+      this.__currentOrderBy = "-accountRequestReviewedAt";
       this.addListenerOnce("appear", () => this.__fetchPage());
     },
 
@@ -171,7 +171,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
         column: this.self().COLUMNS.NAME,
       });
 
-      layout.add(this.__createSortableHeader(this.tr("Username"), "name"), {
+      layout.add(this.__createSortableHeader(this.tr("Username"), "userName"), {
         row: 0,
         column: this.self().COLUMNS.USERNAME,
       });
@@ -181,7 +181,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
         column: this.self().COLUMNS.EMAIL,
       });
 
-      layout.add(this.__createSortableHeader(this.tr("Reviewed At"), "accountRequestedReviewedAt"), {
+      layout.add(this.__createSortableHeader(this.tr("Reviewed At"), "accountRequestReviewedAt"), {
         row: 0,
         column: this.self().COLUMNS.DATE,
       });

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -1,0 +1,251 @@
+/* ************************************************************************
+
+   osparc - the simcore frontend
+
+   https://osparc.io
+
+   Copyright:
+     2024 IT'IS Foundation, https://itis.swiss
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+
+   Authors:
+     * Odei Maiz (odeimaiz)
+
+************************************************************************ */
+
+qx.Class.define("osparc.po.UsersRegistered", {
+  extend: osparc.po.BaseView,
+
+  statics: {
+    COLUMNS: {
+      NAME: 0,
+      USERNAME: 1,
+      EMAIL: 2,
+      DATE: 3,
+      INFO: 4,
+    },
+  },
+
+  members: {
+    __currentFilterText: "",
+    __registeredUsers: null,
+
+    _createChildControlImpl: function(id) {
+      let control;
+      switch (id) {
+        case "header-layout":
+          control = new qx.ui.container.Composite(new qx.ui.layout.HBox(10).set({
+            alignY: "middle"
+          }));
+          this._add(control);
+          break;
+        case "reload-button":
+          control = new qx.ui.form.Button(this.tr("Reload")).set({
+            allowGrowX: false,
+          });
+          control.addListener("execute", () => this.__reload());
+          this.getChildControl("header-layout").add(control);
+          break;
+        case "intro-text":
+          control = new qx.ui.basic.Label(this.tr("List of active, registered, users:")).set({
+            font: "text-14",
+            textColor: "text",
+            allowGrowX: true
+          });
+          this.getChildControl("header-layout").add(control);
+          break;
+        case "loading-spinner":
+          control = new qx.ui.basic.Image("@FontAwesome5Solid/circle-notch/26").set({
+            padding: 6
+          });
+          control.getContentElement().addClass("rotate");
+          this._add(control);
+          break;
+        case "filter-users": {
+          const filterGroupId = "registeredUsersLayout";
+          control = new osparc.filter.TextFilter("text", filterGroupId).set({
+            minWidth: 300,
+          });
+          control.getChildControl("textfield").setPlaceholder(this.tr("Filter by Name, Username or Email"));
+          const msgName = osparc.utils.Utils.capitalize(filterGroupId, "filter");
+          qx.event.message.Bus.getInstance().subscribe(msgName, this.__onFilterChange, this);
+          this._add(control);
+          break;
+        }
+        case "registered-users-container":
+          control = new qx.ui.container.Scroll();
+          this._add(control, {
+            flex: 1
+          });
+          break;
+        case "registered-users-layout": {
+          const grid = new qx.ui.layout.Grid(15, 5);
+          control = new qx.ui.container.Composite(grid);
+          this.getChildControl("registered-users-container").add(control);
+          break;
+        }
+      }
+      return control || this.base(arguments, id);
+    },
+
+    _buildLayout: function() {
+      this.getChildControl("reload-button");
+      this.getChildControl("intro-text");
+      this.getChildControl("loading-spinner");
+      this.__populateRegisteredUsersLayout();
+    },
+
+    __addHeader: function() {
+      const layout = this.getChildControl("registered-users-layout");
+
+      layout.add(new qx.ui.basic.Label(this.tr("Name")).set({
+        font: "text-14"
+      }), {
+        row: 0,
+        column: this.self().COLUMNS.NAME,
+      });
+
+      layout.add(new qx.ui.basic.Label(this.tr("Username")).set({
+        font: "text-14"
+      }), {
+        row: 0,
+        column: this.self().COLUMNS.USERNAME,
+      });
+
+      layout.add(new qx.ui.basic.Label(this.tr("Email")).set({
+        font: "text-14"
+      }), {
+        row: 0,
+        column: this.self().COLUMNS.EMAIL,
+      });
+
+      layout.add(new qx.ui.basic.Label(this.tr("Reviewed At")).set({
+        font: "text-14"
+      }), {
+        row: 0,
+        column: this.self().COLUMNS.DATE,
+      });
+
+      layout.add(new qx.ui.basic.Label(this.tr("Info")).set({
+        font: "text-14"
+      }), {
+        row: 0,
+        column: this.self().COLUMNS.INFO,
+      });
+    },
+
+    __addRows: function(users) {
+      const layout = this.getChildControl("registered-users-layout");
+      const grid = layout.getLayout();
+
+      let row = 1;
+      users.forEach(user => {
+        grid.setRowAlign(row, "left", "middle");
+
+        const fullName = (user.firstName || "") + " " + (user.lastName || "");
+        const fullNameLabel = new qx.ui.basic.Label(fullName.trim() || "-").set({
+          selectable: true,
+        });
+        layout.add(fullNameLabel, {
+          row,
+          column: this.self().COLUMNS.NAME,
+        });
+
+        const usernameLabel = new qx.ui.basic.Label(user.userName || "-").set({
+          selectable: true,
+        });
+        layout.add(usernameLabel, {
+          row,
+          column: this.self().COLUMNS.USERNAME,
+        });
+
+        const emailLabel = new qx.ui.basic.Label(user.email || "-").set({
+          selectable: true,
+        });
+        layout.add(emailLabel, {
+          row,
+          column: this.self().COLUMNS.EMAIL,
+        });
+
+        const dateData = user.accountRequestReviewedAt;
+        const date = dateData ? osparc.utils.Utils.formatDateAndTime(new Date(dateData)) : "-";
+        layout.add(new qx.ui.basic.Label(date), {
+          row,
+          column: this.self().COLUMNS.DATE,
+        });
+
+        const infoButton = osparc.po.UsersPending.createInfoButton(user);
+        layout.add(infoButton, {
+          row,
+          column: this.self().COLUMNS.INFO,
+        });
+
+        row++;
+      });
+    },
+
+    __populateRegisteredUsersLayout: function() {
+      this.getChildControl("loading-spinner").show();
+      this.getChildControl("filter-users").exclude();
+
+      const params = {
+        url: {
+          registered: "true",
+        }
+      };
+      osparc.data.Resources.getInstance().getAllPages("poUsers", params, "getRegisteredUsers")
+        .then(users => {
+          this.getChildControl("filter-users").show();
+          const sortByDate = (a, b) => {
+            const dateA = a.accountRequestReviewedAt ? new Date(a.accountRequestReviewedAt) : new Date(0);
+            const dateB = b.accountRequestReviewedAt ? new Date(b.accountRequestReviewedAt) : new Date(0);
+            return dateB - dateA;
+          };
+          users.sort(sortByDate);
+          this.__registeredUsers = users;
+          this.__renderRegisteredUsers();
+        })
+        .catch(err => osparc.FlashMessenger.logError(err))
+        .finally(() => this.getChildControl("loading-spinner").exclude());
+    },
+
+    __reload: function() {
+      this.getChildControl("registered-users-layout").removeAll();
+      this.__populateRegisteredUsersLayout();
+    },
+
+    __onFilterChange: function(msg) {
+      const data = msg ? msg.getData() : null;
+      this.__currentFilterText = data && data.text ? data.text : "";
+      this.__renderRegisteredUsers();
+    },
+
+    __filterRegisteredUsers: function() {
+      if (!this.__registeredUsers) {
+        return [];
+      }
+
+      const text = this.__currentFilterText.trim();
+      if (!text || text.length < 2) {
+        return this.__registeredUsers;
+      }
+
+      const query = text.toLowerCase();
+      return this.__registeredUsers.filter(user => {
+        const fullName = `${user.firstName || ""} ${user.lastName || ""}`.trim().toLowerCase();
+        const email = (user.email || "").toLowerCase();
+        const username = (user.userName || "").toLowerCase();
+        return [fullName, email, username].some(value => value.includes(query));
+      });
+    },
+
+    __renderRegisteredUsers: function() {
+      const layout = this.getChildControl("registered-users-layout");
+      layout.removeAll();
+      this.__addHeader();
+      this.__addRows(this.__filterRegisteredUsers());
+    },
+  }
+});

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -62,7 +62,9 @@ qx.Class.define("osparc.po.UsersRegistered", {
           break;
         case "registered-users-container":
           control = new qx.ui.container.Scroll();
-          this._add(control);
+          this._add(control, {
+            flex: 1
+          });
           break;
         case "registered-users-layout": {
           const grid = new qx.ui.layout.Grid(20, 5);

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -5,7 +5,7 @@
    https://osparc.io
 
    Copyright:
-     2024 IT'IS Foundation, https://itis.swiss
+     2026 IT'IS Foundation, https://itis.swiss
 
    License:
      MIT: https://opensource.org/licenses/MIT
@@ -27,7 +27,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
       INFO: 4,
     },
 
-    PAGE_LIMIT: 10,
+    PAGE_LIMIT: 20,
   },
 
   members: {
@@ -65,7 +65,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
           this._add(control);
           break;
         case "registered-users-layout": {
-          const grid = new qx.ui.layout.Grid(15, 5);
+          const grid = new qx.ui.layout.Grid(20, 5);
           control = new qx.ui.container.Composite(grid);
           this.getChildControl("registered-users-container").add(control);
           break;
@@ -80,7 +80,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
           this._add(control);
           break;
         case "prev-page-button":
-          control = new qx.ui.form.Button(null, "@MaterialIcons/chevron_left/20").set({
+          control = new qx.ui.form.Button(null, "@MaterialIcons/chevron_left/16").set({
             allowGrowX: false,
             enabled: false,
             toolTipText: this.tr("Previous page"),
@@ -99,7 +99,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
           this.getChildControl("pagination-layout").add(control);
           break;
         case "next-page-button":
-          control = new qx.ui.form.Button(null, "@MaterialIcons/chevron_right/20").set({
+          control = new qx.ui.form.Button(null, "@MaterialIcons/chevron_right/16").set({
             allowGrowX: false,
             enabled: false,
             toolTipText: this.tr("Next page"),

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -164,14 +164,12 @@ qx.Class.define("osparc.po.UsersRegistered", {
     __addHeader: function() {
       const layout = this.getChildControl("registered-users-layout");
 
-      layout.add(new qx.ui.basic.Label(this.tr("Name")).set({
-        font: "text-14"
-      }), {
+      layout.add(this.__createSortableHeader(this.tr("Name"), "name"), {
         row: 0,
         column: this.self().COLUMNS.NAME,
       });
 
-      layout.add(this.__createSortableHeader(this.tr("Username"), "userName"), {
+      layout.add(new qx.ui.basic.Label(this.tr("Username")), { // Not sortable
         row: 0,
         column: this.self().COLUMNS.USERNAME,
       });

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -49,7 +49,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
           this.getChildControl("header-layout").add(control);
           break;
         case "intro-text":
-          control = new qx.ui.basic.Label(this.tr("List of active, registered, users:")).set({
+          control = new qx.ui.basic.Label(this.tr("List of fully registered users:")).set({
             font: "text-14",
             textColor: "text",
             allowGrowX: true

--- a/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersRegistered.js
@@ -45,13 +45,6 @@ qx.Class.define("osparc.po.UsersRegistered", {
           }));
           this._add(control);
           break;
-        case "reload-button":
-          control = new qx.ui.form.Button(this.tr("Reload")).set({
-            allowGrowX: false,
-          });
-          control.addListener("execute", () => this.__reload());
-          this.getChildControl("header-layout").add(control);
-          break;
         case "intro-text":
           control = new qx.ui.basic.Label(this.tr("List of fully registered users:")).set({
             font: "text-14",
@@ -80,9 +73,7 @@ qx.Class.define("osparc.po.UsersRegistered", {
         }
         case "registered-users-container":
           control = new qx.ui.container.Scroll();
-          this._add(control, {
-            flex: 1
-          });
+          this._add(control);
           break;
         case "registered-users-layout": {
           const grid = new qx.ui.layout.Grid(15, 5);
@@ -91,15 +82,19 @@ qx.Class.define("osparc.po.UsersRegistered", {
           break;
         }
         case "pagination-layout":
-          control = new qx.ui.container.Composite(new qx.ui.layout.HBox(10).set({
-            alignY: "middle"
-          }));
+          control = new qx.ui.container.Composite(new qx.ui.layout.HBox(8).set({
+            alignY: "middle",
+            alignX: "left"
+          })).set({
+            marginTop: 5,
+          });
           this._add(control);
           break;
         case "prev-page-button":
-          control = new qx.ui.form.Button(this.tr("Previous")).set({
+          control = new qx.ui.form.Button(null, "@MaterialIcons/chevron_left/20").set({
             allowGrowX: false,
             enabled: false,
+            toolTipText: this.tr("Previous page"),
           });
           control.addListener("execute", () => {
             this.__currentOffset = Math.max(0, this.__currentOffset - this.__pageLimit);
@@ -109,14 +104,16 @@ qx.Class.define("osparc.po.UsersRegistered", {
           break;
         case "page-info-label":
           control = new qx.ui.basic.Label("").set({
-            font: "text-14",
+            font: "text-13",
+            textColor: "text",
           });
           this.getChildControl("pagination-layout").add(control);
           break;
         case "next-page-button":
-          control = new qx.ui.form.Button(this.tr("Next")).set({
+          control = new qx.ui.form.Button(null, "@MaterialIcons/chevron_right/20").set({
             allowGrowX: false,
             enabled: false,
+            toolTipText: this.tr("Next page"),
           });
           control.addListener("execute", () => {
             this.__currentOffset += this.__pageLimit;
@@ -129,12 +126,11 @@ qx.Class.define("osparc.po.UsersRegistered", {
     },
 
     _buildLayout: function() {
-      this.getChildControl("reload-button");
       this.getChildControl("intro-text");
+      this.getChildControl("filter-users").exclude();
       this.getChildControl("loading-spinner");
-      this.getChildControl("prev-page-button");
-      this.getChildControl("page-info-label");
-      this.getChildControl("next-page-button");
+      this.getChildControl("registered-users-container");
+      this.getChildControl("pagination-layout");
       this.__currentOrderBy = "-accountRequestedReviewedAt";
       this.__fetchPage();
     },

--- a/services/static-webserver/client/source/class/osparc/po/UsersSearch.js
+++ b/services/static-webserver/client/source/class/osparc/po/UsersSearch.js
@@ -16,7 +16,7 @@
 
 ************************************************************************ */
 
-qx.Class.define("osparc.po.Users", {
+qx.Class.define("osparc.po.UsersSearch", {
   extend: osparc.po.BaseView,
 
   statics: {


### PR DESCRIPTION
## What do these changes do?

This is just a first iteration on the listing of registered users. So far, POs could only get the information of registered users by searching them first.

This PR adds a new "Active Users" tab (which complements the Review Users one) in the PO Center that lists all registered users for the current product using the ``GET /v0/admin/user-accounts?registered=true`` endpoint with proper server-side pagination and sorting. Now, POs can also go through this list and check users' information.

For the next iteration, PO's feedback, and backend effort, will be needed.

<img width="1093" height="711" alt="image" src="https://github.com/user-attachments/assets/b3ad5adc-fe4f-4ea0-97f8-2483185c2e44" />


## Related issue/s
- related to https://github.com/ITISFoundation/private-issues/issues/23


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
