### PR TITLE
🎨 [Notifications] email template: remove share links

### DIFF
--- a/packages/notifications-library/src/notifications_library/_models.py
+++ b/packages/notifications-library/src/notifications_library/_models.py
@@ -42,12 +42,6 @@ class SocialLink(NamedTuple):
     url: str  # e.g. "https://youtube.com/@company", "https://www.linkedin.com/@company", "https://github.com/ITISFoundation/osparc-simcore"
 
 
-class ShareLink(NamedTuple):
-    name: str  # e.g. "twitter", "linkedin"
-    label: str  # e.g. "Tweet", "Share"
-    url: str  # e.g. "https://twitter.com/tweet", "https://www.linkedin.com/share"
-
-
 class CompanyLink(NamedTuple):
     name: str  # e.g. "osparc.io", "sim4life"
     url: str  # e.g. "https://osparc.io/about/", "https://sim4life.swiss/"
@@ -55,14 +49,12 @@ class CompanyLink(NamedTuple):
 
 # --- type aliases (PEP 695) ---
 type FooterSocialLinks = list[SocialLink]
-type FooterShareLinks = list[ShareLink]
 type CompanyLinks = list[CompanyLink]
 
 
 @dataclass(frozen=True)
 class ProductFooterData:
     social_links: FooterSocialLinks
-    share_links: FooterShareLinks
     company_name: str
     company_address: str
     company_links: CompanyLinks
@@ -81,10 +73,6 @@ class ProductData:
     @property
     def footer_social_links(self) -> FooterSocialLinks:
         return self.footer.social_links
-
-    @property
-    def footer_share_links(self) -> FooterShareLinks:
-        return self.footer.share_links
 
     @property
     def company_name(self) -> str:

--- a/packages/notifications-library/src/notifications_library/templates/email/_base/body_html.j2
+++ b/packages/notifications-library/src/notifications_library/templates/email/_base/body_html.j2
@@ -21,21 +21,6 @@
   "youtube": '<img src="https://cdn.simpleicons.org/youtube/white" alt="YouTube" width="20" height="20" border="0" style="display: block; border: 0; margin-left: 3px; padding-top: 4px;">',
   "github": '<img src="https://cdn.simpleicons.org/github/white" alt="GitHub" width="22" height="21" border="0" style="display: block; border: 0; margin-left: 2px; padding-top: 3px;">'
 } -%}
-{%- set footer_share_link_style = "min-width: 80px; border-radius: 4px; background-color: #808080; color: #ffffff; text-decoration: none; display: inline-block; font-weight: 600; padding: 6px 14px; white-space: nowrap; line-height: 20px;" -%}
-{%- set footer_share_icon_wrapper_style = "display: inline-block; width: 16px; height: 16px; vertical-align: middle; margin-right: 6px; line-height: 1;" -%}
-{%- set footer_share_label_style = "display: inline-block; vertical-align: middle; line-height: 20px;" -%}
-{%- set footer_share_td_style = "padding: 4px 5px;" -%}
-{%- set footer_share_badge_style = "width: 22px; height: 22px; border-radius: 3px; background-color: #353638; color: #ffffff; font-size: 12px; display: inline-block; text-align: center; vertical-align: middle; line-height: 22px;" -%}
-{# zimbra doesn't support the svgs :(
-  "facebook": '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 320 512" aria-hidden="true" focusable="false"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path fill="#ffffff" d="M80 299.3l0 212.7 116 0 0-212.7 86.5 0 18-97.8-104.5 0 0-34.6c0-51.7 20.3-71.5 72.7-71.5 16.3 0 29.4 .4 37 1.2l0-88.7C291.4 4 256.4 0 236.2 0 129.3 0 80 50.5 80 159.4l0 42.1-66 0 0 97.8 66 0z"/></svg>',
-  "twitter": '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 448 512" aria-hidden="true" focusable="false"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path fill="#ffffff" d="M357.2 48L427.8 48 273.6 224.2 455 464 313 464 201.7 318.6 74.5 464 3.8 464 168.7 275.5-5.2 48 140.4 48 240.9 180.9 357.2 48zM332.4 421.8l39.1 0-252.4-333.8-42 0 255.3 333.8z"/></svg>',
-  "linkedin": footer_social_icon_svgs["linkedin"]
-#}
-{%- set footer_share_icon_svgs = {
-  "facebook": '<img src="https://cdn.simpleicons.org/facebook/white" alt="Facebook" width="16" height="16" border="0" style="display: block; border: 0;">',
-  "twitter": '<img src="https://cdn.simpleicons.org/x/white" alt="Twitter" width="14" height="14" border="0" style="display: block; border: 0; padding-top: 1px;">',
-  "linkedin": '<img src="https://img.icons8.com/ios-filled/50/ffffff/linkedin.png" alt="LinkedIn" width="16" height="16" border="0" style="display: block; border: 0;">'
-} -%}
 {%- set footer_company_text_style = "margin: 4px 0; color: #bbbbbb; font-size: 12px;" -%}
 {%- set footer_links_separator_style = "margin: 0 8px; color: #bbbbbb;" -%}
 {%- set link_style = "color: #bbbbbb; font-size: 12px; text-decoration: none;" -%}

--- a/packages/notifications-library/src/notifications_library/templates/email/_base/body_html.j2
+++ b/packages/notifications-library/src/notifications_library/templates/email/_base/body_html.j2
@@ -41,7 +41,6 @@
 {%- set link_style = "color: #bbbbbb; font-size: 12px; text-decoration: none;" -%}
 {%- set footer = product.footer if product.footer is defined else none -%}
 {%- set product_social_links = footer.social_links if footer else [] -%}
-{%- set product_share_links = footer.share_links if footer else [] -%}
 {%- set product_company_name = footer.company_name if footer else '' -%}
 {%- set product_company_address = footer.company_address if footer else '' -%}
 {%- set product_company_links = footer.company_links if footer else [] -%}
@@ -108,33 +107,6 @@
                           {{ social_name[:2] | upper }}
                         {% endif %}
                       </span>
-                    </a>
-                  </td>
-                  {% endfor %}
-                </tr>
-              </table>
-              {% endif %}
-
-              {% if product_share_links %}
-              <table border="0" cellpadding="0" cellspacing="0" align="center" style="margin: 0 auto 16px;">
-                <tr>
-                  {% for share in product_share_links %}
-                  {# Support NamedTuple, tuple, and dict - use index access which works for all #}
-                  {% set share_name = share[0] if share is not mapping else share['name'] %}
-                  {% set share_label = share[1] if share is not mapping else share['label'] %}
-                  {% set share_url = share[2] if share is not mapping else share['url'] %}
-                  {% set share_key = share_name | lower %}
-                  {% set share_icon = footer_share_icon_svgs.get(share_key) %}
-                  <td style="{{ footer_share_td_style }}">
-                    <a href="{{ share_url }}" target="_blank" rel="noopener noreferrer" style="{{ footer_share_link_style }}" title="{{ share_name }}">
-                      <span style="{{ footer_share_icon_wrapper_style }}">
-                        {% if share_icon %}
-                          {{ share_icon | safe }}
-                        {% else %}
-                          <span style="{{ footer_share_badge_style }}">{{ share_name[:1] | upper }}</span>
-                        {% endif %}
-                      </span>
-                      <span style="{{ footer_share_label_style }}">{{ share_label }}</span>
                     </a>
                   </td>
                   {% endfor %}

--- a/packages/notifications-library/tests/conftest.py
+++ b/packages/notifications-library/tests/conftest.py
@@ -16,7 +16,6 @@ from notifications_library._models import (
     ProductData,
     ProductFooterData,
     ProductUIData,
-    ShareLink,
     SharerData,
     SocialLink,
     UserData,
@@ -75,10 +74,6 @@ def product_data(
     footer_data = ProductFooterData(
         social_links=[
             SocialLink(name=link_name, url=link_url) for link_name, link_url in vendor.get("footer_social_links", [])
-        ],
-        share_links=[
-            ShareLink(name=share_name, label=share_label, url=share_url)
-            for share_name, share_label, share_url in vendor.get("footer_share_links", [])
         ],
         company_name=vendor.get("company_name", ""),
         company_address=vendor.get("company_address", ""),

--- a/packages/postgres-database/src/simcore_postgres_database/models/products.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/products.py
@@ -60,7 +60,6 @@ class Vendor(TypedDict):
     ui: NotRequired[VendorUI]
 
     footer_social_links: NotRequired[list[tuple[str, str]]]  # list of (social_media_name, social_media_url)
-    footer_share_links: NotRequired[list[tuple[str, str, str]]]  # list of (share_name, share_label, share_url)
     company_name: NotRequired[str]
     company_address: NotRequired[str]
     company_links: NotRequired[list[tuple[str, str]]]  # list of (link_name, link_url)

--- a/services/notifications/tests/email/conftest.py
+++ b/services/notifications/tests/email/conftest.py
@@ -14,7 +14,6 @@ from notifications_library._models import (
     ProductData,
     ProductFooterData,
     ProductUIData,
-    ShareLink,
     SharerData,
     SocialLink,
     UserData,
@@ -85,10 +84,6 @@ def product_data(
     footer_data = ProductFooterData(
         social_links=[
             SocialLink(name=link_name, url=link_url) for link_name, link_url in vendor.get("footer_social_links", [])
-        ],
-        share_links=[
-            ShareLink(name=share_name, label=share_label, url=share_url)
-            for share_name, share_label, share_url in vendor.get("footer_share_links", [])
         ],
         company_name=vendor.get("company_name", ""),
         company_address=vendor.get("company_address", ""),

--- a/services/notifications/tests/unit/conftest.py
+++ b/services/notifications/tests/unit/conftest.py
@@ -27,7 +27,6 @@ from notifications_library._models import (
     ProductData,
     ProductFooterData,
     ProductUIData,
-    ShareLink,
     SocialLink,
 )
 from pytest_mock import MockerFixture
@@ -252,7 +251,6 @@ def fake_ipinfo(faker: Faker) -> dict[str, Any]:
 def fake_product_data(faker: Faker) -> dict[str, Any]:
     footer_data = ProductFooterData(
         social_links=[SocialLink(name=faker.word(), url=faker.url()) for _ in range(3)],
-        share_links=[ShareLink(name=faker.word(), label=faker.word(), url=faker.url()) for _ in range(3)],
         company_name=faker.company(),
         company_address=faker.address(),
         company_links=[CompanyLink(name=faker.word(), url=faker.url()) for _ in range(3)],

--- a/services/payments/src/simcore_service_payments/services/notifier_email.py
+++ b/services/payments/src/simcore_service_payments/services/notifier_email.py
@@ -163,10 +163,6 @@ def _build_product_context(
         },
         "footer": {
             "social_links": [{"name": name, "url": url} for name, url in vendor.get("footer_social_links", []) or []],
-            "share_links": [
-                {"name": name, "label": label, "url": url}
-                for name, label, url in vendor.get("footer_share_links", []) or []
-            ],
             "company_name": vendor.get("company_name", "") or "",
             "company_address": vendor.get("company_address", "") or "",
             "company_links": [{"name": name, "url": url} for name, url in vendor.get("company_links", []) or []],

--- a/services/web/server/src/simcore_service_webserver/notifications/_helpers.py
+++ b/services/web/server/src/simcore_service_webserver/notifications/_helpers.py
@@ -8,7 +8,6 @@ from notifications_library._models import (
     ProductData,
     ProductFooterData,
     ProductUIData,
-    ShareLink,
     SocialLink,
     UserData,
 )
@@ -42,12 +41,6 @@ def get_product_data(
         social_links=[
             SocialLink(name=link_name, url=link_url)
             for link_name, link_url in (product.vendor.get("footer_social_links", []) if product.vendor else [])
-        ],
-        share_links=[
-            ShareLink(name=share_name, label=share_label, url=share_url)
-            for share_name, share_label, share_url in (
-                product.vendor.get("footer_share_links", []) if product.vendor else []
-            )
         ],
         company_name=product.vendor.get("company_name", "") if product.vendor else "",
         company_address=product.vendor.get("company_address", "") if product.vendor else "",


### PR DESCRIPTION
## What do these changes do?

The **Notifications Service was so well done** that removing the footer_share_links from the DB, already brings what @eofli requested: "remove the share in social media button links from the emails we send".

This PR simply removes “share links” from the email footer model/context and from the base HTML email template. It also cleans up the related code that it's no longer needed.

<img width="1440" height="850" alt="RemoveShareButtons" src="https://github.com/user-attachments/assets/197f09e6-6346-4a9e-bd8b-cb2b39f56e1f" />


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
