### PR TITLE
🐛 [Frontend] Fix: do not autofill Dashboard's search filter when opening MyAccount

### DIFF
--- a/services/static-webserver/client/source/class/osparc/dashboard/SearchBarFilter.js
+++ b/services/static-webserver/client/source/class/osparc/dashboard/SearchBarFilter.js
@@ -169,7 +169,6 @@ qx.Class.define("osparc.dashboard.SearchBarFilter", {
           this._add(control, {
             flex: 1
           });
-          osparc.utils.Utils.disableAutocomplete(control);
           break;
         case "reset-button":
           control = new qx.ui.toolbar.Button(null, "@MaterialIcons/close/20").set({

--- a/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
@@ -553,7 +553,9 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
         required: true,
         placeholder: this.tr("Your current password")
       });
-      currentPassword.getChildControl("passwordField").getContentElement().setAttribute("autocomplete", "current-password");
+      // "new-password" (instead of "current-password") so the browser does not autofill
+      // the saved password into this change-password form.
+      currentPassword.getChildControl("passwordField").getContentElement().setAttribute("autocomplete", "new-password");
 
       const newPassword = new osparc.ui.form.PasswordField().set({
         required: true,

--- a/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
@@ -539,15 +539,13 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
       // autofills the saved email here instead of hijacking unrelated inputs such as the
       // dashboard search bar (osparc/dashboard/SearchBarFilter).
       const username = new qx.ui.form.TextField().set({
-        height: 0,
-        maxHeight: 0,
-        opacity: 0,
         focusable: false,
       });
       username.getContentElement().setAttribute("autocomplete", "username");
       username.getContentElement().setAttribute("aria-hidden", "true");
       username.getContentElement().setAttribute("tabindex", "-1");
-      box.add(username);
+      // add it off-screen so it does not introduce an extra vertical gap
+      box._add(username, { left: -10000, top: -10000 });
 
       const currentPassword = new osparc.ui.form.PasswordField().set({
         required: true,

--- a/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/account/ProfilePage.js
@@ -206,10 +206,6 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
         readOnly: true
       });
 
-      // Prevent the browser from autofilling these fields (e.g. email),
-      // which would otherwise leak into other inputs like the search bar.
-      [userName, firstName, lastName, email, phoneNumber].forEach(field => osparc.utils.Utils.disableAutocomplete(field));
-
       const profileForm = this.__userProfileForm = new qx.ui.form.Form();
       profileForm.add(userName, "UserName", null, "userName");
       profileForm.add(firstName, "First Name", null, "firstName");
@@ -538,20 +534,38 @@ qx.Class.define("osparc.desktop.account.ProfilePage", {
       // layout
       const box = this.self().createSectionBox(this.tr("Password"));
 
+      // Dedicated (visually hidden) username field kept in the DOM next to the password
+      // fields. It gives the browser's password manager a proper "username" target so it
+      // autofills the saved email here instead of hijacking unrelated inputs such as the
+      // dashboard search bar (osparc/dashboard/SearchBarFilter).
+      const username = new qx.ui.form.TextField().set({
+        height: 0,
+        maxHeight: 0,
+        opacity: 0,
+        focusable: false,
+      });
+      username.getContentElement().setAttribute("autocomplete", "username");
+      username.getContentElement().setAttribute("aria-hidden", "true");
+      username.getContentElement().setAttribute("tabindex", "-1");
+      box.add(username);
+
       const currentPassword = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Your current password")
       });
+      currentPassword.getChildControl("passwordField").getContentElement().setAttribute("autocomplete", "current-password");
 
       const newPassword = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Your new password")
       });
+      newPassword.getChildControl("passwordField").getContentElement().setAttribute("autocomplete", "new-password");
 
       const confirm = new osparc.ui.form.PasswordField().set({
         required: true,
         placeholder: this.tr("Retype your new password")
       });
+      confirm.getChildControl("passwordField").getContentElement().setAttribute("autocomplete", "new-password");
 
       const form = new qx.ui.form.Form();
       form.add(currentPassword, "Current Password", null, "curPassword");

--- a/services/static-webserver/client/source/class/osparc/filter/TextFilter.js
+++ b/services/static-webserver/client/source/class/osparc/filter/TextFilter.js
@@ -72,7 +72,6 @@ qx.Class.define("osparc.filter.TextFilter", {
             paddingRight: 15,
             placeholder: this.tr("Filter")
           });
-          osparc.utils.Utils.disableAutocomplete(control);
           this._add(control, {
             width: "100%"
           });

--- a/services/static-webserver/client/source/class/osparc/form/tag/TagItem.js
+++ b/services/static-webserver/client/source/class/osparc/form/tag/TagItem.js
@@ -122,7 +122,6 @@ qx.Class.define("osparc.form.tag.TagItem", {
           control = new qx.ui.form.TextField().set({
             required: true
           });
-          osparc.utils.Utils.disableAutocomplete(control);
           this.__validationManager.add(control);
           break;
         case "description-input":

--- a/services/static-webserver/client/source/class/osparc/utils/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Utils.js
@@ -185,15 +185,6 @@ qx.Class.define("osparc.utils.Utils", {
       return new qx.ui.basic.Image().set(this.getThumbnailProps(size));
     },
 
-    disableAutocomplete: function(control) {
-      if (control && control.getContentElement()) {
-        control.getContentElement().setAttribute("autocomplete", "off");
-        control.getContentElement().setAttribute("type", "search");
-        control.getContentElement().setAttribute("name", "osparcdontautomplete");
-        control.getContentElement().setAttribute("id", "osparcdontautomplete");
-      }
-    },
-
     checkImageExists: function(url) {
       return new Promise(resolve => {
         const img = new Image();


### PR DESCRIPTION
## What do these changes do?

This PR finally fixes the auto-filled search-bar bug.

## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-issues/issues/1874


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
