### PR TITLE
🐛Director-v2: do not clamp required resources when instance type is explicitely setup

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/settings.py
@@ -304,7 +304,7 @@ def _merge_resources_in_settings(
                 empty_resource_entry.value["Reservations"]["GenericResources"].extend([generic_resource])
     if not has_machine_specific_resources:
         # When no machine type is explicitly selected, services may not define CPU/RAM
-        # limitations (defaulting to 0.1% CPU). Enforce a minimum so the dynamic-sidecar
+        # limitations (defaulting to 0.1 CPU, i.e. 10%). Enforce a minimum so the dynamic-sidecar
         # can actually run. When a machine type IS selected the webserver already computed
         # the correct values; applying a floor here would make the service unschedulable
         # on the very node it was pinned to (e.g. 0.6 CPU on t3.large would be raised to

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/docker_service_specs/settings.py
@@ -93,8 +93,7 @@ def extract_service_port_from_settings(
     raise ValueError(msg)
 
 
-# pylint: disable=too-many-branches
-def update_service_params_from_settings(
+def update_service_params_from_settings(  # pylint: disable=too-many-branches # noqa: C901
     labels_service_settings: SimcoreServiceSettingsLabel,
     create_service_params: dict[str, Any],
 ) -> None:
@@ -252,6 +251,7 @@ def _merge_resources_in_settings(
     service_resources: ServiceResourcesDict,
     *,
     placement_substitutions: dict[str, DockerPlacementConstraint],
+    has_machine_specific_resources: bool,
 ) -> deque[SimcoreServiceSettingLabelEntry]:
     """All oSPARC services which have defined resource requirements will be added"""
     log.debug("MERGING\n%s\nAND\n%s", f"{settings=}", f"{service_resources}")
@@ -302,15 +302,19 @@ def _merge_resources_in_settings(
                     }
                 }
                 empty_resource_entry.value["Reservations"]["GenericResources"].extend([generic_resource])
-    # since some services do not define CPU limitations, by default 0.1% CPU is assigned
-    # ensuring limit is at least 1.0 CPUs otherwise the dynamic-sidecar is not able to work
-    # properly
-    empty_resource_entry.value["Limits"]["NanoCPUs"] = max(
-        empty_resource_entry.value["Limits"]["NanoCPUs"], CPU_100_PERCENT
-    )
-    empty_resource_entry.value["Limits"]["MemoryBytes"] = max(
-        empty_resource_entry.value["Limits"]["MemoryBytes"], MEMORY_1GB
-    )
+    if not has_machine_specific_resources:
+        # When no machine type is explicitly selected, services may not define CPU/RAM
+        # limitations (defaulting to 0.1% CPU). Enforce a minimum so the dynamic-sidecar
+        # can actually run. When a machine type IS selected the webserver already computed
+        # the correct values; applying a floor here would make the service unschedulable
+        # on the very node it was pinned to (e.g. 0.6 CPU on t3.large would be raised to
+        # 1.0 CPU, exceeding the node's available capacity after overhead).
+        empty_resource_entry.value["Limits"]["NanoCPUs"] = max(
+            empty_resource_entry.value["Limits"]["NanoCPUs"], CPU_100_PERCENT
+        )
+        empty_resource_entry.value["Limits"]["MemoryBytes"] = max(
+            empty_resource_entry.value["Limits"]["MemoryBytes"], MEMORY_1GB
+        )
 
     result.append(empty_resource_entry)
 
@@ -401,6 +405,7 @@ async def merge_settings_before_use(
     service_user_selection_boot_options: dict[EnvVarKey, str],
     service_resources: ServiceResourcesDict,
     placement_substitutions: dict[str, DockerPlacementConstraint],
+    has_machine_specific_resources: bool,
 ) -> SimcoreServiceSettingsLabel:
     labels_for_involved_services = await get_labels_for_involved_services(
         catalog_client=catalog_client,
@@ -438,7 +443,10 @@ async def merge_settings_before_use(
         )
 
     settings = _merge_resources_in_settings(
-        settings, service_resources, placement_substitutions=placement_substitutions
+        settings,
+        service_resources,
+        placement_substitutions=placement_substitutions,
+        has_machine_specific_resources=has_machine_specific_resources,
     )
     settings = _patch_target_service_into_env_vars(settings)
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_event_create_sidecars.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_event_create_sidecars.py
@@ -177,6 +177,9 @@ class CreateSidecars(DynamicSchedulerEvent):
             service_user_selection_boot_options=boot_options,
             service_resources=scheduler_data.service_resources,
             placement_substitutions=dynamic_services_placement_settings.DIRECTOR_V2_GENERIC_RESOURCE_PLACEMENT_CONSTRAINTS_SUBSTITUTIONS,
+            has_machine_specific_resources=bool(
+                scheduler_data.hardware_info and scheduler_data.hardware_info.aws_ec2_instances
+            ),
         )
 
         groups_extra_properties = get_repository(app, GroupsExtraPropertiesRepository)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Director-v2 somehow clamps the minimal amount of resources when starting the dynamic-sidecar service to 1 CPU/1Gib limits (not touching the reservations). This triggers the issue in https://github.com/ITISFoundation/private-issues/issues/455

1. Webserver computed 0.6 CPUs for the service which is ok for a t3.large (2 CPUs, 8Gib). OPS/System overhead is 1.4 CPUs --> 0.6CPUs remains
2. director-v2 silently changes the limits to 1.0 (@GitHK we need to discuss this)
3. autoscaling then checks if the required machine using 2 - 1.4 - 1 < 0 --> error!


This nevertheless shows that we have some non uniform way of setting up services for dynamic services. 
This is explained in https://github.com/ITISFoundation/private-issues/issues/588

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/private-issues/issues/455
- relates to https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
