### PR TITLE
🎨 [Frontend] Show name of parameter/probe in the secondary panel

### DIFF
--- a/services/static-webserver/client/source/class/osparc/desktop/SlideshowView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/SlideshowView.js
@@ -227,9 +227,9 @@ qx.Class.define("osparc.desktop.SlideshowView", {
       let view;
       if (node.isParameter()) {
         view = osparc.node.slideshow.BaseNodeView.createSettingsGroupBox(this.tr("Settings"));
-        const renderer = new osparc.node.ParameterEditor(node);
-        renderer.buildForm(false);
-        view.add(renderer);
+        const parameterEditor = new osparc.node.ParameterEditor(node);
+        parameterEditor.buildForm();
+        view.add(parameterEditor);
       } else if (node.isFilePicker()) {
         view = new osparc.node.slideshow.FilePickerView();
         view.getOutputsButton().hide();

--- a/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
@@ -862,7 +862,7 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
         this.__populateSecondaryColumnFilePicker(node);
       } else if (node && node.isParameter()) {
         this.__populateSecondaryColumnParameter(node);
-      } else if (node && node.isProbe(node)) {
+      } else if (node && node.isProbe()) {
         this.__populateSecondaryColumnProbe(node);
       } else if (node) {
         this.__populateSecondaryColumnNode(node);

--- a/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
@@ -1096,9 +1096,22 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
       this.__serviceOptionsPage.getChildControl("button").show();
       this.getChildControl("side-panel-right-tabs").setSelection([this.__serviceOptionsPage]);
 
+      const parameterContent = new qx.ui.container.Composite(new qx.ui.layout.VBox(15)).set({
+        backgroundColor: "transparent"
+      });
+
+      const parameterLabel = new qx.ui.basic.Label().set({
+        font: "text-14"
+      });
+      parameter.bind("label", parameterLabel, "value");
+      parameterContent.add(parameterLabel);
+
       const parameterEditor = new osparc.node.ParameterEditor(parameter);
       parameterEditor.buildForm();
-      this.__serviceOptionsPage.add(parameterEditor, {
+      parameterContent.add(parameterEditor, {
+        flex: 1
+      });
+      this.__serviceOptionsPage.add(parameterContent, {
         flex: 1
       });
     },

--- a/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
@@ -1136,10 +1136,8 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
       probe.bind("label", parameterLabel, "value");
       vBox.add(parameterLabel);
 
-      const inputsForm = probe.getPropsForm().set({
-        paddingLeft: 6,
-      });
-      vBox.add(inputsForm, {
+      const probeView = new osparc.node.ProbeView(probe);
+      vBox.add(probeView, {
         flex: 1
       });
 

--- a/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
@@ -1096,9 +1096,9 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
       this.__serviceOptionsPage.getChildControl("button").show();
       this.getChildControl("side-panel-right-tabs").setSelection([this.__serviceOptionsPage]);
 
-      const view = new osparc.node.ParameterEditor(parameter);
-      view.buildForm(false);
-      this.__serviceOptionsPage.add(view, {
+      const parameterEditor = new osparc.node.ParameterEditor(parameter);
+      parameterEditor.buildForm();
+      this.__serviceOptionsPage.add(parameterEditor, {
         flex: 1
       });
     },

--- a/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/WorkbenchView.js
@@ -862,6 +862,8 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
         this.__populateSecondaryColumnFilePicker(node);
       } else if (node && node.isParameter()) {
         this.__populateSecondaryColumnParameter(node);
+      } else if (node && node.isProbe(node)) {
+        this.__populateSecondaryColumnProbe(node);
       } else if (node) {
         this.__populateSecondaryColumnNode(node);
       }
@@ -1096,22 +1098,52 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
       this.__serviceOptionsPage.getChildControl("button").show();
       this.getChildControl("side-panel-right-tabs").setSelection([this.__serviceOptionsPage]);
 
-      const parameterContent = new qx.ui.container.Composite(new qx.ui.layout.VBox(15)).set({
-        backgroundColor: "transparent"
-      });
+      const vBox = new qx.ui.container.Composite(new qx.ui.layout.VBox(16).set({
+        separator: "separator-vertical",
+      }));
 
       const parameterLabel = new qx.ui.basic.Label().set({
-        font: "text-14"
+        font: "text-14",
+        paddingLeft: 6,
       });
       parameter.bind("label", parameterLabel, "value");
-      parameterContent.add(parameterLabel);
+      vBox.add(parameterLabel);
 
-      const parameterEditor = new osparc.node.ParameterEditor(parameter);
+      const parameterEditor = new osparc.node.ParameterEditor(parameter).set({
+        paddingLeft: 6,
+      });
       parameterEditor.buildForm();
-      parameterContent.add(parameterEditor, {
+      vBox.add(parameterEditor, {
         flex: 1
       });
-      this.__serviceOptionsPage.add(parameterContent, {
+      this.__serviceOptionsPage.add(vBox, {
+        flex: 1
+      });
+    },
+
+    __populateSecondaryColumnProbe: function(probe) {
+      this.__serviceOptionsPage.getChildControl("button").show();
+      this.getChildControl("side-panel-right-tabs").setSelection([this.__serviceOptionsPage]);
+
+      const vBox = new qx.ui.container.Composite(new qx.ui.layout.VBox(16).set({
+        separator: "separator-vertical",
+      }));
+
+      const parameterLabel = new qx.ui.basic.Label().set({
+        font: "text-14",
+        paddingLeft: 6,
+      });
+      probe.bind("label", parameterLabel, "value");
+      vBox.add(parameterLabel);
+
+      const inputsForm = probe.getPropsForm().set({
+        paddingLeft: 6,
+      });
+      vBox.add(inputsForm, {
+        flex: 1
+      });
+
+      this.__serviceOptionsPage.add(vBox, {
         flex: 1
       });
     },
@@ -1132,7 +1164,7 @@ qx.Class.define("osparc.desktop.WorkbenchView", {
       const nodeMetadata = node.getMetadata();
       const version = osparc.store.Services.getVersionDisplay(nodeMetadata["key"], nodeMetadata["version"]);
       const header = new qx.ui.basic.Label(`${nodeMetadata["name"]} ${version}`).set({
-        paddingLeft: 5
+        paddingLeft: 6
       });
       vBox.add(header);
 

--- a/services/static-webserver/client/source/class/osparc/node/ParameterEditor.js
+++ b/services/static-webserver/client/source/class/osparc/node/ParameterEditor.js
@@ -112,6 +112,13 @@ qx.Class.define("osparc.node.ParameterEditor", {
       }
       valueField.addListener("changeValue", e => osparc.node.ParameterEditor.setParameterOutputValue(node, e.getData()));
       this.__form.add(valueField, "Value", null, "value");
+      // Replace the text label with an atom to show the parameter icon
+      const labelWidget = this._labels[this._labels.length - 1];
+      if (labelWidget) {
+        this._remove(labelWidget);
+        const atom = new qx.ui.basic.Atom("Value", "@FontAwesome5Solid/sliders-h/14");
+        this._add(atom, {row: this._row - 1, column: 0});
+      }
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/node/ParameterEditor.js
+++ b/services/static-webserver/client/source/class/osparc/node/ParameterEditor.js
@@ -92,28 +92,11 @@ qx.Class.define("osparc.node.ParameterEditor", {
       return control || this.base(arguments, id);
     },
 
-    buildForm: function(allSettings = true) {
+    buildForm: function() {
       this._removeAll();
 
       const node = this.getNode();
-
       const type = this.self().getParameterOutputType(node);
-      if (allSettings) {
-        const label = this.getChildControl("label");
-        label.setValue(node.getLabel());
-        label.bind("value", node, "label");
-        this.__form.add(label, "Label", null, "label");
-
-        const typeBox = this.getChildControl("data-type");
-        typeBox.getSelectables().forEach(selectable => {
-          if (selectable.type === type) {
-            typeBox.setSelection([selectable]);
-            typeBox.setEnabled(false);
-          }
-        });
-        this.__form.add(typeBox, "Data Type", null, "type");
-      }
-
       const valueField = this.getChildControl(type);
       const output = node.getOutput(osparc.data.model.NodePort.PARAM_PORT_KEY);
       if (type === "ref_contentSchema") {

--- a/services/static-webserver/client/source/class/osparc/node/ProbeView.js
+++ b/services/static-webserver/client/source/class/osparc/node/ProbeView.js
@@ -21,7 +21,7 @@ qx.Class.define("osparc.node.ProbeView", {
   construct: function(probe) {
     this.base();
 
-    this._setLayout(new qx.ui.layout.VBox());
+    this._setLayout(new qx.ui.layout.VBox(16));
 
     if (probe) {
       this.setNode(probe);
@@ -104,12 +104,20 @@ qx.Class.define("osparc.node.ProbeView", {
     },
 
     __populateLayout: function(node) {
-      const inputsForm = node.getPropsForm();
-      const inputs = new osparc.desktop.PanelView(this.tr("Inputs"), inputsForm);
-      inputs._innerContainer.set({
-        margin: 8
-      });
+      const inputs = new osparc.desktop.PanelView(this.tr("Input"), node.getPropsForm());
       this._add(inputs);
+
+      const valueContainer = new qx.ui.container.Composite(new qx.ui.layout.HBox(16)).set({
+        paddingTop: 8,
+      });
+      const icon = new qx.ui.basic.Image("@FontAwesome5Solid/thermometer/14");
+      const valueLabel = osparc.node.ProbeView.createProbeValueLabel(node);
+      valueContainer.add(icon);
+      valueContainer.add(valueLabel, {
+        flex: 1
+      });
+      const outputPanel = new osparc.desktop.PanelView(this.tr("Value"), valueContainer);
+      this._add(outputPanel);
     },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/node/ProbeView.js
+++ b/services/static-webserver/client/source/class/osparc/node/ProbeView.js
@@ -49,12 +49,12 @@ qx.Class.define("osparc.node.ProbeView", {
     },
 
     __populateLayout: function(node) {
-      const inputsForm = node.getPropsForm().set({
-        paddingLeft: 6,
+      const inputsForm = node.getPropsForm();
+      const inputs = new osparc.desktop.PanelView(this.tr("Inputs"), inputsForm);
+      inputs._innerContainer.set({
+        margin: 8
       });
-      this._add(inputsForm, {
-        flex: 1
-      });
+      this._add(inputs);
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/node/ProbeView.js
+++ b/services/static-webserver/client/source/class/osparc/node/ProbeView.js
@@ -68,6 +68,8 @@ qx.Class.define("osparc.node.ProbeView", {
               return "";
             }
           });
+        } else {
+          linkLabel.setValue("");
         }
       } else {
         linkLabel.setValue("");
@@ -120,6 +122,11 @@ qx.Class.define("osparc.node.ProbeView", {
       });
       const outputPanel = new osparc.desktop.PanelView(this.tr("Value"), valueContainer);
       this._add(outputPanel);
+      // Hide the value panel when the probe is not connected
+      valueLabel.addListener("changeVisibility", e => {
+        outputPanel.setVisibility(e.getData());
+      });
+      outputPanel.setVisibility(valueLabel.getVisibility());
     },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/node/ProbeView.js
+++ b/services/static-webserver/client/source/class/osparc/node/ProbeView.js
@@ -54,7 +54,7 @@ qx.Class.define("osparc.node.ProbeView", {
           inputNode.bind("outputs", linkLabel, "value", {
             converter: outputs => {
               const output = outputs.find(out => out.getPortKey() === portKey);
-              if (output && output.getValue()) {
+              if (output && output.getValue() !== undefined) {
                 const val = output.getValue();
                 if (node.getMetadata()["key"].includes("probe/array") && Array.isArray(val)) {
                   return "[" + val.join(",") + "]";
@@ -104,6 +104,8 @@ qx.Class.define("osparc.node.ProbeView", {
     },
 
     __populateLayout: function(node) {
+      this._removeAll();
+
       const inputs = new osparc.desktop.PanelView(this.tr("Input"), node.getPropsForm());
       this._add(inputs);
 

--- a/services/static-webserver/client/source/class/osparc/node/ProbeView.js
+++ b/services/static-webserver/client/source/class/osparc/node/ProbeView.js
@@ -30,6 +30,10 @@ qx.Class.define("osparc.node.ProbeView", {
 
   statics: {
     setProbeOutputValue: function(node, linkLabel) {
+      // Remove previous bindings from any source to this label
+      qx.data.SingleValueBinding.removeAllBindingsForObject(linkLabel);
+      linkLabel.setValue("");
+
       const populateLinkLabel = linkInfo => {
         const locationId = linkInfo.store;
         const fileId = linkInfo.path;
@@ -68,11 +72,7 @@ qx.Class.define("osparc.node.ProbeView", {
               return "";
             }
           });
-        } else {
-          linkLabel.setValue("");
         }
-      } else {
-        linkLabel.setValue("");
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/node/ProbeView.js
+++ b/services/static-webserver/client/source/class/osparc/node/ProbeView.js
@@ -29,6 +29,61 @@ qx.Class.define("osparc.node.ProbeView", {
   },
 
   statics: {
+    setProbeOutputValue: function(node, linkLabel) {
+      const populateLinkLabel = linkInfo => {
+        const locationId = linkInfo.store;
+        const fileId = linkInfo.path;
+        osparc.store.Data.getInstance().getPresignedLink(true, locationId, fileId)
+          .then(presignedLinkData => {
+            if ("resp" in presignedLinkData && presignedLinkData.resp) {
+              const filename = linkInfo.filename || osparc.file.FilePicker.getFilenameFromPath(linkInfo);
+              linkLabel.set({
+                value: filename,
+                url: presignedLinkData.resp.link
+              });
+            }
+          });
+      }
+
+      const link = node.getLink("in_1");
+      if (link && "nodeUuid" in link) {
+        const inputNodeId = link["nodeUuid"];
+        const portKey = link["output"];
+        const inputNode = node.getWorkbench().getNode(inputNodeId);
+        if (inputNode) {
+          inputNode.bind("outputs", linkLabel, "value", {
+            converter: outputs => {
+              const output = outputs.find(out => out.getPortKey() === portKey);
+              if (output && output.getValue()) {
+                const val = output.getValue();
+                if (node.getMetadata()["key"].includes("probe/array") && Array.isArray(val)) {
+                  return "[" + val.join(",") + "]";
+                } else if (node.getMetadata()["key"].includes("probe/file")) {
+                  const filename = val.filename || osparc.file.FilePicker.getFilenameFromPath(val);
+                  populateLinkLabel(val);
+                  return filename;
+                }
+                return String(val);
+              }
+              return "";
+            }
+          });
+        }
+      } else {
+        linkLabel.setValue("");
+      }
+    },
+
+    createProbeValueLabel: function(node) {
+      const linkLabel = new osparc.ui.basic.LinkLabel().set({
+        rich: false, // this will make the ellipsis work
+      });
+
+      node.getPropsForm().addListener("linkFieldModified", () => this.setProbeOutputValue(node, linkLabel));
+      this.setProbeOutputValue(node, linkLabel);
+
+      return linkLabel;
+    },
   },
 
   properties: {
@@ -55,6 +110,6 @@ qx.Class.define("osparc.node.ProbeView", {
         margin: 8
       });
       this._add(inputs);
-    }
+    },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/node/ProbeView.js
+++ b/services/static-webserver/client/source/class/osparc/node/ProbeView.js
@@ -18,34 +18,17 @@
 qx.Class.define("osparc.node.ProbeView", {
   extend: qx.ui.core.Widget,
 
-  construct: function(node, portId) {
+  construct: function(probe) {
     this.base();
 
     this._setLayout(new qx.ui.layout.VBox());
 
-    if (node) {
-      this.setNode(node);
-    }
-
-    if (portId) {
-      this.setPortId(portId);
+    if (probe) {
+      this.setNode(probe);
     }
   },
 
   statics: {
-    getOutputValues: function(metaStudy, nodeId, portId) {
-      return new Promise((resolve, reject) => {
-        metaStudy.getIterations()
-          .then(iterations => {
-            const outputValues = [];
-            iterations.forEach(iteration => outputValues.push(osparc.data.model.Study.getOutputValue(iteration, nodeId, portId)));
-            resolve(outputValues);
-          })
-          .catch(err => {
-            reject(err);
-          });
-      });
-    }
   },
 
   properties: {
@@ -55,13 +38,6 @@ qx.Class.define("osparc.node.ProbeView", {
       nullable: false,
       apply: "__applyNode"
     },
-
-    portId: {
-      check: "String",
-      init: null,
-      nullable: false,
-      apply: "__populateLayout"
-    }
   },
 
   members: {
@@ -69,20 +45,15 @@ qx.Class.define("osparc.node.ProbeView", {
       if (!node.isProbe()) {
         console.error("Only Probe nodes are supported");
       }
-      this.__populateLayout();
+      this.__populateLayout(node);
     },
 
-    __populateLayout: function() {
-      const node = this.getNode();
-      const portId = this.getPortId();
-      if (!node) {
-        return;
-      }
-
-      this._removeAll();
-      const outputValues = this.self().getOutputValues(node.getStudy(), node, portId);
-      outputValues.forEach(outputValue => {
-        this._add(new qx.ui.basic.Label(outputValue));
+    __populateLayout: function(node) {
+      const inputsForm = node.getPropsForm().set({
+        paddingLeft: 6,
+      });
+      this._add(inputsForm, {
+        flex: 1
       });
     }
   }

--- a/services/static-webserver/client/source/class/osparc/node/ProbeView.js
+++ b/services/static-webserver/client/source/class/osparc/node/ProbeView.js
@@ -58,7 +58,7 @@ qx.Class.define("osparc.node.ProbeView", {
           inputNode.bind("outputs", linkLabel, "value", {
             converter: outputs => {
               const output = outputs.find(out => out.getPortKey() === portKey);
-              if (output && output.getValue() !== undefined) {
+              if (output && output.getValue() != null) {
                 const val = output.getValue();
                 if (node.getMetadata()["key"].includes("probe/array") && Array.isArray(val)) {
                   return "[" + val.join(",") + "]";

--- a/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
@@ -681,7 +681,7 @@ qx.Class.define("osparc.workbench.NodeUI", {
     },
 
     __turnIntoIteratorIteratedUI: function() {
-      this.removeShadows;
+      this.removeShadows();
       this.__turnIntoParameterUI();
       if (this.hasChildControl("progress")) {
         this.getChildControl("progress").exclude();
@@ -693,18 +693,14 @@ qx.Class.define("osparc.workbench.NodeUI", {
       const width = 120;
       this.__setNodeUIWidth(width);
 
-      const linkLabel = new osparc.ui.basic.LinkLabel().set({
-        paddingLeft: 4,
+      const linkLabel = osparc.node.ProbeView.createProbeValueLabel(this.getNode()).set({
         font: "text-14",
-        rich: false, // this will make the ellipsis work
+        paddingLeft: 4,
       });
       const middleContainer = this.getChildControl("middle-container");
       middleContainer.add(linkLabel, {
         flex: 1
       });
-
-      this.getNode().getPropsForm().addListener("linkFieldModified", () => this.__setProbeValue(linkLabel), this);
-      this.__setProbeValue(linkLabel);
     },
 
     __turnIntoUnknownUI: function() {
@@ -731,51 +727,6 @@ qx.Class.define("osparc.workbench.NodeUI", {
           osparc.wrapper.Svg.removeItem(shadow);
         });
         delete this["shadows"];
-      }
-    },
-
-    __setProbeValue: function(linkLabel) {
-      const populateLinkLabel = linkInfo => {
-        const locationId = linkInfo.store;
-        const fileId = linkInfo.path;
-        osparc.store.Data.getInstance().getPresignedLink(true, locationId, fileId)
-          .then(presignedLinkData => {
-            if ("resp" in presignedLinkData && presignedLinkData.resp) {
-              const filename = linkInfo.filename || osparc.file.FilePicker.getFilenameFromPath(linkInfo);
-              linkLabel.set({
-                value: filename,
-                url: presignedLinkData.resp.link
-              });
-            }
-          });
-      }
-
-      const link = this.getNode().getLink("in_1");
-      if (link && "nodeUuid" in link) {
-        const inputNodeId = link["nodeUuid"];
-        const portKey = link["output"];
-        const inputNode = this.getNode().getWorkbench().getNode(inputNodeId);
-        if (inputNode) {
-          inputNode.bind("outputs", linkLabel, "value", {
-            converter: outputs => {
-              const output = outputs.find(out => out.getPortKey() === portKey);
-              if (output && output.getValue()) {
-                const val = output.getValue();
-                if (this.getNode().getMetadata()["key"].includes("probe/array") && Array.isArray(val)) {
-                  return "[" + val.join(",") + "]";
-                } else if (this.getNode().getMetadata()["key"].includes("probe/file")) {
-                  const filename = val.filename || osparc.file.FilePicker.getFilenameFromPath(val);
-                  populateLinkLabel(val);
-                  return filename;
-                }
-                return String(val);
-              }
-              return "";
-            }
-          });
-        }
-      } else {
-        linkLabel.setValue("");
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
@@ -641,7 +641,7 @@ qx.Class.define("osparc.workbench.NodeUI", {
       });
       const outputToValue = () => {
         const output = this.getNode().getOutput(osparc.data.model.NodePort.PARAM_PORT_KEY);
-        if (output && output.getValue() !== undefined) {
+        if (output && output.getValue() != null) {
           const val = output.getValue();
           if (Array.isArray(val)) {
             return "[" + val.join(",") + "]";

--- a/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
@@ -641,7 +641,7 @@ qx.Class.define("osparc.workbench.NodeUI", {
       });
       const outputToValue = () => {
         const output = this.getNode().getOutput(osparc.data.model.NodePort.PARAM_PORT_KEY);
-        if (output && output.getValue()) {
+        if (output && output.getValue() !== undefined) {
           const val = output.getValue();
           if (Array.isArray(val)) {
             return "[" + val.join(",") + "]";


### PR DESCRIPTION
## What do these changes do?

This PR updates workbench’s secondary (right) panel behavior for Parameter/Probe nodes, aiming to surface the node name at the top and improve the probe/parameter value presentation.

<img width="1440" height="850" alt="ProbesAndParam" src="https://github.com/user-attachments/assets/aa50ed26-e0e9-44f9-8f49-9a2674c8f7fe" />


## Related issue/s
- closes https://github.com/ITISFoundation/osparc-simcore/issues/8394


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
