### PR TITLE
🐛 [Frontend] Fix translations not loading in deployed products

### DIFF
--- a/services/static-webserver/client/compile.json
+++ b/services/static-webserver/client/compile.json
@@ -19,6 +19,7 @@
     "en",
     "es"
   ],
+  "writeAllTranslations": true,
   "applications": [
     {
       "default": true,


### PR DESCRIPTION
## What do these changes do?

This PR adds ``"writeAllTranslations": true`` to the qooxdoo compiler config so that the full application translation catalog (source/translation/*.po) is bundled into every product application, not just one.

The Localization PoC (#9255) shipped .po translations, but on deployed master switching to Spanish had no effect — only ~25 qooxdoo framework strings were translated, none of the app strings.

Root cause is in the qooxdoo compiler's default build path ``(_writeRequiredTranslations`` in ``Target.js``): it attaches the shared ``osparc`` library's ``.po`` catalog per-class, keyed by ``libraryName:localeId``. Because all 9 products share the single osparc library, the compiler ended up writing the full app catalog to only one app (non-deterministically, depending on class processing order), leaving the rest — including osparc and the user-facing products — with only the framework catalog.

<img width="1440" height="850" alt="Locale" src="https://github.com/user-attachments/assets/616701ea-6d8b-4666-9566-4b707cec25d8" />

## Related issue/s
- related to https://github.com/ITISFoundation/private-issues/issues/590


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
