### PR TITLE
♻️Clusters-keeper: migrate to lifespan startup pattern

### DIFF
--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/_meta.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/_meta.py
@@ -39,7 +39,7 @@ APP_STARTED_BANNER_MSG = r"""
 | (____/\| (____/\| (___) |/\____) |   | |   | (____/\| ) \ \__/\____) |       |  /  \ \| (____/\| (____/\| )      | (____/\| ) \ \__
 (_______/(_______/(_______)\_______)   )_(   (_______/|/   \__/\_______)       |_/    \/(_______/(_______/|/       (_______/|/   \__/
                                                                                                                                     {}
-""".format(f"v{__version__}")
+""".format(f"v{__version__}")  # noqa: E501
 
 APP_STARTED_DISABLED_BANNER_MSG = r"""
       _  _              _      _            _
@@ -49,5 +49,7 @@ APP_STARTED_DISABLED_BANNER_MSG = r"""
  | (_| || |\__ \| (_| || |_) || ||  __/| (_| |
   \__,_||_||___/ \__,_||_.__/ |_| \___| \__,_|
 """
+
+APP_STARTING_BANNER_MSG = "{:=^100}".format(f"🚀 App {APP_NAME}=={__version__} starting up 🚀")
 
 APP_FINISHED_BANNER_MSG = "{:=^100}".format(f"🎉 App {APP_NAME}=={__version__} shutdown completed 🎉")

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/core/application.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/core/application.py
@@ -1,13 +1,14 @@
 import logging
 
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager
 from servicelib.fastapi.health import HealthCheckError, health_check_error_handler
+from servicelib.fastapi.lifespan_utils import Lifespan, configure_app_lifespan
 from servicelib.fastapi.monitoring import (
-    setup_prometheus_instrumentation,
+    configure_prometheus_instrumentation,
 )
 from servicelib.fastapi.tracing import (
-    initialize_fastapi_app_tracing,
-    setup_tracing,
+    configure_fastapi_app_tracing,
 )
 from servicelib.tracing import TracingConfig
 
@@ -18,74 +19,84 @@ from .._meta import (
     APP_NAME,
     APP_STARTED_BANNER_MSG,
     APP_STARTED_DISABLED_BANNER_MSG,
+    APP_STARTING_BANNER_MSG,
 )
 from ..api.routes import setup_api_routes
-from ..modules.clusters_management_task import setup as setup_clusters_management
-from ..modules.ec2 import setup as setup_ec2
-from ..modules.rabbitmq import setup as setup_rabbitmq
-from ..modules.redis import setup as setup_redis
-from ..modules.ssm import setup as setup_ssm
-from ..rpc.rpc_routes import setup_rpc_routes
+from ..modules.clusters_management_task import configure_clusters_management
+from ..modules.ec2 import configure_ec2_client
+from ..modules.rabbitmq import configure_rabbitmq_client
+from ..modules.redis import configure_redis_client
+from ..modules.ssm import configure_ssm_client
+from ..rpc.rpc_routes import configure_rpc_routes
 from .settings import ApplicationSettings
 
 _logger = logging.getLogger(__name__)
 
 
-def create_app(settings: ApplicationSettings, tracing_config: TracingConfig) -> FastAPI:
+def _configure_plugins(
+    app: FastAPI,
+    app_lifespan: LifespanManager[FastAPI],
+    settings: ApplicationSettings,
+    tracing_config: TracingConfig,
+) -> None:
+    configure_redis_client(app_lifespan)
+    configure_rabbitmq_client(app_lifespan)
+    configure_ec2_client(app_lifespan)
+    configure_ssm_client(app_lifespan)
+    configure_rpc_routes(app_lifespan)
+    configure_clusters_management(app_lifespan, settings=settings)
+
+    if settings.CLUSTERS_KEEPER_PROMETHEUS_INSTRUMENTATION_ENABLED:
+        configure_prometheus_instrumentation(app, app_lifespan)
+
+    if tracing_config.tracing_enabled:
+        configure_fastapi_app_tracing(
+            app,
+            app_lifespan,
+            tracing_config=tracing_config,
+        )
+
+
+def create_app(
+    settings: ApplicationSettings,
+    tracing_config: TracingConfig,
+    logging_lifespan: Lifespan | None = None,
+) -> FastAPI:
     _logger.info("app settings: %s", settings.model_dump_json(indent=1))
 
-    app = FastAPI(
-        debug=settings.CLUSTERS_KEEPER_DEBUG,
-        title=APP_NAME,
-        description="Service to keep external clusters alive",
-        version=API_VERSION,
-        openapi_url=f"/api/{API_VTAG}/openapi.json",
-        docs_url="/dev/doc",
-        redoc_url=None,  # default disabled
-    )
-    # STATE
-    app.state.settings = settings
-    app.state.tracing_config = tracing_config
-    assert app.state.settings.API_VERSION == API_VERSION  # nosec
+    started_banner = APP_STARTED_BANNER_MSG
+    if any(
+        s is None
+        for s in [
+            settings.CLUSTERS_KEEPER_EC2_ACCESS,
+            settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES,
+        ]
+    ):
+        started_banner = f"{APP_STARTED_BANNER_MSG}\n{APP_STARTED_DISABLED_BANNER_MSG}"
 
-    if tracing_config.tracing_enabled:
-        setup_tracing(
-            app,
-            tracing_config,
+    with configure_app_lifespan(
+        logging_lifespan=logging_lifespan,
+        starting_banner=APP_STARTING_BANNER_MSG,
+        started_banner=started_banner,
+        shutdown_complete_banner=APP_FINISHED_BANNER_MSG,
+    ) as app_lifespan:
+        app = FastAPI(
+            debug=settings.CLUSTERS_KEEPER_DEBUG,
+            title=APP_NAME,
+            description="Service to keep external clusters alive",
+            version=API_VERSION,
+            openapi_url=f"/api/{API_VTAG}/openapi.json",
+            docs_url="/dev/doc",
+            redoc_url=None,  # default disabled
+            lifespan=app_lifespan,
         )
-    if app.state.settings.CLUSTERS_KEEPER_PROMETHEUS_INSTRUMENTATION_ENABLED:
-        setup_prometheus_instrumentation(app)
+        app.state.settings = settings
+        app.state.tracing_config = tracing_config
+        assert app.state.settings.API_VERSION == API_VERSION  # nosec
 
-    # PLUGINS SETUP
-    setup_api_routes(app)
-    setup_rabbitmq(app)
-    setup_rpc_routes(app)
-    setup_ec2(app)
-    setup_ssm(app)
-    setup_redis(app)
-    setup_clusters_management(app)
+        setup_api_routes(app)
+        _configure_plugins(app, app_lifespan, settings, tracing_config)
 
-    if tracing_config.tracing_enabled:
-        initialize_fastapi_app_tracing(app, tracing_config=tracing_config)
-    # ERROR HANDLERS
-    app.add_exception_handler(HealthCheckError, health_check_error_handler)
-
-    # EVENTS
-    async def _on_startup() -> None:
-        print(APP_STARTED_BANNER_MSG, flush=True)  # noqa: T201
-        if any(
-            s is None
-            for s in [
-                settings.CLUSTERS_KEEPER_EC2_ACCESS,
-                settings.CLUSTERS_KEEPER_PRIMARY_EC2_INSTANCES,
-            ]
-        ):
-            print(APP_STARTED_DISABLED_BANNER_MSG, flush=True)  # noqa: T201
-
-    async def _on_shutdown() -> None:
-        print(APP_FINISHED_BANNER_MSG, flush=True)  # noqa: T201
-
-    app.add_event_handler("startup", _on_startup)
-    app.add_event_handler("shutdown", _on_shutdown)
+        app.add_exception_handler(HealthCheckError, health_check_error_handler)
 
     return app

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/main.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/main.py
@@ -5,7 +5,7 @@ from typing import Final
 
 from common_library.json_serialization import json_dumps
 from fastapi import FastAPI
-from servicelib.fastapi.logging_lifespan import create_logging_shutdown_event
+from servicelib.fastapi.logging_lifespan import create_logging_lifespan
 from servicelib.tracing import TracingConfig
 
 from simcore_service_clusters_keeper.core.application import create_app
@@ -25,7 +25,7 @@ _NOISY_LOGGERS: Final[tuple[str, ...]] = (
 def app_factory() -> FastAPI:
     app_settings = ApplicationSettings.create_from_envs()
     tracing_config = TracingConfig.create(service_name=APP_NAME, tracing_settings=app_settings.CLUSTERS_KEEPER_TRACING)
-    logging_shutdown_event = create_logging_shutdown_event(
+    logging_lifespan = create_logging_lifespan(
         log_format_local_dev_enabled=app_settings.CLUSTERS_KEEPER_LOG_FORMAT_LOCAL_DEV_ENABLED,
         logger_filter_mapping=app_settings.CLUSTERS_KEEPER_LOG_FILTER_MAPPING,
         tracing_config=tracing_config,
@@ -37,6 +37,8 @@ def app_factory() -> FastAPI:
         "Application settings: %s",
         json_dumps(app_settings, indent=2, sort_keys=True),
     )
-    app = create_app(settings=app_settings, tracing_config=tracing_config)
-    app.add_event_handler("shutdown", logging_shutdown_event)
-    return app
+    return create_app(
+        settings=app_settings,
+        tracing_config=tracing_config,
+        logging_lifespan=logging_lifespan,
+    )

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_task.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_task.py
@@ -20,20 +20,23 @@ logger = logging.getLogger(__name__)
 
 async def _clusters_management_lifespan(app: FastAPI) -> AsyncIterator[State]:
     app_settings: ApplicationSettings = app.state.settings
+    app.state.clusters_cleaning_task = None
 
     lock_key = f"{APP_NAME}:clusters-management_lock"
     lock_value = json.dumps({})
-    app.state.clusters_cleaning_task = create_periodic_task(
-        exclusive(get_redis_client(app), lock_key=lock_key, lock_value=lock_value)(check_clusters),
-        interval=app_settings.CLUSTERS_KEEPER_TASK_INTERVAL,
-        task_name=_TASK_NAME,
-        app=app,
-    )
 
     try:
+        app.state.clusters_cleaning_task = create_periodic_task(
+            exclusive(get_redis_client(app), lock_key=lock_key, lock_value=lock_value)(check_clusters),
+            interval=app_settings.CLUSTERS_KEEPER_TASK_INTERVAL,
+            task_name=_TASK_NAME,
+            app=app,
+        )
+
         yield {}
     finally:
-        await cancel_wait_task(app.state.clusters_cleaning_task, max_delay=5)
+        if app.state.clusters_cleaning_task:
+            await cancel_wait_task(app.state.clusters_cleaning_task, max_delay=5)
 
 
 def configure_clusters_management(

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_task.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/clusters_management_task.py
@@ -1,9 +1,10 @@
 import json
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator
 
 from common_library.async_tools import cancel_wait_task
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from servicelib.background_task import create_periodic_task
 from servicelib.redis import exclusive
 
@@ -17,31 +18,29 @@ _TASK_NAME = "Clusters-keeper EC2 instances management"
 logger = logging.getLogger(__name__)
 
 
-def on_app_startup(app: FastAPI) -> Callable[[], Awaitable[None]]:
-    async def _startup() -> None:
-        app_settings: ApplicationSettings = app.state.settings
+async def _clusters_management_lifespan(app: FastAPI) -> AsyncIterator[State]:
+    app_settings: ApplicationSettings = app.state.settings
 
-        lock_key = f"{APP_NAME}:clusters-management_lock"
-        lock_value = json.dumps({})
-        app.state.clusters_cleaning_task = create_periodic_task(
-            exclusive(get_redis_client(app), lock_key=lock_key, lock_value=lock_value)(check_clusters),
-            interval=app_settings.CLUSTERS_KEEPER_TASK_INTERVAL,
-            task_name=_TASK_NAME,
-            app=app,
-        )
+    lock_key = f"{APP_NAME}:clusters-management_lock"
+    lock_value = json.dumps({})
+    app.state.clusters_cleaning_task = create_periodic_task(
+        exclusive(get_redis_client(app), lock_key=lock_key, lock_value=lock_value)(check_clusters),
+        interval=app_settings.CLUSTERS_KEEPER_TASK_INTERVAL,
+        task_name=_TASK_NAME,
+        app=app,
+    )
 
-    return _startup
-
-
-def on_app_shutdown(app: FastAPI) -> Callable[[], Awaitable[None]]:
-    async def _stop() -> None:
+    try:
+        yield {}
+    finally:
         await cancel_wait_task(app.state.clusters_cleaning_task, max_delay=5)
 
-    return _stop
 
-
-def setup(app: FastAPI):
-    app_settings: ApplicationSettings = app.state.settings
+def configure_clusters_management(
+    app_lifespan: LifespanManager[FastAPI],
+    settings: ApplicationSettings,
+) -> None:
+    app_settings = settings
     if any(
         s is None
         for s in [
@@ -52,5 +51,5 @@ def setup(app: FastAPI):
     ):
         logger.warning("the clusters management background task is disabled by settings, nothing will happen!")
         return
-    app.add_event_handler("startup", on_app_startup(app))
-    app.add_event_handler("shutdown", on_app_shutdown(app))
+
+    app_lifespan.add(_clusters_management_lifespan)

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/ec2.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/ec2.py
@@ -1,9 +1,11 @@
 import logging
+from collections.abc import AsyncIterator
 from typing import cast
 
 from aws_library.ec2 import SimcoreEC2API
 from aws_library.ec2._errors import EC2NotConnectedError
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from settings_library.ec2 import EC2Settings
 from tenacity.asyncio import AsyncRetrying
 from tenacity.before_sleep import before_sleep_log
@@ -16,16 +18,17 @@ from ..core.settings import get_application_settings
 logger = logging.getLogger(__name__)
 
 
-def setup(app: FastAPI) -> None:
-    async def on_startup() -> None:
-        app.state.ec2_client = None
+async def _ec2_client_lifespan(app: FastAPI) -> AsyncIterator[State]:
+    app.state.ec2_client = None
 
-        settings: EC2Settings | None = get_application_settings(app).CLUSTERS_KEEPER_EC2_ACCESS
+    settings: EC2Settings | None = get_application_settings(app).CLUSTERS_KEEPER_EC2_ACCESS
 
-        if not settings:
-            logger.warning("EC2 client is de-activated in the settings")
-            return
+    if not settings:
+        logger.warning("EC2 client is de-activated in the settings")
+        yield {}
+        return
 
+    try:
         app.state.ec2_client = client = await SimcoreEC2API.create(settings)
 
         async for attempt in AsyncRetrying(
@@ -39,12 +42,14 @@ def setup(app: FastAPI) -> None:
                 if not connected:
                     raise EC2NotConnectedError  # pragma: no cover
 
-    async def on_shutdown() -> None:
+        yield {}
+    finally:
         if app.state.ec2_client:
             await cast(SimcoreEC2API, app.state.ec2_client).close()
 
-    app.add_event_handler("startup", on_startup)
-    app.add_event_handler("shutdown", on_shutdown)
+
+def configure_ec2_client(app_lifespan: LifespanManager[FastAPI]) -> None:
+    app_lifespan.add(_ec2_client_lifespan)
 
 
 def get_ec2_client(app: FastAPI) -> SimcoreEC2API:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/rabbitmq.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/rabbitmq.py
@@ -1,8 +1,10 @@
 import contextlib
 import logging
+from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from models_library.rabbitmq_messages import RabbitMessageBase
 from servicelib.logging_utils import log_catch
 from servicelib.rabbitmq import (
@@ -18,29 +20,32 @@ from ..core.settings import get_application_settings
 logger = logging.getLogger(__name__)
 
 
-def setup(app: FastAPI) -> None:
-    async def on_startup() -> None:
-        app.state.rabbitmq_client = None
-        app.state.rabbitmq_rpc_client = None
-        settings: RabbitSettings | None = get_application_settings(app).CLUSTERS_KEEPER_RABBITMQ
-        if not settings:
-            logger.warning("Rabbit MQ client is de-activated in the settings")
-            return
-        await wait_till_rabbitmq_responsive(settings.dsn)
-        # create the clients
-        app.state.rabbitmq_client = RabbitMQClient(client_name="clusters_keeper", settings=settings)
-        app.state.rabbitmq_rpc_client = await RabbitMQRPCClient.create(
-            client_name="clusters_keeper_rpc_client", settings=settings
-        )
+async def _rabbitmq_lifespan(app: FastAPI) -> AsyncIterator[State]:
+    app.state.rabbitmq_client = None
+    app.state.rabbitmq_rpc_client = None
+    settings: RabbitSettings | None = get_application_settings(app).CLUSTERS_KEEPER_RABBITMQ
+    if not settings:
+        logger.warning("Rabbit MQ client is de-activated in the settings")
+        yield {}
+        return
 
-    async def on_shutdown() -> None:
+    await wait_till_rabbitmq_responsive(settings.dsn)
+    app.state.rabbitmq_client = RabbitMQClient(client_name="clusters_keeper", settings=settings)
+    app.state.rabbitmq_rpc_client = await RabbitMQRPCClient.create(
+        client_name="clusters_keeper_rpc_client", settings=settings
+    )
+
+    try:
+        yield {}
+    finally:
         if app.state.rabbitmq_client:
             await app.state.rabbitmq_client.close()
         if app.state.rabbitmq_rpc_client:
             await app.state.rabbitmq_rpc_client.close()
 
-    app.add_event_handler("startup", on_startup)
-    app.add_event_handler("shutdown", on_shutdown)
+
+def configure_rabbitmq_client(app_lifespan: LifespanManager[FastAPI]) -> None:
+    app_lifespan.add(_rabbitmq_lifespan)
 
 
 def get_rabbitmq_client(app: FastAPI) -> RabbitMQClient:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/rabbitmq.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/rabbitmq.py
@@ -29,13 +29,13 @@ async def _rabbitmq_lifespan(app: FastAPI) -> AsyncIterator[State]:
         yield {}
         return
 
-    await wait_till_rabbitmq_responsive(settings.dsn)
-    app.state.rabbitmq_client = RabbitMQClient(client_name="clusters_keeper", settings=settings)
-    app.state.rabbitmq_rpc_client = await RabbitMQRPCClient.create(
-        client_name="clusters_keeper_rpc_client", settings=settings
-    )
-
     try:
+        await wait_till_rabbitmq_responsive(settings.dsn)
+        app.state.rabbitmq_client = RabbitMQClient(client_name="clusters_keeper", settings=settings)
+        app.state.rabbitmq_rpc_client = await RabbitMQRPCClient.create(
+            client_name="clusters_keeper_rpc_client", settings=settings
+        )
+
         yield {}
     finally:
         if app.state.rabbitmq_client:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/redis.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/redis.py
@@ -17,13 +17,13 @@ async def _redis_lifespan(app: FastAPI) -> AsyncIterator[State]:
     app.state.redis_client_sdk = None
     settings: RedisSettings = get_application_settings(app).CLUSTERS_KEEPER_REDIS
     redis_locks_dsn = settings.build_redis_dsn(RedisDatabase.LOCKS)
-    app.state.redis_client_sdk = redis_client_sdk = RedisClientSDK(
+    redis_client_sdk = app.state.redis_client_sdk = RedisClientSDK(
         redis_locks_dsn,
         client_name=APP_NAME,
     )
-    await redis_client_sdk.setup()
 
     try:
+        await redis_client_sdk.setup()
         yield {}
     finally:
         if redis_client_sdk:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/redis.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/redis.py
@@ -1,7 +1,9 @@
 import logging
+from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from servicelib.redis import RedisClientSDK
 from settings_library.redis import RedisDatabase, RedisSettings
 
@@ -11,21 +13,25 @@ from ..core.settings import get_application_settings
 logger = logging.getLogger(__name__)
 
 
-def setup(app: FastAPI) -> None:
-    async def on_startup() -> None:
-        app.state.redis_client_sdk = None
-        settings: RedisSettings = get_application_settings(app).CLUSTERS_KEEPER_REDIS
-        redis_locks_dsn = settings.build_redis_dsn(RedisDatabase.LOCKS)
-        app.state.redis_client_sdk = RedisClientSDK(redis_locks_dsn, client_name=APP_NAME)
-        await app.state.redis_client_sdk.setup()
+async def _redis_lifespan(app: FastAPI) -> AsyncIterator[State]:
+    app.state.redis_client_sdk = None
+    settings: RedisSettings = get_application_settings(app).CLUSTERS_KEEPER_REDIS
+    redis_locks_dsn = settings.build_redis_dsn(RedisDatabase.LOCKS)
+    app.state.redis_client_sdk = redis_client_sdk = RedisClientSDK(
+        redis_locks_dsn,
+        client_name=APP_NAME,
+    )
+    await redis_client_sdk.setup()
 
-    async def on_shutdown() -> None:
-        redis_client_sdk: None | RedisClientSDK = app.state.redis_client_sdk
+    try:
+        yield {}
+    finally:
         if redis_client_sdk:
             await redis_client_sdk.shutdown()
 
-    app.add_event_handler("startup", on_startup)
-    app.add_event_handler("shutdown", on_shutdown)
+
+def configure_redis_client(app_lifespan: LifespanManager[FastAPI]) -> None:
+    app_lifespan.add(_redis_lifespan)
 
 
 def get_redis_client(app: FastAPI) -> RedisClientSDK:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/ssm.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/ssm.py
@@ -1,9 +1,11 @@
 import logging
+from collections.abc import AsyncIterator
 from typing import cast
 
 from aws_library.ssm import SimcoreSSMAPI
 from aws_library.ssm._errors import SSMNotConnectedError
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from settings_library.ssm import SSMSettings
 from tenacity.asyncio import AsyncRetrying
 from tenacity.before_sleep import before_sleep_log
@@ -16,15 +18,16 @@ from ..core.settings import get_application_settings
 _logger = logging.getLogger(__name__)
 
 
-def setup(app: FastAPI) -> None:
-    async def on_startup() -> None:
-        app.state.ssm_client = None
-        settings: SSMSettings | None = get_application_settings(app).CLUSTERS_KEEPER_SSM_ACCESS
+async def _ssm_client_lifespan(app: FastAPI) -> AsyncIterator[State]:
+    app.state.ssm_client = None
+    settings: SSMSettings | None = get_application_settings(app).CLUSTERS_KEEPER_SSM_ACCESS
 
-        if not settings:
-            _logger.warning("SSM client is de-activated in the settings")
-            return
+    if not settings:
+        _logger.warning("SSM client is de-activated in the settings")
+        yield {}
+        return
 
+    try:
         app.state.ssm_client = client = await SimcoreSSMAPI.create(settings)
 
         async for attempt in AsyncRetrying(
@@ -38,12 +41,14 @@ def setup(app: FastAPI) -> None:
                 if not connected:
                     raise SSMNotConnectedError  # pragma: no cover
 
-    async def on_shutdown() -> None:
+        yield {}
+    finally:
         if app.state.ssm_client:
             await cast(SimcoreSSMAPI, app.state.ssm_client).close()
 
-    app.add_event_handler("startup", on_startup)
-    app.add_event_handler("shutdown", on_shutdown)
+
+def configure_ssm_client(app_lifespan: LifespanManager[FastAPI]) -> None:
+    app_lifespan.add(_ssm_client_lifespan)
 
 
 def get_ssm_client(app: FastAPI) -> SimcoreSSMAPI:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/rpc_routes.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/rpc/rpc_routes.py
@@ -1,6 +1,7 @@
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator
 
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from models_library.api_schemas_clusters_keeper import CLUSTERS_KEEPER_RPC_NAMESPACE
 
 from ..modules.rabbitmq import get_rabbitmq_rpc_client, is_rabbitmq_enabled
@@ -8,23 +9,14 @@ from .clusters import router as clusters_router
 from .ec2_instances import router as ec2_instances_router
 
 
-def on_app_startup(app: FastAPI) -> Callable[[], Awaitable[None]]:
-    async def _start() -> None:
-        if is_rabbitmq_enabled(app):
-            rpc_client = get_rabbitmq_rpc_client(app)
-            for router in [clusters_router, ec2_instances_router]:
-                await rpc_client.register_router(router, CLUSTERS_KEEPER_RPC_NAMESPACE, app)
+async def _rpc_routes_lifespan(app: FastAPI) -> AsyncIterator[State]:
+    if is_rabbitmq_enabled(app):
+        rpc_client = get_rabbitmq_rpc_client(app)
+        for router in [clusters_router, ec2_instances_router]:
+            await rpc_client.register_router(router, CLUSTERS_KEEPER_RPC_NAMESPACE, app)
 
-    return _start
-
-
-def on_app_shutdown(app: FastAPI) -> Callable[[], Awaitable[None]]:
-    async def _stop() -> None:
-        assert app  # nosec
-
-    return _stop
+    yield {}
 
 
-def setup_rpc_routes(app: FastAPI) -> None:
-    app.add_event_handler("startup", on_app_startup(app))
-    app.add_event_handler("shutdown", on_app_shutdown(app))
+def configure_rpc_routes(app_lifespan: LifespanManager[FastAPI]) -> None:
+    app_lifespan.add(_rpc_routes_lifespan)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Clusters-keeper now follows lifespan pattern for application startup

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/4678
- relates to https://github.com/ITISFoundation/private-issues/issues/463
## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
