### PR TITLE
♻️ revert(web-server): remove from_local sender override in support email notifications

### DIFF
--- a/services/web/server/src/simcore_service_webserver/conversations/_conversation_message_service.py
+++ b/services/web/server/src/simcore_service_webserver/conversations/_conversation_message_service.py
@@ -133,7 +133,6 @@ async def _notify_support_reply(
                 channel=Channel.email,
                 group_ids=None,
                 external_contacts=[EmailContact(name=recipient_name, email=recipient_user["email"])],
-                from_local="no-reply",
                 template_name="support_reply",
                 context={
                     "user": {

--- a/services/web/server/src/simcore_service_webserver/notifications/_service.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_service.py
@@ -85,7 +85,6 @@ async def _create_email_addressing(
     group_ids: list[GroupID] | None,
     external_contacts: list[Contact] | None,
     reply_to: Contact | None = None,
-    from_local: str | None = None,
 ) -> EmailAddressing:
     """Build email addressing (from/to) for all recipients.
 
@@ -98,9 +97,6 @@ async def _create_email_addressing(
         name=f"{product.display_name} Support",
         email=product.support_email,
     )
-
-    if from_local:
-        from_contact = from_contact.replace(new_local=from_local, new_name="")
 
     to_contacts: list[EmailContact] = []
 
@@ -223,7 +219,6 @@ async def send_message_from_template(
     group_ids: list[GroupID] | None,
     external_contacts: list[Contact] | None,
     reply_to: Contact | None = None,
-    from_local: str | None = None,
     template_name: str,
     context: dict[str, Any],
 ) -> tuple[TaskUUID | GroupUUID, TaskName]:
@@ -235,7 +230,6 @@ async def send_message_from_template(
                 group_ids=group_ids,
                 external_contacts=external_contacts,
                 reply_to=reply_to,
-                from_local=from_local,
             )
         case _:
             raise NotificationsUnsupportedChannelError(channel=channel)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Reverts the `from_local` sender override feature introduced in #9194, while keeping the `recipient_name` fix (using `or ''` instead of default parameter in `.get()`).

## Related PR/s
- reverts #9194 

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
No changes.