### PR TITLE
🐛 [Frontend] Fix: Activity Overview

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/CardBase.js
@@ -928,23 +928,23 @@ qx.Class.define("osparc.dashboard.CardBase", {
         })
         .finally(() => {
           switch (projectStatus) {
-            case "CLOSING":
+            case osparc.study.Utils.state.STATUS.CLOSING:
               image = "@FontAwesome5Solid/key/";
               toolTip += this.tr("Closing...");
               break;
-            case "CLONING":
+            case osparc.study.Utils.state.STATUS.CLONING:
               image = "@FontAwesome5Solid/clone/";
               toolTip += this.tr("Cloning...");
               break;
-            case "EXPORTING":
+            case osparc.study.Utils.state.STATUS.EXPORTING:
               image = osparc.task.Export.ICON+"/";
               toolTip += this.tr("Exporting...");
               break;
-            case "OPENING":
+            case osparc.study.Utils.state.STATUS.OPENING:
               image = "@FontAwesome5Solid/key/";
               toolTip += this.tr("Opening...");
               break;
-            case "OPENED":
+            case osparc.study.Utils.state.STATUS.OPENED:
               image = "@FontAwesome5Solid/lock/";
               toolTip += this.tr("In use...");
               break;

--- a/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js
@@ -507,7 +507,7 @@ qx.Class.define("osparc.dashboard.StudyBrowser", {
       resourcesList.forEach(study => {
         const state = study["state"];
         const projectStatus = osparc.study.Utils.state.getProjectStatus(state);
-        if (projectStatus === "CLOSING") {
+        if (projectStatus === osparc.study.Utils.state.STATUS.CLOSING) {
           // websocket might have already notified that the state was closed.
           // But the /projects calls response got after the ws message. Ask again to make sure
           const delay = 2000;

--- a/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
@@ -206,6 +206,10 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
         readOnly: true
       });
 
+      // Prevent the browser from autofilling these fields (e.g. email),
+      // which would otherwise leak into other inputs like the search bar.
+      [userName, firstName, lastName, email, phoneNumber].forEach(field => osparc.utils.Utils.disableAutocomplete(field));
+
       const profileForm = this.__userProfileForm = new qx.ui.form.Form();
       profileForm.add(userName, "UserName", null, "userName");
       profileForm.add(firstName, "First Name", null, "firstName");

--- a/services/static-webserver/client/source/class/osparc/jobs/ActivityOverview.js
+++ b/services/static-webserver/client/source/class/osparc/jobs/ActivityOverview.js
@@ -38,6 +38,10 @@ qx.Class.define("osparc.jobs.ActivityOverview", {
     },
   },
 
+  events: {
+    "backToRuns": "qx.event.type.Event",
+  },
+
   members: {
     __runsTable: null,
     __subRunsTable: null,
@@ -78,9 +82,7 @@ qx.Class.define("osparc.jobs.ActivityOverview", {
         });
         stack.setSelection([tasksLayout]);
 
-        tasksLayout.addListener("backToRuns", () => {
-          stack.setSelection([runsHistoryLayout]);
-        });
+        this.addListener("backToRuns", () => stack.setSelection([runsHistoryLayout]));
       }, this);
     },
 
@@ -134,7 +136,7 @@ qx.Class.define("osparc.jobs.ActivityOverview", {
         icon: "@FontAwesome5Solid/arrow-left/20",
         backgroundColor: "transparent"
       });
-      prevBtn.addListener("execute", () => tasksLayout.fireEvent("backToRuns"));
+      prevBtn.addListener("execute", () => this.fireEvent("backToRuns"));
       latestTasksTitleLayout.add(prevBtn);
 
       const latestTasksTitle = new qx.ui.basic.Label(this.tr("Tasks")).set({

--- a/services/static-webserver/client/source/class/osparc/jobs/ActivityOverview.js
+++ b/services/static-webserver/client/source/class/osparc/jobs/ActivityOverview.js
@@ -82,7 +82,9 @@ qx.Class.define("osparc.jobs.ActivityOverview", {
         });
         stack.setSelection([tasksLayout]);
 
-        this.addListener("backToRuns", () => stack.setSelection([runsHistoryLayout]));
+        if (!this.hasListener("backToRuns")) {
+          this.addListener("backToRuns", () => stack.setSelection([runsHistoryLayout]));
+        }
       }, this);
     },
 

--- a/services/static-webserver/client/source/class/osparc/jobs/RunsTable.js
+++ b/services/static-webserver/client/source/class/osparc/jobs/RunsTable.js
@@ -63,7 +63,8 @@ qx.Class.define("osparc.jobs.RunsTable", {
         if (!job) {
           return false;
         }
-        return Object.keys(job.getInfo()).length > 0;
+        const info = job.getInfo();
+        return info ? Object.keys(info).length > 0 : false;
       }
       return false;
     }

--- a/services/static-webserver/client/source/class/osparc/store/Jobs.js
+++ b/services/static-webserver/client/source/class/osparc/store/Jobs.js
@@ -150,9 +150,11 @@ qx.Class.define("osparc.store.Jobs", {
       let job = this.getJob(collectionRunId);
       if (!job) {
         const jobs = this.getJobs();
-        job = new osparc.data.Job({
+        const mergedData = {
           collectionRunId,
-        });
+          "projectIds": [subJobData["project_id"]],
+        };
+        job = new osparc.data.Job(mergedData);
         jobs.push(job);
       }
       const subJob = job.addSubJob(collectionRunId, subJobData);

--- a/services/static-webserver/client/source/class/osparc/store/Jobs.js
+++ b/services/static-webserver/client/source/class/osparc/store/Jobs.js
@@ -152,7 +152,7 @@ qx.Class.define("osparc.store.Jobs", {
         const jobs = this.getJobs();
         const mergedData = {
           collectionRunId,
-          "projectIds": [subJobData["project_id"]],
+          "projectIds": [subJobData["projectUuid"]],
         };
         job = new osparc.data.Job(mergedData);
         jobs.push(job);

--- a/services/static-webserver/client/source/class/osparc/store/Jobs.js
+++ b/services/static-webserver/client/source/class/osparc/store/Jobs.js
@@ -77,7 +77,7 @@ qx.Class.define("osparc.store.Jobs", {
       offset = 0,
       limit = this.self().SERVER_MAX_LIMIT,
       orderBy = {
-        field: "submitted_at",
+        field: "ended_at",
         direction: "desc"
       },
       resolveWResponse = false

--- a/services/static-webserver/client/source/class/osparc/study/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/study/Utils.js
@@ -352,6 +352,15 @@ qx.Class.define("osparc.study.Utils", {
     },
 
     state: {
+      STATUS: {
+        OPENED: "OPENED",
+        OPENING: "OPENING",
+        CLOSED: "CLOSED",
+        CLOSING: "CLOSING",
+        CLONING: "CLONING",
+        EXPORTING: "EXPORTING",
+      },
+
       __getShareState: function(state) {
         if (state && "shareState" in state) {
           return state["shareState"];
@@ -377,7 +386,7 @@ qx.Class.define("osparc.study.Utils", {
 
       isProjectOpen: function(state) {
         const projectStatus = this.getProjectStatus(state);
-        return projectStatus === "OPENED";
+        return projectStatus === this.STATUS.OPENED;
       },
 
       getCurrentGroupIds: function(state) {


### PR DESCRIPTION
## What do these changes do?

Right now, at the project level, we only show the credits used by runs -> computational services. The way this is listed might not be the most intuitive and furthermore it was broken. This PR fixes it.

If one would want to know how many credits a dynamic service used, they need to go to the Billing Center -> Usage. This information should also be exposed at project level.

<img width="1440" height="850" alt="ActivityOverview" src="https://github.com/user-attachments/assets/a7868e57-06c9-448b-ae71-c9f518dc29cf" />


## Related issue/s
- related to https://github.com/ITISFoundation/private-issues/issues/376


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
