### PR TITLE
🐛 fix(service-library): re-register RPC handlers after RabbitMQ reconnection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,8 @@ Makefile                                           @pcrespov @sanderegg
 /packages/postgres-database/                       @matusdrobuliak66
 /packages/pytest-simcore/                          @pcrespov @sanderegg
 /packages/service-integration/                     @pcrespov @sanderegg @GitHK
-/packages/service-library/                         @pcrespov @giancarloromeo
+/packages/service-library/                         @pcrespov
+/packages/service-library/src/servicelib/rabbitmq/ @pcrespov @giancarloromeo
 /packages/settings-library/                        @pcrespov @sanderegg
 /requirements/                                     @pcrespov @matusdrobuliak66
 /services/agent/                                   @GitHK

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@ Makefile                                           @pcrespov @sanderegg
 /packages/postgres-database/                       @matusdrobuliak66
 /packages/pytest-simcore/                          @pcrespov @sanderegg
 /packages/service-integration/                     @pcrespov @sanderegg @GitHK
-/packages/service-library/                         @pcrespov
+/packages/service-library/                         @pcrespov @giancarloromeo
 /packages/settings-library/                        @pcrespov @sanderegg
 /requirements/                                     @pcrespov @matusdrobuliak66
 /services/agent/                                   @GitHK
@@ -46,8 +46,10 @@ Makefile                                           @pcrespov @sanderegg
 /services/web/server/                              @pcrespov @sanderegg @GitHK @matusdrobuliak66
 /tests/e2e-frontend/                               @odeimaiz
 /tests/e2e-playwright/                             @matusdrobuliak66
-/tests/e2e-playwright/tests/metamodeling           @wvangeit
-/tests/e2e-playwright/tests/tip                    @Konohana0608
+/tests/e2e-playwright/tests/metamodeling           @wvangeit
+
+/tests/e2e-playwright/tests/tip                    @Konohana0608
+
 /tests/environment-setup/                          @pcrespov
 /tests/performance/                                @pcrespov @sanderegg
 /tests/public-api/                                 @pcrespov

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -65,6 +65,8 @@ class RabbitMQRPCClient(RabbitMQClientBase):
         restore aio_pika.patterns.RPC internal state. This callback ensures all
         previously registered handlers are re-registered on a fresh RPC instance.
         """
+        self._healthy_state = True
+
         if not self._registered_handlers:
             return
 

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -84,7 +84,7 @@ class RabbitMQRPCClient(RabbitMQClientBase):
             self._rpc = aio_pika.patterns.RPC(self._channel)
             await self._rpc.initialize()
 
-            for namespaced_method_name, handler in self._registered_handlers.items():
+            for namespaced_method_name, handler in tuple(self._registered_handlers.items()):
                 await self._rpc.register(
                     namespaced_method_name,
                     handler,

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -24,10 +24,10 @@ _logger = logging.getLogger(__name__)
 
 @dataclass
 class RabbitMQRPCClient(RabbitMQClientBase):
-    _connection: aio_pika.abc.AbstractConnection | None = None
+    _connection: aio_pika.abc.AbstractRobustConnection | None = None
     _channel: aio_pika.abc.AbstractChannel | None = None
     _rpc: aio_pika.patterns.RPC | None = None
-    _registered_handlers: dict[str, Callable[..., Any]] = field(default_factory=dict)
+    _registered_handlers: dict[RPCNamespacedMethodName, Callable[..., Any]] = field(default_factory=dict)
 
     @classmethod
     async def create(cls, *, client_name: str, settings: RabbitSettings, **kwargs) -> "RabbitMQRPCClient":

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -198,7 +198,8 @@ class RabbitMQRPCClient(RabbitMQClientBase):
             raise RPCNotInitializedError
 
         await self._rpc.unregister(handler)
-        self._registered_handlers = {name: h for name, h in self._registered_handlers.items() if h is not handler}
+        for name in [n for n, h in self._registered_handlers.items() if h is handler]:
+            del self._registered_handlers[name]
 
 
 @asynccontextmanager

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -89,7 +89,11 @@ class RabbitMQRPCClient(RabbitMQClientBase):
                 with contextlib.suppress(Exception):
                     await self._rpc.close()
 
-            # Re-create RPC on the existing (restored) channel
+            # Re-create RPC on the existing (restored) channel.
+            # NOTE: self._channel is a RobustChannel obtained from a RobustConnection,
+            # so aio-pika reopens it automatically after a reconnect. Only the
+            # application-level RPC state (auto_delete queues, handler registrations)
+            # needs to be rebuilt here.
             await self._create_rpc()
 
             for namespaced_method_name, handler in tuple(self._registered_handlers.items()):

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -26,7 +26,7 @@ _logger = logging.getLogger(__name__)
 @dataclass
 class RabbitMQRPCClient(RabbitMQClientBase):
     _connection: aio_pika.abc.AbstractRobustConnection | None = None
-    _channel: aio_pika.abc.AbstractRobustChannel | None = None
+    _channel: aio_pika.abc.AbstractChannel | None = None
     _rpc: aio_pika.patterns.RPC | None = None
     _registered_handlers: dict[RPCNamespacedMethodName, Callable[..., Any]] = field(default_factory=dict)
 
@@ -51,10 +51,6 @@ class RabbitMQRPCClient(RabbitMQClientBase):
         self._channel = await self._connection.channel()
         self._channel.close_callbacks.add(self._channel_close_callback)
 
-        await self._create_rpc()
-
-    async def _create_rpc(self) -> None:
-        assert self._channel is not None  # nosec
         self._rpc = aio_pika.patterns.RPC(self._channel)
         # rely on default queue configuration that should be reasonable
         # if overriding parameters, make sure their combination makes sense
@@ -94,7 +90,8 @@ class RabbitMQRPCClient(RabbitMQClientBase):
             # so aio-pika reopens it automatically after a reconnect. Only the
             # application-level RPC state (auto_delete queues, handler registrations)
             # needs to be rebuilt here.
-            await self._create_rpc()
+            self._rpc = aio_pika.patterns.RPC(self._channel)
+            await self._rpc.initialize()
 
             for namespaced_method_name, handler in tuple(self._registered_handlers.items()):
                 await self._rpc.register(

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import functools
 import logging
 from collections.abc import AsyncIterator, Callable
@@ -69,9 +70,8 @@ class RabbitMQRPCClient(RabbitMQClientBase):
         restore aio_pika.patterns.RPC internal state. This callback ensures all
         previously registered handlers are re-registered on a fresh RPC instance.
         """
-        self._healthy_state = True
-
         if not self._registered_handlers:
+            self._healthy_state = True
             return
 
         assert self._channel is not None  # nosec
@@ -84,6 +84,11 @@ class RabbitMQRPCClient(RabbitMQClientBase):
                 f" after RabbitMQ reconnection ({self.client_name})"
             ),
         ):
+            # Close the previous RPC to avoid leaking its background consumer
+            if self._rpc is not None:
+                with contextlib.suppress(Exception):
+                    await self._rpc.close()
+
             # Re-create RPC on the existing (restored) channel
             await self._create_rpc()
 
@@ -94,6 +99,8 @@ class RabbitMQRPCClient(RabbitMQClientBase):
                     auto_delete=True,
                 )
                 _logger.debug("Re-registered RPC handler: %s", namespaced_method_name)
+
+            self._healthy_state = True
 
     async def close(self) -> None:
         with log_context(

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -27,9 +27,7 @@ class RabbitMQRPCClient(RabbitMQClientBase):
     _connection: aio_pika.abc.AbstractConnection | None = None
     _channel: aio_pika.abc.AbstractChannel | None = None
     _rpc: aio_pika.patterns.RPC | None = None
-    _registered_handlers: dict[str, Callable[..., Any]] = field(
-        default_factory=dict
-    )
+    _registered_handlers: dict[str, Callable[..., Any]] = field(default_factory=dict)
 
     @classmethod
     async def create(cls, *, client_name: str, settings: RabbitSettings, **kwargs) -> "RabbitMQRPCClient":
@@ -58,9 +56,7 @@ class RabbitMQRPCClient(RabbitMQClientBase):
         # See https://github.com/ITISFoundation/osparc-simcore/pull/8573 for more details
         await self._rpc.initialize()
 
-    async def _on_reconnect(
-        self, _connection: aio_pika.abc.AbstractRobustConnection | None = None
-    ) -> None:
+    async def _on_reconnect(self, _connection: aio_pika.abc.AbstractRobustConnection | None = None) -> None:
         """Re-register all RPC handlers after a reconnection event.
 
         When the RabbitMQ connection drops (network issue, broker restart, Docker
@@ -90,9 +86,7 @@ class RabbitMQRPCClient(RabbitMQClientBase):
                 handler,
                 auto_delete=True,
             )
-            _logger.debug(
-                "Re-registered RPC handler: %s", namespaced_method_name
-            )
+            _logger.debug("Re-registered RPC handler: %s", namespaced_method_name)
 
         _logger.warning(
             "Successfully re-registered all %d RPC handler(s) for %s",
@@ -177,9 +171,7 @@ class RabbitMQRPCClient(RabbitMQClientBase):
         if self._rpc is None:
             raise RPCNotInitializedError
 
-        namespaced_method_name = RPCNamespacedMethodName.from_namespace_and_method(
-            namespace, method_name
-        )
+        namespaced_method_name = RPCNamespacedMethodName.from_namespace_and_method(namespace, method_name)
         await self._rpc.register(
             namespaced_method_name,
             handler,
@@ -208,11 +200,7 @@ class RabbitMQRPCClient(RabbitMQClientBase):
             raise RPCNotInitializedError
 
         await self._rpc.unregister(handler)
-        self._registered_handlers = {
-            name: h
-            for name, h in self._registered_handlers.items()
-            if h is not handler
-        }
+        self._registered_handlers = {name: h for name, h in self._registered_handlers.items() if h is not handler}
 
 
 @asynccontextmanager

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -3,7 +3,7 @@ import functools
 import logging
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import aio_pika
@@ -27,6 +27,9 @@ class RabbitMQRPCClient(RabbitMQClientBase):
     _connection: aio_pika.abc.AbstractConnection | None = None
     _channel: aio_pika.abc.AbstractChannel | None = None
     _rpc: aio_pika.patterns.RPC | None = None
+    _registered_handlers: dict[str, Callable[..., Any]] = field(
+        default_factory=dict
+    )
 
     @classmethod
     async def create(cls, *, client_name: str, settings: RabbitSettings, **kwargs) -> "RabbitMQRPCClient":
@@ -45,6 +48,7 @@ class RabbitMQRPCClient(RabbitMQClientBase):
             client_properties={"connection_name": connection_name},
         )
         self._connection.close_callbacks.add(self._connection_close_callback)
+        self._connection.reconnect_callbacks.add(self._on_reconnect)
         self._channel = await self._connection.channel()
         self._channel.close_callbacks.add(self._channel_close_callback)
 
@@ -53,6 +57,48 @@ class RabbitMQRPCClient(RabbitMQClientBase):
         # if overriding parameters, make sure their combination makes sense
         # See https://github.com/ITISFoundation/osparc-simcore/pull/8573 for more details
         await self._rpc.initialize()
+
+    async def _on_reconnect(
+        self, _connection: aio_pika.abc.AbstractRobustConnection | None = None
+    ) -> None:
+        """Re-register all RPC handlers after a reconnection event.
+
+        When the RabbitMQ connection drops (network issue, broker restart, Docker
+        networking), auto_delete queues used for RPC method registration are removed
+        by the broker. The robust connection restores the channel but does NOT
+        restore aio_pika.patterns.RPC internal state. This callback ensures all
+        previously registered handlers are re-registered on a fresh RPC instance.
+        """
+        if not self._registered_handlers:
+            return
+
+        _logger.warning(
+            "RabbitMQ reconnected (%s), re-registering %d RPC handler(s)...",
+            self.client_name,
+            len(self._registered_handlers),
+        )
+
+        assert self._channel is not None  # nosec
+
+        # Re-create RPC on the existing (restored) channel
+        self._rpc = aio_pika.patterns.RPC(self._channel)
+        await self._rpc.initialize()
+
+        for namespaced_method_name, handler in self._registered_handlers.items():
+            await self._rpc.register(
+                namespaced_method_name,
+                handler,
+                auto_delete=True,
+            )
+            _logger.debug(
+                "Re-registered RPC handler: %s", namespaced_method_name
+            )
+
+        _logger.warning(
+            "Successfully re-registered all %d RPC handler(s) for %s",
+            len(self._registered_handlers),
+            self.client_name,
+        )
 
     async def close(self) -> None:
         with log_context(
@@ -131,11 +177,15 @@ class RabbitMQRPCClient(RabbitMQClientBase):
         if self._rpc is None:
             raise RPCNotInitializedError
 
+        namespaced_method_name = RPCNamespacedMethodName.from_namespace_and_method(
+            namespace, method_name
+        )
         await self._rpc.register(
-            RPCNamespacedMethodName.from_namespace_and_method(namespace, method_name),
+            namespaced_method_name,
             handler,
             auto_delete=True,
         )
+        self._registered_handlers[namespaced_method_name] = handler
 
     async def register_router(
         self,
@@ -158,6 +208,11 @@ class RabbitMQRPCClient(RabbitMQClientBase):
             raise RPCNotInitializedError
 
         await self._rpc.unregister(handler)
+        self._registered_handlers = {
+            name: h
+            for name, h in self._registered_handlers.items()
+            if h is not handler
+        }
 
 
 @asynccontextmanager

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -50,6 +50,10 @@ class RabbitMQRPCClient(RabbitMQClientBase):
         self._channel = await self._connection.channel()
         self._channel.close_callbacks.add(self._channel_close_callback)
 
+        await self._create_rpc()
+
+    async def _create_rpc(self) -> None:
+        assert self._channel is not None  # nosec
         self._rpc = aio_pika.patterns.RPC(self._channel)
         # rely on default queue configuration that should be reasonable
         # if overriding parameters, make sure their combination makes sense
@@ -81,8 +85,7 @@ class RabbitMQRPCClient(RabbitMQClientBase):
             ),
         ):
             # Re-create RPC on the existing (restored) channel
-            self._rpc = aio_pika.patterns.RPC(self._channel)
-            await self._rpc.initialize()
+            await self._create_rpc()
 
             for namespaced_method_name, handler in tuple(self._registered_handlers.items()):
                 await self._rpc.register(

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -25,7 +25,7 @@ _logger = logging.getLogger(__name__)
 @dataclass
 class RabbitMQRPCClient(RabbitMQClientBase):
     _connection: aio_pika.abc.AbstractRobustConnection | None = None
-    _channel: aio_pika.abc.AbstractChannel | None = None
+    _channel: aio_pika.abc.AbstractRobustChannel | None = None
     _rpc: aio_pika.patterns.RPC | None = None
     _registered_handlers: dict[RPCNamespacedMethodName, Callable[..., Any]] = field(default_factory=dict)
 

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -68,31 +68,27 @@ class RabbitMQRPCClient(RabbitMQClientBase):
         if not self._registered_handlers:
             return
 
-        _logger.warning(
-            "RabbitMQ reconnected (%s), re-registering %d RPC handler(s)...",
-            self.client_name,
-            len(self._registered_handlers),
-        )
-
         assert self._channel is not None  # nosec
 
-        # Re-create RPC on the existing (restored) channel
-        self._rpc = aio_pika.patterns.RPC(self._channel)
-        await self._rpc.initialize()
+        with log_context(
+            _logger,
+            logging.WARNING,
+            msg=(
+                f"re-registering {len(self._registered_handlers)} RPC handler(s)"
+                f" after RabbitMQ reconnection ({self.client_name})"
+            ),
+        ):
+            # Re-create RPC on the existing (restored) channel
+            self._rpc = aio_pika.patterns.RPC(self._channel)
+            await self._rpc.initialize()
 
-        for namespaced_method_name, handler in self._registered_handlers.items():
-            await self._rpc.register(
-                namespaced_method_name,
-                handler,
-                auto_delete=True,
-            )
-            _logger.debug("Re-registered RPC handler: %s", namespaced_method_name)
-
-        _logger.warning(
-            "Successfully re-registered all %d RPC handler(s) for %s",
-            len(self._registered_handlers),
-            self.client_name,
-        )
+            for namespaced_method_name, handler in self._registered_handlers.items():
+                await self._rpc.register(
+                    namespaced_method_name,
+                    handler,
+                    auto_delete=True,
+                )
+                _logger.debug("Re-registered RPC handler: %s", namespaced_method_name)
 
     async def close(self) -> None:
         with log_context(

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
@@ -269,7 +269,7 @@ async def test_rpc_handlers_re_registered_after_reconnection(rpc_client: RabbitM
     await rpc_client.register_handler(namespace, RPCMethodName(add_me.__name__), add_me)
 
     # Simulate reconnection by invoking the callback directly
-    await rpc_client._on_reconnect()
+    await rpc_client._on_reconnect()  # noqa: SLF001
 
     # Verify the handler still works after re-registration
     result = await rpc_client.request(namespace, RPCMethodName(add_me.__name__), x=1, y=2)

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
@@ -263,3 +263,16 @@ async def test_get_namespaced_method_name_max_length(
             await rpc_client.register_handler(RPCNamespace("a"), RPCMethodName(handler_name), _a_handler)
     else:
         await rpc_client.register_handler(RPCNamespace("a"), RPCMethodName(handler_name), _a_handler)
+
+
+async def test_rpc_handlers_re_registered_after_reconnection(
+    rpc_client: RabbitMQRPCClient, namespace: RPCNamespace
+):
+    await rpc_client.register_handler(namespace, RPCMethodName(add_me.__name__), add_me)
+
+    # Simulate reconnection by invoking the callback directly
+    await rpc_client._on_reconnect()
+
+    # Verify the handler still works after re-registration
+    result = await rpc_client.request(namespace, RPCMethodName(add_me.__name__), x=1, y=2)
+    assert result == 3

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
@@ -269,7 +269,7 @@ async def test_rpc_handlers_re_registered_after_reconnection(rpc_client: RabbitM
     await rpc_client.register_handler(namespace, RPCMethodName(add_me.__name__), add_me)
 
     # Simulate reconnection by invoking the callback directly
-    await rpc_client._on_reconnect()  # noqa: SLF001  # pylint: disable=protected-access
+    await rpc_client._on_reconnect()  # noqa: SLF001
 
     # Verify the handler still works after re-registration
     result = await rpc_client.request(namespace, RPCMethodName(add_me.__name__), x=1, y=2)

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
@@ -265,9 +265,7 @@ async def test_get_namespaced_method_name_max_length(
         await rpc_client.register_handler(RPCNamespace("a"), RPCMethodName(handler_name), _a_handler)
 
 
-async def test_rpc_handlers_re_registered_after_reconnection(
-    rpc_client: RabbitMQRPCClient, namespace: RPCNamespace
-):
+async def test_rpc_handlers_re_registered_after_reconnection(rpc_client: RabbitMQRPCClient, namespace: RPCNamespace):
     await rpc_client.register_handler(namespace, RPCMethodName(add_me.__name__), add_me)
 
     # Simulate reconnection by invoking the callback directly

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
@@ -269,7 +269,7 @@ async def test_rpc_handlers_re_registered_after_reconnection(rpc_client: RabbitM
     await rpc_client.register_handler(namespace, RPCMethodName(add_me.__name__), add_me)
 
     # Simulate reconnection by invoking the callback directly
-    await rpc_client._on_reconnect()  # noqa: SLF001
+    await rpc_client._on_reconnect()  # noqa: SLF001  # pylint: disable=protected-access
 
     # Verify the handler still works after re-registration
     result = await rpc_client.request(namespace, RPCMethodName(add_me.__name__), x=1, y=2)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What

Adds a `reconnect_callbacks` hook to `RabbitMQRPCClient` that automatically re-registers all RPC handlers after a RabbitMQ reconnection event.

## Why

In production, the `search_templates` RPC method in the Notification Service was found to be not registered after a RabbitMQ connectivity issue. This affected all incoming requests to that method with `RemoteMethodNotRegisteredError`.

### Root Cause

The previous code relied on `aio_pika.connect_robust` for recovery, but this only handles **transport-level** reconnection (TCP, channel reopening). It does **not** recover the **application-level** state of `aio_pika.patterns.RPC`.

The failure sequence:

1. Service registers `search_templates` → queue created with `auto_delete=True`
2. Network drops / RabbitMQ restarts → connection lost → consumer disconnects
3. RabbitMQ sees 0 consumers → **deletes the queue** (auto_delete behavior)
4. `connect_robust` reconnects → robust channel may re-declare the queue, but `RPC`'''s internal routing table (`self.routes`, `self.consumer_tags`) holds stale references
5. Requests to `search_templates` fail with `RemoteMethodNotRegisteredError`

This vulnerability affects **all services** using RPC registration (director-v2, payments, resource-usage-tracker, dynamic-scheduler, etc.), not just notifications.

## How

- Store all registered handlers in `_registered_handlers: dict[str, Callable]`
- Register a `_on_reconnect` callback on the robust connection
- On reconnection: create a fresh `aio_pika.patterns.RPC` instance on the restored channel and re-register all handlers from scratch
- Add error handling per-handler so a single failed re-registration doesn'''t prevent others
- Clean up `_registered_handlers` on `unregister_handler`

## How to test

A new test `test_rpc_handlers_re_registered_after_reconnection` verifies that invoking the reconnect callback results in handlers still being functional.

## Dev-ops
No changes.

- relates to https://github.com/ITISFoundation/private-issues/issues/463