### PR TITLE
🐛 [Frontend] Fix: progress and inputUnits

### DIFF
--- a/packages/models-library/src/models_library/api_schemas_webserver/projects_nodes.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects_nodes.py
@@ -1,5 +1,5 @@
 # mypy: disable-error-code=truthy-function
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Any, Literal
 
 from pydantic import ConfigDict, Field
 from pydantic.config import JsonDict
@@ -9,7 +9,7 @@ from ..api_schemas_directorv2.dynamic_services import RetrieveDataOut
 from ..basic_types import PortInt
 from ..groups import GroupID
 from ..projects import ProjectID
-from ..projects_nodes import InputID, InputsDict, PartialNode
+from ..projects_nodes import InputID, InputsDict, PartialNode, UnitStr
 from ..projects_nodes_io import NodeID
 from ..services import ServiceKey, ServicePortKey, ServiceVersion
 from ..services_base import ServiceKeyVersion
@@ -28,7 +28,7 @@ class NodeCreate(InputSchemaWithoutCamelCase):
     service_id: str | None = None
 
 
-BootOptions: TypeAlias = dict
+type BootOptions = dict
 
 
 class NodePatch(InputSchemaWithoutCamelCase):
@@ -45,6 +45,10 @@ class NodePatch(InputSchemaWithoutCamelCase):
     inputs_required: Annotated[
         list[InputID] | None,
         Field(alias="inputsRequired"),
+    ] = None
+    inputs_units: Annotated[
+        dict[InputID, UnitStr] | None,
+        Field(alias="inputsUnits"),
     ] = None
     input_nodes: Annotated[
         list[NodeID] | None,
@@ -106,7 +110,15 @@ class NodeGet(OutputSchema):
     )
     service_state: ServiceState = Field(
         ...,
-        description="the service state * 'pending' - The service is waiting for resources to start * 'pulling' - The service is being pulled from the registry * 'starting' - The service is starting * 'running' - The service is running * 'complete' - The service completed * 'failed' - The service failed to start\n",
+        description=(
+            "the service state"
+            " * 'pending' - The service is waiting for resources to start"
+            " * 'pulling' - The service is being pulled from the registry"
+            " * 'starting' - The service is starting"
+            " * 'running' - The service is running"
+            " * 'complete' - The service completed"
+            " * 'failed' - The service failed to start\n"
+        ),
     )
     service_message: str | None = Field(
         None,
@@ -196,7 +208,7 @@ class NodeOutputs(InputSchemaWithoutCamelCase):
 
 
 class NodeRetrieve(InputSchemaWithoutCamelCase):
-    port_keys: list[ServicePortKey] = []
+    port_keys: Annotated[list[ServicePortKey], Field(default_factory=list)]
 
 
 class NodeRetrieved(RetrieveDataOut):

--- a/packages/models-library/src/models_library/api_schemas_webserver/projects_nodes.py
+++ b/packages/models-library/src/models_library/api_schemas_webserver/projects_nodes.py
@@ -1,6 +1,7 @@
 # mypy: disable-error-code=truthy-function
 from typing import Annotated, Any, Literal
 
+from common_library.basic_types import DEFAULT_FACTORY
 from pydantic import ConfigDict, Field
 from pydantic.config import JsonDict
 
@@ -208,7 +209,7 @@ class NodeOutputs(InputSchemaWithoutCamelCase):
 
 
 class NodeRetrieve(InputSchemaWithoutCamelCase):
-    port_keys: Annotated[list[ServicePortKey], Field(default_factory=list)]
+    port_keys: Annotated[list[ServicePortKey], Field(default_factory=list)] = DEFAULT_FACTORY
 
 
 class NodeRetrieved(RetrieveDataOut):

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -803,7 +803,8 @@ qx.Class.define("osparc.data.model.Node", {
           }
         }
         this.getPropsForm().setInputLinks(inputLinks);
-        this.__settingsForm.setData(inputData);
+        const convertedData = this.getPropsForm().convertInputsToCurrentUnits(inputData);
+        this.__settingsForm.setData(convertedData);
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -1558,14 +1558,36 @@ qx.Class.define("osparc.data.model.Node", {
           }
           case "inputsUnits": {
             const updatedPortKey = path.split("/")[4];
-            const currentInputUnits = this.__getInputUnits() || {};
+            const nodeMD = this.getMetadata();
+            const getDefaultXUnit = portKey => {
+              const portMD = (nodeMD && nodeMD.inputs) ? nodeMD.inputs[portKey] : null;
+              return (portMD && "x_unit" in portMD) ? portMD["x_unit"] : null;
+            };
             if (updatedPortKey === undefined) {
-              // the whole inputsUnits object was added/replaced
-              Object.assign(currentInputUnits, value);
+              // the whole inputsUnits object was added/replaced/removed
+              if (op === "remove" || value === undefined || value === null || Object.keys(value).length === 0) {
+                // units were cleared: switch every port back to its metadata default unit
+                const resetUnits = {};
+                if (nodeMD && nodeMD.inputs) {
+                  Object.keys(nodeMD.inputs).forEach(portKey => {
+                    const defaultXUnit = getDefaultXUnit(portKey);
+                    if (defaultXUnit) {
+                      resetUnits[portKey] = defaultXUnit;
+                    }
+                  });
+                }
+                this.__setInputUnits(resetUnits);
+              } else {
+                this.__setInputUnits(value);
+              }
             } else {
-              currentInputUnits[updatedPortKey] = value;
+              // a single port's unit changed or was removed
+              // on "remove" there is no value, so fall back to the metadata default unit
+              const targetXUnit = (op === "remove" || value === undefined || value === null) ? getDefaultXUnit(updatedPortKey) : value;
+              if (targetXUnit) {
+                this.__setInputUnits({ [updatedPortKey]: targetXUnit });
+              }
             }
-            this.__setInputUnits(currentInputUnits);
             break;
           }
           case "inputNodes":

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -1556,10 +1556,14 @@ qx.Class.define("osparc.data.model.Node", {
             break;
           }
           case "inputsUnits": {
-            // this is never transmitted by the frontend
             const updatedPortKey = path.split("/")[4];
             const currentInputUnits = this.__getInputUnits() || {};
-            currentInputUnits[updatedPortKey] = value;
+            if (updatedPortKey === undefined) {
+              // the whole inputsUnits object was added/replaced
+              Object.assign(currentInputUnits, value);
+            } else {
+              currentInputUnits[updatedPortKey] = value;
+            }
             this.__setInputUnits(currentInputUnits);
             break;
           }
@@ -1630,7 +1634,7 @@ qx.Class.define("osparc.data.model.Node", {
         version: this.getVersion(),
         label: this.getLabel(),
         inputs: this.__getInputData(),
-        inputsUnits: this.__getInputUnits(), // this is not working
+        inputsUnits: this.__getInputUnits(),
         inputNodes: this.getInputNodes(),
         inputsRequired: this.getInputsRequired(),
         bootOptions: this.getBootOptions()

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -615,7 +615,7 @@ qx.Class.define("osparc.data.model.Node", {
 
     __populateProgress: function(nodeData) {
       if ("progress" in nodeData) {
-        const progress = Number.parseInt(nodeData["progress"]);
+        const progress = osparc.data.model.NodeStatus.getValidProgress(nodeData["progress"]);
         const oldProgress = this.getStatus().getProgress();
         if (this.isFilePicker() && oldProgress > 0 && oldProgress < 100) {
           // file is being uploaded

--- a/services/static-webserver/client/source/class/osparc/data/model/NodeStatus.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/NodeStatus.js
@@ -108,8 +108,9 @@ qx.Class.define("osparc.data.model.NodeStatus", {
 
   statics: {
     getValidProgress: function(value) {
-      if (value !== null && !Number.isNaN(value) && value >= 0 && value <= 100) {
-        return Number.parseFloat(value.toFixed(4));
+      const numValue = Number(value);
+      if (value !== null && !Number.isNaN(numValue) && numValue >= 0 && numValue <= 100) {
+        return Number.parseFloat(numValue.toFixed(4));
       }
       return 0;
     },

--- a/services/static-webserver/client/source/class/osparc/data/model/Workbench.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Workbench.js
@@ -814,6 +814,11 @@ qx.Class.define("osparc.data.model.Workbench", {
           Object.keys(workbenchDiffs[nodeId]).forEach(changedFieldKey => {
             // do not patch if it's undefined
             if (nodeData[changedFieldKey] === undefined) {
+              // a field that is in the diff but missing from the serialized node was reset to its default.
+              // inputsUnits must be explicitly sent as {} so the backend clears the previously stored override.
+              if (changedFieldKey === "inputsUnits") {
+                patchData[changedFieldKey] = {};
+              }
               return;
             }
             // if someone else is actively uploading (progress between NOT_STARTED and COMPLETED), don't patch it, the backend already knows

--- a/services/static-webserver/client/source/class/osparc/form/renderer/PropFormBase.js
+++ b/services/static-webserver/client/source/class/osparc/form/renderer/PropFormBase.js
@@ -326,7 +326,11 @@ qx.Class.define("osparc.form.renderer.PropFormBase", {
           return;
         }
         const value = converted[portId];
-        if (value !== null && value !== undefined && !osparc.utils.Ports.isDataALink(value)) {
+        if (
+          value !== null &&
+          value !== undefined &&
+          !osparc.utils.Ports.isDataALink(value)
+        ) {
           converted[portId] = osparc.utils.Units.convertValue(value, metadataPrefix, ctrl.unitPrefix);
         }
       });
@@ -406,7 +410,12 @@ qx.Class.define("osparc.form.renderer.PropFormBase", {
         newValue = String(newValue);
       }
       // scale the numeric range (e.g. integer Spinner min/max) so it stays consistent with the new unit
-      if (typeof item.getMaximum === "function" && typeof item.setMaximum === "function") {
+      if (
+        typeof item.getMaximum === "function" &&
+        typeof item.setMaximum === "function" &&
+        typeof item.getMinimum === "function" &&
+        typeof item.setMinimum === "function"
+      ) {
         const oldMax = item.getMaximum();
         const oldMin = item.getMinimum();
         const newMax = Math.ceil(oldMax * multiplier);

--- a/services/static-webserver/client/source/class/osparc/form/renderer/PropFormBase.js
+++ b/services/static-webserver/client/source/class/osparc/form/renderer/PropFormBase.js
@@ -298,7 +298,11 @@ qx.Class.define("osparc.form.renderer.PropFormBase", {
         if (!item) {
           return;
         }
-        this.__switchPrefix(item, item.unitPrefix, osparc.utils.Units.decomposeXUnit(inputsUnits[portId]).unitPrefix);
+        const xUnit = inputsUnits[portId];
+        if (xUnit === undefined || xUnit === null) {
+          return;
+        }
+        this.__switchPrefix(item, item.unitPrefix, osparc.utils.Units.decomposeXUnit(xUnit).unitPrefix);
       });
     },
 

--- a/services/static-webserver/client/source/class/osparc/form/renderer/PropFormBase.js
+++ b/services/static-webserver/client/source/class/osparc/form/renderer/PropFormBase.js
@@ -302,6 +302,33 @@ qx.Class.define("osparc.form.renderer.PropFormBase", {
       });
     },
 
+    // Incoming input values are expressed in the metadata (x_unit) unit. If a port is currently
+    // displayed in a different unit prefix, convert the value so it matches what the control expects.
+    // This is the inverse of the conversion done in getValues().
+    convertInputsToCurrentUnits: function(inputData) {
+      const converted = Object.assign({}, inputData);
+      const nodeMD = this.getNode().getMetadata();
+      Object.keys(converted).forEach(portId => {
+        const ctrl = this._form.getControl(portId);
+        if (!ctrl || !("unitPrefix" in ctrl)) {
+          return;
+        }
+        const portMD = (nodeMD && nodeMD.inputs) ? nodeMD.inputs[portId] : null;
+        if (!portMD || !("x_unit" in portMD)) {
+          return;
+        }
+        const metadataPrefix = osparc.utils.Units.decomposeXUnit(portMD["x_unit"]).unitPrefix;
+        if (metadataPrefix === ctrl.unitPrefix) {
+          return;
+        }
+        const value = converted[portId];
+        if (value !== null && value !== undefined && !osparc.utils.Ports.isDataALink(value)) {
+          converted[portId] = osparc.utils.Units.convertValue(value, metadataPrefix, ctrl.unitPrefix);
+        }
+      });
+      return converted;
+    },
+
     hasVisibleInputs: function() {
       const children = this._getChildren();
       for (let i=0; i<children.length; i++) {

--- a/services/static-webserver/client/source/class/osparc/form/renderer/PropFormBase.js
+++ b/services/static-webserver/client/source/class/osparc/form/renderer/PropFormBase.js
@@ -280,10 +280,10 @@ qx.Class.define("osparc.form.renderer.PropFormBase", {
       const changedXUnits = {};
       for (const portId in xUnits) {
         if (xUnits[portId] === null) {
-          break;
+          continue;
         }
         if (!("x_unit" in nodeMD.inputs[portId])) {
-          break;
+          continue;
         }
         if (xUnits[portId] !== nodeMD.inputs[portId].x_unit) {
           changedXUnits[portId] = xUnits[portId];
@@ -295,6 +295,9 @@ qx.Class.define("osparc.form.renderer.PropFormBase", {
     setInputsUnits: function(inputsUnits) {
       Object.keys(inputsUnits).forEach(portId => {
         const item = this._form.getControl(portId);
+        if (!item) {
+          return;
+        }
         this.__switchPrefix(item, item.unitPrefix, osparc.utils.Units.decomposeXUnit(inputsUnits[portId]).unitPrefix);
       });
     },
@@ -365,12 +368,27 @@ qx.Class.define("osparc.form.renderer.PropFormBase", {
     },
 
     __switchPrefix: function(item, oldPrefix, newPrefix) {
+      const multiplier = osparc.utils.Units.getMultiplier(oldPrefix, newPrefix);
       let newValue = osparc.utils.Units.convertValue(item.getValue(), oldPrefix, newPrefix);
       item.unitPrefix = newPrefix;
       if ("type" in item && item.type !== "integer") {
         newValue = String(newValue);
       }
-      item.setValue(newValue);
+      // scale the numeric range (e.g. integer Spinner min/max) so it stays consistent with the new unit
+      if (typeof item.getMaximum === "function" && typeof item.setMaximum === "function") {
+        const oldMax = item.getMaximum();
+        const oldMin = item.getMinimum();
+        const newMax = Math.ceil(oldMax * multiplier);
+        const newMin = Math.floor(oldMin * multiplier);
+        // widen the range first so setValue is not clamped, then apply the final scaled range
+        item.setMaximum(Math.max(oldMax, newMax));
+        item.setMinimum(Math.min(oldMin, newMin));
+        item.setValue(newValue);
+        item.setMaximum(newMax);
+        item.setMinimum(newMin);
+      } else {
+        item.setValue(newValue);
+      }
       this.self().updateUnitLabelPrefix(item);
       this.fireDataEvent("unitChanged", {
         portId: item.key,

--- a/services/web/server/src/simcore_service_webserver/api/v0/openapi.json
+++ b/services/web/server/src/simcore_service_webserver/api/v0/openapi.json
@@ -14878,6 +14878,10 @@
         ],
         "title": "BootOption"
       },
+      "BootOptions": {
+        "additionalProperties": true,
+        "type": "object"
+      },
       "CatalogLatestServiceGet": {
         "properties": {
           "key": {
@@ -23398,6 +23402,23 @@
             ],
             "title": "Inputsrequired"
           },
+          "inputsUnits": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/UnitStr"
+                },
+                "propertyNames": {
+                  "$ref": "#/components/schemas/InputID"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Inputsunits"
+          },
           "inputNodes": {
             "anyOf": [
               {
@@ -23429,14 +23450,12 @@
           "bootOptions": {
             "anyOf": [
               {
-                "additionalProperties": true,
-                "type": "object"
+                "$ref": "#/components/schemas/BootOptions"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Bootoptions"
+            ]
           },
           "outputs": {
             "anyOf": [
@@ -23462,8 +23481,7 @@
               "pattern": "^[-_a-zA-Z0-9]+$"
             },
             "type": "array",
-            "title": "Port Keys",
-            "default": []
+            "title": "Port Keys"
           }
         },
         "type": "object",


### PR DESCRIPTION
## What do these changes do?

After the [PR of the month](https://github.com/ITISFoundation/osparc-simcore/pull/8141), the frontend needs to be a bit updated.
- [x] Improve Node ``progress = null`` support
- [x] Support ``input_units``: this was completely out of the PATCHing mechanism

<img width="1840" height="850" alt="InputUnits" src="https://github.com/user-attachments/assets/cd4b8f20-de61-4f20-9f5d-d864dbd64804" />

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
