### PR TITLE
🐛Docker healthcheck: increased start period time to 120s

### DIFF
--- a/.github/skills/healthcheck/SKILL.md
+++ b/.github/skills/healthcheck/SKILL.md
@@ -55,7 +55,7 @@ For the given `target_service`, produce:
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/"]
@@ -188,7 +188,7 @@ In `target_service` Dockerfile production stage:
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/"]

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -160,7 +160,7 @@ RUN chmod +x services/agent/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/health"]

--- a/services/autoscaling/Dockerfile
+++ b/services/autoscaling/Dockerfile
@@ -168,7 +168,7 @@ RUN chmod +x services/autoscaling/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/"]

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -153,7 +153,7 @@ RUN chmod +x services/catalog/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/"]

--- a/services/clusters-keeper/Dockerfile
+++ b/services/clusters-keeper/Dockerfile
@@ -171,7 +171,7 @@ RUN chmod +x services/clusters-keeper/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/"]

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -156,7 +156,7 @@ RUN chmod +x services/dask-sidecar/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://127.0.0.1:8787/health"]

--- a/services/datcore-adapter/Dockerfile
+++ b/services/datcore-adapter/Dockerfile
@@ -154,7 +154,7 @@ RUN chmod +x services/datcore-adapter/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/v0/live"]

--- a/services/director-v2/Dockerfile
+++ b/services/director-v2/Dockerfile
@@ -153,7 +153,7 @@ RUN chmod +x services/director-v2/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/"]

--- a/services/director/Dockerfile
+++ b/services/director/Dockerfile
@@ -149,7 +149,7 @@ RUN chmod +x services/director/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/v0/"]

--- a/services/docker-api-proxy/Dockerfile
+++ b/services/docker-api-proxy/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache \
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD curl --fail-with-body --user ${DOCKER_API_PROXY_USER}:${DOCKER_API_PROXY_PASSWORD} http://localhost:8888/version

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -150,7 +150,7 @@ RUN chmod +x services/dynamic-scheduler/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/health"]

--- a/services/efs-guardian/Dockerfile
+++ b/services/efs-guardian/Dockerfile
@@ -187,7 +187,7 @@ RUN chmod +x services/efs-guardian/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/"]

--- a/services/invitations/Dockerfile
+++ b/services/invitations/Dockerfile
@@ -153,7 +153,7 @@ RUN chmod +x services/invitations/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/"]

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -153,7 +153,7 @@ RUN chmod +x services/payments/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/"]

--- a/services/resource-usage-tracker/Dockerfile
+++ b/services/resource-usage-tracker/Dockerfile
@@ -152,7 +152,7 @@ RUN chmod +x services/resource-usage-tracker/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8000/"]

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -162,7 +162,7 @@ RUN chmod +x services/storage/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8080/v0/"]

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -169,7 +169,7 @@ RUN chmod +x services/web/server/docker/*.sh
 HEALTHCHECK \
   --interval=10s \
   --timeout=5s \
-  --start-period=20s \
+  --start-period=120s \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-m", "common_library.docker_healthcheck", "http://localhost:8080/v0/health"]


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
- A docker container healthcheck works like so:
during start period the health is checked every `start-interval` and fails do not count.
If during that time the check returns a `0` code it will switch to `interval` and fails will count.
If at the end of the time it was still returning `!0` then it will switch to `interval` fails will count.


Now, it seems something is going slower and that is not good. This PR will allow starting the containers, but still not good.

If this happens to also affect the dynamic-sidecar starting time, that is bad news @GitHK 

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
