### PR TITLE
🐛 fix(web-server): Conversation email replies have `no-reply` local in sender

### DIFF
--- a/services/web/server/src/simcore_service_webserver/conversations/_conversation_message_service.py
+++ b/services/web/server/src/simcore_service_webserver/conversations/_conversation_message_service.py
@@ -122,7 +122,7 @@ async def _notify_support_reply(
 
             recipient_user = await users_service.get_user(app, conversation_creator_user_id)
             recipient_name = (
-                f"{recipient_user.get('first_name', '')} {recipient_user.get('last_name', '')}".strip()
+                f"{recipient_user.get('first_name') or ''} {recipient_user.get('last_name') or ''}".strip()
                 or recipient_user["email"]
             )
 

--- a/services/web/server/src/simcore_service_webserver/conversations/_conversation_message_service.py
+++ b/services/web/server/src/simcore_service_webserver/conversations/_conversation_message_service.py
@@ -133,6 +133,7 @@ async def _notify_support_reply(
                 channel=Channel.email,
                 group_ids=None,
                 external_contacts=[EmailContact(name=recipient_name, email=recipient_user["email"])],
+                from_local="no-reply",
                 template_name="support_reply",
                 context={
                     "user": {

--- a/services/web/server/src/simcore_service_webserver/notifications/_service.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_service.py
@@ -100,7 +100,7 @@ async def _create_email_addressing(
     )
 
     if from_local:
-        from_contact = from_contact.replace(new_local=from_local, new_name=None)
+        from_contact = from_contact.replace(new_local=from_local, new_name="")
 
     to_contacts: list[EmailContact] = []
 

--- a/services/web/server/src/simcore_service_webserver/notifications/_service.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_service.py
@@ -85,6 +85,7 @@ async def _create_email_addressing(
     group_ids: list[GroupID] | None,
     external_contacts: list[Contact] | None,
     reply_to: Contact | None = None,
+    from_local: str | None = None,
 ) -> EmailAddressing:
     """Build email addressing (from/to) for all recipients.
 
@@ -97,6 +98,9 @@ async def _create_email_addressing(
         name=f"{product.display_name} Support",
         email=product.support_email,
     )
+
+    if from_local:
+        from_contact = from_contact.replace(new_local=from_local, new_name=None)
 
     to_contacts: list[EmailContact] = []
 
@@ -219,6 +223,7 @@ async def send_message_from_template(
     group_ids: list[GroupID] | None,
     external_contacts: list[Contact] | None,
     reply_to: Contact | None = None,
+    from_local: str | None = None,
     template_name: str,
     context: dict[str, Any],
 ) -> tuple[TaskUUID | GroupUUID, TaskName]:
@@ -230,6 +235,7 @@ async def send_message_from_template(
                 group_ids=group_ids,
                 external_contacts=external_contacts,
                 reply_to=reply_to,
+                from_local=from_local,
             )
         case _:
             raise NotificationsUnsupportedChannelError(channel=channel)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR adjusts the web-server notifications email addressing so callers can override the **local-part** of the sender (“From”) address, and applies it to conversation support-reply emails so they are sent from `no-reply@<support-domain>`.

🚨 The mechanism will change soon (#9190 and following)

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
No changes.