### PR TITLE
🎨Maintenance: improve warning to include overflow connections

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/api/dependencies/database.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/dependencies/database.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ...modules.db.repositories import BaseRepository
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 _POOL_UTILIZATION_WARNING_RATIO = 0.9
 
@@ -32,9 +32,6 @@ def _pool_capacity_metrics(engine: AsyncEngine) -> tuple[int, int, int, float]:
     return in_use, warning_threshold, total_capacity, utilization
 
 
-def _warns_pool_near_limits(engine: AsyncEngine) -> bool:
-    in_use, warning_threshold, total_capacity, _ = _pool_capacity_metrics(engine)
-    return total_capacity > 0 and in_use >= warning_threshold
 
 
 def get_base_repository[RepoType: BaseRepository](engine: AsyncEngine, repo_type: type[RepoType]) -> RepoType:
@@ -44,9 +41,9 @@ def get_base_repository[RepoType: BaseRepository](engine: AsyncEngine, repo_type
     # the max amount of connections is reached
     # now the current solution is to acquire connection when needed.
 
-    if _warns_pool_near_limits(engine):
-        in_use, warning_threshold, total_capacity, utilization = _pool_capacity_metrics(engine)
-        logger.warning(
+    in_use, warning_threshold, total_capacity, utilization = _pool_capacity_metrics(engine)
+    if total_capacity > 0 and in_use >= warning_threshold:
+        _logger.warning(
             "Database connection pool near limits: checked_out=%s threshold=%s total_capacity=%s "
             "utilization=%.1f%% status=%s",
             in_use,

--- a/services/director-v2/src/simcore_service_director_v2/api/dependencies/database.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/dependencies/database.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from collections.abc import AsyncGenerator, Callable
 from typing import Annotated, TypeVar, cast
 
@@ -10,6 +11,8 @@ from ...modules.db.repositories import BaseRepository
 
 logger = logging.getLogger(__name__)
 
+_POOL_UTILIZATION_WARNING_RATIO = 0.9
+
 
 RepoType = TypeVar("RepoType", bound=BaseRepository)
 
@@ -18,24 +21,45 @@ def _get_db_engine(request: Request) -> AsyncEngine:
     return cast(AsyncEngine, request.app.state.engine)
 
 
-def get_base_repository(engine: AsyncEngine, repo_type: type[RepoType]) -> RepoType:
+def _pool_capacity_metrics(engine: AsyncEngine) -> tuple[int, int, int, float]:
+    in_use = engine.pool.checkedout()  # type: ignore # connections in use
+    pool_size = engine.pool.size()  # type: ignore # configured pool size
+    max_overflow = max(int(getattr(engine.pool, "_max_overflow", 0)), 0)
+
+    total_capacity = pool_size + max_overflow
+    warning_threshold = math.ceil(total_capacity * _POOL_UTILIZATION_WARNING_RATIO)
+    utilization = in_use / total_capacity if total_capacity > 0 else 0.0
+    return in_use, warning_threshold, total_capacity, utilization
+
+
+def _warns_pool_near_limits(engine: AsyncEngine) -> bool:
+    in_use, warning_threshold, total_capacity, _ = _pool_capacity_metrics(engine)
+    return total_capacity > 0 and in_use >= warning_threshold
+
+
+def get_base_repository[RepoType: BaseRepository](engine: AsyncEngine, repo_type: type[RepoType]) -> RepoType:
     # NOTE: 2 different ideas were tried here with not so good
     # 1st one was acquiring a connection per repository which lead to the following issue https://github.com/ITISFoundation/osparc-simcore/pull/1966
     # 2nd one was acquiring a connection per request which works but blocks the director-v2 responsiveness once
     # the max amount of connections is reached
     # now the current solution is to acquire connection when needed.
 
-    # Get pool metrics
-    in_use = engine.pool.checkedout()  # type: ignore # connections in use
-    total_size = engine.pool.size()  # type: ignore # current total connections
-
-    if (total_size > 1) and (in_use > (total_size - 2)):
-        logger.warning("Database connection pool near limits: %s", engine.pool.status())
+    if _warns_pool_near_limits(engine):
+        in_use, warning_threshold, total_capacity, utilization = _pool_capacity_metrics(engine)
+        logger.warning(
+            "Database connection pool near limits: checked_out=%s threshold=%s total_capacity=%s "
+            "utilization=%.1f%% status=%s",
+            in_use,
+            warning_threshold,
+            total_capacity,
+            utilization * 100,
+            engine.pool.status(),
+        )
 
     return repo_type(db_engine=engine)
 
 
-def get_repository(
+def get_repository[RepoType: BaseRepository](
     repo_type: type[RepoType],
 ) -> Callable[..., AsyncGenerator[RepoType]]:
     async def _get_repo(

--- a/services/director-v2/src/simcore_service_director_v2/api/dependencies/database.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/dependencies/database.py
@@ -1,7 +1,7 @@
 import logging
 import math
 from collections.abc import AsyncGenerator, Callable
-from typing import Annotated, TypeVar, cast
+from typing import Annotated, cast
 
 from fastapi import Depends
 from fastapi.requests import Request
@@ -12,9 +12,6 @@ from ...modules.db.repositories import BaseRepository
 _logger = logging.getLogger(__name__)
 
 _POOL_UTILIZATION_WARNING_RATIO = 0.9
-
-
-RepoType = TypeVar("RepoType", bound=BaseRepository)
 
 
 def _get_db_engine(request: Request) -> AsyncEngine:
@@ -30,8 +27,6 @@ def _pool_capacity_metrics(engine: AsyncEngine) -> tuple[int, int, int, float]:
     warning_threshold = math.ceil(total_capacity * _POOL_UTILIZATION_WARNING_RATIO)
     utilization = in_use / total_capacity if total_capacity > 0 else 0.0
     return in_use, warning_threshold, total_capacity, utilization
-
-
 
 
 def get_base_repository[RepoType: BaseRepository](engine: AsyncEngine, repo_type: type[RepoType]) -> RepoType:

--- a/services/director-v2/src/simcore_service_director_v2/utils/db.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/db.py
@@ -4,7 +4,8 @@ from fastapi import FastAPI
 from models_library.projects_state import RunningState
 from simcore_postgres_database.models.comp_pipeline import StateType
 
-from ..api.dependencies.database import RepoType, get_base_repository
+from ..api.dependencies.database import get_base_repository
+from ..modules.db.repositories import BaseRepository
 
 DB_TO_RUNNING_STATE = {
     StateType.FAILED: RunningState.FAILED,
@@ -24,5 +25,5 @@ RUNNING_STATE_TO_DB = {v: k for k, v in DB_TO_RUNNING_STATE.items()}
 _logger = logging.getLogger(__name__)
 
 
-def get_repository(app: FastAPI, repo_type: type[RepoType]) -> RepoType:
+def get_repository[RepoType: BaseRepository](app: FastAPI, repo_type: type[RepoType]) -> RepoType:
     return get_base_repository(engine=app.state.engine, repo_type=repo_type)

--- a/services/director-v2/tests/unit/test_api_dependencies_database_pool_warning.py
+++ b/services/director-v2/tests/unit/test_api_dependencies_database_pool_warning.py
@@ -1,0 +1,54 @@
+import logging
+from typing import cast
+from unittest.mock import Mock
+
+import pytest
+from simcore_service_director_v2.api.dependencies.database import get_base_repository
+from simcore_service_director_v2.modules.db.repositories import BaseRepository
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+class DummyRepository(BaseRepository):
+    pass
+
+
+def _create_mocked_engine(*, checked_out: int, pool_size: int, max_overflow: int) -> AsyncEngine:
+    mocked_pool = Mock(_max_overflow=max_overflow)
+    mocked_pool.checkedout.return_value = checked_out
+    mocked_pool.size.return_value = pool_size
+    mocked_pool.status.return_value = (
+        f"Pool size: {pool_size} Current Overflow: {checked_out - pool_size} "
+        f"Current Checked out connections: {checked_out}"
+    )
+
+    mocked_engine = cast(AsyncEngine, Mock(spec=AsyncEngine))
+    mocked_engine.pool = mocked_pool
+    return mocked_engine
+
+
+def test_get_base_repository_does_not_warn_on_transient_spikes_with_available_overflow(
+    caplog: pytest.LogCaptureFixture,
+):
+    engine = _create_mocked_engine(checked_out=10, pool_size=10, max_overflow=20)
+
+    with caplog.at_level(logging.WARNING, logger="simcore_service_director_v2.api.dependencies.database"):
+        repository = get_base_repository(engine=engine, repo_type=DummyRepository)
+
+    assert isinstance(repository, DummyRepository)
+    assert "Database connection pool near limits" not in caplog.text
+
+
+def test_get_base_repository_warns_when_nearing_total_capacity(
+    caplog: pytest.LogCaptureFixture,
+):
+    engine = _create_mocked_engine(checked_out=27, pool_size=10, max_overflow=20)
+
+    with caplog.at_level(logging.WARNING, logger="simcore_service_director_v2.api.dependencies.database"):
+        repository = get_base_repository(engine=engine, repo_type=DummyRepository)
+
+    assert isinstance(repository, DummyRepository)
+    assert "Database connection pool near limits" in caplog.text
+    assert "checked_out=27" in caplog.text
+    assert "threshold=27" in caplog.text
+    assert "total_capacity=30" in caplog.text
+    assert "utilization=90.0%" in caplog.text

--- a/services/director-v2/tests/unit/test_api_dependencies_database_pool_warning.py
+++ b/services/director-v2/tests/unit/test_api_dependencies_database_pool_warning.py
@@ -29,7 +29,7 @@ def _create_mocked_engine(*, checked_out: int, pool_size: int, max_overflow: int
 def test_get_base_repository_does_not_warn_on_transient_spikes_with_available_overflow(
     caplog: pytest.LogCaptureFixture,
 ):
-    engine = _create_mocked_engine(checked_out=10, pool_size=10, max_overflow=20)
+    engine = _create_mocked_engine(checked_out=15, pool_size=10, max_overflow=20)
 
     with caplog.at_level(logging.WARNING, logger="simcore_service_director_v2.api.dependencies.database"):
         repository = get_base_repository(engine=engine, repo_type=DummyRepository)

--- a/services/director-v2/tests/unit/test_modules_osparc_variables.py
+++ b/services/director-v2/tests/unit/test_modules_osparc_variables.py
@@ -29,7 +29,7 @@ from pytest_mock import MockerFixture
 from pytest_simcore.helpers.faker_compose_specs import generate_fake_docker_compose
 from simcore_postgres_database.models.services_environments import VENDOR_SECRET_PREFIX
 from simcore_postgres_database.models.users import UserRole
-from simcore_service_director_v2.api.dependencies.database import RepoType
+from simcore_service_director_v2.modules.db.repositories import BaseRepository
 from simcore_service_director_v2.modules.osparc_variables import substitutions
 from simcore_service_director_v2.modules.osparc_variables._errors import (
     OsparcVariableResolveError,
@@ -123,7 +123,7 @@ def mock_repo_db_engine(mocker: MockerFixture) -> None:
     mocked_engine = AsyncMock()
     mocked_engine.connect = _connect
 
-    def _get_repository(app: FastAPI, repo_type: type[RepoType]) -> RepoType:
+    def _get_repository[RepoType: BaseRepository](app: FastAPI, repo_type: type[RepoType]) -> RepoType:
         return repo_type(db_engine=mocked_engine)
 
     for target in (


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Currently the warning triggers even when there are many connections open (overflow ones) but still a lot of regular connections available.
This PR fixes this by using the total number (regular + overflow)
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
