### PR TITLE
🐛 [Frontend] Fix: Maximum call stack exceeded when moving nodes

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -1324,13 +1324,15 @@ qx.Class.define("osparc.data.model.Node", {
 
     setPosition: function(pos) {
       const {x, y} = pos;
-      if (x === this.__posX && y === this.__posY) {
-        return; // no change
-      }
 
       // keep positions positive
-      this.__posX = parseInt(x) < 0 ? 0 : parseInt(x);
-      this.__posY = parseInt(y) < 0 ? 0 : parseInt(y);
+      const newX = parseInt(x) < 0 ? 0 : parseInt(x);
+      const newY = parseInt(y) < 0 ? 0 : parseInt(y);
+      if (newX === this.__posX && newY === this.__posY) {
+        return; // no change
+      }
+      this.__posX = newX;
+      this.__posY = newY;
 
       const nodeId = this.getNodeId();
       this.fireDataEvent("projectDocumentChanged", {

--- a/services/static-webserver/client/source/class/osparc/data/model/Workbench.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Workbench.js
@@ -892,9 +892,18 @@ qx.Class.define("osparc.data.model.Workbench", {
           }
         });
         this.__addNodesFromPatches(nodesAdded, workbenchPatchesByNode, workbenchUiPatchesByNode);
-      } else {
-        // third, update nodes
-        this.__updateNodesFromPatches(workbenchPatchesByNode);
+      }
+
+      // update existing nodes (patches for nodes that were not just added)
+      const nodesAddedSet = new Set(nodesAdded);
+      const updatePatchesByNode = {};
+      Object.keys(workbenchPatchesByNode).forEach(nodeId => {
+        if (!nodesAddedSet.has(nodeId) && workbenchPatchesByNode[nodeId].length > 0) {
+          updatePatchesByNode[nodeId] = workbenchPatchesByNode[nodeId];
+        }
+      });
+      if (Object.keys(updatePatchesByNode).length > 0) {
+        this.__updateNodesFromPatches(updatePatchesByNode);
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/data/model/Workbench.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Workbench.js
@@ -896,10 +896,24 @@ qx.Class.define("osparc.data.model.Workbench", {
 
       // update existing nodes (patches for nodes that were not just added)
       const nodesAddedSet = new Set(nodesAdded);
+      const nodesRemovedSet = new Set(nodesRemoved);
       const updatePatchesByNode = {};
       Object.keys(workbenchPatchesByNode).forEach(nodeId => {
         if (!nodesAddedSet.has(nodeId) && workbenchPatchesByNode[nodeId].length > 0) {
-          updatePatchesByNode[nodeId] = workbenchPatchesByNode[nodeId];
+          // Filter out inputNodes patches that are already handled by __removeNodesFromPatches.
+          // When nodes are removed, __nodeRemoved already removes the connected edges and updates
+          // inputNodes of the remaining nodes. Applying the inputNodes patches again would operate
+          // on stale indices and incorrectly remove additional connections.
+          const filteredPatches = nodesRemovedSet.size > 0
+            ? workbenchPatchesByNode[nodeId].filter(patch => {
+              const pathParts = patch.path.split("/");
+              const nodeProperty = pathParts[3];
+              return nodeProperty !== "inputNodes";
+            })
+            : workbenchPatchesByNode[nodeId];
+          if (filteredPatches.length > 0) {
+            updatePatchesByNode[nodeId] = filteredPatches;
+          }
         }
       });
       if (Object.keys(updatePatchesByNode).length > 0) {

--- a/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
@@ -412,7 +412,8 @@ qx.Class.define("osparc.workbench.NodeUI", {
 
     __applyNode: function(node) {
       node.addListener("changePosition", e => {
-        this.moveNodeTo(e.getData());
+        const pos = e.getData();
+        this.setDomPosition(pos.x, pos.y);
         this.fireEvent("updateNodeDecorator");
       });
 

--- a/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
@@ -412,9 +412,8 @@ qx.Class.define("osparc.workbench.NodeUI", {
 
     __applyNode: function(node) {
       node.addListener("changePosition", e => {
-        const pos = e.getData();
-        this.setDomPosition(pos.x, pos.y);
-        this.fireEvent("updateNodeDecorator");
+        this.moveNodeTo(e.getData());
+        setTimeout(() => this.fireEvent("updateNodeDecorator"), 50);
       });
 
       if (node.isDynamic()) {

--- a/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
@@ -413,7 +413,6 @@ qx.Class.define("osparc.workbench.NodeUI", {
     __applyNode: function(node) {
       node.addListener("changePosition", e => {
         this.moveNodeTo(e.getData());
-        this.fireEvent("nodeMovingStop");
       });
 
       if (node.isDynamic()) {

--- a/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/NodeUI.js
@@ -413,6 +413,7 @@ qx.Class.define("osparc.workbench.NodeUI", {
     __applyNode: function(node) {
       node.addListener("changePosition", e => {
         this.moveNodeTo(e.getData());
+        this.fireEvent("updateNodeDecorator");
       });
 
       if (node.isDynamic()) {

--- a/services/static-webserver/client/source/class/osparc/workbench/WorkbenchUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/WorkbenchUI.js
@@ -141,6 +141,7 @@ qx.Class.define("osparc.workbench.WorkbenchUI", {
     __selectedAnnotations: null,
     __annotationEditor: null,
     __annotationLastColor: null,
+    __isProcessingStoppedMoving: false,
 
     __applyStudy: function(study) {
       study.getWorkbench().addListener("reloadModel", () => this.__reloadCurrentModel(), this);
@@ -481,6 +482,11 @@ qx.Class.define("osparc.workbench.WorkbenchUI", {
     },
 
     __itemStoppedMoving: function(nodeUI) {
+      if (this.__isProcessingStoppedMoving) {
+        return;
+      }
+      this.__isProcessingStoppedMoving = true;
+
       this.getSelectedNodeUIs().forEach(selectedNodeUI => delete selectedNodeUI["initPos"]);
       this.getSelectedAnnotations().forEach(selectedAnnotation => delete selectedAnnotation["initPos"]);
 
@@ -516,6 +522,8 @@ qx.Class.define("osparc.workbench.WorkbenchUI", {
           child.style.zIndex = "1";
         }
       });
+
+      this.__isProcessingStoppedMoving = false;
     },
 
     __addNodeListeners: function(nodeUI) {

--- a/services/static-webserver/client/source/class/osparc/workbench/WorkbenchUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/WorkbenchUI.js
@@ -837,6 +837,17 @@ qx.Class.define("osparc.workbench.WorkbenchUI", {
       const nodeUI1 = this.getNodeUI(node1Id);
       const nodeUI2 = this.getNodeUI(node2Id);
       if (!nodeUI1 || !nodeUI2) {
+        // NodeUI not yet created (e.g. RTC: node added in same patch batch).
+        // Retry after the missing node's UI is added to the workbench.
+        const missingNodeId = !nodeUI1 ? node1Id : node2Id;
+        const workbench = this.__getWorkbench();
+        const missingNode = workbench.getNode(missingNodeId);
+        if (missingNode) {
+          workbench.addListenerOnce("nodeAdded", () => {
+            // give WorkbenchView time to create the nodeUI from the same event
+            setTimeout(() => this._createEdgeBetweenNodes(node1Id, node2Id, false), 100);
+          }, this);
+        }
         return;
       }
       if (nodeUI1.getCurrentBounds() === null || nodeUI2.getCurrentBounds() === null) {

--- a/services/static-webserver/client/source/class/osparc/workbench/WorkbenchUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/WorkbenchUI.js
@@ -141,7 +141,6 @@ qx.Class.define("osparc.workbench.WorkbenchUI", {
     __selectedAnnotations: null,
     __annotationEditor: null,
     __annotationLastColor: null,
-    __isProcessingStoppedMoving: false,
 
     __applyStudy: function(study) {
       study.getWorkbench().addListener("reloadModel", () => this.__reloadCurrentModel(), this);
@@ -482,11 +481,6 @@ qx.Class.define("osparc.workbench.WorkbenchUI", {
     },
 
     __itemStoppedMoving: function(nodeUI) {
-      if (this.__isProcessingStoppedMoving) {
-        return;
-      }
-      this.__isProcessingStoppedMoving = true;
-
       this.getSelectedNodeUIs().forEach(selectedNodeUI => delete selectedNodeUI["initPos"]);
       this.getSelectedAnnotations().forEach(selectedAnnotation => delete selectedAnnotation["initPos"]);
 
@@ -522,8 +516,6 @@ qx.Class.define("osparc.workbench.WorkbenchUI", {
           child.style.zIndex = "1";
         }
       });
-
-      this.__isProcessingStoppedMoving = false;
     },
 
     __addNodeListeners: function(nodeUI) {

--- a/services/static-webserver/client/source/class/osparc/workbench/WorkbenchUI.js
+++ b/services/static-webserver/client/source/class/osparc/workbench/WorkbenchUI.js
@@ -836,6 +836,9 @@ qx.Class.define("osparc.workbench.WorkbenchUI", {
       // build representation
       const nodeUI1 = this.getNodeUI(node1Id);
       const nodeUI2 = this.getNodeUI(node2Id);
+      if (!nodeUI1 || !nodeUI2) {
+        return;
+      }
       if (nodeUI1.getCurrentBounds() === null || nodeUI2.getCurrentBounds() === null) {
         console.error("bounds not ready");
         return;


### PR DESCRIPTION
## What do these changes do?

Sometimes, an infinite recursion ("Maximum call stack size exceeded") can happen when moving Nodes around, this PR fixes that issue and also and improves edge (link) rendering reliability for nodes added via Real-Time Collaboration (RTC).

<img width="1840" height="850" alt="ModeAndEdges" src="https://github.com/user-attachments/assets/5f725020-0650-4a47-9520-1d51c5f855f3" />

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
