### PR TITLE
🐛 fix(notifications): add `Date` and `Message-ID` headers to outgoing emails

### DIFF
--- a/services/notifications/src/simcore_service_notifications/services/email/_compose.py
+++ b/services/notifications/src/simcore_service_notifications/services/email/_compose.py
@@ -34,14 +34,22 @@ def compose_email(
     # - Postal SMTP: does not add them automatically (github.com/postalserver/postal/issues/153)
     # - AWS SES SMTP: silently overwrites both with its own values regardless — no side effect
     # - Other providers: behaviour varies; setting them here is always safe
-    msg["Date"] = formatdate(localtime=True)
-    sender = from_.addr_spec
-    sender_domain = sender.split("@", 1)[1]
-    msg["Message-ID"] = make_msgid(domain=sender_domain)
-
     if extra_headers:
         for name, value in extra_headers.items():
+            # Prevent duplicates/overrides of required RFC 5322 headers
+            if name.lower() in {"date", "message-id"}:
+                continue
             msg[name] = value
+
+    _local_part, at, sender_domain = from_.addr_spec.rpartition("@")
+    if not at or not sender_domain:
+        err_msg = (
+            f"Invalid sender address (missing domain) for Message-ID generation: {from_.addr_spec}"
+        )
+        raise ValueError(err_msg)
+
+    msg["Date"] = formatdate(localtime=True)
+    msg["Message-ID"] = make_msgid(domain=sender_domain)
 
     if not content_text and not content_html:
         # NOTE: the RFC 5322 standard requires that the email message must have a content, either text or HTML.

--- a/services/notifications/src/simcore_service_notifications/services/email/_compose.py
+++ b/services/notifications/src/simcore_service_notifications/services/email/_compose.py
@@ -1,6 +1,7 @@
 import mimetypes
 from email.headerregistry import Address
 from email.message import EmailMessage
+from email.utils import formatdate, make_msgid
 
 
 def compose_email(
@@ -28,6 +29,15 @@ def compose_email(
         msg["Bcc"] = bcc
 
     msg["Subject"] = subject
+
+    # Always set Date and Message-ID explicitly:
+    # - Postal SMTP: does not add them automatically (github.com/postalserver/postal/issues/153)
+    # - AWS SES SMTP: silently overwrites both with its own values regardless — no side effect
+    # - Other providers: behaviour varies; setting them here is always safe
+    msg["Date"] = formatdate(localtime=True)
+    sender = from_.addr_spec
+    sender_domain = sender.split("@", 1)[1]
+    msg["Message-ID"] = make_msgid(domain=sender_domain)
 
     if extra_headers:
         for name, value in extra_headers.items():

--- a/services/notifications/src/simcore_service_notifications/services/email/_compose.py
+++ b/services/notifications/src/simcore_service_notifications/services/email/_compose.py
@@ -30,10 +30,12 @@ def compose_email(
 
     msg["Subject"] = subject
 
-    # Always set Date and Message-ID explicitly:
+    # NOTE: Always set Date and Message-ID explicitly:
     # - Postal SMTP: does not add them automatically (github.com/postalserver/postal/issues/153)
     # - AWS SES SMTP: silently overwrites both with its own values regardless — no side effect
     # - Other providers: behaviour varies; setting them here is always safe
+    #  
+    # If not defined, emails may land in spam (if email server used does not configure them automatically)
     if extra_headers:
         for name, value in extra_headers.items():
             # Prevent duplicates/overrides of required RFC 5322 headers

--- a/services/notifications/tests/unit/test_api_celery_send_email.py
+++ b/services/notifications/tests/unit/test_api_celery_send_email.py
@@ -125,3 +125,8 @@ async def test_send_mail_with_bcc_and_attachment(
         assert len(attachments) == 1
         assert attachments[0].get_filename() == attachment_filename
         assert attachments[0].get_content() == attachment_content
+
+        # RFC 5322 required headers
+        assert sent_msg["Date"] is not None
+        assert sent_msg["Message-ID"] is not None
+        assert "@test-domain.com>" in sent_msg["Message-ID"]

--- a/services/notifications/tests/unit/test_services_email_compose.py
+++ b/services/notifications/tests/unit/test_services_email_compose.py
@@ -1,0 +1,115 @@
+# pylint: disable=redefined-outer-name
+
+import re
+from email.headerregistry import Address
+from email.utils import parsedate_to_datetime
+
+import pytest
+from simcore_service_notifications.services.email import compose_email
+
+
+@pytest.fixture
+def sender_address() -> Address:
+    return Address(display_name="Support", addr_spec="support@example.com")
+
+
+@pytest.fixture
+def recipient_address() -> Address:
+    return Address(display_name="User", addr_spec="user@test.com")
+
+
+def test_compose_email_sets_date_header(
+    sender_address: Address,
+    recipient_address: Address,
+):
+    msg = compose_email(
+        from_=sender_address,
+        to=recipient_address,
+        subject="Test",
+        content_text="Hello",
+    )
+
+    assert msg["Date"] is not None
+    # Verify it parses as a valid RFC 5322 date
+    parsed = parsedate_to_datetime(msg["Date"])
+    assert parsed is not None
+
+
+def test_compose_email_sets_message_id_header(
+    sender_address: Address,
+    recipient_address: Address,
+):
+    msg = compose_email(
+        from_=sender_address,
+        to=recipient_address,
+        subject="Test",
+        content_text="Hello",
+    )
+
+    assert msg["Message-ID"] is not None
+    # Message-ID must use the sender's domain
+    assert "@example.com>" in msg["Message-ID"]
+
+
+def test_compose_email_message_id_uses_sender_domain(
+    recipient_address: Address,
+):
+    sender = Address(display_name="Ops", addr_spec="noreply@mydomain.org")
+    msg = compose_email(
+        from_=sender,
+        to=recipient_address,
+        subject="Test",
+        content_text="Hello",
+    )
+
+    assert "@mydomain.org>" in msg["Message-ID"]
+
+
+def test_compose_email_message_id_is_unique_per_call(
+    sender_address: Address,
+    recipient_address: Address,
+):
+    msg1 = compose_email(
+        from_=sender_address,
+        to=recipient_address,
+        subject="Test 1",
+        content_text="Hello",
+    )
+    msg2 = compose_email(
+        from_=sender_address,
+        to=recipient_address,
+        subject="Test 2",
+        content_text="Hello",
+    )
+
+    assert msg1["Message-ID"] != msg2["Message-ID"]
+
+
+def test_compose_email_message_id_format(
+    sender_address: Address,
+    recipient_address: Address,
+):
+    msg = compose_email(
+        from_=sender_address,
+        to=recipient_address,
+        subject="Test",
+        content_text="Hello",
+    )
+
+    # RFC 5322 Message-ID format: <local-part@domain>
+    assert re.match(r"^<.+@example\.com>$", msg["Message-ID"])
+
+
+def test_compose_email_date_has_timezone_offset(
+    sender_address: Address,
+    recipient_address: Address,
+):
+    msg = compose_email(
+        from_=sender_address,
+        to=recipient_address,
+        subject="Test",
+        content_text="Hello",
+    )
+
+    # Must NOT contain -0000 (unknown timezone), should have a real offset
+    assert "-0000" not in msg["Date"]


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

Add `Date` and `Message-ID` headers to every outgoing email composed by the notifications service.

<img width="538" height="136" alt="image" src="https://github.com/user-attachments/assets/b0e18f85-fe60-4795-929a-08fd1e10f670" />

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

## How to test
```sh
cd services/notifications
make install-dev
pytest -vv --pdb tests/unit/test_api_celery_send_email.py
pytest -vv --pdb tests/unit/test_services_email_compose.py
```

## Dev-ops
Outgoing emails contain `Date` and `Message-ID` headers.

* Corresponding changes in e2e mail test https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/merge_requests/2071
