### PR TITLE
✨Director-v0: cache services in Redis instead of in-process (⚠️ Devops)

### DIFF
--- a/.github/skills/run-python-tests/SKILL.md
+++ b/.github/skills/run-python-tests/SKILL.md
@@ -47,6 +47,8 @@ This installs the package in editable mode along with all test dependencies into
 
 > **Note**: You only need to re-run `make install-dev` when switching to a different project or after dependency changes. If you already installed for this project in the current session, you can skip this step.
 
+> **Note**: In the service-library, it is `make install-dev[all]` to include all dependencies required for testing.
+
 ### Step 4: Run tests
 
 ```bash

--- a/.github/skills/run-python-tests/SKILL.md
+++ b/.github/skills/run-python-tests/SKILL.md
@@ -64,9 +64,17 @@ pytest tests/unit/test_<name>.py::test_function_name -v
 
 Use `--keep-docker-up` flag when running integration tests to keep docker containers up between sessions.
 
-### Step 4b: Static analysis (optional but recommended)
+### Step 4b: Quick static analysis
+For any code changes, run the following quick checks and fix any issues before running the full test suite. These checks are much faster than the full test run and can catch common issues early.:
 
-Before or after running tests, verify the project passes static analysis from the project directory:
+```bash
+# Type checking with ruff:
+make ruff
+```
+
+### Step 4b: Long static analysis (required before committing changes)
+
+Verify the project passes static analysis from the project directory:
 
 ```bash
 # Type checking with mypy:

--- a/.github/skills/run-python-tests/SKILL.md
+++ b/.github/skills/run-python-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-python-tests
-description: 'Run Python tests and static analysis for any service or package in this monorepo. Use when: running pytest, executing unit tests, running integration tests, test failures, make install-dev, test setup, installing test dependencies, linting with pylint, and type checking with mypy.'
+description: 'Run Python tests for any service or package in this monorepo. Use when: running pytest, executing unit tests, running integration tests, test failures, make install-dev, test setup, installing test dependencies.'
 ---
 
 # Run Python Tests
@@ -11,60 +11,78 @@ description: 'Run Python tests and static analysis for any service or package in
 - Setting up a project for the first time before running tests
 - Debugging test failures related to missing modules or dependencies
 
-## Setup (first time or after switching projects)
+## Procedure
 
-Run these commands before testing this project.
+Follow these steps **in order**. Do not skip the install step unless you have already installed dependencies for this project in the current session.
+
+### Step 1: Activate the workspace virtual environment
 
 ```bash
-# 1. Activate the shared workspace venv (create with `make devenv` at repo root if missing)
 source .venv/bin/activate
+```
 
-# 2. Navigate to the project
-cd services/<service-name>   # e.g. cd services/payments, cd services/web/server
-# or
-cd packages/<package-name>   # e.g. cd packages/models-library
+All projects in this monorepo share a single workspace-level `.venv`, created once via `make devenv` at the repository root. It must be active before any install or test command.
 
-# 3. Install in editable mode with test dependencies
+### Step 2: Change to the project directory
+
+Navigate to the root of the specific service or package you want to test:
+
+```bash
+# For a service:
+cd services/<service-name>
+# e.g. cd services/payments, cd services/web/server
+
+# For a package:
+cd packages/<package-name>
+# e.g. cd packages/models-library, cd packages/pytest-simcore
+```
+
+### Step 3: Install in development mode
+
+```bash
 make install-dev
 ```
 
-## Running Tests
+This installs the package in editable mode along with all test dependencies into the shared `.venv`. This step is **required** before running tests — without it, imports will fail with `ModuleNotFoundError`.
+
+> **Note**: You only need to re-run `make install-dev` when switching to a different project or after dependency changes. If you already installed for this project in the current session, you can skip this step.
+
+### Step 4: Run tests
 
 ```bash
-# Run all tests:
+# Run all tests under the project's tests folder:
 pytest tests/ -v
 
-# Run a single file:
+# Run a single test file under tests/:
 pytest tests/unit/test_<name>.py -v
 
-# Run a single function:
+# Run a single test function under tests/:
 pytest tests/unit/test_<name>.py::test_function_name -v
-
-# Integration tests (keeps containers alive between runs):
-pytest tests/integration -v --keep-docker-up
 ```
 
-The `--keep-docker-up` flag is a pytest option provided by the `pytest-simcore` plugin. It prevents docker containers from being torn down after the test run, saving startup time on subsequent runs.
+> **Warning**: Do **NOT** use `make test*` — these targets normally include `--pdb`, which drops into an interactive debugger on failure and will block execution.
 
-> **Command priority**: `pytest` should always be used over `make test*` in this workflow, because `make test*` includes `--pdb` and blocks non-interactive execution on first failure.
+Use `--keep-docker-up` flag when running integration tests to keep docker containers up between sessions.
 
-### Static analysis (optional)
+### Step 4b: Static analysis (optional but recommended)
+
+Before or after running tests, verify the project passes static analysis from the project directory:
 
 ```bash
-make mypy     # type checking
-make pylint   # linting
+# Type checking with mypy:
+make mypy
+
+# Linting with pylint:
+make pylint
 ```
 
-## Troubleshooting
+These are fast checks that can catch issues without running the full test suite. Run them after making code changes to confirm correctness.
 
-If tests fail due to leftover docker state:
+### Step 5: Troubleshooting
 
-```bash
-# From the repository root:
-make down leave
-```
-
-Then re-run from the project directory.
+1. If tests fail with `ModuleNotFoundError` → re-run `make install-dev` in the project directory (Step 3).
+2. If tests fail with port conflicts or connection errors (stale docker state) → run `make down leave` from the repository root, then retry from Step 2.
+3. If `command not found` or wrong Python version → ensure the venv is active: `source .venv/bin/activate`.
 
 ## Common Mistakes
 
@@ -72,6 +90,7 @@ Then re-run from the project directory.
 |---------|---------|-----|
 | Skipping `make install-dev` | `ModuleNotFoundError` | Run `make install-dev` in the project directory |
 | Running pytest from workspace root | Wrong test discovery or missing conftest | `cd` to the specific project first |
+| Using `make test-unit` / `make test-integration` | Execution blocks on first test failure (`--pdb`) | Use `pytest tests/ -v` directly |
 | Venv not activated | `command not found` or wrong Python | `source .venv/bin/activate` (create it first with `make devenv` at repo root if missing) |
 | Stale docker containers | Port conflicts, connection errors | `make down leave` from workspace root |
 

--- a/.github/skills/run-python-tests/SKILL.md
+++ b/.github/skills/run-python-tests/SKILL.md
@@ -13,7 +13,7 @@ description: 'Run Python tests for any service or package in this monorepo. Use 
 
 ## Procedure
 
-Follow these steps **in order**. Do not skip the install step unless you have already installed dependencies for this project in the current session.
+Follow these steps **in order**. Do not skip the install step unless you have already installed dependencies for this project in the current python virtual environment.
 
 ### Step 1: Activate the workspace virtual environment
 
@@ -64,7 +64,7 @@ pytest tests/unit/test_<name>.py::test_function_name -v
 
 > **Warning**: Do **NOT** use `make test*` — these targets normally include `--pdb`, which drops into an interactive debugger on failure and will block execution.
 
-Use `--keep-docker-up` flag when running integration tests to keep docker containers up between sessions.
+Use `--keep-docker-up` flag when running unit and integration tests to keep docker containers up between sessions and improve performance.
 
 ### Step 4b: Quick static analysis
 For any code changes, run the following quick checks and fix any issues before running the full test suite. These checks are much faster than the full test run and can catch common issues early.:
@@ -74,7 +74,7 @@ For any code changes, run the following quick checks and fix any issues before r
 make ruff
 ```
 
-### Step 4b: Long static analysis (required before committing changes)
+### Step 4c: Long static analysis (required before committing changes)
 
 Verify the project passes static analysis from the project directory:
 
@@ -86,7 +86,7 @@ make mypy
 make pylint
 ```
 
-These are fast checks that can catch issues without running the full test suite. Run them after making code changes to confirm correctness.
+These are slow checks that can catch issues without running the full test suite. Run them after making code changes to confirm correctness.
 
 ### Step 5: Troubleshooting
 

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/docker_registry_images.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/docker_registry_images.py
@@ -1,0 +1,40 @@
+from typing import Any, Literal, Protocol, TypedDict
+
+
+class NodeRequirementsDict(TypedDict):
+    CPU: float
+    RAM: float
+
+
+class ServiceExtrasDict(TypedDict):
+    node_requirements: NodeRequirementsDict
+    build_date: str
+    vcs_ref: str
+    vcs_url: str
+
+
+class ServiceDescriptionDict(TypedDict):
+    key: str
+    version: str
+    type: Literal["computational", "dynamic"]
+
+
+class ServiceInRegistryInfoDict(TypedDict):
+    service_description: ServiceDescriptionDict
+    docker_labels: dict[str, Any]
+    image_path: str
+    internal_port: int | None
+    entry_point: str
+    service_extras: ServiceExtrasDict
+
+
+class PushServicesCallable(Protocol):
+    async def __call__(
+        self,
+        *,
+        number_of_computational_services: int,
+        number_of_interactive_services: int,
+        inter_dependent_services: bool = False,
+        bad_json_format: bool = False,
+        version="1.0.",
+    ) -> list[ServiceInRegistryInfoDict]: ...

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/docker_registry_images.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/docker_registry_images.py
@@ -37,4 +37,5 @@ class PushServicesCallable(Protocol):
         inter_dependent_services: bool = False,
         bad_json_format: bool = False,
         version="1.0.",
+        override_registry_url: str | None = None,
     ) -> list[ServiceInRegistryInfoDict]: ...

--- a/packages/settings-library/src/settings_library/redis.py
+++ b/packages/settings-library/src/settings_library/redis.py
@@ -20,6 +20,7 @@ class RedisDatabase(IntEnum):
     DYNAMIC_SERVICES = 8
     CELERY_TASKS = 9
     DOCUMENTS = 10
+    AIOCACHE = 11
 
 
 class RedisSettings(BaseCustomSettings):

--- a/services/director/requirements/_test.in
+++ b/services/director/requirements/_test.in
@@ -13,7 +13,7 @@ asgi_lifespan
 aioresponses
 docker
 faker
-fakeredis
+fakeredis[lua]
 jsonref
 pytest
 pytest-asyncio

--- a/services/director/requirements/_test.in
+++ b/services/director/requirements/_test.in
@@ -13,6 +13,7 @@ asgi_lifespan
 aioresponses
 docker
 faker
+fakeredis
 jsonref
 pytest
 pytest-asyncio

--- a/services/director/requirements/_test.txt
+++ b/services/director/requirements/_test.txt
@@ -76,6 +76,8 @@ jsonref==1.1.0
     # via
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
+lupa==2.8
+    # via fakeredis
 multidict==6.1.0
     # via
     #   -c requirements/_base.txt

--- a/services/director/requirements/_test.txt
+++ b/services/director/requirements/_test.txt
@@ -26,7 +26,7 @@ attrs==24.2.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   pytest-docker
-certifi==2026.5.20
+certifi==2024.8.30
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt

--- a/services/director/requirements/_test.txt
+++ b/services/director/requirements/_test.txt
@@ -26,7 +26,7 @@ attrs==24.2.0
     #   -c requirements/_base.txt
     #   aiohttp
     #   pytest-docker
-certifi==2024.8.30
+certifi==2026.5.20
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -42,6 +42,8 @@ coverage==7.13.5
 docker==7.1.0
     # via -r requirements/_test.in
 faker==40.11.0
+    # via -r requirements/_test.in
+fakeredis==2.36.0
     # via -r requirements/_test.in
 frozenlist==1.5.0
     # via
@@ -125,6 +127,11 @@ pytest-runner==6.0.1
     # via -r requirements/_test.in
 pytest-sugar==1.1.1
     # via -r requirements/_test.in
+redis==7.4.0
+    # via
+    #   -c requirements/../../../requirements/constraints.txt
+    #   -c requirements/_base.txt
+    #   fakeredis
 requests==2.32.4
     # via
     #   -c requirements/_base.txt
@@ -136,6 +143,8 @@ sniffio==1.3.1
     #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
+sortedcontainers==2.4.0
+    # via fakeredis
 termcolor==3.3.0
     # via pytest-sugar
 urllib3==2.7.0

--- a/services/director/src/simcore_service_director/core/application.py
+++ b/services/director/src/simcore_service_director/core/application.py
@@ -19,6 +19,7 @@ from .._meta import (
 )
 from ..api.rest.routes import setup_api_routes
 from ..instrumentation import setup as setup_instrumentation
+from ..modules.redis import setup as setup_redis
 from ..registry_proxy import setup as setup_registry
 from .settings import ApplicationSettings
 
@@ -54,6 +55,7 @@ def create_app(settings: ApplicationSettings, tracing_config: TracingConfig) -> 
         default_timeout=settings.DIRECTOR_REGISTRY_CLIENT_TIMEOUT,
         tracing_config=tracing_config,
     )
+    setup_redis(app)
     setup_registry(app)
 
     app.add_middleware(RequestCancellationMiddleware)

--- a/services/director/src/simcore_service_director/core/settings.py
+++ b/services/director/src/simcore_service_director/core/settings.py
@@ -87,7 +87,7 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
         RedisSettings | None,
         Field(json_schema_extra={"auto_default_from_env": True}),
     ] = None
-    DIRECTOR_REDIS_CACHE_BACKEND: Literal["memory", "redis"] = "memory"
+    DIRECTOR_REDIS_CACHE_BACKEND: Literal["memory", "redis"] = "redis"
     DIRECTOR_REDIS_CACHE_NAMESPACE: str = "director-v0-registry-cache"
 
     DIRECTOR_SERVICES_CUSTOM_PLACEMENT_CONSTRAINTS: Annotated[

--- a/services/director/src/simcore_service_director/core/settings.py
+++ b/services/director/src/simcore_service_director/core/settings.py
@@ -77,17 +77,19 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
 
     DIRECTOR_DEFAULT_MAX_NANO_CPUS: NonNegativeInt = 0
     DIRECTOR_DEFAULT_MAX_MEMORY: NonNegativeInt = 0
-    DIRECTOR_REGISTRY_CACHING: Annotated[bool, Field(description="cache the docker registry internally")]
+    DIRECTOR_REGISTRY_CACHING: Annotated[bool, Field(description="cache the docker registry")]
     DIRECTOR_REGISTRY_CACHING_TTL: Annotated[
         datetime.timedelta,
-        Field(description="cache time to live value (defaults to 15 minutes)"),
+        Field(description="cache time to live value for the docker registry cache"),
     ]
+    DIRECTOR_REGISTRY_CACHING_REDIS_NAMESPACE: Annotated[
+        str, Field(description="namespace for the docker registry cache in Redis")
+    ] = "director-v0-registry-cache"
 
     DIRECTOR_REDIS: Annotated[
         RedisSettings | None,
         Field(json_schema_extra={"auto_default_from_env": True}),
     ] = None
-    DIRECTOR_REDIS_CACHE_NAMESPACE: str = "director-v0-registry-cache"
 
     DIRECTOR_SERVICES_CUSTOM_PLACEMENT_CONSTRAINTS: Annotated[
         list[DockerPlacementConstraint],

--- a/services/director/src/simcore_service_director/core/settings.py
+++ b/services/director/src/simcore_service_director/core/settings.py
@@ -1,7 +1,7 @@
 import datetime
 import warnings
 from functools import cached_property
-from typing import Annotated, cast
+from typing import Annotated, Literal, cast
 
 from common_library.basic_types import DEFAULT_FACTORY
 from common_library.logging.logging_utils_filtering import LoggerName, MessageSubstring
@@ -19,11 +19,13 @@ from pydantic import (
     NonNegativeInt,
     PositiveInt,
     field_validator,
+    model_validator,
 )
 from servicelib.logging_utils import LogLevelInt
 from settings_library.application import BaseApplicationSettings
 from settings_library.docker_registry import RegistrySettings
 from settings_library.postgres import PostgresSettings
+from settings_library.redis import RedisSettings
 from settings_library.tracing import TracingSettings
 from settings_library.utils_logging import MixinLoggingSettings
 
@@ -52,7 +54,8 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
         bool,
         Field(
             validation_alias=AliasChoices("DIRECTOR_LOG_FORMAT_LOCAL_DEV_ENABLED", "LOG_FORMAT_LOCAL_DEV_ENABLED"),
-            description="Enables local development log format. WARNING: make sure it is disabled if you want to have structured logs!",
+            description="Enables local development log format. "
+            "WARNING: make sure it is disabled if you want to have structured logs!",
         ),
     ]
     DIRECTOR_LOG_FILTER_MAPPING: Annotated[
@@ -60,7 +63,8 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
         Field(
             default_factory=dict,
             validation_alias=AliasChoices("DIRECTOR_LOG_FILTER_MAPPING", "LOG_FILTER_MAPPING"),
-            description="is a dictionary that maps specific loggers (such as 'uvicorn.access' or 'gunicorn.access') to a list of log message patterns that should be filtered out.",
+            description="is a dictionary that maps specific loggers (such as 'uvicorn.access' or 'gunicorn.access') "
+            "to a list of log message patterns that should be filtered out.",
         ),
     ] = DEFAULT_FACTORY
     DIRECTOR_TRACING: Annotated[
@@ -79,6 +83,13 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
         Field(description="cache time to live value (defaults to 15 minutes)"),
     ]
 
+    DIRECTOR_REDIS: Annotated[
+        RedisSettings | None,
+        Field(json_schema_extra={"auto_default_from_env": True}),
+    ] = None
+    DIRECTOR_REDIS_CACHE_BACKEND: Literal["memory", "redis"] = "memory"
+    DIRECTOR_REDIS_CACHE_NAMESPACE: str = "director-v0-registry-cache"
+
     DIRECTOR_SERVICES_CUSTOM_PLACEMENT_CONSTRAINTS: Annotated[
         list[DockerPlacementConstraint],
         Field(default_factory=list, examples=['["node.labels.region==east", "one!=yes"]']),
@@ -95,7 +106,8 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
         Json[dict[DockerLabelKey, str]],
         Field(
             default_factory=lambda: "{}",
-            description="Dynamic placement labels for service node placement. Keys must be in CUSTOM_PLACEMENT_LABEL_KEYS.",
+            description="Dynamic placement labels for service node placement. "
+            "Keys must be in CUSTOM_PLACEMENT_LABEL_KEYS.",
             examples=['{"product-name": "osparc", "user-id": "{user_id}"}'],
         ),
     ] = DEFAULT_FACTORY
@@ -157,7 +169,10 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
     def _validate_osparc_custom_placement_constraints_keys(cls, v: dict[str, str]) -> dict[str, str]:
         invalid_keys = set(v.keys()) - set(OSPARC_CUSTOM_DOCKER_PLACEMENT_CONSTRAINTS_LABEL_KEYS)
         if invalid_keys:
-            msg = f"Invalid placement label keys {invalid_keys}. Must be one of {OSPARC_CUSTOM_DOCKER_PLACEMENT_CONSTRAINTS_LABEL_KEYS}"
+            msg = (
+                f"Invalid placement label keys {invalid_keys}. "
+                f"Must be one of {OSPARC_CUSTOM_DOCKER_PLACEMENT_CONSTRAINTS_LABEL_KEYS}"
+            )
             raise ValueError(msg)
         return v
 
@@ -184,6 +199,20 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
             raise ValueError(msg)
 
         return v
+
+    @model_validator(mode="after")
+    def _validate_redis_settings(self) -> "ApplicationSettings":
+        if (
+            self.DIRECTOR_REGISTRY_CACHING
+            and self.DIRECTOR_REDIS_CACHE_BACKEND == "redis"
+            and self.DIRECTOR_REDIS is None
+        ):
+            msg = (
+                "DIRECTOR_REDIS_CACHE_BACKEND='redis' with DIRECTOR_REGISTRY_CACHING=True "
+                "requires DIRECTOR_REDIS settings"
+            )
+            raise ValueError(msg)
+        return self
 
     @cached_property
     def log_level(self) -> LogLevelInt:

--- a/services/director/src/simcore_service_director/core/settings.py
+++ b/services/director/src/simcore_service_director/core/settings.py
@@ -1,7 +1,7 @@
 import datetime
 import warnings
 from functools import cached_property
-from typing import Annotated, Literal, cast
+from typing import Annotated, cast
 
 from common_library.basic_types import DEFAULT_FACTORY
 from common_library.logging.logging_utils_filtering import LoggerName, MessageSubstring
@@ -87,7 +87,6 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
         RedisSettings | None,
         Field(json_schema_extra={"auto_default_from_env": True}),
     ] = None
-    DIRECTOR_REDIS_CACHE_BACKEND: Literal["memory", "redis"] = "redis"
     DIRECTOR_REDIS_CACHE_NAMESPACE: str = "director-v0-registry-cache"
 
     DIRECTOR_SERVICES_CUSTOM_PLACEMENT_CONSTRAINTS: Annotated[
@@ -202,15 +201,8 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
 
     @model_validator(mode="after")
     def _validate_redis_settings(self) -> "ApplicationSettings":
-        if (
-            self.DIRECTOR_REGISTRY_CACHING
-            and self.DIRECTOR_REDIS_CACHE_BACKEND == "redis"
-            and self.DIRECTOR_REDIS is None
-        ):
-            msg = (
-                "DIRECTOR_REDIS_CACHE_BACKEND='redis' with DIRECTOR_REGISTRY_CACHING=True "
-                "requires DIRECTOR_REDIS settings"
-            )
+        if self.DIRECTOR_REGISTRY_CACHING and self.DIRECTOR_REDIS is None:
+            msg = "DIRECTOR_REGISTRY_CACHING=True requires DIRECTOR_REDIS settings"
             raise ValueError(msg)
         return self
 

--- a/services/director/src/simcore_service_director/modules/redis.py
+++ b/services/director/src/simcore_service_director/modules/redis.py
@@ -1,0 +1,50 @@
+from typing import cast
+
+from fastapi import FastAPI
+from servicelib.redis import RedisClientsManager, RedisManagerDBConfig
+from settings_library.redis import RedisDatabase
+
+from .._meta import APP_NAME
+from ..core.settings import ApplicationSettings, get_application_settings
+
+
+def setup(app: FastAPI) -> None:
+    async def on_startup() -> None:
+        settings: ApplicationSettings = get_application_settings(app)
+
+        app.state.redis_clients_manager = None
+        if not settings.DIRECTOR_REGISTRY_CACHING or settings.DIRECTOR_REDIS_CACHE_BACKEND != "redis":
+            return
+
+        redis_settings = settings.DIRECTOR_REDIS
+        if redis_settings is None:
+            msg = (
+                "DIRECTOR_REDIS_CACHE_BACKEND='redis' with DIRECTOR_REGISTRY_CACHING=True "
+                "requires DIRECTOR_REDIS settings"
+            )
+            raise RuntimeError(msg)
+
+        app.state.redis_clients_manager = redis_clients_manager = RedisClientsManager(
+            databases_configs={
+                RedisManagerDBConfig(database=db)
+                for db in (
+                    RedisDatabase.LOCKS,
+                    RedisDatabase.AIOCACHE,
+                )
+            },
+            settings=redis_settings,
+            client_name=APP_NAME,
+        )
+        await redis_clients_manager.setup()
+
+    async def on_shutdown() -> None:
+        redis_clients_manager: RedisClientsManager | None = app.state.redis_clients_manager
+        if redis_clients_manager:
+            await redis_clients_manager.shutdown()
+
+    app.add_event_handler("startup", on_startup)
+    app.add_event_handler("shutdown", on_shutdown)
+
+
+def get_redis_client_manager(app: FastAPI) -> RedisClientsManager:
+    return cast(RedisClientsManager, app.state.redis_clients_manager)

--- a/services/director/src/simcore_service_director/modules/redis.py
+++ b/services/director/src/simcore_service_director/modules/redis.py
@@ -13,15 +13,12 @@ def setup(app: FastAPI) -> None:
         settings: ApplicationSettings = get_application_settings(app)
 
         app.state.redis_clients_manager = None
-        if not settings.DIRECTOR_REGISTRY_CACHING or settings.DIRECTOR_REDIS_CACHE_BACKEND != "redis":
+        if not settings.DIRECTOR_REGISTRY_CACHING:
             return
 
         redis_settings = settings.DIRECTOR_REDIS
         if redis_settings is None:
-            msg = (
-                "DIRECTOR_REDIS_CACHE_BACKEND='redis' with DIRECTOR_REGISTRY_CACHING=True "
-                "requires DIRECTOR_REDIS settings"
-            )
+            msg = "DIRECTOR_REGISTRY_CACHING=True requires DIRECTOR_REDIS settings"
             raise RuntimeError(msg)
 
         app.state.redis_clients_manager = redis_clients_manager = RedisClientsManager(

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -553,7 +553,7 @@ async def get_image_labels(
                     "application/vnd.docker.distribution.manifest.list.v2+json",
                     "application/vnd.oci.image.index.v1+json",
                 ):
-                    _logger.info(
+                    _logger.debug(
                         "Docker image %s:%s contains multiple architectures %s. "
                         "Currently defaulting to first architecture",
                         image,

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -205,8 +205,6 @@ async def registry_request(
     cache: BaseCache = app.state.registry_cache_memory
     cache_key = f"{method}_{path}"
     if use_cache and (cached_response := await cache.get(cache_key)):
-        if isinstance(cached_response, list):
-            cached_response = tuple(cached_response)
         assert isinstance(cached_response, tuple)  # nosec
         return cast(tuple[dict, Mapping], cached_response)
     # Add proper Accept headers for manifest requests for accepting both v1 and v2
@@ -236,10 +234,9 @@ async def registry_request(
         raise DirectorRuntimeError(msg=msg) from exc
 
     if app_settings.DIRECTOR_REGISTRY_CACHING and method.upper() == "GET":
-        cached_response: tuple[dict, dict[str, str]] = (response, dict(response_headers))
         await cache.set(
             cache_key,
-            cached_response,
+            (response, response_headers),
             ttl=app_settings.DIRECTOR_REGISTRY_CACHING_TTL.total_seconds(),
         )
 

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -39,8 +39,9 @@ from .core.errors import (
 from .core.settings import ApplicationSettings, get_application_settings
 
 DEPENDENCIES_LABEL_KEY: str = "simcore.service.dependencies"
-_REGISTRY_CACHE_REFRESH_MARKER_KEY: Final[str] = "director:registry_cache:refresh_marker"
-_REGISTRY_CACHE_REFRESH_LOCK_KEY: Final[str] = "director:registry_cache:refresh_lock"
+_REDIS_NAMESPACE: Final[str] = "director:registry_cache"
+_REGISTRY_CACHE_REFRESH_MARKER_KEY: Final[str] = f"{_REDIS_NAMESPACE}:refresh_marker"
+_REGISTRY_CACHE_REFRESH_LOCK_KEY: Final[str] = f"{_REDIS_NAMESPACE}:refresh_lock"
 
 VERSION_REG = re.compile(
     r"^(0|[1-9]\d*)(\.(0|[1-9]\d*)){2}(-(0|[1-9]\d*|\d*[-a-zA-Z][-\da-zA-Z]*)(\.(0|[1-9]\d*|\d*[-a-zA-Z][-\da-zA-Z]*))*)?(\+[-\da-zA-Z]+(\.[-\da-zA-Z-]+)*)?$"

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -8,6 +8,7 @@ from typing import Any, Final, cast
 
 import httpx
 from aiocache import Cache, SimpleMemoryCache  # type: ignore[import-untyped]
+from aiocache.base import BaseCache  # type: ignore[import-untyped]
 from common_library.async_tools import cancel_wait_task
 from common_library.json_serialization import json_loads
 from fastapi import FastAPI, status
@@ -16,6 +17,7 @@ from servicelib.fastapi.httpx_client import get_httpx_client
 from servicelib.logging_utils import log_catch, log_context
 from servicelib.tracing import traced
 from servicelib.utils import limited_as_completed
+from settings_library.redis import RedisDatabase
 from tenacity import retry
 from tenacity.before_sleep import before_sleep_log
 from tenacity.retry import retry_if_exception_type
@@ -200,9 +202,11 @@ async def registry_request(
     use_cache: bool,
     **request_kwargs,
 ) -> tuple[dict, Mapping]:
-    cache: SimpleMemoryCache = app.state.registry_cache_memory
+    cache: BaseCache = app.state.registry_cache_memory
     cache_key = f"{method}_{path}"
     if use_cache and (cached_response := await cache.get(cache_key)):
+        if isinstance(cached_response, list):
+            cached_response = tuple(cached_response)
         assert isinstance(cached_response, tuple)  # nosec
         return cast(tuple[dict, Mapping], cached_response)
     # Add proper Accept headers for manifest requests for accepting both v1 and v2
@@ -232,9 +236,10 @@ async def registry_request(
         raise DirectorRuntimeError(msg=msg) from exc
 
     if app_settings.DIRECTOR_REGISTRY_CACHING and method.upper() == "GET":
+        cached_response: tuple[dict, dict[str, str]] = (response, dict(response_headers))
         await cache.set(
             cache_key,
-            (response, response_headers),
+            cached_response,
             ttl=app_settings.DIRECTOR_REGISTRY_CACHING_TTL.total_seconds(),
         )
 
@@ -261,13 +266,40 @@ async def _list_all_services_task(*, app: FastAPI) -> None:
         await list_services(app, ServiceType.ALL, update_cache=True)
 
 
+def _create_registry_cache(app_settings: ApplicationSettings) -> BaseCache:
+    if app_settings.DIRECTOR_REGISTRY_CACHING and app_settings.DIRECTOR_REDIS_CACHE_BACKEND == "redis":
+        assert app_settings.DIRECTOR_REDIS is not None  # nosec
+        assert Cache.REDIS is not None  # nosec
+        redis_settings = app_settings.DIRECTOR_REDIS
+        connection_pool_kwargs: dict[str, Any] = {}
+        if redis_settings.REDIS_USER:
+            connection_pool_kwargs["username"] = redis_settings.REDIS_USER
+
+        return cast(
+            BaseCache,
+            Cache(
+                Cache.REDIS,
+                endpoint=redis_settings.REDIS_HOST,
+                port=redis_settings.REDIS_PORT,
+                db=int(RedisDatabase.AIOCACHE),
+                password=(redis_settings.REDIS_PASSWORD.get_secret_value() if redis_settings.REDIS_PASSWORD else None),
+                ssl=redis_settings.REDIS_SECURE,
+                connection_pool_kwargs=connection_pool_kwargs if connection_pool_kwargs else None,
+                namespace=app_settings.DIRECTOR_REDIS_CACHE_NAMESPACE,
+            ),
+        )
+
+    cache = Cache(Cache.MEMORY)
+    assert isinstance(cache, SimpleMemoryCache)  # nosec
+    return cache
+
+
 def setup(app: FastAPI) -> None:
     async def on_startup() -> None:
-        cache = Cache(Cache.MEMORY)
-        assert isinstance(cache, SimpleMemoryCache)  # nosec
+        app_settings = get_application_settings(app)
+        cache = _create_registry_cache(app_settings)
         app.state.registry_cache_memory = cache
         await _setup_registry(app)
-        app_settings = get_application_settings(app)
         app.state.auto_cache_task = None
         if app_settings.DIRECTOR_REGISTRY_CACHING:
             app.state.auto_cache_task = create_periodic_task(
@@ -280,6 +312,8 @@ def setup(app: FastAPI) -> None:
     async def on_shutdown() -> None:
         if app.state.auto_cache_task:
             await cancel_wait_task(app.state.auto_cache_task)
+        if app.state.registry_cache_memory:
+            await app.state.registry_cache_memory.close()
 
     app.add_event_handler("startup", on_startup)
     app.add_event_handler("shutdown", on_shutdown)

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -378,7 +378,7 @@ def _create_registry_cache(app_settings: ApplicationSettings) -> BaseCache | Non
             password=(redis_settings.REDIS_PASSWORD.get_secret_value() if redis_settings.REDIS_PASSWORD else None),
             ssl=redis_settings.REDIS_SECURE,
             connection_pool_kwargs=connection_pool_kwargs if connection_pool_kwargs else None,
-            namespace=app_settings.DIRECTOR_REDIS_CACHE_NAMESPACE,
+            namespace=app_settings.DIRECTOR_REGISTRY_CACHING_REDIS_NAMESPACE,
         ),
     )
 

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -291,7 +291,7 @@ async def _is_cache_fresh(app: FastAPI) -> bool:
         redis_client: RedisClientSDK = redis_manager.client(database=RedisDatabase.LOCKS)
         marker_exists = await redis_client.redis.exists(_REGISTRY_CACHE_REFRESH_MARKER_KEY)
         if marker_exists:
-            _logger.info("Cache freshness marker found, skipping refresh")
+            _logger.debug("Cache freshness marker found, skipping refresh")
             return True
     except Exception:
         _logger.warning("Error checking cache freshness marker", exc_info=True)

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -205,7 +205,6 @@ async def registry_request(
     cache: BaseCache = app.state.registry_cache_memory
     cache_key = f"{method}_{path}"
     if use_cache and (cached_response := await cache.get(cache_key)):
-        assert isinstance(cached_response, tuple)  # nosec
         return cast(tuple[dict, Mapping], cached_response)
     # Add proper Accept headers for manifest requests for accepting both v1 and v2
     if "manifests/" in path and method.upper() == "GET":
@@ -236,7 +235,7 @@ async def registry_request(
     if app_settings.DIRECTOR_REGISTRY_CACHING and method.upper() == "GET":
         await cache.set(
             cache_key,
-            (response, response_headers),
+            (response, dict(response_headers)),
             ttl=app_settings.DIRECTOR_REGISTRY_CACHING_TTL.total_seconds(),
         )
 

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncGenerator, Mapping
 from typing import Any, Final, cast
 
 import httpx
-from aiocache import Cache, SimpleMemoryCache  # type: ignore[import-untyped]
+from aiocache import Cache  # type: ignore[import-untyped]
 from aiocache.base import BaseCache  # type: ignore[import-untyped]
 from common_library.async_tools import cancel_wait_task
 from common_library.json_serialization import json_loads
@@ -220,9 +220,9 @@ async def registry_request(
     use_cache: bool,
     **request_kwargs,
 ) -> tuple[dict, Mapping]:
-    cache: BaseCache = app.state.registry_cache_memory
+    cache: BaseCache | None = app.state.registry_cache_memory
     cache_key = f"{method}_{path}"
-    if use_cache and (cached_response := await cache.get(cache_key)):
+    if use_cache and cache and (cached_response := await cache.get(cache_key)):
         cached_body, cached_headers = cast(tuple[dict, Mapping], cached_response)
         return cached_body, _normalize_headers(cached_headers)
     # Add proper Accept headers for manifest requests for accepting both v1 and v2
@@ -253,6 +253,7 @@ async def registry_request(
 
     if app_settings.DIRECTOR_REGISTRY_CACHING and method.upper() == "GET":
         normalized_headers = _normalize_headers(response_headers)
+        assert cache is not None  # nosec
         await cache.set(
             cache_key,
             (response, normalized_headers),
@@ -281,7 +282,7 @@ async def _setup_registry(app: FastAPI) -> None:
 async def _is_cache_fresh(app: FastAPI) -> bool:
     """Check if cache freshness marker exists in Redis (skip refresh if fresh)."""
     app_settings = get_application_settings(app)
-    if not app_settings.DIRECTOR_REGISTRY_CACHING or app_settings.DIRECTOR_REDIS_CACHE_BACKEND != "redis":
+    if not app_settings.DIRECTOR_REGISTRY_CACHING:
         return False
 
     redis_manager = _get_redis_clients_manager(app)
@@ -303,7 +304,7 @@ async def _is_cache_fresh(app: FastAPI) -> bool:
 async def _set_cache_fresh_marker(app: FastAPI) -> None:
     """Set cache freshness marker in Redis after successful refresh."""
     app_settings = get_application_settings(app)
-    if not app_settings.DIRECTOR_REGISTRY_CACHING or app_settings.DIRECTOR_REDIS_CACHE_BACKEND != "redis":
+    if not app_settings.DIRECTOR_REGISTRY_CACHING:
         return
 
     redis_manager = _get_redis_clients_manager(app)
@@ -347,16 +348,7 @@ async def _list_all_services_task_locked(*, app: FastAPI) -> None:
 
 @traced
 async def _list_all_services_task(*, app: FastAPI) -> None:
-    """Refresh cache with optional distributed lock to prevent concurrent updates from multiple replicas."""
-    app_settings = get_application_settings(app)
-
-    # Without Redis backend, just update the cache
-    if not app_settings.DIRECTOR_REGISTRY_CACHING or app_settings.DIRECTOR_REDIS_CACHE_BACKEND != "redis":
-        with log_context(_logger, logging.INFO, msg="Updating cache with services (memory backend)"):
-            await list_services(app, ServiceType.ALL, update_cache=True)
-        return
-
-    # With Redis backend, try to use distributed lock
+    """Refresh cache with distributed lock to prevent concurrent updates from multiple replicas."""
     try:
         await _list_all_services_task_locked(app=app)
     except CouldNotAcquireLockError:
@@ -365,32 +357,30 @@ async def _list_all_services_task(*, app: FastAPI) -> None:
         _logger.exception("Error during cache refresh with lock, skipping this cycle")
 
 
-def _create_registry_cache(app_settings: ApplicationSettings) -> BaseCache:
-    if app_settings.DIRECTOR_REGISTRY_CACHING and app_settings.DIRECTOR_REDIS_CACHE_BACKEND == "redis":
-        assert app_settings.DIRECTOR_REDIS is not None  # nosec
-        assert Cache.REDIS is not None  # nosec
-        redis_settings = app_settings.DIRECTOR_REDIS
-        connection_pool_kwargs: dict[str, Any] = {}
-        if redis_settings.REDIS_USER:
-            connection_pool_kwargs["username"] = redis_settings.REDIS_USER
+def _create_registry_cache(app_settings: ApplicationSettings) -> BaseCache | None:
+    if not app_settings.DIRECTOR_REGISTRY_CACHING:
+        return None
 
-        return cast(
-            BaseCache,
-            Cache(
-                Cache.REDIS,
-                endpoint=redis_settings.REDIS_HOST,
-                port=redis_settings.REDIS_PORT,
-                db=int(RedisDatabase.AIOCACHE),
-                password=(redis_settings.REDIS_PASSWORD.get_secret_value() if redis_settings.REDIS_PASSWORD else None),
-                ssl=redis_settings.REDIS_SECURE,
-                connection_pool_kwargs=connection_pool_kwargs if connection_pool_kwargs else None,
-                namespace=app_settings.DIRECTOR_REDIS_CACHE_NAMESPACE,
-            ),
-        )
+    assert app_settings.DIRECTOR_REDIS is not None  # nosec
+    assert Cache.REDIS is not None  # nosec
+    redis_settings = app_settings.DIRECTOR_REDIS
+    connection_pool_kwargs: dict[str, Any] = {}
+    if redis_settings.REDIS_USER:
+        connection_pool_kwargs["username"] = redis_settings.REDIS_USER
 
-    cache = Cache(Cache.MEMORY)
-    assert isinstance(cache, SimpleMemoryCache)  # nosec
-    return cache
+    return cast(
+        BaseCache,
+        Cache(
+            Cache.REDIS,
+            endpoint=redis_settings.REDIS_HOST,
+            port=redis_settings.REDIS_PORT,
+            db=int(RedisDatabase.AIOCACHE),
+            password=(redis_settings.REDIS_PASSWORD.get_secret_value() if redis_settings.REDIS_PASSWORD else None),
+            ssl=redis_settings.REDIS_SECURE,
+            connection_pool_kwargs=connection_pool_kwargs if connection_pool_kwargs else None,
+            namespace=app_settings.DIRECTOR_REDIS_CACHE_NAMESPACE,
+        ),
+    )
 
 
 def setup(app: FastAPI) -> None:

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -54,6 +54,12 @@ class ServiceType(enum.Enum):
     DYNAMIC = "dynamic"
 
 
+def _normalize_headers(headers: Mapping[str, Any] | None) -> dict[str, str]:
+    if not headers:
+        return {}
+    return {str(k).lower(): str(v) for k, v in headers.items()}
+
+
 async def _basic_auth_registry_request(app: FastAPI, path: str, method: str, **request_kwargs) -> tuple[dict, Mapping]:
     app_settings = get_application_settings(app)
     # try the registry with basic authentication first, spare 1 call
@@ -205,7 +211,8 @@ async def registry_request(
     cache: BaseCache = app.state.registry_cache_memory
     cache_key = f"{method}_{path}"
     if use_cache and (cached_response := await cache.get(cache_key)):
-        return cast(tuple[dict, Mapping], cached_response)
+        cached_body, cached_headers = cast(tuple[dict, Mapping], cached_response)
+        return cached_body, _normalize_headers(cached_headers)
     # Add proper Accept headers for manifest requests for accepting both v1 and v2
     if "manifests/" in path and method.upper() == "GET":
         headers = request_kwargs.get("headers", {})
@@ -233,13 +240,15 @@ async def registry_request(
         raise DirectorRuntimeError(msg=msg) from exc
 
     if app_settings.DIRECTOR_REGISTRY_CACHING and method.upper() == "GET":
+        normalized_headers = _normalize_headers(response_headers)
         await cache.set(
             cache_key,
-            (response, dict(response_headers)),
+            (response, normalized_headers),
             ttl=app_settings.DIRECTOR_REGISTRY_CACHING_TTL.total_seconds(),
         )
+        return response, normalized_headers
 
-    return response, response_headers
+    return response, _normalize_headers(response_headers)
 
 
 async def _setup_registry(app: FastAPI) -> None:
@@ -341,8 +350,8 @@ async def _list_repositories_gen(
         prefetch_task: asyncio.Task | None = None
         try:
             while True:
-                if "Link" in headers:
-                    next_path = str(headers["Link"]).split(";")[0].strip("<>").removeprefix("/v2/")
+                if link_header := headers.get("link"):
+                    next_path = str(link_header).split(";")[0].strip("<>").removeprefix("/v2/")
                     prefetch_task = asyncio.create_task(
                         registry_request(app, path=next_path, method="GET", use_cache=not update_cache)
                     )
@@ -375,8 +384,8 @@ async def list_image_tags_gen(app: FastAPI, image_key: str, *, update_cache=Fals
         prefetch_task: asyncio.Task | None = None
         try:
             while True:
-                if "Link" in headers:
-                    next_path = str(headers["Link"]).split(";")[0].strip("<>").removeprefix("/v2/")
+                if link_header := headers.get("link"):
+                    next_path = str(link_header).split(";")[0].strip("<>").removeprefix("/v2/")
                     prefetch_task = asyncio.create_task(
                         registry_request(app, path=next_path, method="GET", use_cache=not update_cache)
                     )
@@ -411,7 +420,7 @@ async def list_image_tags(app: FastAPI, image_key: str) -> list[str]:
     return image_tags
 
 
-_DOCKER_CONTENT_DIGEST_HEADER: Final[str] = "Docker-Content-Digest"
+_DOCKER_CONTENT_DIGEST_HEADER: Final[str] = "docker-content-digest"
 
 
 async def get_image_digest(app: FastAPI, image: str, tag: str) -> str | None:

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -15,6 +15,10 @@ from fastapi import FastAPI, status
 from servicelib.background_task import create_periodic_task
 from servicelib.fastapi.httpx_client import get_httpx_client
 from servicelib.logging_utils import log_catch, log_context
+from servicelib.redis import RedisClientsManager
+from servicelib.redis._client import RedisClientSDK
+from servicelib.redis._decorators import exclusive
+from servicelib.redis._errors import CouldNotAcquireLockError
 from servicelib.tracing import traced
 from servicelib.utils import limited_as_completed
 from settings_library.redis import RedisDatabase
@@ -35,6 +39,8 @@ from .core.errors import (
 from .core.settings import ApplicationSettings, get_application_settings
 
 DEPENDENCIES_LABEL_KEY: str = "simcore.service.dependencies"
+_REGISTRY_CACHE_REFRESH_MARKER_KEY: Final[str] = "director:registry_cache:refresh_marker"
+_REGISTRY_CACHE_REFRESH_LOCK_KEY: Final[str] = "director:registry_cache:refresh_lock"
 
 VERSION_REG = re.compile(
     r"^(0|[1-9]\d*)(\.(0|[1-9]\d*)){2}(-(0|[1-9]\d*|\d*[-a-zA-Z][-\da-zA-Z]*)(\.(0|[1-9]\d*|\d*[-a-zA-Z][-\da-zA-Z]*))*)?(\+[-\da-zA-Z]+(\.[-\da-zA-Z-]+)*)?$"
@@ -58,6 +64,11 @@ def _normalize_headers(headers: Mapping[str, Any] | None) -> dict[str, str]:
     if not headers:
         return {}
     return {str(k).lower(): str(v) for k, v in headers.items()}
+
+
+def _get_redis_clients_manager(app: FastAPI) -> RedisClientsManager | None:
+    """Get Redis clients manager from app state, returns None if not configured."""
+    return getattr(app.state, "redis_clients_manager", None)
 
 
 async def _basic_auth_registry_request(app: FastAPI, path: str, method: str, **request_kwargs) -> tuple[dict, Mapping]:
@@ -265,10 +276,91 @@ async def _setup_registry(app: FastAPI) -> None:
         await _wait_until_registry_responsive(app)
 
 
+async def _is_cache_fresh(app: FastAPI) -> bool:
+    """Check if cache freshness marker exists in Redis (skip refresh if fresh)."""
+    app_settings = get_application_settings(app)
+    if not app_settings.DIRECTOR_REGISTRY_CACHING or app_settings.DIRECTOR_REDIS_CACHE_BACKEND != "redis":
+        return False
+
+    redis_manager = _get_redis_clients_manager(app)
+    if redis_manager is None:
+        return False
+
+    try:
+        redis_client: RedisClientSDK = redis_manager.client(database=RedisDatabase.LOCKS)
+        marker_exists = await redis_client.redis.exists(_REGISTRY_CACHE_REFRESH_MARKER_KEY)
+        if marker_exists:
+            _logger.info("Cache freshness marker found, skipping refresh")
+            return True
+    except Exception:
+        _logger.warning("Error checking cache freshness marker", exc_info=True)
+
+    return False
+
+
+async def _set_cache_fresh_marker(app: FastAPI) -> None:
+    """Set cache freshness marker in Redis after successful refresh."""
+    app_settings = get_application_settings(app)
+    if not app_settings.DIRECTOR_REGISTRY_CACHING or app_settings.DIRECTOR_REDIS_CACHE_BACKEND != "redis":
+        return
+
+    redis_manager = _get_redis_clients_manager(app)
+    if redis_manager is None:
+        return
+
+    try:
+        redis_client: RedisClientSDK = redis_manager.client(database=RedisDatabase.LOCKS)
+        # Set marker TTL to half the cache TTL, so it expires if no refresh happens
+        marker_ttl = int(app_settings.DIRECTOR_REGISTRY_CACHING_TTL.total_seconds() / 2)
+        await redis_client.redis.setex(_REGISTRY_CACHE_REFRESH_MARKER_KEY, marker_ttl, "1")
+        _logger.info("Cache freshness marker set with TTL=%s seconds", marker_ttl)
+    except Exception:
+        _logger.warning("Error setting cache freshness marker", exc_info=True)
+
+
+def _get_redis_client_for_lock(app: FastAPI) -> RedisClientSDK:
+    """Get Redis client from LOCKS database, raises error if not configured."""
+    redis_manager = _get_redis_clients_manager(app)
+    if redis_manager is None:
+        msg = "Redis manager not available for cache lock"
+        raise RuntimeError(msg)
+    return redis_manager.client(database=RedisDatabase.LOCKS)
+
+
+@traced
+@exclusive(
+    redis_client=_get_redis_client_for_lock,
+    lock_key=_REGISTRY_CACHE_REFRESH_LOCK_KEY,
+    blocking=False,
+)
+async def _list_all_services_task_locked(*, app: FastAPI) -> None:
+    """Refresh cache (called with distributed lock from @exclusive decorator)."""
+    with log_context(_logger, logging.INFO, msg="Updating cache with services (with lock)"):
+        cache_is_fresh = await _is_cache_fresh(app)
+        if not cache_is_fresh:
+            await list_services(app, ServiceType.ALL, update_cache=True)
+            # Mark cache as fresh after successful refresh
+            await _set_cache_fresh_marker(app)
+
+
 @traced
 async def _list_all_services_task(*, app: FastAPI) -> None:
-    with log_context(_logger, logging.INFO, msg="Updating cache with services"):
-        await list_services(app, ServiceType.ALL, update_cache=True)
+    """Refresh cache with optional distributed lock to prevent concurrent updates from multiple replicas."""
+    app_settings = get_application_settings(app)
+
+    # Without Redis backend, just update the cache
+    if not app_settings.DIRECTOR_REGISTRY_CACHING or app_settings.DIRECTOR_REDIS_CACHE_BACKEND != "redis":
+        with log_context(_logger, logging.INFO, msg="Updating cache with services (memory backend)"):
+            await list_services(app, ServiceType.ALL, update_cache=True)
+        return
+
+    # With Redis backend, try to use distributed lock
+    try:
+        await _list_all_services_task_locked(app=app)
+    except CouldNotAcquireLockError:
+        _logger.debug("Another replica is refreshing cache, skipping this cycle")
+    except Exception:
+        _logger.exception("Error during cache refresh with lock, skipping this cycle")
 
 
 def _create_registry_cache(app_settings: ApplicationSettings) -> BaseCache:
@@ -309,7 +401,7 @@ def setup(app: FastAPI) -> None:
         if app_settings.DIRECTOR_REGISTRY_CACHING:
             app.state.auto_cache_task = create_periodic_task(
                 _list_all_services_task,
-                interval=app_settings.DIRECTOR_REGISTRY_CACHING_TTL / 2,
+                interval=app_settings.DIRECTOR_REGISTRY_CACHING_TTL / 4,
                 task_name="director-auto-cache-task",
                 app=app,
             )
@@ -460,12 +552,12 @@ async def get_image_labels(
                     "application/vnd.docker.distribution.manifest.list.v2+json",
                     "application/vnd.oci.image.index.v1+json",
                 ):
-                    # default to x86_64 architecture
                     _logger.info(
-                        "Docker image %s:%s contains multiple architectures. "
+                        "Docker image %s:%s contains multiple architectures %s. "
                         "Currently defaulting to first architecture",
                         image,
                         tag,
+                        [manifest.get("platform", {}) for manifest in request_result.get("manifests", [])],
                     )
                     manifests = request_result.get("manifests", [])
                     if not manifests:

--- a/services/director/src/simcore_service_director/registry_proxy.py
+++ b/services/director/src/simcore_service_director/registry_proxy.py
@@ -255,7 +255,8 @@ async def registry_request(
         await cache.set(
             cache_key,
             (response, normalized_headers),
-            ttl=app_settings.DIRECTOR_REGISTRY_CACHING_TTL.total_seconds(),
+            ttl=app_settings.DIRECTOR_REGISTRY_CACHING_TTL.total_seconds()
+            * 2,  # cache TTL should be longer than refresh interval to avoid cache misses
         )
         return response, normalized_headers
 
@@ -311,7 +312,7 @@ async def _set_cache_fresh_marker(app: FastAPI) -> None:
     try:
         redis_client: RedisClientSDK = redis_manager.client(database=RedisDatabase.LOCKS)
         # Set marker TTL to half the cache TTL, so it expires if no refresh happens
-        marker_ttl = int(app_settings.DIRECTOR_REGISTRY_CACHING_TTL.total_seconds() / 2)
+        marker_ttl = int(app_settings.DIRECTOR_REGISTRY_CACHING_TTL.total_seconds())
         await redis_client.redis.setex(_REGISTRY_CACHE_REFRESH_MARKER_KEY, marker_ttl, "1")
         _logger.info("Cache freshness marker set with TTL=%s seconds", marker_ttl)
     except Exception:

--- a/services/director/tests/unit/conftest.py
+++ b/services/director/tests/unit/conftest.py
@@ -31,6 +31,7 @@ pytest_plugins = [
     "pytest_simcore.faker_projects_data",
     "pytest_simcore.faker_users_data",
     "pytest_simcore.logging",
+    "pytest_simcore.redis_service",
     "pytest_simcore.repository_paths",
     "pytest_simcore.simcore_service_library_fixtures",
 ]

--- a/services/director/tests/unit/conftest.py
+++ b/services/director/tests/unit/conftest.py
@@ -6,15 +6,21 @@
 from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 import pytest
+import redis.asyncio as redis_asyncio
 import simcore_service_director
 from asgi_lifespan import LifespanManager
+from fakeredis import FakeServer
+from fakeredis.aioredis import FakeConnection
 from fastapi import FastAPI
+from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from servicelib.tracing import TracingConfig
 from settings_library.docker_registry import RegistrySettings
+from settings_library.redis import RedisSettings
 from simcore_service_director._meta import APP_NAME
 from simcore_service_director.core.application import create_app
 from simcore_service_director.core.settings import ApplicationSettings
@@ -213,3 +219,30 @@ def configure_registry_redis_backend(
             "REDIS_PASSWORD": "null",
         },
     )
+
+
+@pytest.fixture
+def with_disabled_auto_caching_task(mocker: MockerFixture) -> mock.Mock:
+    return mocker.patch("simcore_service_director.registry_proxy._list_all_services_task", autospec=True)
+
+
+@pytest.fixture
+def use_in_memory_redis(mocker: MockerFixture) -> RedisSettings:
+    # Also patch the redis client of aiocache to use fakeredis,
+    # so that the registry proxy tests can run without a real Redis server
+    fake_server = FakeServer()
+    OriginalPool = redis_asyncio.ConnectionPool
+
+    def fake_connection_pool(*args, **kwargs) -> redis_asyncio.ConnectionPool:
+        kwargs["connection_class"] = FakeConnection
+        kwargs["server"] = fake_server
+        return OriginalPool(*args, **kwargs)
+
+    mocker.patch(
+        "redis.asyncio.from_url",
+        lambda *a, **kw: redis_asyncio.Redis(  # noqa: ARG005
+            connection_pool=fake_connection_pool(**kw),
+        ),
+    )
+    mocker.patch("redis.asyncio.ConnectionPool", fake_connection_pool)
+    return RedisSettings()

--- a/services/director/tests/unit/conftest.py
+++ b/services/director/tests/unit/conftest.py
@@ -198,3 +198,14 @@ def configured_docker_network(
         monkeypatch,
         {"DIRECTOR_SIMCORE_SERVICES_NETWORK_NAME": with_docker_network["Name"]},
     )
+
+
+@pytest.fixture
+def configure_registry_redis_backend(
+    app_environment: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> EnvVarsDict:
+    return app_environment | setenvs_from_dict(
+        monkeypatch,
+        {"DIRECTOR_REDIS_CACHE_BACKEND": "redis"},
+    )

--- a/services/director/tests/unit/conftest.py
+++ b/services/director/tests/unit/conftest.py
@@ -80,7 +80,6 @@ def configure_registry_access(
             "REGISTRY_URL": docker_registry,
             "REGISTRY_PATH": docker_registry,
             "REGISTRY_SSL": False,
-            "DIRECTOR_REGISTRY_CACHING": False,
         },
     )
 
@@ -97,7 +96,6 @@ def configure_external_registry_access(
         envs={
             **external_registry_settings.model_dump(by_alias=True, exclude_none=True),
             "REGISTRY_PW": external_registry_settings.REGISTRY_PW.get_secret_value(),
-            "DIRECTOR_REGISTRY_CACHING": False,
         },
     )
 
@@ -127,9 +125,16 @@ def configure_custom_registry(
             "REGISTRY_USER": registry_user,
             "REGISTRY_PW": registry_pw,
             "REGISTRY_SSL": False,
-            "DIRECTOR_REGISTRY_CACHING": False,
         },
     )
+
+
+@pytest.fixture
+def configure_registry_caching(
+    app_environment: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> EnvVarsDict:
+    return app_environment | setenvs_from_dict(monkeypatch, {"DIRECTOR_REGISTRY_CACHING": True})
 
 
 @pytest.fixture
@@ -147,6 +152,7 @@ def app_environment(
         {
             **docker_compose_service_environment_dict,
             "DIRECTOR_TRACING": "null",
+            "DIRECTOR_REGISTRY_CACHING": False,
         },
     )
 

--- a/services/director/tests/unit/conftest.py
+++ b/services/director/tests/unit/conftest.py
@@ -214,7 +214,6 @@ def configure_registry_redis_backend(
     return app_environment | setenvs_from_dict(
         monkeypatch,
         {
-            "DIRECTOR_REDIS_CACHE_BACKEND": "redis",
             "REDIS_USER": "null",
             "REDIS_PASSWORD": "null",
         },

--- a/services/director/tests/unit/conftest.py
+++ b/services/director/tests/unit/conftest.py
@@ -207,5 +207,9 @@ def configure_registry_redis_backend(
 ) -> EnvVarsDict:
     return app_environment | setenvs_from_dict(
         monkeypatch,
-        {"DIRECTOR_REDIS_CACHE_BACKEND": "redis"},
+        {
+            "DIRECTOR_REDIS_CACHE_BACKEND": "redis",
+            "REDIS_USER": "null",
+            "REDIS_PASSWORD": "null",
+        },
     )

--- a/services/director/tests/unit/fixtures/fake_services.py
+++ b/services/director/tests/unit/fixtures/fake_services.py
@@ -12,46 +12,26 @@ import sys
 from collections.abc import Awaitable, Iterator
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Literal, Protocol, TypedDict
+from typing import Any, Literal
 
+import httpx
 import pytest
-import requests
 from aiodocker import utils
 from aiodocker.docker import Docker
 from aiodocker.exceptions import DockerError
+from pytest_simcore.helpers.docker_registry_images import (
+    NodeRequirementsDict,
+    PushServicesCallable,
+    ServiceDescriptionDict,
+    ServiceExtrasDict,
+    ServiceInRegistryInfoDict,
+)
 from simcore_service_director.core.settings import ApplicationSettings
 
 _logger = logging.getLogger(__name__)
 
 
 CURRENT_DIR = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
-
-
-class NodeRequirementsDict(TypedDict):
-    CPU: float
-    RAM: float
-
-
-class ServiceExtrasDict(TypedDict):
-    node_requirements: NodeRequirementsDict
-    build_date: str
-    vcs_ref: str
-    vcs_url: str
-
-
-class ServiceDescriptionDict(TypedDict):
-    key: str
-    version: str
-    type: Literal["computational", "dynamic"]
-
-
-class ServiceInRegistryInfoDict(TypedDict):
-    service_description: ServiceDescriptionDict
-    docker_labels: dict[str, Any]
-    image_path: str
-    internal_port: int | None
-    entry_point: str
-    service_extras: ServiceExtrasDict
 
 
 def _create_service_description(
@@ -84,7 +64,7 @@ def _create_docker_labels(service_description: ServiceDescriptionDict, *, bad_js
     return docker_labels
 
 
-async def _create_base_image(labels, tag) -> dict[str, Any]:
+async def _create_base_image(labels: dict[str, Any], tag: str) -> dict[str, Any]:
     dockerfile = """
 FROM alpine
 CMD while true; do sleep 10; done
@@ -93,10 +73,8 @@ CMD while true; do sleep 10; done
     tar_obj = utils.mktar_from_dockerfile(f)
 
     # build docker base image
-    docker = Docker()
-    base_docker_image = await docker.images.build(fileobj=tar_obj, encoding="gzip", rm=True, labels=labels, tag=tag)
-    await docker.close()
-    return base_docker_image
+    async with Docker() as docker:
+        return await docker.images.build(fileobj=tar_obj, encoding="gzip", rm=True, labels=labels, tag=tag)
 
 
 async def _build_and_push_image(
@@ -176,14 +154,8 @@ async def _build_and_push_image(
     await _create_base_image(docker_labels, image_tag)
 
     # push image to registry
-    try:
-        docker = Docker()
+    async with Docker() as docker:
         await docker.images.push(image_tag)
-    finally:
-        await docker.close()
-
-    # remove image from host
-    # docker.images.remove(image_tag)
 
     return ServiceInRegistryInfoDict(
         service_description=service_description,
@@ -216,7 +188,7 @@ def _clean_registry(list_of_images: list[ServiceInRegistryInfoDict]) -> None:
         registry_url = image["image_path"].split("/")[0]
 
         url = f"http://{registry_url}/v2/{name}/manifests/{tag}"
-        response = requests.get(url, headers=request_headers, timeout=10)
+        response = httpx.get(url, headers=request_headers, timeout=10)
         if response.status_code == 404:
             _logger.warning("Image %s not found in registry, skipping deletion", image["image_path"])
             continue
@@ -226,20 +198,8 @@ def _clean_registry(list_of_images: list[ServiceInRegistryInfoDict]) -> None:
         docker_content_digest = response.headers["Docker-Content-Digest"]
         # remove the image from the registry
         delete_url = f"http://{registry_url}/v2/{name}/manifests/{docker_content_digest}"
-        delete_resp = requests.delete(delete_url, timeout=5)
+        delete_resp = httpx.delete(delete_url, timeout=5)
         delete_resp.raise_for_status()
-
-
-class PushServicesCallable(Protocol):
-    async def __call__(
-        self,
-        *,
-        number_of_computational_services: int,
-        number_of_interactive_services: int,
-        inter_dependent_services: bool = False,
-        bad_json_format: bool = False,
-        version="1.0.",
-    ) -> list[ServiceInRegistryInfoDict]: ...
 
 
 @pytest.fixture

--- a/services/director/tests/unit/fixtures/fake_services.py
+++ b/services/director/tests/unit/fixtures/fake_services.py
@@ -194,7 +194,7 @@ def _clean_registry(list_of_images: list[ServiceInRegistryInfoDict]) -> None:
             continue
         response.raise_for_status()
 
-        _logger.info("Image %s manifest response %s, headers %s", image["image_path"], response.text, response.headers)
+        _logger.debug("Image %s manifest response %s, headers %s", image["image_path"], response.text, response.headers)
         docker_content_digest = response.headers["Docker-Content-Digest"]
         # remove the image from the registry
         delete_url = f"http://{registry_url}/v2/{name}/manifests/{docker_content_digest}"

--- a/services/director/tests/unit/fixtures/fake_services.py
+++ b/services/director/tests/unit/fixtures/fake_services.py
@@ -64,7 +64,7 @@ def _create_docker_labels(service_description: ServiceDescriptionDict, *, bad_js
     return docker_labels
 
 
-async def _create_base_image(labels: dict[str, Any], tag: str) -> dict[str, Any]:
+async def _create_base_image(docker: Docker, labels: dict[str, Any], tag: str) -> dict[str, Any]:
     dockerfile = """
 FROM alpine
 CMD while true; do sleep 10; done
@@ -73,8 +73,7 @@ CMD while true; do sleep 10; done
     tar_obj = utils.mktar_from_dockerfile(f)
 
     # build docker base image
-    async with Docker() as docker:
-        return await docker.images.build(fileobj=tar_obj, encoding="gzip", rm=True, labels=labels, tag=tag)
+    return await docker.images.build(fileobj=tar_obj, encoding="gzip", rm=True, labels=labels, tag=tag)
 
 
 async def _build_and_push_image(
@@ -151,10 +150,10 @@ async def _build_and_push_image(
     docker_labels["org.label-schema.vcs-url"] = service_extras["vcs_url"]
 
     image_tag = registry_url + "/{key}:{version}".format(key=service_description["key"], version=tag)
-    await _create_base_image(docker_labels, image_tag)
-
-    # push image to registry
     async with Docker() as docker:
+        await _create_base_image(docker, docker_labels, image_tag)
+
+        # push image to registry
         await docker.images.push(image_tag)
 
     return ServiceInRegistryInfoDict(
@@ -181,25 +180,31 @@ def _clean_registry(list_of_images: list[ServiceInRegistryInfoDict]) -> None:
             ]
         )
     }
-    for image in list_of_images:
-        service_description = image["service_description"]
-        tag = service_description["version"]
-        name = service_description["key"]
-        registry_url = image["image_path"].split("/")[0]
+    with httpx.Client(headers=request_headers, timeout=10) as client:
+        for image in list_of_images:
+            service_description = image["service_description"]
+            tag = service_description["version"]
+            name = service_description["key"]
+            registry_url = image["image_path"].split("/")[0]
 
-        url = f"http://{registry_url}/v2/{name}/manifests/{tag}"
-        response = httpx.get(url, headers=request_headers, timeout=10)
-        if response.status_code == 404:
-            _logger.warning("Image %s not found in registry, skipping deletion", image["image_path"])
-            continue
-        response.raise_for_status()
+            url = f"http://{registry_url}/v2/{name}/manifests/{tag}"
+            response = client.get(url)
+            if response.status_code == 404:
+                _logger.warning("Image %s not found in registry, skipping deletion", image["image_path"])
+                continue
+            response.raise_for_status()
 
-        _logger.debug("Image %s manifest response %s, headers %s", image["image_path"], response.text, response.headers)
-        docker_content_digest = response.headers["Docker-Content-Digest"]
-        # remove the image from the registry
-        delete_url = f"http://{registry_url}/v2/{name}/manifests/{docker_content_digest}"
-        delete_resp = httpx.delete(delete_url, timeout=5)
-        delete_resp.raise_for_status()
+            _logger.debug(
+                "Image %s manifest response %s, headers %s",
+                image["image_path"],
+                response.text,
+                response.headers,
+            )
+            docker_content_digest = response.headers["Docker-Content-Digest"]
+            # remove the image from the registry
+            delete_url = f"http://{registry_url}/v2/{name}/manifests/{docker_content_digest}"
+            delete_resp = client.delete(delete_url, timeout=5)
+            delete_resp.raise_for_status()
 
 
 @pytest.fixture

--- a/services/director/tests/unit/test_core_settings.py
+++ b/services/director/tests/unit/test_core_settings.py
@@ -18,6 +18,7 @@ from simcore_service_director.core.settings import ApplicationSettings
 def test_valid_application_settings(app_environment: EnvVarsDict):
     settings = ApplicationSettings()  # type: ignore
     assert settings
+    assert settings.DIRECTOR_REDIS_CACHE_BACKEND == "redis"
 
     assert settings == ApplicationSettings.create_from_envs()
 

--- a/services/director/tests/unit/test_core_settings.py
+++ b/services/director/tests/unit/test_core_settings.py
@@ -38,6 +38,65 @@ def test_invalid_client_timeout_raises(app_environment: EnvVarsDict, monkeypatch
         ApplicationSettings.create_from_envs()
 
 
+def test_redis_backend_requires_redis_settings_when_caching_enabled(
+    app_environment: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    setenvs_from_dict(
+        monkeypatch,
+        {
+            **app_environment,
+            "DIRECTOR_REGISTRY_CACHING": "True",
+            "DIRECTOR_REDIS_CACHE_BACKEND": "redis",
+            "DIRECTOR_REDIS": "null",
+        },
+    )
+
+    with pytest.raises(
+        ValidationError,
+        match=(
+            "DIRECTOR_REDIS_CACHE_BACKEND='redis' with DIRECTOR_REGISTRY_CACHING=True requires DIRECTOR_REDIS settings"
+        ),
+    ):
+        ApplicationSettings.create_from_envs()
+
+
+def test_redis_backend_does_not_require_redis_settings_when_caching_disabled(
+    app_environment: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    setenvs_from_dict(
+        monkeypatch,
+        {
+            **app_environment,
+            "DIRECTOR_REGISTRY_CACHING": "False",
+            "DIRECTOR_REDIS_CACHE_BACKEND": "redis",
+            "DIRECTOR_REDIS": "null",
+        },
+    )
+
+    settings = ApplicationSettings.create_from_envs()
+    assert settings.DIRECTOR_REDIS is None
+
+
+def test_redis_settings_can_be_configured(app_environment: EnvVarsDict, monkeypatch: pytest.MonkeyPatch):
+    setenvs_from_dict(
+        monkeypatch,
+        {
+            **app_environment,
+            "DIRECTOR_REGISTRY_CACHING": "True",
+            "DIRECTOR_REDIS_CACHE_BACKEND": "redis",
+            "DIRECTOR_REDIS": '{"REDIS_SECURE": false, "REDIS_HOST": "redis", "REDIS_PORT": 6379}',
+        },
+    )
+
+    settings = ApplicationSettings.create_from_envs()
+
+    assert settings.DIRECTOR_REDIS is not None
+    assert settings.DIRECTOR_REDIS.REDIS_HOST == "redis"
+    assert settings.DIRECTOR_REDIS.REDIS_PORT == 6379
+
+
 def test_docker_container_env_sample(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("DIRECTOR_DEFAULT_MAX_MEMORY", raising=False)
 

--- a/services/director/tests/unit/test_core_settings.py
+++ b/services/director/tests/unit/test_core_settings.py
@@ -18,7 +18,6 @@ from simcore_service_director.core.settings import ApplicationSettings
 def test_valid_application_settings(app_environment: EnvVarsDict):
     settings = ApplicationSettings()  # type: ignore
     assert settings
-    assert settings.DIRECTOR_REDIS_CACHE_BACKEND == "redis"
 
     assert settings == ApplicationSettings.create_from_envs()
 
@@ -48,16 +47,13 @@ def test_redis_backend_requires_redis_settings_when_caching_enabled(
         {
             **app_environment,
             "DIRECTOR_REGISTRY_CACHING": "True",
-            "DIRECTOR_REDIS_CACHE_BACKEND": "redis",
             "DIRECTOR_REDIS": "null",
         },
     )
 
     with pytest.raises(
         ValidationError,
-        match=(
-            "DIRECTOR_REDIS_CACHE_BACKEND='redis' with DIRECTOR_REGISTRY_CACHING=True requires DIRECTOR_REDIS settings"
-        ),
+        match="DIRECTOR_REGISTRY_CACHING=True requires DIRECTOR_REDIS settings",
     ):
         ApplicationSettings.create_from_envs()
 
@@ -71,7 +67,6 @@ def test_redis_backend_does_not_require_redis_settings_when_caching_disabled(
         {
             **app_environment,
             "DIRECTOR_REGISTRY_CACHING": "False",
-            "DIRECTOR_REDIS_CACHE_BACKEND": "redis",
             "DIRECTOR_REDIS": "null",
         },
     )
@@ -86,7 +81,6 @@ def test_redis_settings_can_be_configured(app_environment: EnvVarsDict, monkeypa
         {
             **app_environment,
             "DIRECTOR_REGISTRY_CACHING": "True",
-            "DIRECTOR_REDIS_CACHE_BACKEND": "redis",
             "DIRECTOR_REDIS": '{"REDIS_SECURE": false, "REDIS_HOST": "redis", "REDIS_PORT": 6379}',
         },
     )

--- a/services/director/tests/unit/test_modules_redis.py
+++ b/services/director/tests/unit/test_modules_redis.py
@@ -7,6 +7,7 @@ from settings_library.redis import RedisSettings
 
 
 async def test_redis_module_initializes_and_shuts_down(
+    docker_registry: str,
     configure_registry_caching: EnvVarsDict,
     configure_registry_redis_backend: EnvVarsDict,
     use_in_memory_redis: RedisSettings,

--- a/services/director/tests/unit/test_modules_redis.py
+++ b/services/director/tests/unit/test_modules_redis.py
@@ -11,14 +11,6 @@ from simcore_service_director.core.application import create_app
 from simcore_service_director.core.settings import ApplicationSettings
 
 
-async def test_redis_module_starts_disabled_by_default(app_settings: ApplicationSettings):
-    tracing_config = TracingConfig.create(service_name=APP_NAME, tracing_settings=None)
-    app = create_app(settings=app_settings, tracing_config=tracing_config)
-
-    async with LifespanManager(app):
-        assert app.state.redis_clients_manager is None
-
-
 async def test_redis_module_initializes_and_shuts_down(
     monkeypatch: pytest.MonkeyPatch,
     app_environment: EnvVarsDict,
@@ -59,5 +51,6 @@ async def test_redis_module_initializes_and_shuts_down(
 
     async with LifespanManager(app):
         assert set_up_called is True
+        assert app.state.redis_clients_manager is not None
 
     assert shut_down_called is True

--- a/services/director/tests/unit/test_modules_redis.py
+++ b/services/director/tests/unit/test_modules_redis.py
@@ -1,0 +1,63 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+
+import pytest
+from asgi_lifespan import LifespanManager
+from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from servicelib.tracing import TracingConfig
+from simcore_service_director._meta import APP_NAME
+from simcore_service_director.core.application import create_app
+from simcore_service_director.core.settings import ApplicationSettings
+
+
+async def test_redis_module_starts_disabled_by_default(app_settings: ApplicationSettings):
+    tracing_config = TracingConfig.create(service_name=APP_NAME, tracing_settings=None)
+    app = create_app(settings=app_settings, tracing_config=tracing_config)
+
+    async with LifespanManager(app):
+        assert app.state.redis_clients_manager is None
+
+
+async def test_redis_module_initializes_and_shuts_down(
+    monkeypatch: pytest.MonkeyPatch,
+    app_environment: EnvVarsDict,
+):
+    set_up_called = False
+    shut_down_called = False
+
+    class _FakeRedisClientsManager:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def setup(self) -> None:
+            nonlocal set_up_called
+            set_up_called = True
+
+        async def shutdown(self) -> None:
+            nonlocal shut_down_called
+            shut_down_called = True
+
+    monkeypatch.setattr(
+        "simcore_service_director.modules.redis.RedisClientsManager",
+        _FakeRedisClientsManager,
+    )
+
+    setenvs_from_dict(
+        monkeypatch,
+        {
+            **app_environment,
+            "DIRECTOR_REGISTRY_CACHING": "True",
+            "DIRECTOR_REDIS_CACHE_BACKEND": "redis",
+            "DIRECTOR_REDIS": '{"REDIS_HOST": "redis", "REDIS_PORT": 6379}',
+        },
+    )
+    settings = ApplicationSettings.create_from_envs()
+
+    tracing_config = TracingConfig.create(service_name=APP_NAME, tracing_settings=None)
+    app = create_app(settings=settings, tracing_config=tracing_config)
+
+    async with LifespanManager(app):
+        assert set_up_called is True
+
+    assert shut_down_called is True

--- a/services/director/tests/unit/test_modules_redis.py
+++ b/services/director/tests/unit/test_modules_redis.py
@@ -1,15 +1,20 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 
+from unittest import mock
+
 from fastapi import FastAPI
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.redis import RedisSettings
 
 
 async def test_redis_module_initializes_and_shuts_down(
-    docker_registry: str,
+    configure_registry_access: EnvVarsDict,
     configure_registry_caching: EnvVarsDict,
     configure_registry_redis_backend: EnvVarsDict,
+    with_disabled_auto_caching_task: mock.Mock,
     use_in_memory_redis: RedisSettings,
     app: FastAPI,
-): ...
+    app_settings: EnvVarsDict,
+):
+    print(app_settings)

--- a/services/director/tests/unit/test_modules_redis.py
+++ b/services/director/tests/unit/test_modules_redis.py
@@ -1,56 +1,14 @@
 # pylint: disable=redefined-outer-name
 # pylint: disable=unused-argument
 
-import pytest
-from asgi_lifespan import LifespanManager
-from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
+from fastapi import FastAPI
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from servicelib.tracing import TracingConfig
-from simcore_service_director._meta import APP_NAME
-from simcore_service_director.core.application import create_app
-from simcore_service_director.core.settings import ApplicationSettings
+from settings_library.redis import RedisSettings
 
 
 async def test_redis_module_initializes_and_shuts_down(
-    monkeypatch: pytest.MonkeyPatch,
-    app_environment: EnvVarsDict,
-):
-    set_up_called = False
-    shut_down_called = False
-
-    class _FakeRedisClientsManager:
-        def __init__(self, **_kwargs):
-            pass
-
-        async def setup(self) -> None:
-            nonlocal set_up_called
-            set_up_called = True
-
-        async def shutdown(self) -> None:
-            nonlocal shut_down_called
-            shut_down_called = True
-
-    monkeypatch.setattr(
-        "simcore_service_director.modules.redis.RedisClientsManager",
-        _FakeRedisClientsManager,
-    )
-
-    setenvs_from_dict(
-        monkeypatch,
-        {
-            **app_environment,
-            "DIRECTOR_REGISTRY_CACHING": "True",
-            "DIRECTOR_REDIS_CACHE_BACKEND": "redis",
-            "DIRECTOR_REDIS": '{"REDIS_HOST": "redis", "REDIS_PORT": 6379}',
-        },
-    )
-    settings = ApplicationSettings.create_from_envs()
-
-    tracing_config = TracingConfig.create(service_name=APP_NAME, tracing_settings=None)
-    app = create_app(settings=settings, tracing_config=tracing_config)
-
-    async with LifespanManager(app):
-        assert set_up_called is True
-        assert app.state.redis_clients_manager is not None
-
-    assert shut_down_called is True
+    configure_registry_caching: EnvVarsDict,
+    configure_registry_redis_backend: EnvVarsDict,
+    use_in_memory_redis: RedisSettings,
+    app: FastAPI,
+): ...

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -61,6 +61,17 @@ def configure_registry_redis_backend(
 
 
 @pytest.fixture
+def configure_registry_memory_backend(
+    app_environment: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> EnvVarsDict:
+    return app_environment | setenvs_from_dict(
+        monkeypatch,
+        {"DIRECTOR_REDIS_CACHE_BACKEND": "memory"},
+    )
+
+
+@pytest.fixture
 async def use_in_memory_redis(mocker: MockerFixture) -> RedisSettings:
     fake_server = FakeServer()
     OriginalPool = redis_asyncio.ConnectionPool
@@ -91,7 +102,7 @@ def configure_registry_cache_backend(
     if request.param == "redis":
         request.getfixturevalue("use_in_memory_redis")
         return request.getfixturevalue("configure_registry_redis_backend")
-    return configure_registry_caching
+    return request.getfixturevalue("configure_registry_memory_backend")
 
 
 @pytest.fixture

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -13,7 +13,10 @@ from unittest import mock
 
 import httpx
 import pytest
+import redis.asyncio as redis_asyncio
 import respx
+from fakeredis import FakeServer
+from fakeredis.aioredis import FakeConnection
 from fastapi import FastAPI, status
 from pytest_benchmark.plugin import BenchmarkFixture
 from pytest_mock.plugin import MockerFixture
@@ -21,6 +24,7 @@ from pytest_simcore.helpers.docker_registry_images import PushServicesCallable
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.docker_registry import RegistrySettings
+from settings_library.redis import RedisSettings
 from simcore_service_director import registry_proxy
 from simcore_service_director.core.settings import ApplicationSettings, get_application_settings
 
@@ -54,6 +58,26 @@ def configure_registry_redis_backend(
         monkeypatch,
         {"DIRECTOR_REDIS_CACHE_BACKEND": "redis"},
     )
+
+
+@pytest.fixture
+async def use_in_memory_redis(mocker: MockerFixture) -> RedisSettings:
+    fake_server = FakeServer()
+    OriginalPool = redis_asyncio.ConnectionPool
+
+    def fake_connection_pool(*args, **kwargs) -> redis_asyncio.ConnectionPool:
+        kwargs["connection_class"] = FakeConnection
+        kwargs["server"] = fake_server
+        return OriginalPool(*args, **kwargs)
+
+    mocker.patch(
+        "redis.asyncio.from_url",
+        lambda *a, **kw: redis_asyncio.Redis(  # noqa: ARG005
+            connection_pool=fake_connection_pool(**kw),
+        ),
+    )
+    mocker.patch("redis.asyncio.ConnectionPool", fake_connection_pool)
+    return RedisSettings()
 
 
 @pytest.fixture(

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -235,10 +235,10 @@ def configure_registry_caching(app_environment: EnvVarsDict, monkeypatch: pytest
 
 @pytest.fixture
 def configure_registry_redis_backend(
-    configure_registry_caching: EnvVarsDict,
+    app_environment: EnvVarsDict,
     monkeypatch: pytest.MonkeyPatch,
 ) -> EnvVarsDict:
-    return configure_registry_caching | setenvs_from_dict(
+    return app_environment | setenvs_from_dict(
         monkeypatch,
         {"DIRECTOR_REDIS_CACHE_BACKEND": "redis"},
     )
@@ -255,7 +255,6 @@ def configure_registry_cache_backend(
 ) -> EnvVarsDict:
     if request.param == "redis":
         request.getfixturevalue("fakeredis_aiocache_client")
-        monkeypatch.setattr("simcore_service_director.core.application.setup_redis", lambda app: None)  # noqa: ARG005
         return request.getfixturevalue("configure_registry_redis_backend")
     return configure_registry_caching
 

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -285,22 +285,11 @@ async def app_with_registry_cache_backend(
 
 @pytest.fixture
 def fakeredis_aiocache_client(
-    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
 ) -> FakeAsyncRedis:
     fake_client = FakeAsyncRedis()
-
-    monkeypatch.setattr(
-        "redis.asyncio.from_url",
-        lambda *args, **kwargs: fake_client,  # noqa: ARG005
-    )
-    monkeypatch.setattr(
-        "aiocache.backends.redis.redis.ConnectionPool",
-        lambda *args, **kwargs: object(),  # noqa: ARG005
-    )
-    monkeypatch.setattr(
-        "aiocache.backends.redis.redis.Redis",
-        lambda *args, **kwargs: fake_client,  # noqa: ARG005
-    )
+    mocker.patch("redis.asyncio.Redis", fake_client)
+    mocker.patch("aiocache.backends.redis.redis.Redis", fake_client)
 
     return fake_client
 

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -267,7 +267,8 @@ async def test_list_services(
 
 async def test_registry_caching(
     configure_registry_access: EnvVarsDict,
-    configure_registry_cache_backend: EnvVarsDict,
+    configure_registry_caching: EnvVarsDict,
+    # configure_registry_cache_backend: EnvVarsDict,
     with_disabled_auto_caching: mock.Mock,
     mocker: MockerFixture,
     app_settings: ApplicationSettings,

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -269,7 +269,7 @@ async def test_list_services(
 async def test_registry_caching(
     configure_registry_access: EnvVarsDict,
     configure_registry_caching: EnvVarsDict,
-    # configure_registry_cache_backend: EnvVarsDict,
+    configure_registry_cache_backend: EnvVarsDict,
     with_disabled_auto_caching: mock.Mock,
     mocker: MockerFixture,
     app_settings: ApplicationSettings,

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -9,23 +9,19 @@ import asyncio
 import json
 import logging
 import time
-from collections.abc import AsyncIterator
 from unittest import mock
 
 import httpx
 import pytest
 import respx
-from asgi_lifespan import LifespanManager
 from fakeredis import FakeAsyncRedis
 from fastapi import FastAPI, status
 from pytest_benchmark.plugin import BenchmarkFixture
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from servicelib.tracing import TracingConfig
 from settings_library.docker_registry import RegistrySettings
 from simcore_service_director import registry_proxy
-from simcore_service_director.core.application import create_app
 from simcore_service_director.core.settings import ApplicationSettings, get_application_settings
 
 _logger = logging.getLogger(__name__)
@@ -260,29 +256,6 @@ def configure_registry_cache_backend(
 
 
 @pytest.fixture
-def app_settings_with_registry_cache_backend(configure_registry_cache_backend: EnvVarsDict) -> ApplicationSettings:
-    return ApplicationSettings.create_from_envs()
-
-
-@pytest.fixture
-async def app_with_registry_cache_backend(
-    app_settings_with_registry_cache_backend: ApplicationSettings,
-    is_pdb_enabled: bool,
-) -> AsyncIterator[FastAPI]:
-    tracing_config = TracingConfig.create(
-        service_name=app_settings_with_registry_cache_backend.APP_NAME,
-        tracing_settings=None,
-    )
-    the_test_app = create_app(settings=app_settings_with_registry_cache_backend, tracing_config=tracing_config)
-    async with LifespanManager(
-        the_test_app,
-        startup_timeout=None if is_pdb_enabled else 10,
-        shutdown_timeout=None if is_pdb_enabled else 10,
-    ):
-        yield the_test_app
-
-
-@pytest.fixture
 def fakeredis_aiocache_client(
     mocker: MockerFixture,
 ) -> FakeAsyncRedis:
@@ -303,22 +276,22 @@ async def test_registry_caching(
     configure_registry_cache_backend: EnvVarsDict,
     with_disabled_auto_caching: mock.Mock,
     mocker: MockerFixture,
-    app_settings_with_registry_cache_backend: ApplicationSettings,
-    app_with_registry_cache_backend: FastAPI,
+    app_settings: ApplicationSettings,
+    app: FastAPI,
     push_services,
 ):
     images = await push_services(number_of_computational_services=31, number_of_interactive_services=33)
-    assert app_settings_with_registry_cache_backend.DIRECTOR_REGISTRY_CACHING is True
+    assert app_settings.DIRECTOR_REGISTRY_CACHING is True
 
     retried_request_spy = mocker.spy(registry_proxy, "_retried_request")
 
-    services = await registry_proxy.list_services(app_with_registry_cache_backend, registry_proxy.ServiceType.ALL)
+    services = await registry_proxy.list_services(app, registry_proxy.ServiceType.ALL)
     assert len(services) == len(images)
 
     request_count_after_first_call = retried_request_spy.call_count
     assert request_count_after_first_call > 0
 
-    services = await registry_proxy.list_services(app_with_registry_cache_backend, registry_proxy.ServiceType.ALL)
+    services = await registry_proxy.list_services(app, registry_proxy.ServiceType.ALL)
     assert len(services) == len(images)
     assert retried_request_spy.call_count == request_count_after_first_call
 

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -50,17 +50,6 @@ def configure_registry_access_both_versions(
 
 
 @pytest.fixture
-def configure_registry_redis_backend(
-    app_environment: EnvVarsDict,
-    monkeypatch: pytest.MonkeyPatch,
-) -> EnvVarsDict:
-    return app_environment | setenvs_from_dict(
-        monkeypatch,
-        {"DIRECTOR_REDIS_CACHE_BACKEND": "redis"},
-    )
-
-
-@pytest.fixture
 def configure_registry_memory_backend(
     app_environment: EnvVarsDict,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -1,5 +1,9 @@
-# pylint: disable=W0613, W0621
-# pylint: disable=unused-variable
+# pylint:disable=protected-access
+# pylint:disable=redefined-outer-name
+# pylint:disable=too-many-arguments
+# pylint:disable=unused-argument
+# pylint:disable=unused-variable
+
 
 import asyncio
 import json
@@ -251,7 +255,7 @@ def configure_registry_cache_backend(
 ) -> EnvVarsDict:
     if request.param == "redis":
         request.getfixturevalue("fakeredis_aiocache_client")
-        monkeypatch.setattr("simcore_service_director.core.application.setup_redis", lambda app: None)
+        monkeypatch.setattr("simcore_service_director.core.application.setup_redis", lambda app: None)  # noqa: ARG005
         return request.getfixturevalue("configure_registry_redis_backend")
     return configure_registry_caching
 
@@ -287,15 +291,15 @@ def fakeredis_aiocache_client(
 
     monkeypatch.setattr(
         "redis.asyncio.from_url",
-        lambda *args, **kwargs: fake_client,
+        lambda *args, **kwargs: fake_client,  # noqa: ARG005
     )
     monkeypatch.setattr(
         "aiocache.backends.redis.redis.ConnectionPool",
-        lambda *args, **kwargs: object(),
+        lambda *args, **kwargs: object(),  # noqa: ARG005
     )
     monkeypatch.setattr(
         "aiocache.backends.redis.redis.Redis",
-        lambda *args, **kwargs: fake_client,
+        lambda *args, **kwargs: fake_client,  # noqa: ARG005
     )
 
     return fake_client

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -5,18 +5,23 @@ import asyncio
 import json
 import logging
 import time
+from collections.abc import AsyncIterator
 from unittest import mock
 
 import httpx
 import pytest
 import respx
+from asgi_lifespan import LifespanManager
+from fakeredis import FakeAsyncRedis
 from fastapi import FastAPI, status
 from pytest_benchmark.plugin import BenchmarkFixture
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
+from servicelib.tracing import TracingConfig
 from settings_library.docker_registry import RegistrySettings
 from simcore_service_director import registry_proxy
+from simcore_service_director.core.application import create_app
 from simcore_service_director.core.settings import ApplicationSettings, get_application_settings
 
 _logger = logging.getLogger(__name__)
@@ -225,32 +230,105 @@ def configure_registry_caching(app_environment: EnvVarsDict, monkeypatch: pytest
 
 
 @pytest.fixture
+def configure_registry_redis_backend(
+    configure_registry_caching: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> EnvVarsDict:
+    return configure_registry_caching | setenvs_from_dict(
+        monkeypatch,
+        {"DIRECTOR_REDIS_CACHE_BACKEND": "redis"},
+    )
+
+
+@pytest.fixture(
+    params=["memory", "redis"],
+    ids=["memory-backend", "redis-backend"],
+)
+def configure_registry_cache_backend(
+    request: pytest.FixtureRequest,
+    configure_registry_caching: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> EnvVarsDict:
+    if request.param == "redis":
+        request.getfixturevalue("fakeredis_aiocache_client")
+        monkeypatch.setattr("simcore_service_director.core.application.setup_redis", lambda app: None)
+        return request.getfixturevalue("configure_registry_redis_backend")
+    return configure_registry_caching
+
+
+@pytest.fixture
+def app_settings_with_registry_cache_backend(configure_registry_cache_backend: EnvVarsDict) -> ApplicationSettings:
+    return ApplicationSettings.create_from_envs()
+
+
+@pytest.fixture
+async def app_with_registry_cache_backend(
+    app_settings_with_registry_cache_backend: ApplicationSettings,
+    is_pdb_enabled: bool,
+) -> AsyncIterator[FastAPI]:
+    tracing_config = TracingConfig.create(
+        service_name=app_settings_with_registry_cache_backend.APP_NAME,
+        tracing_settings=None,
+    )
+    the_test_app = create_app(settings=app_settings_with_registry_cache_backend, tracing_config=tracing_config)
+    async with LifespanManager(
+        the_test_app,
+        startup_timeout=None if is_pdb_enabled else 10,
+        shutdown_timeout=None if is_pdb_enabled else 10,
+    ):
+        yield the_test_app
+
+
+@pytest.fixture
+def fakeredis_aiocache_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> FakeAsyncRedis:
+    fake_client = FakeAsyncRedis()
+
+    monkeypatch.setattr(
+        "redis.asyncio.from_url",
+        lambda *args, **kwargs: fake_client,
+    )
+    monkeypatch.setattr(
+        "aiocache.backends.redis.redis.ConnectionPool",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "aiocache.backends.redis.redis.Redis",
+        lambda *args, **kwargs: fake_client,
+    )
+
+    return fake_client
+
+
+@pytest.fixture
 def with_disabled_auto_caching(mocker: MockerFixture) -> mock.Mock:
     return mocker.patch("simcore_service_director.registry_proxy._list_all_services_task", autospec=True)
 
 
 async def test_registry_caching(
     configure_registry_access: EnvVarsDict,
-    configure_registry_caching: EnvVarsDict,
+    configure_registry_cache_backend: EnvVarsDict,
     with_disabled_auto_caching: mock.Mock,
-    app_settings: ApplicationSettings,
-    app: FastAPI,
+    mocker: MockerFixture,
+    app_settings_with_registry_cache_backend: ApplicationSettings,
+    app_with_registry_cache_backend: FastAPI,
     push_services,
 ):
-    images = await push_services(number_of_computational_services=201, number_of_interactive_services=201)
-    assert app_settings.DIRECTOR_REGISTRY_CACHING is True
+    images = await push_services(number_of_computational_services=31, number_of_interactive_services=33)
+    assert app_settings_with_registry_cache_backend.DIRECTOR_REGISTRY_CACHING is True
 
-    start_time = time.perf_counter()
-    services = await registry_proxy.list_services(app, registry_proxy.ServiceType.ALL)
-    time_to_retrieve_without_cache = time.perf_counter() - start_time
+    retried_request_spy = mocker.spy(registry_proxy, "_retried_request")
+
+    services = await registry_proxy.list_services(app_with_registry_cache_backend, registry_proxy.ServiceType.ALL)
     assert len(services) == len(images)
-    start_time = time.perf_counter()
-    services = await registry_proxy.list_services(app, registry_proxy.ServiceType.ALL)
-    time_to_retrieve_with_cache = time.perf_counter() - start_time
+
+    request_count_after_first_call = retried_request_spy.call_count
+    assert request_count_after_first_call > 0
+
+    services = await registry_proxy.list_services(app_with_registry_cache_backend, registry_proxy.ServiceType.ALL)
     assert len(services) == len(images)
-    assert time_to_retrieve_with_cache < time_to_retrieve_without_cache
-    print("time to retrieve services without cache: ", time_to_retrieve_without_cache)
-    print("time to retrieve services with cache: ", time_to_retrieve_with_cache)
+    assert retried_request_spy.call_count == request_count_after_first_call
 
 
 @pytest.fixture

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -13,10 +13,7 @@ from unittest import mock
 
 import httpx
 import pytest
-import redis.asyncio as redis_asyncio
 import respx
-from fakeredis import FakeServer
-from fakeredis.aioredis import FakeConnection
 from fastapi import FastAPI, status
 from pytest_benchmark.plugin import BenchmarkFixture
 from pytest_mock.plugin import MockerFixture
@@ -24,7 +21,6 @@ from pytest_simcore.helpers.docker_registry_images import PushServicesCallable
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.docker_registry import RegistrySettings
-from settings_library.redis import RedisSettings
 from simcore_service_director import registry_proxy
 from simcore_service_director.core.settings import ApplicationSettings, get_application_settings
 
@@ -60,26 +56,6 @@ def configure_registry_memory_backend(
     )
 
 
-@pytest.fixture
-def use_in_memory_redis(mocker: MockerFixture) -> RedisSettings:
-    fake_server = FakeServer()
-    OriginalPool = redis_asyncio.ConnectionPool
-
-    def fake_connection_pool(*args, **kwargs) -> redis_asyncio.ConnectionPool:
-        kwargs["connection_class"] = FakeConnection
-        kwargs["server"] = fake_server
-        return OriginalPool(*args, **kwargs)
-
-    mocker.patch(
-        "redis.asyncio.from_url",
-        lambda *a, **kw: redis_asyncio.Redis(  # noqa: ARG005
-            connection_pool=fake_connection_pool(**kw),
-        ),
-    )
-    mocker.patch("redis.asyncio.ConnectionPool", fake_connection_pool)
-    return RedisSettings()
-
-
 @pytest.fixture(
     params=["memory", "redis"],
     ids=["memory-backend", "redis-backend"],
@@ -92,11 +68,6 @@ def configure_registry_cache_backend(
         request.getfixturevalue("use_in_memory_redis")
         return request.getfixturevalue("configure_registry_redis_backend")
     return request.getfixturevalue("configure_registry_memory_backend")
-
-
-@pytest.fixture
-def with_disabled_auto_caching_task(mocker: MockerFixture) -> mock.Mock:
-    return mocker.patch("simcore_service_director.registry_proxy._list_all_services_task", autospec=True)
 
 
 async def test_list_no_services_available(

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -72,7 +72,7 @@ def configure_registry_memory_backend(
 
 
 @pytest.fixture
-async def use_in_memory_redis(mocker: MockerFixture) -> RedisSettings:
+def use_in_memory_redis(mocker: MockerFixture) -> RedisSettings:
     fake_server = FakeServer()
     OriginalPool = redis_asyncio.ConnectionPool
 

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -57,21 +57,6 @@ def configure_registry_redis_backend(
     )
 
 
-@pytest.fixture(
-    params=["memory", "redis"],
-    ids=["memory-backend", "redis-backend"],
-)
-def configure_registry_cache_backend(
-    request: pytest.FixtureRequest,
-    configure_registry_caching: EnvVarsDict,
-    monkeypatch: pytest.MonkeyPatch,
-) -> EnvVarsDict:
-    if request.param == "redis":
-        request.getfixturevalue("fakeredis_aiocache_client")
-        return request.getfixturevalue("configure_registry_redis_backend")
-    return configure_registry_caching
-
-
 @pytest.fixture
 def fakeredis_aiocache_client(
     mocker: MockerFixture,
@@ -83,8 +68,22 @@ def fakeredis_aiocache_client(
     return fake_client
 
 
+@pytest.fixture(
+    params=["memory", "redis"],
+    ids=["memory-backend", "redis-backend"],
+)
+def configure_registry_cache_backend(
+    request: pytest.FixtureRequest,
+    configure_registry_caching: EnvVarsDict,
+) -> EnvVarsDict:
+    if request.param == "redis":
+        request.getfixturevalue("fakeredis_aiocache_client")
+        return request.getfixturevalue("configure_registry_redis_backend")
+    return configure_registry_caching
+
+
 @pytest.fixture
-def with_disabled_auto_caching(mocker: MockerFixture) -> mock.Mock:
+def with_disabled_auto_caching_task(mocker: MockerFixture) -> mock.Mock:
     return mocker.patch("simcore_service_director.registry_proxy._list_all_services_task", autospec=True)
 
 
@@ -270,7 +269,7 @@ async def test_registry_caching(
     configure_registry_access: EnvVarsDict,
     configure_registry_caching: EnvVarsDict,
     configure_registry_cache_backend: EnvVarsDict,
-    with_disabled_auto_caching: mock.Mock,
+    with_disabled_auto_caching_task: mock.Mock,
     mocker: MockerFixture,
     app_settings: ApplicationSettings,
     app: FastAPI,

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -27,6 +27,66 @@ from simcore_service_director.core.settings import ApplicationSettings, get_appl
 _logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(params=["docker_registry", "docker_registry_v2"], ids=["registry_v3", "registry_v2"])
+def configure_registry_access_both_versions(
+    app_environment: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> EnvVarsDict:
+    """Parametrized fixture that tests with both registry v3 and v2 - use only for specific tests that need both"""
+    registry_url = request.getfixturevalue(request.param)
+    return app_environment | setenvs_from_dict(
+        monkeypatch,
+        envs={
+            "REGISTRY_URL": registry_url,
+            "REGISTRY_PATH": registry_url,
+            "REGISTRY_SSL": False,
+        },
+    )
+
+
+@pytest.fixture
+def configure_registry_redis_backend(
+    app_environment: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> EnvVarsDict:
+    return app_environment | setenvs_from_dict(
+        monkeypatch,
+        {"DIRECTOR_REDIS_CACHE_BACKEND": "redis"},
+    )
+
+
+@pytest.fixture(
+    params=["memory", "redis"],
+    ids=["memory-backend", "redis-backend"],
+)
+def configure_registry_cache_backend(
+    request: pytest.FixtureRequest,
+    configure_registry_caching: EnvVarsDict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> EnvVarsDict:
+    if request.param == "redis":
+        request.getfixturevalue("fakeredis_aiocache_client")
+        return request.getfixturevalue("configure_registry_redis_backend")
+    return configure_registry_caching
+
+
+@pytest.fixture
+def fakeredis_aiocache_client(
+    mocker: MockerFixture,
+) -> FakeAsyncRedis:
+    fake_client = FakeAsyncRedis()
+    mocker.patch("redis.asyncio.Redis", fake_client)
+    mocker.patch("aiocache.backends.redis.redis.Redis", fake_client)
+
+    return fake_client
+
+
+@pytest.fixture
+def with_disabled_auto_caching(mocker: MockerFixture) -> mock.Mock:
+    return mocker.patch("simcore_service_director.registry_proxy._list_all_services_task", autospec=True)
+
+
 async def test_list_no_services_available(
     configure_registry_access: EnvVarsDict,
     app: FastAPI,
@@ -103,25 +163,6 @@ async def test_list_interactive_service_dependencies(
             assert len(image_dependencies) == len(docker_dependencies)
             assert image_dependencies[0]["key"] == docker_dependencies[0]["key"]
             assert image_dependencies[0]["tag"] == docker_dependencies[0]["tag"]
-
-
-@pytest.fixture(params=["docker_registry", "docker_registry_v2"], ids=["registry_v3", "registry_v2"])
-def configure_registry_access_both_versions(
-    app_environment: EnvVarsDict,
-    monkeypatch: pytest.MonkeyPatch,
-    request: pytest.FixtureRequest,
-) -> EnvVarsDict:
-    """Parametrized fixture that tests with both registry v3 and v2 - use only for specific tests that need both"""
-    registry_url = request.getfixturevalue(request.param)
-    return app_environment | setenvs_from_dict(
-        monkeypatch,
-        envs={
-            "REGISTRY_URL": registry_url,
-            "REGISTRY_PATH": registry_url,
-            "REGISTRY_SSL": False,
-            "DIRECTOR_REGISTRY_CACHING": False,
-        },
-    )
 
 
 async def test_get_image_labels(
@@ -222,53 +263,6 @@ async def test_list_services(
     await push_services(number_of_computational_services=21, number_of_interactive_services=21)
     services = await registry_proxy.list_services(app, registry_proxy.ServiceType.ALL)
     assert len(services) == 42
-
-
-@pytest.fixture
-def configure_registry_caching(app_environment: EnvVarsDict, monkeypatch: pytest.MonkeyPatch) -> EnvVarsDict:
-    return app_environment | setenvs_from_dict(monkeypatch, {"DIRECTOR_REGISTRY_CACHING": True})
-
-
-@pytest.fixture
-def configure_registry_redis_backend(
-    app_environment: EnvVarsDict,
-    monkeypatch: pytest.MonkeyPatch,
-) -> EnvVarsDict:
-    return app_environment | setenvs_from_dict(
-        monkeypatch,
-        {"DIRECTOR_REDIS_CACHE_BACKEND": "redis"},
-    )
-
-
-@pytest.fixture(
-    params=["memory", "redis"],
-    ids=["memory-backend", "redis-backend"],
-)
-def configure_registry_cache_backend(
-    request: pytest.FixtureRequest,
-    configure_registry_caching: EnvVarsDict,
-    monkeypatch: pytest.MonkeyPatch,
-) -> EnvVarsDict:
-    if request.param == "redis":
-        request.getfixturevalue("fakeredis_aiocache_client")
-        return request.getfixturevalue("configure_registry_redis_backend")
-    return configure_registry_caching
-
-
-@pytest.fixture
-def fakeredis_aiocache_client(
-    mocker: MockerFixture,
-) -> FakeAsyncRedis:
-    fake_client = FakeAsyncRedis()
-    mocker.patch("redis.asyncio.Redis", fake_client)
-    mocker.patch("aiocache.backends.redis.redis.Redis", fake_client)
-
-    return fake_client
-
-
-@pytest.fixture
-def with_disabled_auto_caching(mocker: MockerFixture) -> mock.Mock:
-    return mocker.patch("simcore_service_director.registry_proxy._list_all_services_task", autospec=True)
 
 
 async def test_registry_caching(
@@ -400,7 +394,6 @@ def configure_authed_registry_access(
             "REGISTRY_USER": "testuser",
             "REGISTRY_PW": "testpassword",
             "REGISTRY_SSL": "false",
-            "DIRECTOR_REGISTRY_CACHING": "false",
         },
     )
 

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -45,31 +45,6 @@ def configure_registry_access_both_versions(
     )
 
 
-@pytest.fixture
-def configure_registry_memory_backend(
-    app_environment: EnvVarsDict,
-    monkeypatch: pytest.MonkeyPatch,
-) -> EnvVarsDict:
-    return app_environment | setenvs_from_dict(
-        monkeypatch,
-        {"DIRECTOR_REDIS_CACHE_BACKEND": "memory"},
-    )
-
-
-@pytest.fixture(
-    params=["memory", "redis"],
-    ids=["memory-backend", "redis-backend"],
-)
-def configure_registry_cache_backend(
-    request: pytest.FixtureRequest,
-    configure_registry_caching: EnvVarsDict,
-) -> EnvVarsDict:
-    if request.param == "redis":
-        request.getfixturevalue("use_in_memory_redis")
-        return request.getfixturevalue("configure_registry_redis_backend")
-    return request.getfixturevalue("configure_registry_memory_backend")
-
-
 async def test_list_no_services_available(
     configure_registry_access: EnvVarsDict,
     app: FastAPI,
@@ -250,7 +225,9 @@ async def test_list_services(
 
 async def test_registry_caching(
     configure_registry_access: EnvVarsDict,
-    configure_registry_cache_backend: EnvVarsDict,
+    configure_registry_caching: EnvVarsDict,
+    configure_registry_redis_backend: EnvVarsDict,
+    use_in_memory_redis,
     with_disabled_auto_caching_task: mock.Mock,
     mocker: MockerFixture,
     app_settings: ApplicationSettings,

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -14,7 +14,6 @@ from unittest import mock
 import httpx
 import pytest
 import respx
-from fakeredis import FakeAsyncRedis
 from fastapi import FastAPI, status
 from pytest_benchmark.plugin import BenchmarkFixture
 from pytest_mock.plugin import MockerFixture
@@ -57,17 +56,6 @@ def configure_registry_redis_backend(
     )
 
 
-@pytest.fixture
-def fakeredis_aiocache_client(
-    mocker: MockerFixture,
-) -> FakeAsyncRedis:
-    fake_client = FakeAsyncRedis()
-    mocker.patch("redis.asyncio.Redis", fake_client)
-    mocker.patch("aiocache.backends.redis.redis.Redis", fake_client)
-
-    return fake_client
-
-
 @pytest.fixture(
     params=["memory", "redis"],
     ids=["memory-backend", "redis-backend"],
@@ -77,7 +65,7 @@ def configure_registry_cache_backend(
     configure_registry_caching: EnvVarsDict,
 ) -> EnvVarsDict:
     if request.param == "redis":
-        request.getfixturevalue("fakeredis_aiocache_client")
+        request.getfixturevalue("use_in_memory_redis")
         return request.getfixturevalue("configure_registry_redis_backend")
     return configure_registry_caching
 
@@ -267,7 +255,6 @@ async def test_list_services(
 
 async def test_registry_caching(
     configure_registry_access: EnvVarsDict,
-    configure_registry_caching: EnvVarsDict,
     configure_registry_cache_backend: EnvVarsDict,
     with_disabled_auto_caching_task: mock.Mock,
     mocker: MockerFixture,

--- a/services/director/tests/unit/test_registry_proxy.py
+++ b/services/director/tests/unit/test_registry_proxy.py
@@ -18,6 +18,7 @@ from fakeredis import FakeAsyncRedis
 from fastapi import FastAPI, status
 from pytest_benchmark.plugin import BenchmarkFixture
 from pytest_mock.plugin import MockerFixture
+from pytest_simcore.helpers.docker_registry_images import PushServicesCallable
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.docker_registry import RegistrySettings
@@ -102,7 +103,7 @@ async def test_list_no_services_available(
 async def test_list_computational_services(
     configure_registry_access: EnvVarsDict,
     app: FastAPI,
-    push_services,
+    push_services: PushServicesCallable,
 ):
     await push_services(number_of_computational_services=6, number_of_interactive_services=3)
 
@@ -113,7 +114,7 @@ async def test_list_computational_services(
 async def test_list_interactive_services(
     configure_registry_access: EnvVarsDict,
     app: FastAPI,
-    push_services,
+    push_services: PushServicesCallable,
 ):
     await push_services(number_of_computational_services=5, number_of_interactive_services=4)
     interactive_services = await registry_proxy.list_services(app, registry_proxy.ServiceType.DYNAMIC)
@@ -123,7 +124,7 @@ async def test_list_interactive_services(
 async def test_list_of_image_tags(
     configure_registry_access: EnvVarsDict,
     app: FastAPI,
-    push_services,
+    push_services: PushServicesCallable,
 ):
     images = await push_services(number_of_computational_services=5, number_of_interactive_services=3)
     image_number = {}
@@ -142,7 +143,7 @@ async def test_list_of_image_tags(
 async def test_list_interactive_service_dependencies(
     configure_registry_access: EnvVarsDict,
     app: FastAPI,
-    push_services,
+    push_services: PushServicesCallable,
 ):
     images = await push_services(
         number_of_computational_services=2,
@@ -168,7 +169,7 @@ async def test_list_interactive_service_dependencies(
 async def test_get_image_labels(
     configure_registry_access_both_versions: EnvVarsDict,
     app: FastAPI,
-    push_services,
+    push_services: PushServicesCallable,
 ):
     images = await push_services(
         number_of_computational_services=1,
@@ -240,7 +241,7 @@ def test_get_service_last_names():
 async def test_get_image_details(
     configure_registry_access: EnvVarsDict,
     app: FastAPI,
-    push_services,
+    push_services: PushServicesCallable,
 ):
     images = await push_services(number_of_computational_services=1, number_of_interactive_services=1)
     for image in images:
@@ -258,7 +259,7 @@ async def test_list_services(
     configure_registry_access: EnvVarsDict,
     configure_number_concurrency_calls: EnvVarsDict,
     app: FastAPI,
-    push_services,
+    push_services: PushServicesCallable,
 ):
     await push_services(number_of_computational_services=21, number_of_interactive_services=21)
     services = await registry_proxy.list_services(app, registry_proxy.ServiceType.ALL)
@@ -273,7 +274,7 @@ async def test_registry_caching(
     mocker: MockerFixture,
     app_settings: ApplicationSettings,
     app: FastAPI,
-    push_services,
+    push_services: PushServicesCallable,
 ):
     images = await push_services(number_of_computational_services=31, number_of_interactive_services=33)
     assert app_settings.DIRECTOR_REGISTRY_CACHING is True

--- a/services/docker-compose-ops.yml
+++ b/services/docker-compose-ops.yml
@@ -42,7 +42,15 @@ services:
     networks:
       - simcore_default
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:5555/"]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--quiet",
+          "--tries=1",
+          "--spider",
+          "http://localhost:5555/",
+        ]
       interval: 5s
       timeout: 10s
       retries: 3
@@ -83,7 +91,15 @@ services:
     networks:
       - simcore_default
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8025/"]
+      test:
+        [
+          "CMD",
+          "wget",
+          "--quiet",
+          "--tries=1",
+          "--spider",
+          "http://localhost:8025/",
+        ]
       interval: 5s
       timeout: 10s
       retries: 3
@@ -127,7 +143,8 @@ services:
         deferred_tasks:${REDIS_HOST}:${REDIS_PORT}:7:${REDIS_PASSWORD},
         dynamic_services:${REDIS_HOST}:${REDIS_PORT}:8:${REDIS_PASSWORD},
         celery_tasks:${REDIS_HOST}:${REDIS_PORT}:9:${REDIS_PASSWORD},
-        documents:${REDIS_HOST}:${REDIS_PORT}:10:${REDIS_PASSWORD}
+        documents:${REDIS_HOST}:${REDIS_PORT}:10:${REDIS_PASSWORD},
+        aiocache:${REDIS_HOST}:${REDIS_PORT}:11:${REDIS_PASSWORD}
       # If you add/remove a db, do not forget to update the --databases entry in the docker-compose.yml
     ports:
       - "18081:8081"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -182,7 +182,7 @@ services:
         "--loglevel",
         "verbose",
         "--databases",
-        "11",
+        "12",
         "--appendonly",
         "yes",
         "--requirepass",

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -417,6 +417,7 @@ services:
     environment:
       <<:
         - *postgres_settings
+        - *redis_settings
         - *registry_settings
         - *tracing_open_telemetry_environments
 

--- a/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
@@ -63,7 +63,7 @@ services:
         "--loglevel",
         "verbose",
         "--databases",
-        "11",
+        "12",
         "--appendonly",
         "yes",
         "--requirepass",

--- a/services/web/server/tests/unit/with_dbs/docker-compose.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose.yml
@@ -46,11 +46,11 @@ services:
         "--loglevel",
         "verbose",
         "--databases",
-        "11",
+        "12",
         "--appendonly",
         "yes",
         "--requirepass",
-        "${TEST_REDIS_PASSWORD}"
+        "${TEST_REDIS_PASSWORD}",
       ]
   rabbit:
     image: itisfoundation/rabbitmq:4.1.6-management


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Previously each director-v0 replica was sporting its own in-process cache, thus on start hitting the docker registry to get its list of docker images, docker labels, etc etc. Since the docker registry starts being very full, this starts being too much. Also on every restart of the director-v0 it would do it again even though no changes in the docker registry happened in between.

This PR introduces Redis through the current `aiocache` mechanism, thus per construction each director-v0 replica shares the cache with each other.
Additionally they each run a background task that runs exclusively to refresh the cache and keep it warm with a TTL/4 interval using a Redis marker that has a TTL time to live. The cache itself has a TTL * 2 time to live.

After this PR, the cache shall remain warm even after director-v0 restarts. Now if one wants to manually refresh the cache, one need to remove the marker in redis locks and the refresh will happen automatically.

New director caching mechanism:
```mermaid
flowchart TD
    A[Startup] --> B[Create cache backend]
    B --> C{Caching enabled?}
    C -- no --> D[Requests always go to registry]
    C -- yes --> E[Periodic refresh task starts]
    E --> F[Refresh every TTL/4]
    F --> G[Fetch registry data with update_cache=True]
    G --> H[Write aiocache entries with TTL]
    H --> I[Readers hit cache via registry_request]
    I --> J{Cache hit?}
    J -- yes --> K[Return cached body + headers]
    J -- no --> L[Call registry, then cache GET response]
    E --> M[Redis freshness marker]
    M --> N[Marker TTL = TTL/2]
    N --> F
    A --> O[Shutdown closes task + cache]
```
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/private-issues/issues/565 
- relates to https://github.com/ITISFoundation/private-issues/issues/463
## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
- https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/2063
⚠️ New Redis DB for Aiocache library
<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
