### PR TITLE
🎨 [Frontend] Move ``Country of Residence`` to its own section

### DIFF
--- a/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
@@ -38,6 +38,7 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
     }
     this._add(this.__createPasswordSection());
     this._add(this.__createContactSection());
+    this._add(this.__createCountrySection());
     this._add(this.__createTransferProjectsSection());
     this._add(this.__createDeleteAccount());
 
@@ -80,11 +81,14 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
     __sms2FAItem: null,
     __personalInfoModel: null,
     __personalInfoRenderer: null,
+    __countryInfoModel: null,
+    __countryInfoRenderer: null,
 
     __fetchMyProfile: function() {
       this.__userProfileRenderer.setEnabled(false);
       this.__privacyRenderer.setEnabled(false);
       this.__personalInfoRenderer.setEnabled(false);
+      this.__countryInfoRenderer.setEnabled(false);
 
       osparc.data.Resources.getOne("profile", {}, null, false)
         .then(profile => {
@@ -93,6 +97,7 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
           this.__userProfileRenderer.setEnabled(true);
           this.__privacyRenderer.setEnabled(true);
           this.__personalInfoRenderer.setEnabled(true);
+          this.__countryInfoRenderer.setEnabled(true);
         })
         .catch(err => console.error(err));
     },
@@ -115,8 +120,10 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
             "address": contact["address"] || "",
             "city": contact["city"] || "",
             "state": contact["state"] || "",
-            "country": contact["country"] || "",
             "postalCode": contact["postalCode"] || "",
+          });
+          this.__countryInfoModel.set({
+            "country": contact["country"] || "",
           });
         }
       }
@@ -606,18 +613,13 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
         readOnly: true,
       });
 
-      const state = new qx.ui.form.TextField().set({
-        placeholder: this.tr("State"),
-        readOnly: true,
-      });
-
-      const country = new qx.ui.form.TextField().set({
-        placeholder: this.tr("Country"),
-        readOnly: true,
-      });
-
       const postalCode = new qx.ui.form.TextField().set({
         placeholder: this.tr("Postal Code"),
+        readOnly: true,
+      });
+
+      const state = new qx.ui.form.TextField().set({
+        placeholder: this.tr("State"),
         readOnly: true,
       });
 
@@ -625,9 +627,8 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
       personalInfoForm.add(institution, osparc.product.Utils.getInstitutionAlias().label, null, "institution");
       personalInfoForm.add(address, this.tr("Address"), null, "address");
       personalInfoForm.add(city, this.tr("City"), null, "city");
-      personalInfoForm.add(state, this.tr("State"), null, "state");
-      personalInfoForm.add(country, this.tr("Country"), null, "country");
       personalInfoForm.add(postalCode, this.tr("Postal Code"), null, "postalCode");
+      personalInfoForm.add(state, this.tr("State"), null, "state");
       this.__personalInfoRenderer = new qx.ui.form.renderer.Single(personalInfoForm);
       box.add(this.__personalInfoRenderer);
 
@@ -636,9 +637,8 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
         "institution": null,
         "address": null,
         "city": null,
-        "state": null,
-        "country": null,
         "postalCode": null,
+        "state": null,
       };
 
       const model = this.__personalInfoModel = qx.data.marshal.Json.createModel(raw);
@@ -647,9 +647,35 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
       controller.addTarget(institution, "value", "institution", true);
       controller.addTarget(address, "value", "address", true);
       controller.addTarget(city, "value", "city", true);
-      controller.addTarget(state, "value", "state", true);
-      controller.addTarget(country, "value", "country", true);
       controller.addTarget(postalCode, "value", "postalCode", true);
+      controller.addTarget(state, "value", "state", true);
+
+      return box;
+    },
+
+    __createCountrySection: function() {
+      // layout
+      const box = this.self().createSectionBox(this.tr("Country of Residence"));
+      box.addHelper(this.tr("Tax and VAT regulations depend on the country of residence."));
+
+      const country = new qx.ui.form.TextField().set({
+        placeholder: this.tr("Country"),
+        readOnly: true,
+      });
+
+      const countryInfoForm = new qx.ui.form.Form();
+      countryInfoForm.add(country, this.tr("Country"), null, "country");
+      this.__countryInfoRenderer = new qx.ui.form.renderer.Single(countryInfoForm);
+      box.add(this.__countryInfoRenderer);
+
+      // binding to a model
+      const raw = {
+        "country": null,
+      };
+
+      const model = this.__countryInfoModel = qx.data.marshal.Json.createModel(raw);
+      const controller = new qx.data.controller.Object(model);
+      controller.addTarget(country, "value", "country", true);
 
       return box;
     },

--- a/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
@@ -83,6 +83,7 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
     __personalInfoRenderer: null,
     __countryInfoModel: null,
     __countryInfoRenderer: null,
+    __countrySection: null,
 
     __fetchMyProfile: function() {
       this.__userProfileRenderer.setEnabled(false);
@@ -126,6 +127,8 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
             "country": contact["country"] || "",
           });
         }
+        const hasCountry = Boolean(data && data["contact"] && data["contact"]["country"]);
+        this.__countrySection.setVisibility(hasCountry ? "visible" : "excluded");
       }
       this.__updateProfileBtn.setEnabled(false);
 
@@ -655,7 +658,9 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
 
     __createCountrySection: function() {
       // layout
-      const box = this.self().createSectionBox(this.tr("Country of Residence"));
+      const box = this.__countrySection = this.self().createSectionBox(this.tr("Country of Residence")).set({
+        visibility: "excluded",
+      });
       box.addHelper(this.tr("Tax and VAT regulations depend on the country of residence."));
 
       const country = new qx.ui.form.TextField().set({


### PR DESCRIPTION
## What do these changes do?

...and add a helping text to explain why the Country of Residence is important to us.

<img width="1440" height="850" alt="Country" src="https://github.com/user-attachments/assets/bc5cee03-d4df-4015-b834-fbf820f4a222" />

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
