### PR TITLE
[e2e] Update expected list of files in ti-postpro

### DIFF
--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -254,7 +254,7 @@ def _run_classic_ti_step(  # noqa: PLR0915
             params.page.get_by_test_id("outputsBtn").get_by_text(text_on_output_button).click()
 
         else:
-            expected_outputs = ["output_1.zip", "TIP_report.pdf", "results.csv"]
+            expected_outputs = ["output_1.zip", "TIP_report.pdf", "results.csv", "MIDA_Anisotropic.smash", "WM.cache"]
             text_on_output_button = f"Outputs ({len(expected_outputs)})"
             params.page.get_by_test_id("outputsBtn").get_by_text(text_on_output_button).click()
 

--- a/tests/e2e-playwright/tests/tip/test_ti_plan.py
+++ b/tests/e2e-playwright/tests/tip/test_ti_plan.py
@@ -249,7 +249,7 @@ def _run_classic_ti_step(  # noqa: PLR0915
 
     with log_context(logging.INFO, "Check outputs", logger=log_ctx.logger):
         if params.is_product_lite:
-            expected_outputs = ["results.csv"]
+            expected_outputs = ["results.csv", "MIDA_Anisotropic.smash", "WM.cache"]
             text_on_output_button = f"Outputs ({len(expected_outputs)})"
             params.page.get_by_test_id("outputsBtn").get_by_text(text_on_output_button).click()
 


### PR DESCRIPTION
## What do these changes do?

In TIP v5 the number of files generated by ti-postpro changed:
- 3 files in lite mode
- 5 files in pro mode

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
