### PR TITLE
♻️ Fix rclone mount to use storage-provided S3 path instead of local bucket config

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_data/data_manager.py
@@ -246,7 +246,7 @@ async def _start_mount_if_required(
     async with progress_bar.sub_progress(steps=2, description=f"starting mount of {destination_path.name}") as sub_prog:
         s3_object = __create_s3_object_key(project_id, node_id, destination_path)
 
-        await filemanager.create_r_clone_mounted_directory_entry(
+        mount_s3_link = await filemanager.get_directory_mount_s3_link(
             user_id=user_id, s3_object=s3_object, store_id=SIMCORE_LOCATION
         )
         await sub_prog.update(1)
@@ -257,6 +257,7 @@ async def _start_mount_if_required(
             node_id=node_id,
             remote_type=MountRemoteType.S3,
             remote_path=s3_object,
+            mount_s3_link=mount_s3_link,
         )
 
 

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/filemanager.py
@@ -87,12 +87,21 @@ async def get_download_link_from_s3(
         return URL(f"{file_link}")
 
 
-async def create_r_clone_mounted_directory_entry(
+async def get_directory_mount_s3_link(
     *,
     user_id: UserID,
     s3_object: StorageFileID,
     store_id: LocationID | None,
-) -> None:
+) -> AnyUrl:
+    """Requests storage for the S3 link to be used when mounting a directory via rclone.
+
+    The link is provided by storage (``s3://<bucket>/<s3_object>``) so that the mount
+    targets the bucket actually used by storage.
+
+    NOTE: the upload is completed immediately to register the directory entry in
+    storage (file_meta_data) and avoid leaving a dangling pending entry behind. The
+    actual data transfer is then managed externally by the rclone mount.
+    """
     _, upload_links = await get_upload_links_from_s3(
         user_id=user_id,
         store_name=None,
@@ -104,6 +113,7 @@ async def create_r_clone_mounted_directory_entry(
         is_directory=True,
         sha256_checksum=None,
     )
+    assert upload_links.urls  # nosec
     async with ClientSessionContextManager(None) as session:
         await _filemanager_utils.complete_upload(
             session,
@@ -111,6 +121,7 @@ async def create_r_clone_mounted_directory_entry(
             [],
             is_directory=True,
         )
+    return upload_links.urls[0]
 
 
 async def get_upload_links_from_s3(

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Final
@@ -7,7 +8,7 @@ from uuid import uuid4
 
 from common_library.async_tools import cancel_wait_task
 from models_library.projects_nodes_io import NodeID, StorageFileID
-from pydantic import NonNegativeInt
+from pydantic import AnyUrl, NonNegativeInt
 from servicelib.background_task import create_periodic_task
 from servicelib.logging_utils import log_catch, log_context
 from settings_library.r_clone import RCloneSettings
@@ -38,6 +39,7 @@ class _TrackedMount:  # pylint:disable=too-many-instance-attributes
         mount_remote_type: MountRemoteType,
         *,
         remote_path: StorageFileID,
+        mount_s3_path: str,
         local_mount_path: Path,
         index: NonNegativeInt,
         delegate: DelegateInterface,
@@ -70,7 +72,7 @@ class _TrackedMount:  # pylint:disable=too-many-instance-attributes
             local_mount_path=self.local_mount_path,
             index=self.index,
             r_clone_config_content=get_config_content(r_clone_settings, mount_remote_type),
-            remote_path=f"{r_clone_settings.R_CLONE_S3.S3_BUCKET_NAME}/{self.remote_path}",
+            remote_path=mount_s3_path,
             rc_user=self._rc_user,
             rc_password=self._rc_password,
             delegate=self.delegate,
@@ -181,6 +183,7 @@ class RCloneMountManager:
         node_id: NodeID,
         remote_type: MountRemoteType,
         remote_path: StorageFileID,
+        mount_s3_link: AnyUrl,
     ) -> None:
         with log_context(
             _logger,
@@ -198,6 +201,7 @@ class RCloneMountManager:
                 self.r_clone_settings,
                 remote_type,
                 remote_path=remote_path,
+                mount_s3_path=re.sub(r"^s3://", "", f"{mount_s3_link}"),
                 local_mount_path=local_mount_path,
                 index=index,
                 delegate=self.delegate,

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_manager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_mount/_manager.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Final
@@ -29,6 +28,7 @@ _MIN_PATH_PARTS: Final[NonNegativeInt] = 3
 _DEFAULT_MOUNT_ACTIVITY_UPDATE_INTERVAL: Final[timedelta] = timedelta(seconds=5)
 _MOUNT_RESPONSIVE_CHECK_INTERVAL: Final[timedelta] = timedelta(seconds=6)
 _CONSECUTIVE_UNRESPONSIVE_THRESHOLD: Final[NonNegativeInt] = 3
+_S3_SCHEME_PREFIX: Final[str] = "s3://"
 
 
 class _TrackedMount:  # pylint:disable=too-many-instance-attributes
@@ -201,7 +201,7 @@ class RCloneMountManager:
                 self.r_clone_settings,
                 remote_type,
                 remote_path=remote_path,
-                mount_s3_path=re.sub(r"^s3://", "", f"{mount_s3_link}"),
+                mount_s3_path=f"{mount_s3_link}".removeprefix(_S3_SCHEME_PREFIX),
                 local_mount_path=local_mount_path,
                 index=index,
                 delegate=self.delegate,

--- a/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_mount.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_mount.py
@@ -24,7 +24,7 @@ from faker import Faker
 from models_library.api_schemas_storage.storage_schemas import S3BucketName
 from models_library.projects_nodes_io import NodeID, StorageFileID
 from moto.server import ThreadedMotoServer
-from pydantic import ByteSize, NonNegativeInt, TypeAdapter
+from pydantic import AnyUrl, ByteSize, NonNegativeInt, TypeAdapter
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict, setenvs_from_dict
 from servicelib.file_utils import create_sha256_checksum
 from servicelib.logging_utils import _dampen_noisy_loggers
@@ -331,6 +331,7 @@ async def test_workflow(
         local_mount_path=local_mount_path,
         remote_type=MountRemoteType.S3,
         remote_path=remote_path,
+        mount_s3_link=TypeAdapter(AnyUrl).validate_python(f"s3://{bucket_name}/{remote_path}"),
         node_id=node_id,
         index=index,
     )
@@ -371,6 +372,7 @@ async def test_container_recovers_and_shutdown_is_emitted(
     docker_swarm: None,
     moto_server: None,
     r_clone_mount_manager: RCloneMountManager,
+    bucket_name: S3BucketName,
     node_id: NodeID,
     remote_path: StorageFileID,
     local_mount_path: Path,
@@ -381,6 +383,7 @@ async def test_container_recovers_and_shutdown_is_emitted(
         local_mount_path=local_mount_path,
         remote_type=MountRemoteType.S3,
         remote_path=remote_path,
+        mount_s3_link=TypeAdapter(AnyUrl).validate_python(f"s3://{bucket_name}/{remote_path}"),
         node_id=node_id,
         index=index,
     )
@@ -453,6 +456,7 @@ async def test_refresh_path(
             local_mount_path=local,
             remote_type=MountRemoteType.S3,
             remote_path=remote,
+            mount_s3_link=TypeAdapter(AnyUrl).validate_python(f"s3://{bucket_name}/{remote}"),
             node_id=node_id,
             index=index,
         )

--- a/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_mount.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_mount.py
@@ -57,6 +57,14 @@ def bucket_name(faker: Faker) -> S3BucketName:
 
 
 @pytest.fixture
+def mount_s3_link_from_remote(bucket_name: S3BucketName) -> Callable[[StorageFileID], AnyUrl]:
+    def _build(remote_path: StorageFileID) -> AnyUrl:
+        return TypeAdapter(AnyUrl).validate_python(f"s3://{bucket_name}/{remote_path}")
+
+    return _build
+
+
+@pytest.fixture
 def mock_environment(monkeypatch: pytest.MonkeyPatch, bucket_name: S3BucketName) -> EnvVarsDict:
     return setenvs_from_dict(
         monkeypatch,
@@ -317,6 +325,7 @@ async def test_workflow(
     r_clone_mount_manager: RCloneMountManager,
     r_clone_settings: RCloneSettings,
     bucket_name: S3BucketName,
+    mount_s3_link_from_remote: Callable[[StorageFileID], AnyUrl],
     node_id: NodeID,
     remote_path: StorageFileID,
     local_mount_path: Path,
@@ -331,7 +340,7 @@ async def test_workflow(
         local_mount_path=local_mount_path,
         remote_type=MountRemoteType.S3,
         remote_path=remote_path,
-        mount_s3_link=TypeAdapter(AnyUrl).validate_python(f"s3://{bucket_name}/{remote_path}"),
+        mount_s3_link=mount_s3_link_from_remote(remote_path),
         node_id=node_id,
         index=index,
     )
@@ -373,6 +382,7 @@ async def test_container_recovers_and_shutdown_is_emitted(
     moto_server: None,
     r_clone_mount_manager: RCloneMountManager,
     bucket_name: S3BucketName,
+    mount_s3_link_from_remote: Callable[[StorageFileID], AnyUrl],
     node_id: NodeID,
     remote_path: StorageFileID,
     local_mount_path: Path,
@@ -383,7 +393,7 @@ async def test_container_recovers_and_shutdown_is_emitted(
         local_mount_path=local_mount_path,
         remote_type=MountRemoteType.S3,
         remote_path=remote_path,
-        mount_s3_link=TypeAdapter(AnyUrl).validate_python(f"s3://{bucket_name}/{remote_path}"),
+        mount_s3_link=mount_s3_link_from_remote(remote_path),
         node_id=node_id,
         index=index,
     )
@@ -419,6 +429,49 @@ async def test_refresh_path_with_no_tracked_mount(
         await r_clone_mount_manager.refresh_path(remote_path=remote_path)
 
 
+@pytest.mark.parametrize("with_prefix", [True, False])
+async def test_ensure_mounted_handles_optional_s3_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+    r_clone_settings: RCloneSettings,
+    mocked_shutdown: AsyncMock,
+    vfs_cache_path: Path,
+    local_mount_path: Path,
+    bucket_name: S3BucketName,
+    node_id: NodeID,
+    remote_path: StorageFileID,
+    with_prefix: bool,
+):
+    async def _fake_start_mount(self: _TrackedMount) -> None:
+        return
+
+    monkeypatch.setattr(_TrackedMount, "start_mount", _fake_start_mount)
+
+    r_clone_mount_manager = RCloneMountManager(
+        r_clone_settings, requires_data_mounting=True, delegate=_TestingDelegate(vfs_cache_path, mocked_shutdown)
+    )
+
+    expected_remote_path = f"{bucket_name}/{remote_path}"
+    mount_s3_link = (
+        cast(AnyUrl, f"s3://{expected_remote_path}") if with_prefix else cast(AnyUrl, f"{expected_remote_path}")
+    )
+
+    await r_clone_mount_manager.ensure_mounted(
+        local_mount_path=local_mount_path,
+        remote_type=MountRemoteType.S3,
+        remote_path=remote_path,
+        mount_s3_link=mount_s3_link,
+        node_id=node_id,
+        index=0,
+    )
+
+    mount_id = get_mount_id(local_mount_path, 0)
+    tracked_mount = r_clone_mount_manager._tracked_mounts[mount_id]  # noqa: SLF001
+    assert tracked_mount._container_manager.remote_path == expected_remote_path  # noqa: SLF001
+
+    r_clone_mount_manager._tracked_mounts.clear()  # noqa: SLF001
+    r_clone_mount_manager._reverse_path_search.clear()  # noqa: SLF001
+
+
 @pytest.mark.parametrize("file_count", [10])
 @pytest.mark.parametrize("file_size", [TypeAdapter(ByteSize).validate_python("100kb")])
 @pytest.mark.parametrize("recursive", [True, False])
@@ -429,6 +482,7 @@ async def test_refresh_path(
     r_clone_mount_manager: RCloneMountManager,
     r_clone_settings: RCloneSettings,
     bucket_name: S3BucketName,
+    mount_s3_link_from_remote: Callable[[StorageFileID], AnyUrl],
     node_id: NodeID,
     local_mount_path: Path,
     remote_path: StorageFileID,
@@ -456,7 +510,7 @@ async def test_refresh_path(
             local_mount_path=local,
             remote_type=MountRemoteType.S3,
             remote_path=remote,
-            mount_s3_link=TypeAdapter(AnyUrl).validate_python(f"s3://{bucket_name}/{remote}"),
+            mount_s3_link=mount_s3_link_from_remote(remote),
             node_id=node_id,
             index=index,
         )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->



No longer constructs s3 path but it uses the one provided by storage. This way buckets can be injected by storage in the future.




## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/9257

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
