### PR TITLE
🎨 [Frontend] Enh: Show download progress feedback when downloading files

### DIFF
--- a/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
+++ b/services/static-webserver/client/source/class/osparc/file/FileLabelWithActions.js
@@ -267,9 +267,8 @@ qx.Class.define("osparc.file.FileLabelWithActions", {
         "@FontAwesome5Solid/trash/14",
         this.tr("Deleting files..."),
       );
+      progressWindow.addHideButton();
       if (task.getAbortHref()) {
-        const cancelButton = progressWindow.addCancelButton();
-        cancelButton.setLabel(this.tr("Hide"));
         const abortButton = new qx.ui.form.Button().set({
           label: this.tr("Cancel"),
           center: true,

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -222,7 +222,26 @@ qx.Class.define("osparc.file.FilePicker", {
 
     downloadOutput: function(node, downloadFileBtn) {
       downloadFileBtn.setFetching(true);
-      const doneCb = () => downloadFileBtn.setFetching(false);
+      const progressWindow = new osparc.ui.window.Progress(
+        qx.locale.Manager.tr("Downloading file"),
+        "@FontAwesome5Solid/download/14",
+        qx.locale.Manager.tr("Starting download..."),
+      );
+      progressWindow.open();
+      const progressCb = ({loaded, total, progress}) => {
+        if (progress !== null) {
+          progressWindow.setProgress(progress * 100);
+        }
+        const loadedStr = osparc.utils.Utils.bytesToSize(loaded);
+        const totalStr = total ? osparc.utils.Utils.bytesToSize(total) : "?";
+        progressWindow.setMessage(
+          qx.locale.Manager.tr("Downloading: ") + loadedStr + " / " + totalStr
+        );
+      };
+      const doneCb = () => {
+        downloadFileBtn.setFetching(false);
+        progressWindow.close();
+      };
       if (osparc.file.FilePicker.isOutputFromStore(node.getOutputs())) {
         this.self().getOutputFileMetadata(node)
           .then(fileMetadata => {
@@ -232,7 +251,7 @@ qx.Class.define("osparc.file.FilePicker", {
               osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
                 .then(data => {
                   if (data) {
-                    osparc.utils.Utils.downloadNatively(data.link, data.fileName)
+                    osparc.utils.Utils.downloadNatively(data.link, data.fileName, progressCb)
                       .then(() => doneCb())
                       .catch(() => doneCb());
                   } else {
@@ -247,7 +266,7 @@ qx.Class.define("osparc.file.FilePicker", {
           .catch(() => doneCb());
       } else if (osparc.file.FilePicker.isOutputDownloadLink(node.getOutputs())) {
         const outFileValue = osparc.file.FilePicker.getOutput(node.getOutputs());
-        osparc.utils.Utils.downloadNatively(outFileValue["downloadLink"], outFileValue["label"])
+        osparc.utils.Utils.downloadNatively(outFileValue["downloadLink"], outFileValue["label"], progressCb)
           .then(() => doneCb())
           .catch(() => doneCb());
       }

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -220,24 +220,48 @@ qx.Class.define("osparc.file.FilePicker", {
       }
     },
 
+    // Track active downloads by node ID so recreated buttons can pick up progress
+    __activeDownloads: {},
+
     downloadOutput: function(node, downloadFileBtn) {
+      const nodeId = node.getNodeId();
+      // If a download is already in progress for this node, just register the button
+      if (this.__activeDownloads[nodeId]) {
+        this.__activeDownloads[nodeId].btn = downloadFileBtn;
+        this.__applyDownloadState(downloadFileBtn, this.__activeDownloads[nodeId]);
+        return;
+      }
+
       downloadFileBtn.setFetching(true);
-      const originalLabel = downloadFileBtn.getLabel();
+      const state = {
+        btn: downloadFileBtn,
+        originalLabel: downloadFileBtn.getLabel(),
+        progress: null,
+        label: null,
+      };
+      this.__activeDownloads[nodeId] = state;
+
       const btnWidth = downloadFileBtn.getSizeHint().width;
       downloadFileBtn.setMinWidth(btnWidth);
+
       const progressCb = ({loaded, total, progress}) => {
         if (progress !== null) {
-          const pct = Math.round(progress * 100);
-          downloadFileBtn.setLabel(`${pct}%`);
+          state.label = `${Math.round(progress * 100)}%`;
         } else {
-          const loadedStr = osparc.utils.Utils.bytesToSize(loaded);
-          downloadFileBtn.setLabel(loadedStr);
+          state.label = osparc.utils.Utils.bytesToSize(loaded);
+        }
+        state.progress = progress;
+        if (state.btn) {
+          state.btn.setLabel(state.label);
         }
       };
       const doneCb = () => {
-        downloadFileBtn.setFetching(false);
-        downloadFileBtn.setLabel(originalLabel);
-        downloadFileBtn.resetMinWidth();
+        if (state.btn) {
+          state.btn.setFetching(false);
+          state.btn.setLabel(state.originalLabel);
+          state.btn.resetMinWidth();
+        }
+        delete this.__activeDownloads[nodeId];
       };
       if (osparc.file.FilePicker.isOutputFromStore(node.getOutputs())) {
         this.self().getOutputFileMetadata(node)
@@ -266,6 +290,13 @@ qx.Class.define("osparc.file.FilePicker", {
         osparc.utils.Utils.downloadNatively(outFileValue["downloadLink"], outFileValue["label"], progressCb)
           .then(() => doneCb())
           .catch(() => doneCb());
+      }
+    },
+
+    __applyDownloadState: function(btn, state) {
+      btn.setFetching(true);
+      if (state.label) {
+        btn.setLabel(state.label);
       }
     },
 
@@ -409,6 +440,12 @@ qx.Class.define("osparc.file.FilePicker", {
         allowGrowX: false
       });
       downloadFileBtn.addListener("execute", () => osparc.file.FilePicker.downloadOutput(node, downloadFileBtn));
+      // If a download is already active for this node, attach the new button to it
+      const activeDownload = osparc.file.FilePicker.__activeDownloads[node.getNodeId()];
+      if (activeDownload) {
+        activeDownload.btn = downloadFileBtn;
+        osparc.file.FilePicker.__applyDownloadState(downloadFileBtn, activeDownload);
+      }
       return downloadFileBtn;
     },
 

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -221,8 +221,8 @@ qx.Class.define("osparc.file.FilePicker", {
     },
 
     downloadOutput: function(node, downloadFileBtn) {
-      const progressCb = () => downloadFileBtn.setFetching(true);
-      const loadedCb = () => downloadFileBtn.setFetching(false);
+      downloadFileBtn.setFetching(true);
+      const doneCb = () => downloadFileBtn.setFetching(false);
       if (osparc.file.FilePicker.isOutputFromStore(node.getOutputs())) {
         this.self().getOutputFileMetadata(node)
           .then(fileMetadata => {
@@ -232,14 +232,24 @@ qx.Class.define("osparc.file.FilePicker", {
               osparc.utils.Utils.retrieveURLAndDownload(locationId, fileId)
                 .then(data => {
                   if (data) {
-                    osparc.utils.Utils.downloadLink(data.link, "GET", data.fileName, progressCb, loadedCb);
+                    osparc.utils.Utils.downloadNatively(data.link, data.fileName)
+                      .then(() => doneCb())
+                      .catch(() => doneCb());
+                  } else {
+                    doneCb();
                   }
-                });
+                })
+                .catch(() => doneCb());
+            } else {
+              doneCb();
             }
-          });
+          })
+          .catch(() => doneCb());
       } else if (osparc.file.FilePicker.isOutputDownloadLink(node.getOutputs())) {
         const outFileValue = osparc.file.FilePicker.getOutput(node.getOutputs());
-        osparc.utils.Utils.downloadLink(outFileValue["downloadLink"], "GET", outFileValue["label"], progressCb, loadedCb);
+        osparc.utils.Utils.downloadNatively(outFileValue["downloadLink"], outFileValue["label"])
+          .then(() => doneCb())
+          .catch(() => doneCb());
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -227,6 +227,7 @@ qx.Class.define("osparc.file.FilePicker", {
         "@FontAwesome5Solid/download/14",
         qx.locale.Manager.tr("Starting download..."),
       );
+      progressWindow.addHideButton();
       progressWindow.open();
       const progressCb = ({loaded, total, progress}) => {
         if (progress !== null) {

--- a/services/static-webserver/client/source/class/osparc/file/FilePicker.js
+++ b/services/static-webserver/client/source/class/osparc/file/FilePicker.js
@@ -222,26 +222,22 @@ qx.Class.define("osparc.file.FilePicker", {
 
     downloadOutput: function(node, downloadFileBtn) {
       downloadFileBtn.setFetching(true);
-      const progressWindow = new osparc.ui.window.Progress(
-        qx.locale.Manager.tr("Downloading file"),
-        "@FontAwesome5Solid/download/14",
-        qx.locale.Manager.tr("Starting download..."),
-      );
-      progressWindow.addHideButton();
-      progressWindow.open();
+      const originalLabel = downloadFileBtn.getLabel();
+      const btnWidth = downloadFileBtn.getSizeHint().width;
+      downloadFileBtn.setMinWidth(btnWidth);
       const progressCb = ({loaded, total, progress}) => {
         if (progress !== null) {
-          progressWindow.setProgress(progress * 100);
+          const pct = Math.round(progress * 100);
+          downloadFileBtn.setLabel(`${pct}%`);
+        } else {
+          const loadedStr = osparc.utils.Utils.bytesToSize(loaded);
+          downloadFileBtn.setLabel(loadedStr);
         }
-        const loadedStr = osparc.utils.Utils.bytesToSize(loaded);
-        const totalStr = total ? osparc.utils.Utils.bytesToSize(total) : "?";
-        progressWindow.setMessage(
-          qx.locale.Manager.tr("Downloading: ") + loadedStr + " / " + totalStr
-        );
       };
       const doneCb = () => {
         downloadFileBtn.setFetching(false);
-        progressWindow.close();
+        downloadFileBtn.setLabel(originalLabel);
+        downloadFileBtn.resetMinWidth();
       };
       if (osparc.file.FilePicker.isOutputFromStore(node.getOutputs())) {
         this.self().getOutputFileMetadata(node)

--- a/services/static-webserver/client/source/class/osparc/jobs/SubRunsTable.js
+++ b/services/static-webserver/client/source/class/osparc/jobs/SubRunsTable.js
@@ -177,7 +177,7 @@ qx.Class.define("osparc.jobs.SubRunsTable", {
           }
           const logDownloadLink = subJob.getLogDownloadLink()
           if (logDownloadLink) {
-            osparc.utils.Utils.downloadLink(logDownloadLink, "GET", rowData["name"] + ".zip");
+            osparc.utils.Utils.downloadNatively(logDownloadLink, rowData["name"] + ".zip");
           } else {
             osparc.FlashMessenger.logAs(this.tr("No logs available"), "WARNING");
           }

--- a/services/static-webserver/client/source/class/osparc/jobs/SubRunsTable.js
+++ b/services/static-webserver/client/source/class/osparc/jobs/SubRunsTable.js
@@ -177,7 +177,13 @@ qx.Class.define("osparc.jobs.SubRunsTable", {
           }
           const logDownloadLink = subJob.getLogDownloadLink()
           if (logDownloadLink) {
-            osparc.utils.Utils.downloadNatively(logDownloadLink, rowData["name"] + ".zip");
+            osparc.utils.Utils.downloadNatively(logDownloadLink, rowData["name"] + ".zip")
+              .catch(err => {
+                if (err && err.name === "AbortError") {
+                  return;
+                }
+                osparc.FlashMessenger.logError(err);
+              });
           } else {
             osparc.FlashMessenger.logAs(this.tr("No logs available"), "WARNING");
           }

--- a/services/static-webserver/client/source/class/osparc/task/ExportData.js
+++ b/services/static-webserver/client/source/class/osparc/task/ExportData.js
@@ -33,8 +33,9 @@ qx.Class.define("osparc.task.ExportData", {
       exportDataTaskUI.setTask(task);
       osparc.task.TasksContainer.getInstance().addTaskUI(exportDataTaskUI);
 
+      let progressWindow = null;
       if (popUpProgressWindow) {
-        const progressWindow = new osparc.ui.window.Progress(
+        progressWindow = new osparc.ui.window.Progress(
           qx.locale.Manager.tr("Downloading files"),
           osparc.task.ExportData+"/14",
           qx.locale.Manager.tr("Compressing files..."),
@@ -65,7 +66,6 @@ qx.Class.define("osparc.task.ExportData", {
           }
         });
 
-        task.addListener("resultReceived", () => progressWindow.close());
         task.addListener("taskAborted", () => progressWindow.close());
         task.addListener("pollingError", () => progressWindow.close());
 
@@ -93,11 +93,44 @@ qx.Class.define("osparc.task.ExportData", {
                   };
                   osparc.data.Resources.fetch("tasks", "delete", deleteParams);
                 };
-                osparc.utils.Utils.downloadNatively(data.link, fileName)
-                  .then(() => cleanupTask())
-                  .catch(() => cleanupTask());
+                const progressCb = progressWindow ? ({loaded, total, progress}) => {
+                  if (progress !== null) {
+                    progressWindow.setProgress(progress * 100);
+                  }
+                  const loadedStr = osparc.utils.Utils.bytesToSize(loaded);
+                  const totalStr = total ? osparc.utils.Utils.bytesToSize(total) : "?";
+                  progressWindow.setMessage(
+                    qx.locale.Manager.tr("Downloading: ") + loadedStr + " / " + totalStr
+                  );
+                } : null;
+                if (progressWindow) {
+                  progressWindow.setMessage(qx.locale.Manager.tr("Starting download..."));
+                  progressWindow.setProgress(0);
+                }
+                osparc.utils.Utils.downloadNatively(data.link, fileName, progressCb)
+                  .then(() => {
+                    if (progressWindow) {
+                      progressWindow.close();
+                    }
+                    cleanupTask();
+                  })
+                  .catch(() => {
+                    if (progressWindow) {
+                      progressWindow.close();
+                    }
+                    cleanupTask();
+                  });
+              } else if (progressWindow) {
+                progressWindow.close();
               }
             })
+            .catch(() => {
+              if (progressWindow) {
+                progressWindow.close();
+              }
+            });
+        } else if (progressWindow) {
+          progressWindow.close();
         }
       });
       task.addListener("taskAborted", () => {

--- a/services/static-webserver/client/source/class/osparc/task/ExportData.js
+++ b/services/static-webserver/client/source/class/osparc/task/ExportData.js
@@ -40,10 +40,8 @@ qx.Class.define("osparc.task.ExportData", {
           osparc.task.ExportData+"/14",
           qx.locale.Manager.tr("Compressing files..."),
         );
-
+        progressWindow.addHideButton();
         if (task.getAbortHref()) {
-          const cancelButton = progressWindow.addCancelButton();
-          cancelButton.setLabel(qx.locale.Manager.tr("Hide"));
           const abortButton = new qx.ui.form.Button().set({
             label: qx.locale.Manager.tr("Cancel"),
             center: true,

--- a/services/static-webserver/client/source/class/osparc/task/ExportData.js
+++ b/services/static-webserver/client/source/class/osparc/task/ExportData.js
@@ -85,16 +85,17 @@ qx.Class.define("osparc.task.ExportData", {
             .then(data => {
               if (data && data.link) {
                 const fileName = taskData["result"].split("/").pop();
-                const progressCb = null;
-                const loadedCb = () => {
+                const cleanupTask = () => {
                   const deleteParams = {
                     url: {
                       taskId: task.getTaskId(),
                     }
                   };
                   osparc.data.Resources.fetch("tasks", "delete", deleteParams);
-                }
-                osparc.utils.Utils.downloadLink(data.link, "GET", fileName, progressCb, loadedCb);
+                };
+                osparc.utils.Utils.downloadNatively(data.link, fileName)
+                  .then(() => cleanupTask())
+                  .catch(() => cleanupTask());
               }
             })
         }

--- a/services/static-webserver/client/source/class/osparc/ui/window/Progress.js
+++ b/services/static-webserver/client/source/class/osparc/ui/window/Progress.js
@@ -54,5 +54,11 @@ qx.Class.define("osparc.ui.window.Progress", {
       }
       return control || this.base(arguments, id);
     },
+
+    addHideButton: function() {
+      const hideButton = this.addCancelButton();
+      hideButton.setLabel(qx.locale.Manager.tr("Hide"));
+      return hideButton;
+    },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/ui/window/Progress.js
+++ b/services/static-webserver/client/source/class/osparc/ui/window/Progress.js
@@ -16,6 +16,10 @@ qx.Class.define("osparc.ui.window.Progress", {
 
     const progressBar = this.getChildControl("progress-bar");
     this.bind("progress", progressBar, "value");
+
+    this.set({
+      minWidth: 350,
+    });
   },
 
   properties: {

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -1128,31 +1128,38 @@ qx.Class.define("osparc.utils.Utils", {
      * @param {String} fileName Suggested file name
      * @param {Function} [progressCb] Optional callback receiving {loaded, total, progress} during download
      */
-    downloadNatively: function(url, fileName, progressCb) {
+    downloadNatively: async function(url, fileName, progressCb) {
       if (window.showSaveFilePicker) {
-        return this.self().__downloadWithFileSystemAccess(url, fileName, progressCb);
+        try {
+          return await this.self().__downloadWithFileSystemAccess(url, fileName, progressCb);
+        } catch (err) {
+          // Fall back to fetch+blob if user activation expired or picker was denied
+          if (err.name === "NotAllowedError" || err.name === "SecurityError") {
+            return this.self().__downloadWithFetchBlob(url, fileName, progressCb);
+          }
+          throw err;
+        }
       }
       return this.self().__downloadWithFetchBlob(url, fileName, progressCb);
     },
 
     __downloadWithFileSystemAccess: async function(url, fileName, progressCb) {
-      const extension = fileName.split(".").pop() || "";
+      const extension = (fileName.split(".").pop() || "").toLowerCase();
       const mimeTypes = {
         "zip": "application/zip",
         "tar": "application/x-tar",
         "gz": "application/gzip",
       };
-      const accept = {};
-      if (mimeTypes[extension]) {
-        accept[mimeTypes[extension]] = ["." + extension];
-      }
-      const fileHandle = await window.showSaveFilePicker({
+      const pickerOpts = {
         suggestedName: fileName,
-        types: [{
+      };
+      if (mimeTypes[extension]) {
+        pickerOpts.types = [{
           description: "Downloaded file",
-          accept: accept,
-        }],
-      });
+          accept: { [mimeTypes[extension]]: ["." + extension] },
+        }];
+      }
+      const fileHandle = await window.showSaveFilePicker(pickerOpts);
       const writable = await fileHandle.createWritable();
       const response = await fetch(url);
       if (!response.ok) {

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -1123,15 +1123,19 @@ qx.Class.define("osparc.utils.Utils", {
      * which prompts the user for a save location and streams data directly to disk.
      * Falls back to fetch + blob download for browsers without File System Access API support.
      * Unlike downloadLink(), this avoids buffering the entire file in an XHR response.
+     *
+     * @param {String} url The URL to download from
+     * @param {String} fileName Suggested file name
+     * @param {Function} [progressCb] Optional callback receiving {loaded, total, progress} during download
      */
-    downloadNatively: function(url, fileName) {
+    downloadNatively: function(url, fileName, progressCb) {
       if (window.showSaveFilePicker) {
-        return this.self().__downloadWithFileSystemAccess(url, fileName);
+        return this.self().__downloadWithFileSystemAccess(url, fileName, progressCb);
       }
-      return this.self().__downloadWithFetchBlob(url, fileName);
+      return this.self().__downloadWithFetchBlob(url, fileName, progressCb);
     },
 
-    __downloadWithFileSystemAccess: async function(url, fileName) {
+    __downloadWithFileSystemAccess: async function(url, fileName, progressCb) {
       const extension = fileName.split(".").pop() || "";
       const mimeTypes = {
         "zip": "application/zip",
@@ -1155,16 +1159,54 @@ qx.Class.define("osparc.utils.Utils", {
         await writable.abort();
         throw new Error(`Download failed: ${response.status}`);
       }
-      await response.body.pipeTo(writable);
+      if (progressCb && response.body) {
+        const contentLength = parseInt(response.headers.get("Content-Length") || "0", 10);
+        const reader = response.body.getReader();
+        let loaded = 0;
+        while (true) {
+          const {done, value} = await reader.read();
+          if (done) break;
+          loaded += value.byteLength;
+          await writable.write(value);
+          progressCb({
+            loaded,
+            total: contentLength || null,
+            progress: contentLength ? loaded / contentLength : null,
+          });
+        }
+        await writable.close();
+      } else {
+        await response.body.pipeTo(writable);
+      }
     },
 
-    __downloadWithFetchBlob: async function(url, fileName) {
+    __downloadWithFetchBlob: async function(url, fileName, progressCb) {
       const response = await fetch(url);
       if (!response.ok) {
         throw new Error(`Download failed: ${response.status}`);
       }
-      const blob = await response.blob();
-      osparc.utils.Utils.downloadBlobContent(blob, fileName);
+      if (progressCb && response.body) {
+        const contentLength = parseInt(response.headers.get("Content-Length") || "0", 10);
+        const reader = response.body.getReader();
+        const chunks = [];
+        let loaded = 0;
+        while (true) {
+          const {done, value} = await reader.read();
+          if (done) break;
+          chunks.push(value);
+          loaded += value.byteLength;
+          progressCb({
+            loaded,
+            total: contentLength || null,
+            progress: contentLength ? loaded / contentLength : null,
+          });
+        }
+        const blob = new Blob(chunks);
+        osparc.utils.Utils.downloadBlobContent(blob, fileName);
+      } else {
+        const blob = await response.blob();
+        osparc.utils.Utils.downloadBlobContent(blob, fileName);
+      }
     },
 
     filenameFromContentDisposition: function(xhr) {

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -1118,6 +1118,55 @@ qx.Class.define("osparc.utils.Utils", {
       downloadAnchorNode.remove();
     },
 
+    /**
+     * Downloads a file using the File System Access API (showSaveFilePicker) when available,
+     * which prompts the user for a save location and streams data directly to disk.
+     * Falls back to fetch + blob download for browsers without File System Access API support.
+     * Unlike downloadLink(), this avoids buffering the entire file in an XHR response.
+     */
+    downloadNatively: function(url, fileName) {
+      if (window.showSaveFilePicker) {
+        return this.self().__downloadWithFileSystemAccess(url, fileName);
+      }
+      return this.self().__downloadWithFetchBlob(url, fileName);
+    },
+
+    __downloadWithFileSystemAccess: async function(url, fileName) {
+      const extension = fileName.split(".").pop() || "";
+      const mimeTypes = {
+        "zip": "application/zip",
+        "tar": "application/x-tar",
+        "gz": "application/gzip",
+      };
+      const accept = {};
+      if (mimeTypes[extension]) {
+        accept[mimeTypes[extension]] = ["." + extension];
+      }
+      const fileHandle = await window.showSaveFilePicker({
+        suggestedName: fileName,
+        types: [{
+          description: "Downloaded file",
+          accept: accept,
+        }],
+      });
+      const writable = await fileHandle.createWritable();
+      const response = await fetch(url);
+      if (!response.ok) {
+        await writable.abort();
+        throw new Error(`Download failed: ${response.status}`);
+      }
+      await response.body.pipeTo(writable);
+    },
+
+    __downloadWithFetchBlob: async function(url, fileName) {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Download failed: ${response.status}`);
+      }
+      const blob = await response.blob();
+      osparc.utils.Utils.downloadBlobContent(blob, fileName);
+    },
+
     filenameFromContentDisposition: function(xhr) {
       // https://stackoverflow.com/questions/40939380/how-to-get-file-name-from-content-disposition
       let filename = "";


### PR DESCRIPTION
## What do these changes do?

Replaces the old XHR-based download approach (which buffered entire files with no visible feedback) with the File System Access API [showSaveFilePicker](https://developer.mozilla.org/en-US/docs/Web/API/Window/showSaveFilePicker), when available (not available over http), and reports download progress in real time.

Also, when downloading the files from the File Picker, the Download button now shows live progress (42%) in its label while downloading.

<img width="1440" height="850" alt="DownloadFile" src="https://github.com/user-attachments/assets/2bf37002-e304-4eea-9b40-9e6a64de725b" />


## Related issue/s
- closes https://github.com/ITISFoundation/osparc-issues/issues/1876
- related to https://github.com/ITISFoundation/osparc-simcore/pull/9071


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
