### PR TITLE
♻️Storage: migrate to lifespan startup pattern + reduce duplicated code

### DIFF
--- a/packages/aws-library/requirements/_base.in
+++ b/packages/aws-library/requirements/_base.in
@@ -10,6 +10,8 @@
 aioboto3
 aiocache
 arrow
+fastapi
+fastapi-lifespan-manager
 pydantic[email]
 types-aiobotocore[ec2,s3,ssm]
 opentelemetry-instrumentation-botocore

--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -20,17 +20,6 @@ aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.13.5
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   aiobotocore
     #   aiodocker
@@ -52,7 +41,6 @@ anyio==4.12.1
 arrow==1.4.0
     # via
     #   -r requirements/../../../packages/models-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   -r requirements/_base.in
 attrs==26.1.0
@@ -71,17 +59,6 @@ botocore-stubs==1.42.41
     # via types-aiobotocore
 certifi==2026.2.25
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   httpcore
     #   httpx
@@ -118,17 +95,6 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 hyperframe==6.1.0
@@ -146,13 +112,9 @@ jmespath==1.1.0
     #   boto3
     #   botocore
 jsonref==1.1.0
-    # via
-    #   -r requirements/../../../packages/models-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    # via -r requirements/../../../packages/models-library/requirements/_base.in
 jsonschema==4.26.0
-    # via
-    #   -r requirements/../../../packages/models-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
+    # via -r requirements/../../../packages/models-library/requirements/_base.in
 jsonschema-specifications==2025.9.1
     # via jsonschema
 markdown-it-py==4.0.0
@@ -246,26 +208,9 @@ opentelemetry-util-http==0.63b1
     #   opentelemetry-instrumentation-requests
 orjson==3.11.9
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
 packaging==26.0
     # via opentelemetry-instrumentation
 pamqp==3.3.0
@@ -276,17 +221,6 @@ propcache==0.4.1
     #   yarl
 protobuf==6.33.5
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -296,29 +230,11 @@ pycryptodome==3.23.0
     # via stream-zip
 pydantic==2.11.10
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/_base.in
-    #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   -r requirements/_base.in
     #   fast-depends
     #   pydantic-extra-types
@@ -328,31 +244,12 @@ pydantic-core==2.33.2
 pydantic-extra-types==2.11.1
     # via
     #   -r requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
     #   -r requirements/../../../packages/models-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
-    #   -r requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/_base.in
 pydantic-settings==2.7.0
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/models-library/requirements/_base.in
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/_base.in
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
-    #   -r requirements/../../../packages/settings-library/requirements/_base.in
 pygments==2.19.2
     # via rich
 pyinstrument==5.1.2
@@ -366,47 +263,14 @@ python-dotenv==1.2.2
     # via pydantic-settings
 pyyaml==6.0.3
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 redis==7.4.0
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/service-library/requirements/_base.in
 referencing==0.35.1
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   jsonschema
     #   jsonschema-specifications
@@ -415,7 +279,6 @@ requests==2.32.5
 rich==14.3.3
     # via
     #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
-    #   -r requirements/../../../packages/settings-library/requirements/_base.in
     #   typer
 rpds-py==0.30.0
     # via
@@ -438,9 +301,7 @@ toolz==1.1.0
 tqdm==4.67.3
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 typer==0.24.1
-    # via
-    #   -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
-    #   -r requirements/../../../packages/settings-library/requirements/_base.in
+    # via -r requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/_base.in
 types-aiobotocore==3.3.0
     # via -r requirements/_base.in
 types-aiobotocore-ec2==3.3.0
@@ -472,17 +333,6 @@ tzdata==2025.3
     # via arrow
 urllib3==2.7.0
     # via
-    #   -c requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/models-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/service-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../packages/common-library/requirements/../../../requirements/constraints.txt
-    #   -c requirements/../../../packages/settings-library/requirements/../../../requirements/constraints.txt
     #   -c requirements/../../../requirements/constraints.txt
     #   botocore
     #   requests

--- a/packages/aws-library/requirements/_test.in
+++ b/packages/aws-library/requirements/_test.in
@@ -11,8 +11,10 @@
 # testing
 coverage
 faker
+fastapi-lifespan-manager
 fastapi
 httpx
+asgi-lifespan
 moto[server]
 pint
 pytest

--- a/packages/aws-library/requirements/_test.txt
+++ b/packages/aws-library/requirements/_test.txt
@@ -13,6 +13,8 @@ anyio==4.12.1
     #   -c requirements/_base.txt
     #   httpx
     #   starlette
+asgi-lifespan==2.1.0
+    # via -r requirements/_test.in
 attrs==26.1.0
     # via
     #   -c requirements/_base.txt
@@ -77,6 +79,10 @@ docker==7.1.0
 faker==40.11.0
     # via -r requirements/_test.in
 fastapi==0.135.1
+    # via
+    #   -r requirements/_test.in
+    #   fastapi-lifespan-manager
+fastapi-lifespan-manager==0.1.4
     # via -r requirements/_test.in
 flask==3.1.3
     # via
@@ -282,6 +288,8 @@ six==1.17.0
     #   -c requirements/_base.txt
     #   python-dateutil
     #   rfc3339-validator
+sniffio==1.3.1
+    # via asgi-lifespan
 starlette==0.52.1
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/packages/aws-library/src/aws_library/ec2/__init__.py
+++ b/packages/aws-library/src/aws_library/ec2/__init__.py
@@ -5,6 +5,7 @@ from ._errors import (
     EC2NotConnectedError,
     EC2RuntimeError,
 )
+from ._fastapi_lifespan import configure_ec2_client
 from ._models import (
     AWS_TAG_KEY_MAX_LENGTH,
     AWS_TAG_KEY_MIN_LENGTH,
@@ -40,5 +41,5 @@ __all__: tuple[str, ...] = (
     "GenericResourceValueType",
     "Resources",
     "SimcoreEC2API",
+    "configure_ec2_client",
 )
-# nopycln: file

--- a/packages/aws-library/src/aws_library/ec2/_fastapi_lifespan.py
+++ b/packages/aws-library/src/aws_library/ec2/_fastapi_lifespan.py
@@ -1,0 +1,60 @@
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable
+
+from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
+from settings_library.ec2 import EC2Settings
+from tenacity.asyncio import AsyncRetrying
+from tenacity.before_sleep import before_sleep_log
+from tenacity.stop import stop_after_delay
+from tenacity.wait import wait_random_exponential
+
+from aws_library.ec2._client import SimcoreEC2API
+from aws_library.ec2._errors import EC2NotConnectedError
+
+_logger = logging.getLogger(__name__)
+
+type EC2ClientFactory = Callable[[FastAPI, EC2Settings], Awaitable[SimcoreEC2API]]
+
+
+async def _default_create_ec2_client(_: FastAPI, settings: EC2Settings) -> SimcoreEC2API:
+    return await SimcoreEC2API.create(settings)
+
+
+def configure_ec2_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: EC2Settings | None,
+    client_name: str,
+    app_state_attr: str = "ec2_client",
+    client_factory: EC2ClientFactory | None = None,
+) -> None:
+    async def _lifespan(app: FastAPI) -> AsyncIterator[State]:
+        setattr(app.state, app_state_attr, None)
+
+        if settings is None:
+            _logger.warning("EC2 client '%s' is de-activated in the settings", client_name)
+            yield {}
+            return
+
+        ec2_client: SimcoreEC2API | None = None
+        try:
+            ec2_client = await (client_factory or _default_create_ec2_client)(app, settings)
+            async for attempt in AsyncRetrying(
+                reraise=True,
+                stop=stop_after_delay(120),
+                wait=wait_random_exponential(max=30),
+                before_sleep=before_sleep_log(_logger, logging.WARNING),
+            ):
+                with attempt:
+                    connected = await ec2_client.ping()
+                    if not connected:
+                        raise EC2NotConnectedError
+
+            setattr(app.state, app_state_attr, ec2_client)
+            yield {}
+        finally:
+            if ec2_client is not None:
+                await ec2_client.close()
+
+    app_lifespan.add(_lifespan)

--- a/packages/aws-library/src/aws_library/ssm/__init__.py
+++ b/packages/aws-library/src/aws_library/ssm/__init__.py
@@ -8,6 +8,7 @@ from ._errors import (
     SSMRuntimeError,
     SSMSendCommandInstancesNotReadyError,
 )
+from ._fastapi_lifespan import configure_ssm_client
 
 __all__: tuple[str, ...] = (
     "SSMAccessError",
@@ -18,6 +19,5 @@ __all__: tuple[str, ...] = (
     "SSMRuntimeError",
     "SSMSendCommandInstancesNotReadyError",
     "SimcoreSSMAPI",
+    "configure_ssm_client",
 )
-
-# nopycln: file

--- a/packages/aws-library/src/aws_library/ssm/_fastapi_lifespan.py
+++ b/packages/aws-library/src/aws_library/ssm/_fastapi_lifespan.py
@@ -1,0 +1,57 @@
+import logging
+from collections.abc import AsyncIterator
+
+from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
+from settings_library.ssm import SSMSettings
+from tenacity.asyncio import AsyncRetrying
+from tenacity.before_sleep import before_sleep_log
+from tenacity.stop import stop_after_delay
+from tenacity.wait import wait_random_exponential
+
+from aws_library.ssm._client import SimcoreSSMAPI
+from aws_library.ssm._errors import SSMNotConnectedError
+
+_logger = logging.getLogger(__name__)
+
+
+async def _default_create_ssm_client(_: FastAPI, settings: SSMSettings) -> SimcoreSSMAPI:
+    return await SimcoreSSMAPI.create(settings)
+
+
+def configure_ssm_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: SSMSettings | None,
+    client_name: str,
+    app_state_attr: str = "ssm_client",
+) -> None:
+    async def _lifespan(app: FastAPI) -> AsyncIterator[State]:
+        setattr(app.state, app_state_attr, None)
+
+        if settings is None:
+            _logger.warning("SSM client '%s' is de-activated in the settings", client_name)
+            yield {}
+            return
+
+        ssm_client = None
+        try:
+            ssm_client = await _default_create_ssm_client(app, settings)
+            async for attempt in AsyncRetrying(
+                reraise=True,
+                stop=stop_after_delay(120),
+                wait=wait_random_exponential(max=30),
+                before_sleep=before_sleep_log(_logger, logging.WARNING),
+            ):
+                with attempt:
+                    connected = await ssm_client.ping()
+                    if not connected:
+                        raise SSMNotConnectedError
+
+            setattr(app.state, app_state_attr, ssm_client)
+            yield {}
+        finally:
+            if ssm_client is not None:
+                await ssm_client.close()
+
+    app_lifespan.add(_lifespan)

--- a/packages/aws-library/tests/test_ec2_lifespan.py
+++ b/packages/aws-library/tests/test_ec2_lifespan.py
@@ -93,8 +93,10 @@ async def test_configure_ec2_client_closes_client_if_ping_fails(
             return False
 
     class _SingleAsyncRetrying:
-        def __aiter__(self):
+        def __init__(self) -> None:
             self._yielded = False
+
+        def __aiter__(self):
             return self
 
         async def __anext__(self) -> _SingleAttempt:

--- a/packages/aws-library/tests/test_ec2_lifespan.py
+++ b/packages/aws-library/tests/test_ec2_lifespan.py
@@ -1,0 +1,126 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+import pytest
+from asgi_lifespan import LifespanManager as ASGILifespanManager
+from aws_library.ec2 import configure_ec2_client
+from aws_library.ec2._errors import EC2NotConnectedError
+from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager
+from pydantic import Field
+from pytest_mock import MockerFixture, MockType
+from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from settings_library.application import BaseApplicationSettings
+from settings_library.ec2 import EC2Settings
+
+
+@pytest.fixture
+def mock_ec2_client_create(mocker: MockerFixture) -> MockType:
+    mock_ec2_client = mocker.AsyncMock()
+    mock_ec2_client.ping = mocker.AsyncMock(return_value=True)
+    mock_ec2_client.close = mocker.AsyncMock()
+    return mocker.patch("aws_library.ec2._fastapi_lifespan.SimcoreEC2API.create", return_value=mock_ec2_client)
+
+
+@pytest.fixture
+def app_environment(monkeypatch: pytest.MonkeyPatch) -> EnvVarsDict:
+    return setenvs_from_dict(monkeypatch, EC2Settings.model_json_schema()["examples"][0])
+
+
+async def test_configure_ec2_client_publishes_client_in_app_state(
+    app_environment: EnvVarsDict,
+    mock_ec2_client_create: MockType,
+):
+    assert app_environment
+
+    class AppSettings(BaseApplicationSettings):
+        EC2_ACCESS: EC2Settings = Field(..., json_schema_extra={"auto_default_from_env": True})
+
+    settings = AppSettings.create_from_envs()
+
+    app_lifespan = LifespanManager()
+    configure_ec2_client(
+        app_lifespan,
+        settings=settings.EC2_ACCESS,
+        client_name="test_ec2_client",
+    )
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    async with ASGILifespanManager(app, startup_timeout=10, shutdown_timeout=10):
+        mock_ec2_client_create.assert_called_once_with(settings.EC2_ACCESS)
+        mock_ec2_client_create.return_value.ping.assert_called_once()
+        assert app.state.ec2_client == mock_ec2_client_create.return_value
+
+    mock_ec2_client_create.return_value.close.assert_called_once()
+
+
+async def test_configure_ec2_client_with_none_settings(
+    mock_ec2_client_create: MockType,
+):
+    app_lifespan = LifespanManager()
+    configure_ec2_client(
+        app_lifespan,
+        settings=None,
+        client_name="disabled_ec2_client",
+    )
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    async with ASGILifespanManager(app, startup_timeout=10, shutdown_timeout=10):
+        assert app.state.ec2_client is None
+
+    mock_ec2_client_create.assert_not_called()
+
+
+async def test_configure_ec2_client_closes_client_if_ping_fails(
+    app_environment: EnvVarsDict,
+    mock_ec2_client_create: MockType,
+    mocker: MockerFixture,
+):
+    assert app_environment
+
+    class AppSettings(BaseApplicationSettings):
+        EC2_ACCESS: EC2Settings = Field(..., json_schema_extra={"auto_default_from_env": True})
+
+    class _SingleAttempt:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    class _SingleAsyncRetrying:
+        def __aiter__(self):
+            self._yielded = False
+            return self
+
+        async def __anext__(self) -> _SingleAttempt:
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return _SingleAttempt()
+
+    mocker.patch("aws_library.ec2._fastapi_lifespan.AsyncRetrying", return_value=_SingleAsyncRetrying())
+
+    settings = AppSettings.create_from_envs()
+    mock_ec2_client_create.return_value.ping.return_value = False
+
+    app_lifespan = LifespanManager()
+    configure_ec2_client(
+        app_lifespan,
+        settings=settings.EC2_ACCESS,
+        client_name="test_ec2_client",
+    )
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    with pytest.raises(EC2NotConnectedError):
+        async with ASGILifespanManager(app, startup_timeout=10, shutdown_timeout=10):
+            pytest.fail("lifespan startup should fail before entering the context")
+
+    mock_ec2_client_create.assert_called_once_with(settings.EC2_ACCESS)
+    mock_ec2_client_create.return_value.ping.assert_called_once()
+    mock_ec2_client_create.return_value.close.assert_called_once()

--- a/packages/aws-library/tests/test_ec2_lifespan.py
+++ b/packages/aws-library/tests/test_ec2_lifespan.py
@@ -14,6 +14,7 @@ from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.application import BaseApplicationSettings
 from settings_library.ec2 import EC2Settings
+from tenacity import AsyncRetrying, stop_after_attempt, wait_none
 
 
 @pytest.fixture
@@ -85,27 +86,10 @@ async def test_configure_ec2_client_closes_client_if_ping_fails(
     class AppSettings(BaseApplicationSettings):
         EC2_ACCESS: EC2Settings = Field(..., json_schema_extra={"auto_default_from_env": True})
 
-    class _SingleAttempt:
-        def __enter__(self) -> None:
-            return None
-
-        def __exit__(self, exc_type, exc, tb) -> bool:
-            return False
-
-    class _SingleAsyncRetrying:
-        def __init__(self) -> None:
-            self._yielded = False
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self) -> _SingleAttempt:
-            if self._yielded:
-                raise StopAsyncIteration
-            self._yielded = True
-            return _SingleAttempt()
-
-    mocker.patch("aws_library.ec2._fastapi_lifespan.AsyncRetrying", return_value=_SingleAsyncRetrying())
+    mocker.patch(
+        "aws_library.ec2._fastapi_lifespan.AsyncRetrying",
+        return_value=AsyncRetrying(reraise=True, stop=stop_after_attempt(1), wait=wait_none()),
+    )
 
     settings = AppSettings.create_from_envs()
     mock_ec2_client_create.return_value.ping.return_value = False

--- a/packages/aws-library/tests/test_ssm_lifespan.py
+++ b/packages/aws-library/tests/test_ssm_lifespan.py
@@ -14,6 +14,7 @@ from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.application import BaseApplicationSettings
 from settings_library.ssm import SSMSettings
+from tenacity import AsyncRetrying, stop_after_attempt, wait_none
 
 
 @pytest.fixture
@@ -85,27 +86,10 @@ async def test_configure_ssm_client_closes_client_if_ping_fails(
     class AppSettings(BaseApplicationSettings):
         SSM_ACCESS: SSMSettings = Field(..., json_schema_extra={"auto_default_from_env": True})
 
-    class _SingleAttempt:
-        def __enter__(self) -> None:
-            return None
-
-        def __exit__(self, exc_type, exc, tb) -> bool:
-            return False
-
-    class _SingleAsyncRetrying:
-        def __init__(self) -> None:
-            self._yielded = False
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self) -> _SingleAttempt:
-            if self._yielded:
-                raise StopAsyncIteration
-            self._yielded = True
-            return _SingleAttempt()
-
-    mocker.patch("aws_library.ssm._fastapi_lifespan.AsyncRetrying", return_value=_SingleAsyncRetrying())
+    mocker.patch(
+        "aws_library.ssm._fastapi_lifespan.AsyncRetrying",
+        return_value=AsyncRetrying(reraise=True, stop=stop_after_attempt(1), wait=wait_none()),
+    )
 
     settings = AppSettings.create_from_envs()
     mock_ssm_client_create.return_value.ping.return_value = False

--- a/packages/aws-library/tests/test_ssm_lifespan.py
+++ b/packages/aws-library/tests/test_ssm_lifespan.py
@@ -93,8 +93,10 @@ async def test_configure_ssm_client_closes_client_if_ping_fails(
             return False
 
     class _SingleAsyncRetrying:
-        def __aiter__(self):
+        def __init__(self) -> None:
             self._yielded = False
+
+        def __aiter__(self):
             return self
 
         async def __anext__(self) -> _SingleAttempt:

--- a/packages/aws-library/tests/test_ssm_lifespan.py
+++ b/packages/aws-library/tests/test_ssm_lifespan.py
@@ -1,0 +1,126 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+import pytest
+from asgi_lifespan import LifespanManager as ASGILifespanManager
+from aws_library.ssm import configure_ssm_client
+from aws_library.ssm._errors import SSMNotConnectedError
+from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager
+from pydantic import Field
+from pytest_mock import MockerFixture, MockType
+from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from settings_library.application import BaseApplicationSettings
+from settings_library.ssm import SSMSettings
+
+
+@pytest.fixture
+def mock_ssm_client_create(mocker: MockerFixture) -> MockType:
+    mock_ssm_client = mocker.AsyncMock()
+    mock_ssm_client.ping = mocker.AsyncMock(return_value=True)
+    mock_ssm_client.close = mocker.AsyncMock()
+    return mocker.patch("aws_library.ssm._fastapi_lifespan.SimcoreSSMAPI.create", return_value=mock_ssm_client)
+
+
+@pytest.fixture
+def app_environment(monkeypatch: pytest.MonkeyPatch) -> EnvVarsDict:
+    return setenvs_from_dict(monkeypatch, SSMSettings.model_json_schema()["examples"][0])
+
+
+async def test_configure_ssm_client_publishes_client_in_app_state(
+    app_environment: EnvVarsDict,
+    mock_ssm_client_create: MockType,
+):
+    assert app_environment
+
+    class AppSettings(BaseApplicationSettings):
+        SSM_ACCESS: SSMSettings = Field(..., json_schema_extra={"auto_default_from_env": True})
+
+    settings = AppSettings.create_from_envs()
+
+    app_lifespan = LifespanManager()
+    configure_ssm_client(
+        app_lifespan,
+        settings=settings.SSM_ACCESS,
+        client_name="test_ssm_client",
+    )
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    async with ASGILifespanManager(app, startup_timeout=10, shutdown_timeout=10):
+        mock_ssm_client_create.assert_called_once_with(settings.SSM_ACCESS)
+        mock_ssm_client_create.return_value.ping.assert_called_once()
+        assert app.state.ssm_client == mock_ssm_client_create.return_value
+
+    mock_ssm_client_create.return_value.close.assert_called_once()
+
+
+async def test_configure_ssm_client_with_none_settings(
+    mock_ssm_client_create: MockType,
+):
+    app_lifespan = LifespanManager()
+    configure_ssm_client(
+        app_lifespan,
+        settings=None,
+        client_name="disabled_ssm_client",
+    )
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    async with ASGILifespanManager(app, startup_timeout=10, shutdown_timeout=10):
+        assert app.state.ssm_client is None
+
+    mock_ssm_client_create.assert_not_called()
+
+
+async def test_configure_ssm_client_closes_client_if_ping_fails(
+    app_environment: EnvVarsDict,
+    mock_ssm_client_create: MockType,
+    mocker: MockerFixture,
+):
+    assert app_environment
+
+    class AppSettings(BaseApplicationSettings):
+        SSM_ACCESS: SSMSettings = Field(..., json_schema_extra={"auto_default_from_env": True})
+
+    class _SingleAttempt:
+        def __enter__(self) -> None:
+            return None
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    class _SingleAsyncRetrying:
+        def __aiter__(self):
+            self._yielded = False
+            return self
+
+        async def __anext__(self) -> _SingleAttempt:
+            if self._yielded:
+                raise StopAsyncIteration
+            self._yielded = True
+            return _SingleAttempt()
+
+    mocker.patch("aws_library.ssm._fastapi_lifespan.AsyncRetrying", return_value=_SingleAsyncRetrying())
+
+    settings = AppSettings.create_from_envs()
+    mock_ssm_client_create.return_value.ping.return_value = False
+
+    app_lifespan = LifespanManager()
+    configure_ssm_client(
+        app_lifespan,
+        settings=settings.SSM_ACCESS,
+        client_name="test_ssm_client",
+    )
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    with pytest.raises(SSMNotConnectedError):
+        async with ASGILifespanManager(app, startup_timeout=10, shutdown_timeout=10):
+            pytest.fail("lifespan startup should fail before entering the context")
+
+    mock_ssm_client_create.assert_called_once_with(settings.SSM_ACCESS)
+    mock_ssm_client_create.return_value.ping.assert_called_once()
+    mock_ssm_client_create.return_value.close.assert_called_once()

--- a/packages/service-library/src/servicelib/fastapi/httpx_client.py
+++ b/packages/service-library/src/servicelib/fastapi/httpx_client.py
@@ -15,32 +15,6 @@ from .lifespan_utils import PublisherLifespan, create_publisher_lifespan, lifesp
 _logger = logging.getLogger(__name__)
 
 
-def setup_httpx_client(
-    app: FastAPI,
-    *,
-    default_timeout: datetime.timedelta = datetime.timedelta(seconds=20),
-    max_keepalive_connections: int = 20,
-    tracing_config: TracingConfig | None,
-) -> None:
-    async def on_startup() -> None:
-        client = httpx.AsyncClient(
-            transport=httpx.AsyncHTTPTransport(http2=True),
-            limits=httpx.Limits(max_keepalive_connections=max_keepalive_connections),
-            timeout=default_timeout.total_seconds(),
-        )
-        if tracing_config:
-            setup_httpx_client_tracing(client, tracing_config=tracing_config)
-        app.state.httpx_client = client
-
-    async def on_shutdown() -> None:
-        client = app.state.httpx_client
-        assert isinstance(client, httpx.AsyncClient)  # nosec
-        await client.aclose()
-
-    app.add_event_handler("startup", on_startup)
-    app.add_event_handler("shutdown", on_shutdown)
-
-
 class HttpxLifespanState(StrEnum):
     HTTPX_CLIENT = "httpx_client"
 

--- a/packages/service-library/src/servicelib/fastapi/rabbitmq_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/rabbitmq_lifespan.py
@@ -1,44 +1,138 @@
 import logging
 from collections.abc import AsyncIterator
+from enum import StrEnum
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import State
-from pydantic import BaseModel, ValidationError
+from fastapi_lifespan_manager import LifespanManager, State
 from settings_library.rabbit import RabbitSettings
 
-from ..rabbitmq import wait_till_rabbitmq_responsive
+from ..logging_utils import log_catch
+from ..rabbitmq import RabbitMQClient, RabbitMQRPCClient, wait_till_rabbitmq_responsive
 from .lifespan_utils import (
-    LifespanOnStartupError,
+    PublisherLifespan,
+    create_publisher_lifespan,
     lifespan_context,
 )
 
 _logger = logging.getLogger(__name__)
 
 
-class RabbitMQConfigurationError(LifespanOnStartupError):
-    msg_template = "Invalid RabbitMQ config on startup : {validation_error}"
+class _RabbitMQLifespanState(StrEnum):
+    RABBITMQ_CLIENT = "rabbitmq.client"
+    RABBITMQ_RPC_CLIENT = "rabbitmq.rpc_client"
 
 
-class RabbitMQLifespanState(BaseModel):
-    RABBIT_SETTINGS: RabbitSettings
+def _create_rabbitmq_client_lifespan(
+    settings: RabbitSettings | None,
+    *,
+    client_name: str,
+    wait_for_connectivity: bool,
+) -> PublisherLifespan:
+    async def _lifespan(_: FastAPI, state: State) -> AsyncIterator[State]:
+        _lifespan_name = f"{__name__}._rabbitmq_client_lifespan[{client_name}]"
+
+        with lifespan_context(_logger, logging.INFO, _lifespan_name, state) as called_state:
+            if settings is None:
+                yield {
+                    _RabbitMQLifespanState.RABBITMQ_CLIENT: None,
+                    **called_state,
+                }
+                return
+
+            if wait_for_connectivity:
+                await wait_till_rabbitmq_responsive(settings.dsn)
+
+            rabbitmq_client = RabbitMQClient(client_name=client_name, settings=settings)
+            try:
+                yield {
+                    _RabbitMQLifespanState.RABBITMQ_CLIENT: rabbitmq_client,
+                    **called_state,
+                }
+            finally:
+                with log_catch(_logger, reraise=False):
+                    await rabbitmq_client.close()
+
+    return _lifespan
 
 
-async def rabbitmq_connectivity_lifespan(_: FastAPI, state: State) -> AsyncIterator[State]:
-    """Ensures RabbitMQ connectivity during lifespan.
+def _create_rabbitmq_rpc_client_lifespan(
+    settings: RabbitSettings | None,
+    *,
+    client_name: str,
+    wait_for_connectivity: bool,
+) -> PublisherLifespan:
+    async def _lifespan(_: FastAPI, state: State) -> AsyncIterator[State]:
+        _lifespan_name = f"{__name__}._rabbitmq_rpc_client_lifespan[{client_name}]"
 
-    For creating clients, use additional lifespans like rabbitmq_rpc_client_context.
-    """
-    _lifespan_name = f"{__name__}.{rabbitmq_connectivity_lifespan.__name__}"
+        with lifespan_context(_logger, logging.INFO, _lifespan_name, state) as called_state:
+            if settings is None:
+                yield {
+                    _RabbitMQLifespanState.RABBITMQ_RPC_CLIENT: None,
+                    **called_state,
+                }
+                return
 
-    with lifespan_context(_logger, logging.INFO, _lifespan_name, state) as called_state:
-        # Validate input state
-        try:
-            rabbit_state = RabbitMQLifespanState.model_validate(state)
-            rabbit_dsn_with_secrets = rabbit_state.RABBIT_SETTINGS.dsn
-        except ValidationError as exc:
-            raise RabbitMQConfigurationError(validation_error=exc, state=state) from exc
+            if wait_for_connectivity:
+                await wait_till_rabbitmq_responsive(settings.dsn)
 
-        # Wait for RabbitMQ to be responsive
-        await wait_till_rabbitmq_responsive(rabbit_dsn_with_secrets)
+            rabbitmq_rpc_client = await RabbitMQRPCClient.create(client_name=client_name, settings=settings)
+            try:
+                yield {
+                    _RabbitMQLifespanState.RABBITMQ_RPC_CLIENT: rabbitmq_rpc_client,
+                    **called_state,
+                }
+            finally:
+                with log_catch(_logger, reraise=False):
+                    await rabbitmq_rpc_client.close()
 
-        yield {"RABBIT_CONNECTIVITY_LIFESPAN_NAME": _lifespan_name, **called_state}
+    return _lifespan
+
+
+def configure_rabbitmq_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RabbitSettings | None,
+    client_name: str,
+    app_state_attr: str = "rabbitmq_client",
+    wait_for_connectivity: bool = True,
+) -> None:
+    rabbitmq_lifespan_manager: LifespanManager[FastAPI] = LifespanManager()
+    rabbitmq_lifespan_manager.add(
+        _create_rabbitmq_client_lifespan(
+            settings,
+            client_name=client_name,
+            wait_for_connectivity=wait_for_connectivity,
+        )
+    )
+    rabbitmq_lifespan_manager.add(
+        create_publisher_lifespan(
+            state_key=_RabbitMQLifespanState.RABBITMQ_CLIENT,
+            app_state_attr=app_state_attr,
+        )
+    )
+    app_lifespan.include(rabbitmq_lifespan_manager)
+
+
+def configure_rabbitmq_rpc_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RabbitSettings | None,
+    client_name: str,
+    app_state_attr: str = "rabbitmq_rpc_client",
+    wait_for_connectivity: bool = True,
+) -> None:
+    rabbitmq_lifespan_manager: LifespanManager[FastAPI] = LifespanManager()
+    rabbitmq_lifespan_manager.add(
+        _create_rabbitmq_rpc_client_lifespan(
+            settings,
+            client_name=client_name,
+            wait_for_connectivity=wait_for_connectivity,
+        )
+    )
+    rabbitmq_lifespan_manager.add(
+        create_publisher_lifespan(
+            state_key=_RabbitMQLifespanState.RABBITMQ_RPC_CLIENT,
+            app_state_attr=app_state_attr,
+        )
+    )
+    app_lifespan.include(rabbitmq_lifespan_manager)

--- a/packages/service-library/src/servicelib/fastapi/redis_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/redis_lifespan.py
@@ -2,70 +2,20 @@ import asyncio
 import logging
 from collections.abc import AsyncIterator
 from enum import StrEnum
-from typing import Annotated
 
 from fastapi import FastAPI
 from fastapi_lifespan_manager import LifespanManager, State
-from pydantic import BaseModel, StringConstraints, ValidationError
 from settings_library.redis import RedisDatabase, RedisSettings
 
-from ..logging_utils import log_catch, log_context
+from ..logging_utils import log_catch
 from ..redis import RedisClientSDK, RedisClientsManager, RedisManagerDBConfig
 from .lifespan_utils import (
-    LifespanOnStartupError,
     PublisherLifespan,
     create_publisher_lifespan,
     lifespan_context,
 )
 
 _logger = logging.getLogger(__name__)
-
-
-class RedisConfigurationError(LifespanOnStartupError):
-    msg_template = "Invalid redis config on startup : {validation_error}"
-
-
-class RedisLifespanState(BaseModel):
-    REDIS_SETTINGS: RedisSettings
-    REDIS_CLIENT_NAME: Annotated[str, StringConstraints(min_length=3, max_length=32)]
-    REDIS_CLIENT_DB: RedisDatabase
-
-
-async def redis_client_sdk_lifespan(_: FastAPI, state: State) -> AsyncIterator[State]:
-    _lifespan_name = f"{__name__}.{redis_client_sdk_lifespan.__name__}"
-
-    with lifespan_context(_logger, logging.INFO, _lifespan_name, state) as called_state:
-        # Validate input state
-        try:
-            redis_state = RedisLifespanState.model_validate(state)
-            redis_dsn_with_secrets = redis_state.REDIS_SETTINGS.build_redis_dsn(redis_state.REDIS_CLIENT_DB)
-        except ValidationError as exc:
-            raise RedisConfigurationError(validation_error=exc, state=state) from exc
-
-        # Setup client
-        with log_context(
-            _logger,
-            logging.INFO,
-            f"Creating redis client with name={redis_state.REDIS_CLIENT_NAME}",
-        ):
-            # NOTE: sdk integrates waiting until connection is ready
-            # and will raise an exception if it cannot connect
-            redis_client = RedisClientSDK(
-                redis_dsn_with_secrets,
-                client_name=redis_state.REDIS_CLIENT_NAME,
-            )
-            await redis_client.setup()
-
-        try:
-            yield {"REDIS_CLIENT_SDK": redis_client, **called_state}
-        finally:
-            # Teardown client
-            with log_catch(_logger, reraise=False):
-                await asyncio.wait_for(
-                    redis_client.shutdown(),
-                    # NOTE: shutdown already has a _HEALTHCHECK_TASK_TIMEOUT_S of 10s
-                    timeout=20,
-                )
 
 
 class _RedisClientsManagerLifespanState(StrEnum):

--- a/packages/service-library/src/servicelib/fastapi/redis_lifespan.py
+++ b/packages/service-library/src/servicelib/fastapi/redis_lifespan.py
@@ -1,16 +1,22 @@
 import asyncio
 import logging
 from collections.abc import AsyncIterator
+from enum import StrEnum
 from typing import Annotated
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import State
+from fastapi_lifespan_manager import LifespanManager, State
 from pydantic import BaseModel, StringConstraints, ValidationError
 from settings_library.redis import RedisDatabase, RedisSettings
 
 from ..logging_utils import log_catch, log_context
-from ..redis import RedisClientSDK
-from .lifespan_utils import LifespanOnStartupError, lifespan_context
+from ..redis import RedisClientSDK, RedisClientsManager, RedisManagerDBConfig
+from .lifespan_utils import (
+    LifespanOnStartupError,
+    PublisherLifespan,
+    create_publisher_lifespan,
+    lifespan_context,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -60,3 +66,124 @@ async def redis_client_sdk_lifespan(_: FastAPI, state: State) -> AsyncIterator[S
                     # NOTE: shutdown already has a _HEALTHCHECK_TASK_TIMEOUT_S of 10s
                     timeout=20,
                 )
+
+
+class _RedisClientsManagerLifespanState(StrEnum):
+    REDIS_CLIENTS_MANAGER = "redis.clients_manager"
+
+
+def _create_redis_clients_manager_lifespan(
+    settings: RedisSettings,
+    databases_configs: set[RedisManagerDBConfig],
+    client_name: str,
+) -> PublisherLifespan:
+    async def _lifespan(_: FastAPI, state: State) -> AsyncIterator[State]:
+        _lifespan_name = f"{__name__}._redis_clients_manager_lifespan[{client_name}]"
+
+        with lifespan_context(_logger, logging.INFO, _lifespan_name, state) as called_state:
+            manager = RedisClientsManager(
+                databases_configs=databases_configs,
+                settings=settings,
+                client_name=client_name,
+            )
+            await manager.setup()
+
+            try:
+                yield {
+                    _RedisClientsManagerLifespanState.REDIS_CLIENTS_MANAGER: manager,
+                    **called_state,
+                }
+            finally:
+                with log_catch(_logger, reraise=False):
+                    await asyncio.wait_for(manager.shutdown(), timeout=20)
+
+    return _lifespan
+
+
+def configure_redis_clients_manager(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RedisSettings,
+    databases_configs: set[RedisManagerDBConfig],
+    client_name: str,
+    app_state_attr: str = "redis_clients_manager",
+) -> None:
+    """Configure a RedisClientsManager lifespan and publish it to app.state.
+
+    Args:
+        app_lifespan: The application LifespanManager to add the Redis lifespan to.
+        settings: Redis connection settings.
+        databases_configs: Set of database configurations (database + decode_responses flags).
+        client_name: Name used to identify this Redis client (appears in Redis CLIENT LIST).
+        app_state_attr: Attribute name on app.state where the manager is stored.
+            Defaults to "redis_clients_manager".
+    """
+    redis_lifespan_manager: LifespanManager[FastAPI] = LifespanManager()
+    redis_lifespan_manager.add(_create_redis_clients_manager_lifespan(settings, databases_configs, client_name))
+    redis_lifespan_manager.add(
+        create_publisher_lifespan(
+            state_key=_RedisClientsManagerLifespanState.REDIS_CLIENTS_MANAGER,
+            app_state_attr=app_state_attr,
+        )
+    )
+    app_lifespan.include(redis_lifespan_manager)
+
+
+class _RedisClientSDKLifespanState(StrEnum):
+    REDIS_CLIENT_SDK_SIMPLE = "redis.client_sdk_simple"
+
+
+def _create_redis_client_sdk_lifespan(
+    settings: RedisSettings,
+    database: RedisDatabase,
+    client_name: str,
+) -> PublisherLifespan:
+    async def _lifespan(_: FastAPI, state: State) -> AsyncIterator[State]:
+        _lifespan_name = f"{__name__}._redis_client_sdk_lifespan[{client_name}]"
+
+        with lifespan_context(_logger, logging.INFO, _lifespan_name, state) as called_state:
+            redis_client = RedisClientSDK(
+                settings.build_redis_dsn(database),
+                client_name=client_name,
+            )
+            await redis_client.setup()
+
+            try:
+                yield {
+                    _RedisClientSDKLifespanState.REDIS_CLIENT_SDK_SIMPLE: redis_client,
+                    **called_state,
+                }
+            finally:
+                with log_catch(_logger, reraise=False):
+                    await asyncio.wait_for(redis_client.shutdown(), timeout=20)
+
+    return _lifespan
+
+
+def configure_redis_client_sdk(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RedisSettings,
+    database: RedisDatabase,
+    client_name: str,
+    app_state_attr: str = "redis_client_sdk",
+) -> None:
+    """Configure a single RedisClientSDK lifespan and publish it to app.state.
+
+    Args:
+        app_lifespan: The application LifespanManager to add the Redis lifespan to.
+        settings: Redis connection settings.
+        database: The Redis database to connect to.
+        client_name: Name used to identify this Redis client (appears in Redis CLIENT LIST).
+        app_state_attr: Attribute name on app.state where the SDK is stored.
+            Defaults to "redis_client_sdk".
+    """
+    redis_lifespan_manager: LifespanManager[FastAPI] = LifespanManager()
+    redis_lifespan_manager.add(_create_redis_client_sdk_lifespan(settings, database, client_name))
+    redis_lifespan_manager.add(
+        create_publisher_lifespan(
+            state_key=_RedisClientSDKLifespanState.REDIS_CLIENT_SDK_SIMPLE,
+            app_state_attr=app_state_attr,
+        )
+    )
+    app_lifespan.include(redis_lifespan_manager)

--- a/packages/service-library/tests/fastapi/test_rabbitmq_lifespan.py
+++ b/packages/service-library/tests/fastapi/test_rabbitmq_lifespan.py
@@ -1,27 +1,21 @@
-# pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
 # pylint: disable=too-many-arguments
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
-from collections.abc import AsyncIterator
-
 import pytest
 import servicelib.fastapi.rabbitmq_lifespan
-import servicelib.rabbitmq
 from asgi_lifespan import LifespanManager as ASGILifespanManager
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
 from pydantic import Field
 from pytest_mock import MockerFixture, MockType
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from servicelib.fastapi.rabbitmq_lifespan import (
-    RabbitMQConfigurationError,
-    RabbitMQLifespanState,
-    rabbitmq_connectivity_lifespan,
+    configure_rabbitmq_client,
+    configure_rabbitmq_rpc_client,
 )
-from servicelib.rabbitmq import rabbitmq_rpc_client_context
 from settings_library.application import BaseApplicationSettings
 from settings_library.rabbit import RabbitSettings
 
@@ -36,15 +30,25 @@ def mock_rabbitmq_connection(mocker: MockerFixture) -> MockType:
 
 
 @pytest.fixture
-def mock_rabbitmq_rpc_client_class(mocker: MockerFixture) -> MockType:
+def mock_rabbitmq_client_class(mocker: MockerFixture) -> MockType:
+    mock_client_instance = mocker.AsyncMock()
+    mock_client_instance.close = mocker.AsyncMock()
+    return mocker.patch.object(
+        servicelib.fastapi.rabbitmq_lifespan,
+        "RabbitMQClient",
+        return_value=mock_client_instance,
+    )
+
+
+@pytest.fixture
+def mock_rabbitmq_rpc_client_create(mocker: MockerFixture) -> MockType:
     mock_rpc_client_instance = mocker.AsyncMock()
-    mocker.patch.object(
-        servicelib.rabbitmq._client_rpc.RabbitMQRPCClient,  # noqa: SLF001
+    mock_rpc_client_instance.close = mocker.AsyncMock()
+    return mocker.patch.object(
+        servicelib.fastapi.rabbitmq_lifespan.RabbitMQRPCClient,
         "create",
         return_value=mock_rpc_client_instance,
     )
-    mock_rpc_client_instance.close = mocker.AsyncMock()
-    return mock_rpc_client_instance
 
 
 @pytest.fixture
@@ -52,51 +56,26 @@ def app_environment(monkeypatch: pytest.MonkeyPatch) -> EnvVarsDict:
     return setenvs_from_dict(monkeypatch, RabbitSettings.model_json_schema()["examples"][0])
 
 
-@pytest.fixture
-def app_lifespan(
+async def test_configure_rabbitmq_client_publishes_client_in_app_state(
+    is_pdb_enabled: bool,
     app_environment: EnvVarsDict,
     mock_rabbitmq_connection: MockType,
-    mock_rabbitmq_rpc_client_class: MockType,
-) -> LifespanManager:
+    mock_rabbitmq_client_class: MockType,
+):
     assert app_environment
 
     class AppSettings(BaseApplicationSettings):
         RABBITMQ: RabbitSettings = Field(..., json_schema_extra={"auto_default_from_env": True})
 
-    # setup settings
-    async def my_app_settings(app: FastAPI) -> AsyncIterator[State]:
-        app.state.settings = AppSettings.create_from_envs()
-
-        yield RabbitMQLifespanState(
-            RABBIT_SETTINGS=app.state.settings.RABBITMQ,
-        ).model_dump()
-
-    # setup rpc-client using rabbitmq_rpc_client_context
-    async def my_app_rpc_client(app: FastAPI, state: State) -> AsyncIterator[State]:
-        assert "RABBIT_CONNECTIVITY_LIFESPAN_NAME" in state
-
-        async with rabbitmq_rpc_client_context("rpc_client", app.state.settings.RABBITMQ) as rpc_client:
-            app.state.rpc_client = rpc_client
-            yield {}
+    settings = AppSettings.create_from_envs()
 
     app_lifespan = LifespanManager()
-    app_lifespan.add(my_app_settings)
-    app_lifespan.add(rabbitmq_connectivity_lifespan)
-    app_lifespan.add(my_app_rpc_client)
+    configure_rabbitmq_client(
+        app_lifespan,
+        settings=settings.RABBITMQ,
+        client_name="test_rabbit_client",
+    )
 
-    assert not mock_rabbitmq_connection.called
-    assert not mock_rabbitmq_rpc_client_class.called
-
-    return app_lifespan
-
-
-async def test_lifespan_rabbitmq_in_an_app(
-    is_pdb_enabled: bool,
-    app_environment: EnvVarsDict,
-    mock_rabbitmq_connection: MockType,
-    mock_rabbitmq_rpc_client_class: MockType,
-    app_lifespan: LifespanManager,
-):
     app = FastAPI(lifespan=app_lifespan)
 
     async with ASGILifespanManager(
@@ -104,38 +83,98 @@ async def test_lifespan_rabbitmq_in_an_app(
         startup_timeout=None if is_pdb_enabled else 10,
         shutdown_timeout=None if is_pdb_enabled else 10,
     ):
-        # Verify that RabbitMQ responsiveness was checked
-        mock_rabbitmq_connection.assert_called_once_with(app.state.settings.RABBITMQ.dsn)
+        mock_rabbitmq_connection.assert_called_once_with(settings.RABBITMQ.dsn)
+        mock_rabbitmq_client_class.assert_called_once_with(
+            client_name="test_rabbit_client",
+            settings=settings.RABBITMQ,
+        )
+        assert app.state.rabbitmq_client == mock_rabbitmq_client_class.return_value
 
-        # Verify that RabbitMQ settings are in the lifespan manager state
-        assert app.state.settings.RABBITMQ
-        assert app.state.rpc_client
-
-    # No explicit shutdown logic for RabbitMQ in this case
-    assert mock_rabbitmq_rpc_client_class.close.called
+    mock_rabbitmq_client_class.return_value.close.assert_called_once()
 
 
-async def test_lifespan_rabbitmq_with_invalid_settings(
+async def test_configure_rabbitmq_rpc_client_publishes_rpc_client_in_app_state(
     is_pdb_enabled: bool,
+    app_environment: EnvVarsDict,
+    mock_rabbitmq_connection: MockType,
+    mock_rabbitmq_rpc_client_create: MockType,
 ):
-    async def my_app_settings(app: FastAPI) -> AsyncIterator[State]:
-        yield {"RABBIT_SETTINGS": None}
+    assert app_environment
+
+    class AppSettings(BaseApplicationSettings):
+        RABBITMQ: RabbitSettings = Field(..., json_schema_extra={"auto_default_from_env": True})
+
+    settings = AppSettings.create_from_envs()
 
     app_lifespan = LifespanManager()
-    app_lifespan.add(my_app_settings)
-    app_lifespan.add(rabbitmq_connectivity_lifespan)
+    configure_rabbitmq_rpc_client(
+        app_lifespan,
+        settings=settings.RABBITMQ,
+        client_name="test_rabbit_rpc_client",
+    )
 
     app = FastAPI(lifespan=app_lifespan)
 
-    with pytest.raises(RabbitMQConfigurationError, match="Invalid RabbitMQ") as excinfo:
-        async with ASGILifespanManager(
-            app,
-            startup_timeout=None if is_pdb_enabled else 10,
-            shutdown_timeout=None if is_pdb_enabled else 10,
-        ):
-            ...
+    async with ASGILifespanManager(
+        app,
+        startup_timeout=None if is_pdb_enabled else 10,
+        shutdown_timeout=None if is_pdb_enabled else 10,
+    ):
+        mock_rabbitmq_connection.assert_called_once_with(settings.RABBITMQ.dsn)
+        mock_rabbitmq_rpc_client_create.assert_called_once_with(
+            client_name="test_rabbit_rpc_client",
+            settings=settings.RABBITMQ,
+        )
+        assert app.state.rabbitmq_rpc_client == mock_rabbitmq_rpc_client_create.return_value
 
-    exception = excinfo.value
-    assert isinstance(exception, RabbitMQConfigurationError)
-    assert exception.validation_error
-    assert exception.state["RABBIT_SETTINGS"] is None
+    mock_rabbitmq_rpc_client_create.return_value.close.assert_called_once()
+
+
+async def test_configure_rabbitmq_client_with_none_settings(
+    is_pdb_enabled: bool,
+    mock_rabbitmq_connection: MockType,
+    mock_rabbitmq_client_class: MockType,
+):
+    app_lifespan = LifespanManager()
+    configure_rabbitmq_client(
+        app_lifespan,
+        settings=None,
+        client_name="disabled_rabbit_client",
+    )
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    async with ASGILifespanManager(
+        app,
+        startup_timeout=None if is_pdb_enabled else 10,
+        shutdown_timeout=None if is_pdb_enabled else 10,
+    ):
+        assert app.state.rabbitmq_client is None
+
+    mock_rabbitmq_connection.assert_not_called()
+    mock_rabbitmq_client_class.assert_not_called()
+
+
+async def test_configure_rabbitmq_rpc_client_with_none_settings(
+    is_pdb_enabled: bool,
+    mock_rabbitmq_connection: MockType,
+    mock_rabbitmq_rpc_client_create: MockType,
+):
+    app_lifespan = LifespanManager()
+    configure_rabbitmq_rpc_client(
+        app_lifespan,
+        settings=None,
+        client_name="disabled_rabbit_rpc_client",
+    )
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    async with ASGILifespanManager(
+        app,
+        startup_timeout=None if is_pdb_enabled else 10,
+        shutdown_timeout=None if is_pdb_enabled else 10,
+    ):
+        assert app.state.rabbitmq_rpc_client is None
+
+    mock_rabbitmq_connection.assert_not_called()
+    mock_rabbitmq_rpc_client_create.assert_not_called()

--- a/packages/service-library/tests/fastapi/test_redis_lifespan.py
+++ b/packages/service-library/tests/fastapi/test_redis_lifespan.py
@@ -19,8 +19,11 @@ from pytest_simcore.helpers.typing_env import EnvVarsDict
 from servicelib.fastapi.redis_lifespan import (
     RedisConfigurationError,
     RedisLifespanState,
+    configure_redis_client_sdk,
+    configure_redis_clients_manager,
     redis_client_sdk_lifespan,
 )
+from servicelib.redis import RedisManagerDBConfig
 from settings_library.application import BaseApplicationSettings
 from settings_library.redis import RedisDatabase, RedisSettings
 
@@ -126,3 +129,108 @@ async def test_lifespan_redis_database_with_invalid_settings(
     assert isinstance(exception, RedisConfigurationError)
     assert exception.validation_error
     assert exception.state["REDIS_SETTINGS"] is None
+
+
+async def test_configure_redis_client_sdk_publishes_client_in_app_state(
+    is_pdb_enabled: bool,
+    app_environment: EnvVarsDict,
+    mock_redis_client_sdk: MockType,
+):
+    assert app_environment
+
+    class AppSettings(BaseApplicationSettings):
+        CATALOG_REDIS: Annotated[
+            RedisSettings,
+            Field(json_schema_extra={"auto_default_from_env": True}),
+        ]
+
+    settings = AppSettings.create_from_envs()
+
+    app_lifespan = LifespanManager()
+    configure_redis_client_sdk(
+        app_lifespan,
+        settings=settings.CATALOG_REDIS,
+        database=RedisDatabase.LOCKS,
+        client_name="test_client",
+    )
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    async with ASGILifespanManager(
+        app,
+        startup_timeout=None if is_pdb_enabled else 10,
+        shutdown_timeout=None if is_pdb_enabled else 10,
+    ):
+        mock_redis_client_sdk.assert_called_once_with(
+            settings.CATALOG_REDIS.build_redis_dsn(RedisDatabase.LOCKS),
+            client_name="test_client",
+        )
+        assert app.state.redis_client_sdk == mock_redis_client_sdk.return_value
+
+    redis_client: Any = mock_redis_client_sdk.return_value
+    redis_client.shutdown.assert_called_once()
+
+
+async def test_configure_redis_clients_manager_has_clients_for_required_dbs(
+    is_pdb_enabled: bool,
+    app_environment: EnvVarsDict,
+    mocker: MockerFixture,
+):
+    assert app_environment
+
+    class AppSettings(BaseApplicationSettings):
+        CATALOG_REDIS: Annotated[
+            RedisSettings,
+            Field(json_schema_extra={"auto_default_from_env": True}),
+        ]
+
+    settings = AppSettings.create_from_envs()
+
+    required_dbs: set[RedisDatabase] = {
+        RedisDatabase.LOCKS,
+        RedisDatabase.CELERY_TASKS,
+    }
+    expected_dsn_by_db: dict[RedisDatabase, str] = {
+        db: settings.CATALOG_REDIS.build_redis_dsn(db) for db in required_dbs
+    }
+
+    clients_by_db: dict[RedisDatabase, Any] = {}
+
+    def _redis_client_factory(redis_dsn: str, **_: Any) -> Any:
+        matching_db = next(db for db, dsn in expected_dsn_by_db.items() if dsn == redis_dsn)
+        client = mocker.AsyncMock()
+        client.is_healthy = True
+        clients_by_db[matching_db] = client
+        return client
+
+    mocker.patch(
+        "servicelib.redis._clients_manager.RedisClientSDK",
+        side_effect=_redis_client_factory,
+    )
+
+    app_lifespan = LifespanManager()
+    configure_redis_clients_manager(
+        app_lifespan,
+        settings=settings.CATALOG_REDIS,
+        databases_configs={RedisManagerDBConfig(database=db) for db in required_dbs},
+        client_name="test_manager",
+    )
+
+    app = FastAPI(lifespan=app_lifespan)
+
+    async with ASGILifespanManager(
+        app,
+        startup_timeout=None if is_pdb_enabled else 10,
+        shutdown_timeout=None if is_pdb_enabled else 10,
+    ):
+        manager = app.state.redis_clients_manager
+        assert manager.healthy
+
+        for db in required_dbs:
+            client = manager.client(db)
+            assert client == clients_by_db[db]
+
+        assert set(clients_by_db) == required_dbs
+
+    for client in clients_by_db.values():
+        client.shutdown.assert_called_once()

--- a/packages/service-library/tests/fastapi/test_redis_lifespan.py
+++ b/packages/service-library/tests/fastapi/test_redis_lifespan.py
@@ -1,27 +1,22 @@
-# pylint: disable=protected-access
 # pylint: disable=redefined-outer-name
 # pylint: disable=too-many-arguments
 # pylint: disable=unused-argument
 # pylint: disable=unused-variable
 
-from collections.abc import AsyncIterator
 from typing import Annotated, Any
 
 import pytest
 import servicelib.fastapi.redis_lifespan
 from asgi_lifespan import LifespanManager as ASGILifespanManager
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
 from pydantic import Field
 from pytest_mock import MockerFixture, MockType
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from servicelib.fastapi.redis_lifespan import (
-    RedisConfigurationError,
-    RedisLifespanState,
     configure_redis_client_sdk,
     configure_redis_clients_manager,
-    redis_client_sdk_lifespan,
 )
 from servicelib.redis import RedisManagerDBConfig
 from settings_library.application import BaseApplicationSettings
@@ -40,95 +35,6 @@ def mock_redis_client_sdk(mocker: MockerFixture) -> MockType:
 @pytest.fixture
 def app_environment(monkeypatch: pytest.MonkeyPatch) -> EnvVarsDict:
     return setenvs_from_dict(monkeypatch, RedisSettings.model_json_schema()["examples"][0])
-
-
-@pytest.fixture
-def app_lifespan(
-    app_environment: EnvVarsDict,
-    mock_redis_client_sdk: MockType,
-) -> LifespanManager:
-    assert app_environment
-
-    class AppSettings(BaseApplicationSettings):
-        CATALOG_REDIS: Annotated[
-            RedisSettings,
-            Field(json_schema_extra={"auto_default_from_env": True}),
-        ]
-
-    async def my_app_settings(app: FastAPI) -> AsyncIterator[State]:
-        app.state.settings = AppSettings.create_from_envs()
-
-        yield RedisLifespanState(
-            REDIS_SETTINGS=app.state.settings.CATALOG_REDIS,
-            REDIS_CLIENT_NAME="test_client",
-            REDIS_CLIENT_DB=RedisDatabase.LOCKS,
-        ).model_dump()
-
-    app_lifespan = LifespanManager()
-    app_lifespan.add(my_app_settings)
-    app_lifespan.add(redis_client_sdk_lifespan)
-
-    assert not mock_redis_client_sdk.called
-
-    return app_lifespan
-
-
-async def test_lifespan_redis_database_in_an_app(
-    is_pdb_enabled: bool,
-    app_environment: EnvVarsDict,
-    mock_redis_client_sdk: MockType,
-    app_lifespan: LifespanManager,
-):
-    app = FastAPI(lifespan=app_lifespan)
-
-    async with ASGILifespanManager(
-        app,
-        startup_timeout=None if is_pdb_enabled else 10,
-        shutdown_timeout=None if is_pdb_enabled else 10,
-    ) as asgi_manager:
-        # Verify that the Redis client SDK was created
-        mock_redis_client_sdk.assert_called_once_with(
-            app.state.settings.CATALOG_REDIS.build_redis_dsn(RedisDatabase.LOCKS),
-            client_name="test_client",
-        )
-
-        # Verify that the Redis client SDK is in the lifespan manager state
-        assert "REDIS_CLIENT_SDK" in asgi_manager._state  # noqa: SLF001
-        assert app.state.settings.CATALOG_REDIS
-        assert (
-            asgi_manager._state["REDIS_CLIENT_SDK"]  # noqa: SLF001
-            == mock_redis_client_sdk.return_value
-        )
-
-    # Verify that the Redis client SDK was shut down
-    redis_client: Any = mock_redis_client_sdk.return_value
-    redis_client.shutdown.assert_called_once()
-
-
-async def test_lifespan_redis_database_with_invalid_settings(
-    is_pdb_enabled: bool,
-):
-    async def my_app_settings(app: FastAPI) -> AsyncIterator[State]:
-        yield {"REDIS_SETTINGS": None}
-
-    app_lifespan = LifespanManager()
-    app_lifespan.add(my_app_settings)
-    app_lifespan.add(redis_client_sdk_lifespan)
-
-    app = FastAPI(lifespan=app_lifespan)
-
-    with pytest.raises(RedisConfigurationError, match="Invalid redis") as excinfo:
-        async with ASGILifespanManager(
-            app,
-            startup_timeout=None if is_pdb_enabled else 10,
-            shutdown_timeout=None if is_pdb_enabled else 10,
-        ):
-            ...
-
-    exception = excinfo.value
-    assert isinstance(exception, RedisConfigurationError)
-    assert exception.validation_error
-    assert exception.state["REDIS_SETTINGS"] is None
 
 
 async def test_configure_redis_client_sdk_publishes_client_in_app_state(

--- a/services/autoscaling/src/simcore_service_autoscaling/core/application.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/application.py
@@ -61,8 +61,8 @@ def _configure_plugins(
 
     configure_docker_client(app_lifespan)
     configure_rabbitmq_client(app_lifespan, settings=settings.AUTOSCALING_RABBITMQ)
-    configure_ec2_client(app_lifespan)
-    configure_ssm_client(app_lifespan)
+    configure_ec2_client(app_lifespan, settings=settings.AUTOSCALING_EC2_ACCESS)
+    configure_ssm_client(app_lifespan, settings=settings.AUTOSCALING_SSM_ACCESS)
     configure_redis_client(app_lifespan, settings=settings.AUTOSCALING_REDIS)
 
     if (

--- a/services/autoscaling/src/simcore_service_autoscaling/core/application.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/application.py
@@ -63,7 +63,7 @@ def _configure_plugins(
     configure_rabbitmq_client(app_lifespan)
     configure_ec2_client(app_lifespan)
     configure_ssm_client(app_lifespan)
-    configure_redis_client(app_lifespan)
+    configure_redis_client(app_lifespan, settings=settings.AUTOSCALING_REDIS)
 
     if (
         settings.AUTOSCALING_EC2_ACCESS is not None

--- a/services/autoscaling/src/simcore_service_autoscaling/core/application.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/core/application.py
@@ -60,7 +60,7 @@ def _configure_plugins(
         configure_fastapi_app_tracing(app, app_lifespan, tracing_config=tracing_config)
 
     configure_docker_client(app_lifespan)
-    configure_rabbitmq_client(app_lifespan)
+    configure_rabbitmq_client(app_lifespan, settings=settings.AUTOSCALING_RABBITMQ)
     configure_ec2_client(app_lifespan)
     configure_ssm_client(app_lifespan)
     configure_redis_client(app_lifespan, settings=settings.AUTOSCALING_REDIS)

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ec2.py
@@ -1,58 +1,33 @@
-import logging
-from collections.abc import AsyncIterator
 from typing import cast
 
 from aws_library.ec2 import SimcoreEC2API
-from aws_library.ec2._errors import EC2NotConnectedError
+from aws_library.ec2 import configure_ec2_client as _configure_ec2_client
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
 from settings_library.ec2 import EC2Settings
-from tenacity.asyncio import AsyncRetrying
-from tenacity.before_sleep import before_sleep_log
-from tenacity.stop import stop_after_delay
-from tenacity.wait import wait_random_exponential
 
 from ..core.errors import ConfigurationError
 from .instrumentation import has_instrumentation, instrument_ec2_client_methods
 
-_logger = logging.getLogger(__name__)
+
+async def _create_ec2_client(app: FastAPI, settings: EC2Settings) -> SimcoreEC2API:
+    ec2_client = await SimcoreEC2API.create(settings)
+    if not has_instrumentation(app):
+        return ec2_client
+    return instrument_ec2_client_methods(app, ec2_client)
 
 
-async def _ec2_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    app.state.ec2_client = None
-    settings: EC2Settings | None = app.state.settings.AUTOSCALING_EC2_ACCESS
-
-    if not settings:
-        _logger.warning("EC2 client is de-activated in the settings")
-        yield {}
-        return
-
-    try:
-        if has_instrumentation(app):
-            client = instrument_ec2_client_methods(app, await SimcoreEC2API.create(settings))
-        else:
-            client = await SimcoreEC2API.create(settings)
-        app.state.ec2_client = client
-
-        async for attempt in AsyncRetrying(
-            reraise=True,
-            stop=stop_after_delay(120),
-            wait=wait_random_exponential(max=30),
-            before_sleep=before_sleep_log(_logger, logging.WARNING),
-        ):
-            with attempt:
-                connected = await client.ping()
-                if not connected:
-                    raise EC2NotConnectedError  # pragma: no cover
-
-        yield {}
-    finally:
-        if app.state.ec2_client:
-            await cast(SimcoreEC2API, app.state.ec2_client).close()
-
-
-def configure_ec2_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_ec2_lifespan)
+def configure_ec2_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: EC2Settings | None,
+) -> None:
+    _configure_ec2_client(
+        app_lifespan,
+        settings=settings,
+        client_name="autoscaling",
+        client_factory=_create_ec2_client,
+    )
 
 
 def get_ec2_client(app: FastAPI) -> SimcoreEC2API:

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/rabbitmq.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/rabbitmq.py
@@ -1,13 +1,13 @@
 import contextlib
 import logging
-from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
 from models_library.rabbitmq_messages import RabbitMessageBase
+from servicelib.fastapi.rabbitmq_lifespan import configure_rabbitmq_client as _configure_rabbitmq_client
 from servicelib.logging_utils import log_catch
-from servicelib.rabbitmq import RabbitMQClient, wait_till_rabbitmq_responsive
+from servicelib.rabbitmq import RabbitMQClient
 from settings_library.rabbit import RabbitSettings
 
 from ..core.errors import ConfigurationError
@@ -15,24 +15,16 @@ from ..core.errors import ConfigurationError
 logger = logging.getLogger(__name__)
 
 
-async def _rabbitmq_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    app.state.rabbitmq_client = None
-    settings: RabbitSettings | None = app.state.settings.AUTOSCALING_RABBITMQ
-    if not settings:
-        logger.warning("Rabbit MQ client is de-activated in the settings")
-        yield {}
-        return
-    await wait_till_rabbitmq_responsive(settings.dsn)
-    app.state.rabbitmq_client = RabbitMQClient(client_name="autoscaling", settings=settings)
-    try:
-        yield {}
-    finally:
-        if app.state.rabbitmq_client:
-            await app.state.rabbitmq_client.close()
-
-
-def configure_rabbitmq_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_rabbitmq_lifespan)
+def configure_rabbitmq_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RabbitSettings | None,
+) -> None:
+    _configure_rabbitmq_client(
+        app_lifespan,
+        settings=settings,
+        client_name="autoscaling",
+    )
 
 
 def get_rabbitmq_client(app: FastAPI) -> RabbitMQClient:

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/redis.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/redis.py
@@ -1,34 +1,25 @@
-import logging
-from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
+from servicelib.fastapi.redis_lifespan import configure_redis_client_sdk
 from servicelib.redis import RedisClientSDK
 from settings_library.redis import RedisDatabase, RedisSettings
 
 from .._meta import APP_NAME
 
-logger = logging.getLogger(__name__)
 
-
-async def _redis_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    app.state.redis_client_sdk = None
-    settings: RedisSettings = app.state.settings.AUTOSCALING_REDIS
-    try:
-        redis_locks_dsn = settings.build_redis_dsn(RedisDatabase.LOCKS)
-        app.state.redis_client_sdk = RedisClientSDK(redis_locks_dsn, client_name=APP_NAME)
-        await app.state.redis_client_sdk.setup()
-
-        yield {}
-    finally:
-        redis_client_sdk: None | RedisClientSDK = app.state.redis_client_sdk
-        if redis_client_sdk:
-            await redis_client_sdk.shutdown()
-
-
-def configure_redis_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_redis_lifespan)
+def configure_redis_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RedisSettings,
+) -> None:
+    configure_redis_client_sdk(
+        app_lifespan,
+        settings=settings,
+        database=RedisDatabase.LOCKS,
+        client_name=APP_NAME,
+    )
 
 
 def get_redis_client(app: FastAPI) -> RedisClientSDK:

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/ssm.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/ssm.py
@@ -1,54 +1,24 @@
-import logging
-from collections.abc import AsyncIterator
 from typing import cast
 
 from aws_library.ssm import SimcoreSSMAPI
-from aws_library.ssm._errors import SSMNotConnectedError
+from aws_library.ssm import configure_ssm_client as _configure_ssm_client
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
 from settings_library.ssm import SSMSettings
-from tenacity.asyncio import AsyncRetrying
-from tenacity.before_sleep import before_sleep_log
-from tenacity.stop import stop_after_delay
-from tenacity.wait import wait_random_exponential
 
 from ..core.errors import ConfigurationError
-from ..core.settings import get_application_settings
-
-_logger = logging.getLogger(__name__)
 
 
-async def _ssm_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    app.state.ssm_client = None
-    settings: SSMSettings | None = get_application_settings(app).AUTOSCALING_SSM_ACCESS
-
-    if not settings:
-        _logger.warning("SSM client is de-activated in the settings")
-        yield {}
-        return
-
-    try:
-        app.state.ssm_client = client = await SimcoreSSMAPI.create(settings)
-
-        async for attempt in AsyncRetrying(
-            reraise=True,
-            stop=stop_after_delay(120),
-            wait=wait_random_exponential(max=30),
-            before_sleep=before_sleep_log(_logger, logging.WARNING),
-        ):
-            with attempt:
-                connected = await client.ping()
-                if not connected:
-                    raise SSMNotConnectedError  # pragma: no cover
-
-        yield {}
-    finally:
-        if app.state.ssm_client:
-            await cast(SimcoreSSMAPI, app.state.ssm_client).close()
-
-
-def configure_ssm_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_ssm_lifespan)
+def configure_ssm_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: SSMSettings | None,
+) -> None:
+    _configure_ssm_client(
+        app_lifespan,
+        settings=settings,
+        client_name="autoscaling",
+    )
 
 
 def get_ssm_client(app: FastAPI) -> SimcoreSSMAPI:

--- a/services/catalog/src/simcore_service_catalog/clients/rabbitmq.py
+++ b/services/catalog/src/simcore_service_catalog/clients/rabbitmq.py
@@ -1,10 +1,10 @@
 import logging
-from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
-from servicelib.rabbitmq import RabbitMQRPCClient, wait_till_rabbitmq_responsive
+from fastapi_lifespan_manager import LifespanManager
+from servicelib.fastapi.rabbitmq_lifespan import configure_rabbitmq_rpc_client
+from servicelib.rabbitmq import RabbitMQRPCClient
 from settings_library.rabbit import RabbitSettings
 
 from .._meta import PROJECT_NAME
@@ -12,29 +12,16 @@ from .._meta import PROJECT_NAME
 _logger = logging.getLogger(__name__)
 
 
-def get_rabbitmq_settings(app: FastAPI) -> RabbitSettings:
-    settings: RabbitSettings = app.state.settings.CATALOG_RABBITMQ
-    return settings
-
-
-async def rabbitmq_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    settings: RabbitSettings = get_rabbitmq_settings(app)
-    await wait_till_rabbitmq_responsive(settings.dsn)
-
-    app.state.rabbitmq_rpc_client = await RabbitMQRPCClient.create(
-        client_name=f"{PROJECT_NAME}_rpc_client", settings=settings
+def configure_rabbitmq_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RabbitSettings,
+) -> None:
+    configure_rabbitmq_rpc_client(
+        app_lifespan,
+        settings=settings,
+        client_name=f"{PROJECT_NAME}_rpc_client",
     )
-
-    try:
-        yield {}
-    finally:
-        if app.state.rabbitmq_rpc_client:
-            await app.state.rabbitmq_rpc_client.close()
-            app.state.rabbitmq_rpc_client = None
-
-
-def configure_rabbitmq_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(rabbitmq_lifespan)
 
 
 def get_rabbitmq_rpc_client(app: FastAPI) -> RabbitMQRPCClient:

--- a/services/catalog/src/simcore_service_catalog/core/application.py
+++ b/services/catalog/src/simcore_service_catalog/core/application.py
@@ -43,7 +43,7 @@ def _configure_plugins(
         settings=settings.CATALOG_POSTGRES,
     )
     configure_default_product_name(app_lifespan)
-    configure_rabbitmq_client(app_lifespan)
+    configure_rabbitmq_client(app_lifespan, settings=settings.CATALOG_RABBITMQ)
     configure_rpc_api(app_lifespan)
     configure_director(app_lifespan)
     configure_function_services(app_lifespan)

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/core/application.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/core/application.py
@@ -39,7 +39,7 @@ def _configure_plugins(
     settings: ApplicationSettings,
     tracing_config: TracingConfig,
 ) -> None:
-    configure_redis_client(app_lifespan)
+    configure_redis_client(app_lifespan, settings=settings.CLUSTERS_KEEPER_REDIS)
     configure_rabbitmq_client(app_lifespan)
     configure_ec2_client(app_lifespan)
     configure_ssm_client(app_lifespan)

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/core/application.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/core/application.py
@@ -41,8 +41,8 @@ def _configure_plugins(
 ) -> None:
     configure_redis_client(app_lifespan, settings=settings.CLUSTERS_KEEPER_REDIS)
     configure_rabbitmq_client(app_lifespan, settings=settings.CLUSTERS_KEEPER_RABBITMQ)
-    configure_ec2_client(app_lifespan)
-    configure_ssm_client(app_lifespan)
+    configure_ec2_client(app_lifespan, settings=settings.CLUSTERS_KEEPER_EC2_ACCESS)
+    configure_ssm_client(app_lifespan, settings=settings.CLUSTERS_KEEPER_SSM_ACCESS)
     configure_rpc_routes(app_lifespan)
     configure_clusters_management(app_lifespan, settings=settings)
 

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/core/application.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/core/application.py
@@ -40,7 +40,7 @@ def _configure_plugins(
     tracing_config: TracingConfig,
 ) -> None:
     configure_redis_client(app_lifespan, settings=settings.CLUSTERS_KEEPER_REDIS)
-    configure_rabbitmq_client(app_lifespan)
+    configure_rabbitmq_client(app_lifespan, settings=settings.CLUSTERS_KEEPER_RABBITMQ)
     configure_ec2_client(app_lifespan)
     configure_ssm_client(app_lifespan)
     configure_rpc_routes(app_lifespan)

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/ec2.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/ec2.py
@@ -1,55 +1,24 @@
-import logging
-from collections.abc import AsyncIterator
 from typing import cast
 
 from aws_library.ec2 import SimcoreEC2API
-from aws_library.ec2._errors import EC2NotConnectedError
+from aws_library.ec2 import configure_ec2_client as _configure_ec2_client
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
 from settings_library.ec2 import EC2Settings
-from tenacity.asyncio import AsyncRetrying
-from tenacity.before_sleep import before_sleep_log
-from tenacity.stop import stop_after_delay
-from tenacity.wait import wait_random_exponential
 
 from ..core.errors import ConfigurationError
-from ..core.settings import get_application_settings
-
-logger = logging.getLogger(__name__)
 
 
-async def _ec2_client_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    app.state.ec2_client = None
-
-    settings: EC2Settings | None = get_application_settings(app).CLUSTERS_KEEPER_EC2_ACCESS
-
-    if not settings:
-        logger.warning("EC2 client is de-activated in the settings")
-        yield {}
-        return
-
-    try:
-        app.state.ec2_client = client = await SimcoreEC2API.create(settings)
-
-        async for attempt in AsyncRetrying(
-            reraise=True,
-            stop=stop_after_delay(120),
-            wait=wait_random_exponential(max=30),
-            before_sleep=before_sleep_log(logger, logging.WARNING),
-        ):
-            with attempt:
-                connected = await client.ping()
-                if not connected:
-                    raise EC2NotConnectedError  # pragma: no cover
-
-        yield {}
-    finally:
-        if app.state.ec2_client:
-            await cast(SimcoreEC2API, app.state.ec2_client).close()
-
-
-def configure_ec2_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_ec2_client_lifespan)
+def configure_ec2_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: EC2Settings | None,
+) -> None:
+    _configure_ec2_client(
+        app_lifespan,
+        settings=settings,
+        client_name="clusters_keeper",
+    )
 
 
 def get_ec2_client(app: FastAPI) -> SimcoreEC2API:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/rabbitmq.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/rabbitmq.py
@@ -1,51 +1,41 @@
 import contextlib
 import logging
-from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
 from models_library.rabbitmq_messages import RabbitMessageBase
-from servicelib.logging_utils import log_catch
-from servicelib.rabbitmq import (
-    RabbitMQClient,
-    RabbitMQRPCClient,
-    wait_till_rabbitmq_responsive,
+from servicelib.fastapi.rabbitmq_lifespan import (
+    configure_rabbitmq_client as _configure_rabbitmq_client,
 )
+from servicelib.fastapi.rabbitmq_lifespan import (
+    configure_rabbitmq_rpc_client as _configure_rabbitmq_rpc_client,
+)
+from servicelib.logging_utils import log_catch
+from servicelib.rabbitmq import RabbitMQClient, RabbitMQRPCClient
 from settings_library.rabbit import RabbitSettings
 
 from ..core.errors import ConfigurationError
-from ..core.settings import get_application_settings
 
 logger = logging.getLogger(__name__)
 
 
-async def _rabbitmq_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    app.state.rabbitmq_client = None
-    app.state.rabbitmq_rpc_client = None
-    settings: RabbitSettings | None = get_application_settings(app).CLUSTERS_KEEPER_RABBITMQ
-    if not settings:
-        logger.warning("Rabbit MQ client is de-activated in the settings")
-        yield {}
-        return
-
-    try:
-        await wait_till_rabbitmq_responsive(settings.dsn)
-        app.state.rabbitmq_client = RabbitMQClient(client_name="clusters_keeper", settings=settings)
-        app.state.rabbitmq_rpc_client = await RabbitMQRPCClient.create(
-            client_name="clusters_keeper_rpc_client", settings=settings
-        )
-
-        yield {}
-    finally:
-        if app.state.rabbitmq_client:
-            await app.state.rabbitmq_client.close()
-        if app.state.rabbitmq_rpc_client:
-            await app.state.rabbitmq_rpc_client.close()
-
-
-def configure_rabbitmq_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_rabbitmq_lifespan)
+def configure_rabbitmq_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RabbitSettings | None,
+) -> None:
+    _configure_rabbitmq_client(
+        app_lifespan,
+        settings=settings,
+        client_name="clusters_keeper",
+    )
+    _configure_rabbitmq_rpc_client(
+        app_lifespan,
+        settings=settings,
+        client_name="clusters_keeper_rpc_client",
+        wait_for_connectivity=False,
+    )
 
 
 def get_rabbitmq_client(app: FastAPI) -> RabbitMQClient:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/redis.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/redis.py
@@ -1,37 +1,25 @@
-import logging
-from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
+from servicelib.fastapi.redis_lifespan import configure_redis_client_sdk
 from servicelib.redis import RedisClientSDK
 from settings_library.redis import RedisDatabase, RedisSettings
 
 from .._meta import APP_NAME
-from ..core.settings import get_application_settings
-
-logger = logging.getLogger(__name__)
 
 
-async def _redis_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    app.state.redis_client_sdk = None
-    settings: RedisSettings = get_application_settings(app).CLUSTERS_KEEPER_REDIS
-    redis_locks_dsn = settings.build_redis_dsn(RedisDatabase.LOCKS)
-    redis_client_sdk = app.state.redis_client_sdk = RedisClientSDK(
-        redis_locks_dsn,
+def configure_redis_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RedisSettings,
+) -> None:
+    configure_redis_client_sdk(
+        app_lifespan,
+        settings=settings,
+        database=RedisDatabase.LOCKS,
         client_name=APP_NAME,
     )
-
-    try:
-        await redis_client_sdk.setup()
-        yield {}
-    finally:
-        if redis_client_sdk:
-            await redis_client_sdk.shutdown()
-
-
-def configure_redis_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_redis_lifespan)
 
 
 def get_redis_client(app: FastAPI) -> RedisClientSDK:

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/ssm.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/ssm.py
@@ -1,54 +1,24 @@
-import logging
-from collections.abc import AsyncIterator
 from typing import cast
 
 from aws_library.ssm import SimcoreSSMAPI
-from aws_library.ssm._errors import SSMNotConnectedError
+from aws_library.ssm import configure_ssm_client as _configure_ssm_client
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
 from settings_library.ssm import SSMSettings
-from tenacity.asyncio import AsyncRetrying
-from tenacity.before_sleep import before_sleep_log
-from tenacity.stop import stop_after_delay
-from tenacity.wait import wait_random_exponential
 
 from ..core.errors import ConfigurationError
-from ..core.settings import get_application_settings
-
-_logger = logging.getLogger(__name__)
 
 
-async def _ssm_client_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    app.state.ssm_client = None
-    settings: SSMSettings | None = get_application_settings(app).CLUSTERS_KEEPER_SSM_ACCESS
-
-    if not settings:
-        _logger.warning("SSM client is de-activated in the settings")
-        yield {}
-        return
-
-    try:
-        app.state.ssm_client = client = await SimcoreSSMAPI.create(settings)
-
-        async for attempt in AsyncRetrying(
-            reraise=True,
-            stop=stop_after_delay(120),
-            wait=wait_random_exponential(max=30),
-            before_sleep=before_sleep_log(_logger, logging.WARNING),
-        ):
-            with attempt:
-                connected = await client.ping()
-                if not connected:
-                    raise SSMNotConnectedError  # pragma: no cover
-
-        yield {}
-    finally:
-        if app.state.ssm_client:
-            await cast(SimcoreSSMAPI, app.state.ssm_client).close()
-
-
-def configure_ssm_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_ssm_client_lifespan)
+def configure_ssm_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: SSMSettings | None,
+) -> None:
+    _configure_ssm_client(
+        app_lifespan,
+        settings=settings,
+        client_name="clusters_keeper",
+    )
 
 
 def get_ssm_client(app: FastAPI) -> SimcoreSSMAPI:

--- a/services/director/src/simcore_service_director/core/application.py
+++ b/services/director/src/simcore_service_director/core/application.py
@@ -43,7 +43,7 @@ def _configure_plugins(
         tracing_config=tracing_config,
     )
     if settings.DIRECTOR_REGISTRY_CACHING:
-        configure_redis_clients_manager(app_lifespan)
+        configure_redis_clients_manager(app_lifespan, settings=settings.DIRECTOR_REDIS)
 
     configure_registry_lifespans(app_lifespan)
 

--- a/services/director/src/simcore_service_director/modules/redis.py
+++ b/services/director/src/simcore_service_director/modules/redis.py
@@ -1,48 +1,38 @@
-from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
+from servicelib.fastapi.redis_lifespan import (
+    configure_redis_clients_manager as _sl_configure_redis_clients_manager,
+)
 from servicelib.redis import RedisClientsManager, RedisManagerDBConfig
-from settings_library.redis import RedisDatabase
+from settings_library.redis import RedisDatabase, RedisSettings
 
 from .._meta import APP_NAME
-from ..core.settings import ApplicationSettings, get_application_settings
-
-
-async def _redis_clients_manager_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    redis_clients_manager: RedisClientsManager | None = None
-    try:
-        settings: ApplicationSettings = get_application_settings(app)
-        redis_settings = settings.DIRECTOR_REDIS
-        if redis_settings is None:
-            msg = (
-                "DIRECTOR_REDIS_CACHE_BACKEND='redis' with DIRECTOR_REGISTRY_CACHING=True "
-                "requires DIRECTOR_REDIS settings"
-            )
-            raise RuntimeError(msg)
-        app.state.redis_clients_manager = redis_clients_manager = RedisClientsManager(
-            databases_configs={
-                RedisManagerDBConfig(database=db)
-                for db in (
-                    RedisDatabase.LOCKS,
-                    RedisDatabase.AIOCACHE,
-                )
-            },
-            settings=redis_settings,
-            client_name=APP_NAME,
-        )
-        await redis_clients_manager.setup()
-        yield {}
-    finally:
-        if redis_clients_manager is not None:
-            await redis_clients_manager.shutdown()
 
 
 def configure_redis_clients_manager(
     app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RedisSettings | None,
 ) -> None:
-    app_lifespan.add(_redis_clients_manager_lifespan)
+    if settings is None:
+        msg = (
+            "DIRECTOR_REDIS_CACHE_BACKEND='redis' with DIRECTOR_REGISTRY_CACHING=True requires DIRECTOR_REDIS settings"
+        )
+        raise RuntimeError(msg)
+    _sl_configure_redis_clients_manager(
+        app_lifespan,
+        settings=settings,
+        databases_configs={
+            RedisManagerDBConfig(database=db)
+            for db in (
+                RedisDatabase.LOCKS,
+                RedisDatabase.AIOCACHE,
+            )
+        },
+        client_name=APP_NAME,
+    )
 
 
 def get_redis_client_manager(app: FastAPI) -> RedisClientsManager:

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/core/application.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/core/application.py
@@ -60,7 +60,7 @@ def _configure_plugins(
     configure_director_v2(app_lifespan)
     configure_director_v0(app_lifespan)
     configure_catalog(app_lifespan)
-    configure_rabbitmq_client(app_lifespan)
+    configure_rabbitmq_client(app_lifespan, settings=settings.DYNAMIC_SCHEDULER_RABBITMQ)
     configure_rpc_api(app_lifespan)
     configure_redis_clients(app_lifespan, settings=settings.DYNAMIC_SCHEDULER_REDIS)
     configure_notifier(app_lifespan)

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/core/application.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/core/application.py
@@ -62,7 +62,7 @@ def _configure_plugins(
     configure_catalog(app_lifespan)
     configure_rabbitmq_client(app_lifespan)
     configure_rpc_api(app_lifespan)
-    configure_redis_clients(app_lifespan)
+    configure_redis_clients(app_lifespan, settings=settings.DYNAMIC_SCHEDULER_REDIS)
     configure_notifier(app_lifespan)
     configure_service_tracker(app_lifespan)
     configure_deferred_manager(app_lifespan)

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/rabbitmq.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/rabbitmq.py
@@ -1,35 +1,35 @@
-from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
 from models_library.rabbitmq_messages import RabbitMessageBase
-from servicelib.rabbitmq import (
-    RabbitMQClient,
-    RabbitMQRPCClient,
-    wait_till_rabbitmq_responsive,
+from servicelib.fastapi.rabbitmq_lifespan import (
+    configure_rabbitmq_client as _configure_rabbitmq_client,
 )
+from servicelib.fastapi.rabbitmq_lifespan import (
+    configure_rabbitmq_rpc_client as _configure_rabbitmq_rpc_client,
+)
+from servicelib.rabbitmq import RabbitMQClient, RabbitMQRPCClient
 from settings_library.rabbit import RabbitSettings
 
 
-async def _rabbitmq_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    settings: RabbitSettings = app.state.settings.DYNAMIC_SCHEDULER_RABBITMQ
-
-    await wait_till_rabbitmq_responsive(settings.dsn)
-
-    app.state.rabbitmq_client = RabbitMQClient(client_name="dynamic_scheduler", settings=settings)
-    app.state.rabbitmq_rpc_client = await RabbitMQRPCClient.create(
-        client_name="dynamic_scheduler_rpc_client", settings=settings
+def configure_rabbitmq_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RabbitSettings,
+) -> None:
+    _configure_rabbitmq_client(
+        app_lifespan,
+        settings=settings,
+        client_name="dynamic_scheduler",
+        wait_for_connectivity=True,
     )
-
-    yield {}
-
-    await app.state.rabbitmq_client.close()
-    await app.state.rabbitmq_rpc_client.close()
-
-
-def configure_rabbitmq_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_rabbitmq_lifespan)
+    _configure_rabbitmq_rpc_client(
+        app_lifespan,
+        settings=settings,
+        client_name="dynamic_scheduler_rpc_client",
+        wait_for_connectivity=False,
+    )
 
 
 def get_rabbitmq_client(app: FastAPI) -> RabbitMQClient:

--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/redis.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/redis.py
@@ -1,8 +1,10 @@
-from collections.abc import AsyncIterator
-from typing import Final
+from typing import Final, cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
+from servicelib.fastapi.redis_lifespan import (
+    configure_redis_clients_manager as _sl_configure_redis_clients_manager,
+)
 from servicelib.redis import RedisClientSDK, RedisClientsManager, RedisManagerDBConfig
 from settings_library.redis import RedisDatabase, RedisSettings
 
@@ -20,28 +22,24 @@ _BINARY_DBS: Final[set[RedisDatabase]] = {
 _ALL_REDIS_DATABASES: Final[set[RedisDatabase]] = _DECODE_DBS | _BINARY_DBS
 
 
-async def _redis_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    settings: RedisSettings = app.state.settings.DYNAMIC_SCHEDULER_REDIS
-
-    app.state.redis_clients_manager = manager = RedisClientsManager(
-        {RedisManagerDBConfig(database=x, decode_responses=False) for x in _BINARY_DBS}
-        | {RedisManagerDBConfig(database=x, decode_responses=True) for x in _DECODE_DBS},
-        settings,
+def configure_redis_clients(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RedisSettings,
+) -> None:
+    _sl_configure_redis_clients_manager(
+        app_lifespan,
+        settings=settings,
+        databases_configs=(
+            {RedisManagerDBConfig(database=x, decode_responses=False) for x in _BINARY_DBS}
+            | {RedisManagerDBConfig(database=x, decode_responses=True) for x in _DECODE_DBS}
+        ),
         client_name=APP_NAME,
     )
-    await manager.setup()
-
-    yield {}
-
-    await manager.shutdown()
-
-
-def configure_redis_clients(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_redis_lifespan)
 
 
 def get_redis_client(app: FastAPI, database: RedisDatabase) -> RedisClientSDK:
-    manager: RedisClientsManager = app.state.redis_clients_manager
+    manager = cast(RedisClientsManager, app.state.redis_clients_manager)
     return manager.client(database)
 
 

--- a/services/notifications/src/simcore_service_notifications/clients/rabbitmq.py
+++ b/services/notifications/src/simcore_service_notifications/clients/rabbitmq.py
@@ -1,32 +1,22 @@
-from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
-from servicelib.rabbitmq import RabbitMQRPCClient, wait_till_rabbitmq_responsive
+from fastapi_lifespan_manager import LifespanManager
+from servicelib.fastapi.rabbitmq_lifespan import configure_rabbitmq_rpc_client
+from servicelib.rabbitmq import RabbitMQRPCClient
 from settings_library.rabbit import RabbitSettings
 
-from ..core.settings import ApplicationSettings
 
-
-async def _rabbitmq_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    settings: ApplicationSettings = app.state.settings
-    rabbit_settings: RabbitSettings = settings.NOTIFICATIONS_RABBITMQ
-    app.state.rabbitmq_rpc_client = None
-
-    await wait_till_rabbitmq_responsive(rabbit_settings.dsn)
-
-    app.state.rabbitmq_rpc_client = await RabbitMQRPCClient.create(
-        client_name="notifications_rpc_client", settings=rabbit_settings
+def configure_rabbitmq_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RabbitSettings,
+) -> None:
+    configure_rabbitmq_rpc_client(
+        app_lifespan,
+        settings=settings,
+        client_name="notifications_rpc_client",
     )
-
-    yield {}
-
-    await app.state.rabbitmq_rpc_client.close()
-
-
-def configure_rabbitmq_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_rabbitmq_lifespan)
 
 
 def get_rabbitmq_rpc_client(app: FastAPI) -> RabbitMQRPCClient:

--- a/services/notifications/src/simcore_service_notifications/clients/redis.py
+++ b/services/notifications/src/simcore_service_notifications/clients/redis.py
@@ -1,35 +1,25 @@
-from collections.abc import AsyncIterator
+from typing import cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
+from fastapi_lifespan_manager import LifespanManager
+from servicelib.fastapi.redis_lifespan import configure_redis_client_sdk
 from servicelib.redis import RedisClientSDK
-from settings_library.celery import CelerySettings
-from settings_library.redis import RedisDatabase
-
-from ..core.settings import ApplicationSettings
+from settings_library.redis import RedisDatabase, RedisSettings
 
 
-async def _redis_lifespan(app: FastAPI) -> AsyncIterator[State]:
-    settings: ApplicationSettings = app.state.settings
-    assert settings.NOTIFICATIONS_CELERY is not None  # nosec
-    celery_settings: CelerySettings = settings.NOTIFICATIONS_CELERY
-
-    app.state.celery_tasks_redis_client_sdk = redis_client_sdk = RedisClientSDK(
-        celery_settings.CELERY_REDIS_RESULT_BACKEND.build_redis_dsn(RedisDatabase.CELERY_TASKS),
+def configure_redis_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RedisSettings,
+) -> None:
+    configure_redis_client_sdk(
+        app_lifespan,
+        settings=settings,
+        database=RedisDatabase.CELERY_TASKS,
         client_name="notifications_celery_tasks",
+        app_state_attr="celery_tasks_redis_client_sdk",
     )
-    await redis_client_sdk.setup()
-
-    yield {}
-
-    await redis_client_sdk.shutdown()
-
-
-def configure_redis_client(app_lifespan: LifespanManager[FastAPI]) -> None:
-    app_lifespan.add(_redis_lifespan)
 
 
 def get_redis_client(app: FastAPI) -> RedisClientSDK:
-    assert hasattr(app.state, "celery_tasks_redis_client_sdk"), "Redis client not setup for this app"  # nosec
-    assert isinstance(app.state.celery_tasks_redis_client_sdk, RedisClientSDK)  # nosec
-    return app.state.celery_tasks_redis_client_sdk
+    return cast(RedisClientSDK, app.state.celery_tasks_redis_client_sdk)

--- a/services/notifications/src/simcore_service_notifications/core/application.py
+++ b/services/notifications/src/simcore_service_notifications/core/application.py
@@ -51,7 +51,11 @@ def _configure_plugins(
         configure_rabbitmq_client(app_lifespan)
         configure_rpc_api(app_lifespan)
 
-    configure_redis_client(app_lifespan)
+    assert settings.NOTIFICATIONS_CELERY is not None  # nosec
+    configure_redis_client(
+        app_lifespan,
+        settings=settings.NOTIFICATIONS_CELERY.CELERY_REDIS_RESULT_BACKEND,
+    )
     configure_task_manager(app_lifespan)
 
     if settings.NOTIFICATIONS_PROMETHEUS_INSTRUMENTATION_ENABLED:

--- a/services/notifications/src/simcore_service_notifications/core/application.py
+++ b/services/notifications/src/simcore_service_notifications/core/application.py
@@ -48,7 +48,7 @@ def _configure_plugins(
     configure_postgres_liveness(app_lifespan)
 
     if not settings.NOTIFICATIONS_WORKER_MODE:
-        configure_rabbitmq_client(app_lifespan)
+        configure_rabbitmq_client(app_lifespan, settings=settings.NOTIFICATIONS_RABBITMQ)
         configure_rpc_api(app_lifespan)
 
     assert settings.NOTIFICATIONS_CELERY is not None  # nosec

--- a/services/storage/src/simcore_service_storage/_meta.py
+++ b/services/storage/src/simcore_service_storage/_meta.py
@@ -14,6 +14,7 @@ API_VERSION: Final[VersionStr] = info.__version__
 API_VTAG: Final[str] = info.api_prefix_path_tag
 SUMMARY: Final[str] = info.get_summary()
 APP_NAME: Final[str] = info.app_name
+APP_STARTING_BANNER_MSG: Final[str] = info.get_starting_banner()
 
 ## https://patorjk.com/software/taag/#p=display&f=Standard&t=Storage
 APP_STARTED_BANNER_MSG = r"""

--- a/services/storage/src/simcore_service_storage/core/application.py
+++ b/services/storage/src/simcore_service_storage/core/application.py
@@ -68,7 +68,7 @@ def _configure_plugins(
     configure_s3_client(app_lifespan)
 
     # Redis for caching and locks
-    configure_redis_clients(app_lifespan)
+    configure_redis_clients(app_lifespan, settings=settings.STORAGE_REDIS)
 
     # RabbitMQ for messaging
     configure_rabbitmq_client(app_lifespan)

--- a/services/storage/src/simcore_service_storage/core/application.py
+++ b/services/storage/src/simcore_service_storage/core/application.py
@@ -8,19 +8,19 @@ import logging
 from common_library.basic_types import BootModeEnum
 from fastapi import FastAPI
 from fastapi.middleware.gzip import GZipMiddleware
+from fastapi_lifespan_manager import LifespanManager
 from fastapi_pagination import add_pagination
 from servicelib.fastapi import timing_middleware
 from servicelib.fastapi.cancellation_middleware import RequestCancellationMiddleware
-from servicelib.fastapi.httpx_client import setup_httpx_client
+from servicelib.fastapi.httpx_client import configure_httpx_client
+from servicelib.fastapi.lifespan_utils import configure_app_lifespan
 from servicelib.fastapi.monitoring import (
-    setup_prometheus_instrumentation,
+    configure_prometheus_instrumentation,
 )
 from servicelib.fastapi.openapi import override_fastapi_openapi_method
 from servicelib.fastapi.profiler import ProfilerMiddleware
 from servicelib.fastapi.tracing import (
-    get_tracing_config,
-    initialize_fastapi_app_tracing,
-    setup_tracing,
+    configure_fastapi_app_tracing,
 )
 from servicelib.tracing import TracingConfig
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -31,89 +31,109 @@ from .._meta import (
     APP_FINISHED_BANNER_MSG,
     APP_NAME,
     APP_STARTED_BANNER_MSG,
+    APP_STARTING_BANNER_MSG,
     APP_WORKER_STARTED_BANNER_MSG,
 )
 from ..api.rest.routes import setup_rest_api_routes
-from ..dsm import setup_dsm
-from ..dsm_cleaner import setup_dsm_cleaner
+from ..dsm import configure_dsm_provider
+from ..dsm_cleaner import configure_dsm_cleaner
 from ..exceptions.handlers import set_exception_handlers
-from ..modules.celery import setup_task_manager
-from ..modules.db import setup_db
-from ..modules.rabbitmq import setup_rabbitmq
-from ..modules.redis import setup as setup_redis
-from ..modules.s3 import setup_s3
+from ..modules.celery import configure_celery_task_manager
+from ..modules.db import configure_db
+from ..modules.rabbitmq import configure_rabbitmq_client
+from ..modules.redis import configure_redis_clients
+from ..modules.s3 import configure_s3_client
 from .settings import ApplicationSettings
 
 _logger = logging.getLogger(__name__)
 
 
-def create_app(settings: ApplicationSettings, tracing_config: TracingConfig) -> FastAPI:  # noqa: C901
-    app = FastAPI(
-        debug=settings.SC_BOOT_MODE in {BootModeEnum.DEBUG, BootModeEnum.DEVELOPMENT, BootModeEnum.LOCAL},
-        title=APP_NAME,
-        description="Service that manages osparc storage backend",
-        version=API_VERSION,
-        openapi_url=f"/api/{API_VTAG}/openapi.json",
-        docs_url="/dev/doc",
-        redoc_url=None,  # default disabled
+def _configure_plugins(
+    app: FastAPI,
+    app_lifespan: LifespanManager,
+    settings: ApplicationSettings,
+    tracing_config: TracingConfig,
+) -> None:
+    """Configure all application plugins in the correct dependency order."""
+    # Setup httpx client lifecycle
+    configure_httpx_client(
+        app_lifespan,
+        tracing_config=tracing_config,
     )
-    override_fastapi_openapi_method(app)
-    add_pagination(app)
 
-    # STATE
-    app.state.settings = settings
-    app.state.tracing_config = tracing_config
+    # Core infrastructure: database
+    configure_db(app_lifespan)
+
+    # S3 client for storage operations
+    configure_s3_client(app_lifespan)
+
+    # Redis for caching and locks
+    configure_redis_clients(app_lifespan)
+
+    # RabbitMQ for messaging
+    configure_rabbitmq_client(app_lifespan)
+
+    # Celery task manager (depends on Redis)
+    if settings.STORAGE_CELERY:
+        configure_celery_task_manager(app_lifespan, settings.STORAGE_CELERY)
+
+    # DSM provider (data storage manager)
+    configure_dsm_provider(app_lifespan)
+
+    # DSM cleaner (depends on DSM provider and Celery)
+    if settings.STORAGE_CLEANER_INTERVAL_S and not settings.STORAGE_WORKER_MODE:
+        configure_dsm_cleaner(app_lifespan)
+
+    # Monitoring and tracing
+    if settings.STORAGE_MONITORING_ENABLED:
+        configure_prometheus_instrumentation(app, app_lifespan)
 
     if tracing_config.tracing_enabled:
-        setup_tracing(app, tracing_config)
+        configure_fastapi_app_tracing(app, app_lifespan, tracing_config=tracing_config)
 
-    setup_db(app)
-    setup_s3(app)
-    setup_httpx_client(
-        app,
-        tracing_config=get_tracing_config(app),
-    )
 
-    setup_redis(app)
-    setup_rabbitmq(app)
+def create_app(settings: ApplicationSettings, tracing_config: TracingConfig) -> FastAPI:
+    # Determine the correct startup banner based on worker mode
+    started_banner = APP_WORKER_STARTED_BANNER_MSG if settings.STORAGE_WORKER_MODE else APP_STARTED_BANNER_MSG
 
-    if settings.STORAGE_CELERY:
-        setup_task_manager(app, settings=settings.STORAGE_CELERY)
+    with configure_app_lifespan(
+        starting_banner=APP_STARTING_BANNER_MSG,
+        started_banner=started_banner,
+        shutdown_complete_banner=APP_FINISHED_BANNER_MSG,
+    ) as app_lifespan:
+        app = FastAPI(
+            debug=settings.SC_BOOT_MODE in {BootModeEnum.DEBUG, BootModeEnum.DEVELOPMENT, BootModeEnum.LOCAL},
+            title=APP_NAME,
+            description="Service that manages osparc storage backend",
+            version=API_VERSION,
+            openapi_url=f"/api/{API_VTAG}/openapi.json",
+            docs_url="/dev/doc",
+            redoc_url=None,  # default disabled
+            lifespan=app_lifespan,
+        )
+        override_fastapi_openapi_method(app)
+        add_pagination(app)
 
+        # STATE
+        app.state.settings = settings
+        app.state.tracing_config = tracing_config
+
+        # Configure all plugins in dependency order
+        _configure_plugins(app, app_lifespan, settings, tracing_config)
+
+        # Configure middleware (in reverse order due to how middleware is applied)
+        if settings.STORAGE_PROFILING:
+            app.add_middleware(ProfilerMiddleware)
+
+        if settings.SC_BOOT_MODE != BootModeEnum.PRODUCTION:
+            # middleware to time requests (ONLY for development)
+            app.add_middleware(BaseHTTPMiddleware, dispatch=timing_middleware.add_process_time_header)
+
+        app.add_middleware(GZipMiddleware)
+        app.add_middleware(RequestCancellationMiddleware)
+
+    # Setup routes and exception handlers (outside the lifespan context)
     setup_rest_api_routes(app, API_VTAG)
     set_exception_handlers(app)
-
-    setup_dsm(app)
-    if settings.STORAGE_CLEANER_INTERVAL_S and not settings.STORAGE_WORKER_MODE:
-        setup_dsm_cleaner(app)
-
-    if settings.STORAGE_PROFILING:
-        app.add_middleware(ProfilerMiddleware)
-
-    if settings.SC_BOOT_MODE != BootModeEnum.PRODUCTION:
-        # middleware to time requests (ONLY for development)
-        app.add_middleware(BaseHTTPMiddleware, dispatch=timing_middleware.add_process_time_header)
-
-    app.add_middleware(GZipMiddleware)
-
-    app.add_middleware(RequestCancellationMiddleware)
-
-    if settings.STORAGE_MONITORING_ENABLED:
-        setup_prometheus_instrumentation(app)
-
-    if tracing_config.tracing_enabled:
-        initialize_fastapi_app_tracing(app, tracing_config=tracing_config)
-
-    async def _on_startup() -> None:
-        if settings.STORAGE_WORKER_MODE:
-            print(APP_WORKER_STARTED_BANNER_MSG, flush=True)  # noqa: T201
-        else:
-            print(APP_STARTED_BANNER_MSG, flush=True)  # noqa: T201
-
-    async def _on_shutdown() -> None:
-        print(APP_FINISHED_BANNER_MSG, flush=True)  # noqa: T201
-
-    app.add_event_handler("startup", _on_startup)
-    app.add_event_handler("shutdown", _on_shutdown)
 
     return app

--- a/services/storage/src/simcore_service_storage/core/application.py
+++ b/services/storage/src/simcore_service_storage/core/application.py
@@ -71,7 +71,7 @@ def _configure_plugins(
     configure_redis_clients(app_lifespan, settings=settings.STORAGE_REDIS)
 
     # RabbitMQ for messaging
-    configure_rabbitmq_client(app_lifespan)
+    configure_rabbitmq_client(app_lifespan, settings=settings.STORAGE_RABBITMQ)
 
     # Celery task manager (depends on Redis)
     if settings.STORAGE_CELERY:

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -1,7 +1,10 @@
 import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import cast
 
 from fastapi import FastAPI
+from servicelib.fastapi.lifespan_utils import LifespanManager
 
 from .datcore_dsm import DatCoreDataManager, create_datcore_data_manager
 from .dsm_factory import DataManagerProvider
@@ -11,8 +14,12 @@ from .simcore_s3_dsm import SimcoreS3DataManager, create_simcore_s3_data_manager
 logger = logging.getLogger(__name__)
 
 
-def setup_dsm(app: FastAPI) -> None:
-    async def _on_startup() -> None:
+@asynccontextmanager
+async def _dsm_provider_lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """Lifespan context manager for DSM provider."""
+    app.state.dsm_provider = None
+
+    try:
         dsm_provider = DataManagerProvider(app=app)
         dsm_provider.register_builder(
             SimcoreS3DataManager.get_location_id(),
@@ -26,15 +33,14 @@ def setup_dsm(app: FastAPI) -> None:
         )
         app.state.dsm_provider = dsm_provider
 
-    async def _on_shutdown() -> None:
-        if app.state.dsm_provider:
-            # nothing to do
-            ...
+        yield
+    finally:
+        pass
 
-    # ------
 
-    app.add_event_handler("startup", _on_startup)
-    app.add_event_handler("shutdown", _on_shutdown)
+def configure_dsm_provider(app_lifespan: LifespanManager) -> None:
+    """Configure DSM provider lifespan."""
+    app_lifespan.add(_dsm_provider_lifespan)
 
 
 def get_dsm_provider(app: FastAPI) -> DataManagerProvider:

--- a/services/storage/src/simcore_service_storage/dsm.py
+++ b/services/storage/src/simcore_service_storage/dsm.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from typing import cast
 
 from fastapi import FastAPI
-from servicelib.fastapi.lifespan_utils import LifespanManager
+from fastapi_lifespan_manager import LifespanManager
 
 from .datcore_dsm import DatCoreDataManager, create_datcore_data_manager
 from .dsm_factory import DataManagerProvider

--- a/services/storage/src/simcore_service_storage/dsm_cleaner.py
+++ b/services/storage/src/simcore_service_storage/dsm_cleaner.py
@@ -20,12 +20,15 @@
 
 import asyncio
 import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import cast
 
 from common_library.async_tools import cancel_wait_task
 from fastapi import FastAPI
 from servicelib.background_task_utils import exclusive_periodic
+from servicelib.fastapi.lifespan_utils import LifespanManager
 from servicelib.logging_utils import log_context
 from servicelib.tracing import traced
 from settings_library.redis import RedisDatabase
@@ -50,8 +53,12 @@ async def dsm_cleaner_task(app: FastAPI) -> None:
         await simcore_s3_dsm.clean_expired_uploads()
 
 
-def setup_dsm_cleaner(app: FastAPI) -> None:
-    async def _on_startup() -> None:
+@asynccontextmanager
+async def _dsm_cleaner_lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """Lifespan context manager for DSM cleaner."""
+    app.state.dsm_cleaner_task = None
+
+    try:
         cfg = get_application_settings(app)
         assert cfg.STORAGE_CLEANER_INTERVAL_S  # nosec
 
@@ -65,9 +72,12 @@ def setup_dsm_cleaner(app: FastAPI) -> None:
 
         app.state.dsm_cleaner_task = asyncio.create_task(_periodic_dsm_clean(), name=_TASK_NAME_PERIODICALLY_CLEAN_DSM)
 
-    async def _on_shutdown() -> None:
-        assert isinstance(app.state.dsm_cleaner_task, asyncio.Task)  # nosec
-        await cancel_wait_task(app.state.dsm_cleaner_task)
+        yield
+    finally:
+        if isinstance(app.state.dsm_cleaner_task, asyncio.Task):
+            await cancel_wait_task(app.state.dsm_cleaner_task)
 
-    app.add_event_handler("startup", _on_startup)
-    app.add_event_handler("shutdown", _on_shutdown)
+
+def configure_dsm_cleaner(app_lifespan: LifespanManager) -> None:
+    """Configure DSM cleaner lifespan."""
+    app_lifespan.add(_dsm_cleaner_lifespan)

--- a/services/storage/src/simcore_service_storage/dsm_cleaner.py
+++ b/services/storage/src/simcore_service_storage/dsm_cleaner.py
@@ -27,8 +27,8 @@ from typing import cast
 
 from common_library.async_tools import cancel_wait_task
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager
 from servicelib.background_task_utils import exclusive_periodic
-from servicelib.fastapi.lifespan_utils import LifespanManager
 from servicelib.logging_utils import log_context
 from servicelib.tracing import traced
 from settings_library.redis import RedisDatabase

--- a/services/storage/src/simcore_service_storage/modules/celery/__init__.py
+++ b/services/storage/src/simcore_service_storage/modules/celery/__init__.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
 from celery_library import CeleryTaskManager
 from celery_library.app import create_app
@@ -9,6 +11,7 @@ from models_library.api_schemas_storage.storage_schemas import (
     FileUploadCompletionBody,
     FoldersBody,
 )
+from servicelib.fastapi.lifespan_utils import LifespanManager
 from servicelib.logging_utils import log_context
 from settings_library.celery import CelerySettings
 from settings_library.redis import RedisDatabase
@@ -18,8 +21,12 @@ from ..redis import get_redis_client_manager
 _logger = logging.getLogger(__name__)
 
 
-def setup_task_manager(app: FastAPI, settings: CelerySettings) -> None:
-    async def on_startup() -> None:
+@asynccontextmanager
+async def _celery_task_manager_lifespan(app: FastAPI, settings: CelerySettings) -> AsyncGenerator[None]:
+    """Lifespan context manager for Celery task manager."""
+    app.state.task_manager = None
+
+    try:
         with log_context(_logger, logging.INFO, "Setting up Celery"):
             app.state.task_manager = CeleryTaskManager(
                 create_app(settings),
@@ -30,7 +37,20 @@ def setup_task_manager(app: FastAPI, settings: CelerySettings) -> None:
             register_celery_types()
             register_pydantic_types(FileUploadCompletionBody, FoldersBody)
 
-    app.add_event_handler("startup", on_startup)
+        yield
+    finally:
+        pass
+
+
+def configure_celery_task_manager(app_lifespan: LifespanManager, settings: CelerySettings) -> None:
+    """Configure Celery task manager lifespan."""
+
+    @asynccontextmanager
+    async def _wrapped_lifespan(app: FastAPI) -> AsyncGenerator[None]:
+        async with _celery_task_manager_lifespan(app, settings):
+            yield
+
+    app_lifespan.add(_wrapped_lifespan)
 
 
 def get_task_manager_from_app(app: FastAPI) -> CeleryTaskManager:

--- a/services/storage/src/simcore_service_storage/modules/celery/__init__.py
+++ b/services/storage/src/simcore_service_storage/modules/celery/__init__.py
@@ -7,11 +7,11 @@ from celery_library.app import create_app
 from celery_library.backends import RedisTaskStore
 from celery_library.types import register_celery_types, register_pydantic_types
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager
 from models_library.api_schemas_storage.storage_schemas import (
     FileUploadCompletionBody,
     FoldersBody,
 )
-from servicelib.fastapi.lifespan_utils import LifespanManager
 from servicelib.logging_utils import log_context
 from settings_library.celery import CelerySettings
 from settings_library.redis import RedisDatabase

--- a/services/storage/src/simcore_service_storage/modules/db/__init__.py
+++ b/services/storage/src/simcore_service_storage/modules/db/__init__.py
@@ -3,8 +3,8 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager
 from servicelib.fastapi.db_asyncpg_engine import close_db_connection, connect_to_db
-from servicelib.fastapi.lifespan_utils import LifespanManager
 from servicelib.retry_policies import PostgresRetryPolicyUponInitialization
 from sqlalchemy.ext.asyncio import AsyncEngine
 from tenacity import retry

--- a/services/storage/src/simcore_service_storage/modules/db/__init__.py
+++ b/services/storage/src/simcore_service_storage/modules/db/__init__.py
@@ -1,7 +1,10 @@
 import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from servicelib.fastapi.db_asyncpg_engine import close_db_connection, connect_to_db
+from servicelib.fastapi.lifespan_utils import LifespanManager
 from servicelib.retry_policies import PostgresRetryPolicyUponInitialization
 from sqlalchemy.ext.asyncio import AsyncEngine
 from tenacity import retry
@@ -12,18 +15,27 @@ from ...core.settings import get_application_settings
 _logger = logging.getLogger(__name__)
 
 
-def setup_db(app: FastAPI) -> None:
+@asynccontextmanager
+async def _db_lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """Lifespan context manager for database connection."""
+    app.state.engine = None
+
     @retry(**PostgresRetryPolicyUponInitialization(_logger).kwargs)
-    async def _on_startup() -> None:
+    async def _setup() -> None:
         app_settings = get_application_settings(app)
         assert app_settings.STORAGE_POSTGRES is not None  # nosec
         await connect_to_db(app, app_settings.STORAGE_POSTGRES, application_name=APP_NAME)
 
-    async def _on_shutdown() -> None:
+    try:
+        await _setup()
+        yield
+    finally:
         await close_db_connection(app)
 
-    app.add_event_handler("startup", _on_startup)
-    app.add_event_handler("shutdown", _on_shutdown)
+
+def configure_db(app_lifespan: LifespanManager) -> None:
+    """Configure database lifespan."""
+    app_lifespan.add(_db_lifespan)
 
 
 def get_db_engine(app: FastAPI) -> AsyncEngine:

--- a/services/storage/src/simcore_service_storage/modules/rabbitmq.py
+++ b/services/storage/src/simcore_service_storage/modules/rabbitmq.py
@@ -1,7 +1,4 @@
 import logging
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
-from typing import cast
 
 from fastapi import FastAPI
 from fastapi_lifespan_manager import LifespanManager
@@ -14,36 +11,28 @@ from models_library.rabbitmq_messages import (
 )
 from models_library.users import UserID
 from pydantic import TypeAdapter, ValidationError
+from servicelib.fastapi.rabbitmq_lifespan import configure_rabbitmq_client as _configure_rabbitmq_client
 from servicelib.logging_utils import log_catch, log_context
 from servicelib.rabbitmq import RabbitMQClient
+from settings_library.rabbit import RabbitSettings
 
 from .._meta import APP_NAME
-from ..core.settings import get_application_settings
 
 _logger = logging.getLogger(__name__)
 
 
-@asynccontextmanager
-async def _rabbitmq_client_lifespan(app: FastAPI) -> AsyncGenerator[None]:
-    """Lifespan context manager for RabbitMQ client."""
-    app.state.rabbitmq_client = None
-
-    try:
-        settings = get_application_settings(app).STORAGE_RABBITMQ
-        app.state.rabbitmq_client = RabbitMQClient(
-            client_name=f"{APP_NAME}",
-            settings=settings,
-        )
-        yield
-    finally:
-        if app.state.rabbitmq_client:
-            await cast(RabbitMQClient, app.state.rabbitmq_client).close()
-            app.state.rabbitmq_client = None
-
-
-def configure_rabbitmq_client(app_lifespan: LifespanManager) -> None:
+def configure_rabbitmq_client(
+    app_lifespan: LifespanManager,
+    *,
+    settings: RabbitSettings,
+) -> None:
     """Configure RabbitMQ client lifespan."""
-    app_lifespan.add(_rabbitmq_client_lifespan)
+    _configure_rabbitmq_client(
+        app_lifespan,
+        settings=settings,
+        client_name=APP_NAME,
+        wait_for_connectivity=False,
+    )
 
 
 def get_rabbitmq_client(app: FastAPI) -> RabbitMQClient:

--- a/services/storage/src/simcore_service_storage/modules/rabbitmq.py
+++ b/services/storage/src/simcore_service_storage/modules/rabbitmq.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from typing import cast
 
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager
 from models_library.basic_regex import SIMCORE_S3_FILE_ID_ALLOWED_PREFIXES
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import DatCoreFileID, NodeID, StorageFileID
@@ -13,7 +14,6 @@ from models_library.rabbitmq_messages import (
 )
 from models_library.users import UserID
 from pydantic import TypeAdapter, ValidationError
-from servicelib.fastapi.lifespan_utils import LifespanManager
 from servicelib.logging_utils import log_catch, log_context
 from servicelib.rabbitmq import RabbitMQClient
 

--- a/services/storage/src/simcore_service_storage/modules/rabbitmq.py
+++ b/services/storage/src/simcore_service_storage/modules/rabbitmq.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import cast
 
 from fastapi import FastAPI
@@ -11,6 +13,7 @@ from models_library.rabbitmq_messages import (
 )
 from models_library.users import UserID
 from pydantic import TypeAdapter, ValidationError
+from servicelib.fastapi.lifespan_utils import LifespanManager
 from servicelib.logging_utils import log_catch, log_context
 from servicelib.rabbitmq import RabbitMQClient
 
@@ -20,22 +23,27 @@ from ..core.settings import get_application_settings
 _logger = logging.getLogger(__name__)
 
 
-def setup_rabbitmq(app: FastAPI) -> None:
-    async def on_startup() -> None:
+@asynccontextmanager
+async def _rabbitmq_client_lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """Lifespan context manager for RabbitMQ client."""
+    app.state.rabbitmq_client = None
+
+    try:
         settings = get_application_settings(app).STORAGE_RABBITMQ
         app.state.rabbitmq_client = RabbitMQClient(
             client_name=f"{APP_NAME}",
             settings=settings,
         )
-
-    async def on_shutdown() -> None:
+        yield
+    finally:
         if app.state.rabbitmq_client:
             await cast(RabbitMQClient, app.state.rabbitmq_client).close()
             app.state.rabbitmq_client = None
 
-    app.state.rabbitmq_client = None
-    app.add_event_handler("startup", on_startup)
-    app.add_event_handler("shutdown", on_shutdown)
+
+def configure_rabbitmq_client(app_lifespan: LifespanManager) -> None:
+    """Configure RabbitMQ client lifespan."""
+    app_lifespan.add(_rabbitmq_client_lifespan)
 
 
 def get_rabbitmq_client(app: FastAPI) -> RabbitMQClient:

--- a/services/storage/src/simcore_service_storage/modules/redis.py
+++ b/services/storage/src/simcore_service_storage/modules/redis.py
@@ -1,47 +1,31 @@
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
 from typing import cast
 
 from fastapi import FastAPI
 from fastapi_lifespan_manager import LifespanManager
+from servicelib.fastapi.redis_lifespan import configure_redis_clients_manager
 from servicelib.redis import RedisClientsManager, RedisManagerDBConfig
-from settings_library.redis import RedisDatabase
+from settings_library.redis import RedisDatabase, RedisSettings
 
 from .._meta import APP_NAME
-from ..core.settings import get_application_settings
 
 
-@asynccontextmanager
-async def _redis_clients_lifespan(app: FastAPI) -> AsyncGenerator[None]:
-    """Lifespan context manager for Redis clients."""
-    app.state.redis_clients_manager = None
-
-    try:
-        redis_settings = get_application_settings(app).STORAGE_REDIS
-
-        redis_clients_manager = RedisClientsManager(
-            databases_configs={
-                RedisManagerDBConfig(database=db)
-                for db in (
-                    RedisDatabase.LOCKS,
-                    RedisDatabase.CELERY_TASKS,
-                )
-            },
-            settings=redis_settings,
-            client_name=APP_NAME,
-        )
-        await redis_clients_manager.setup()
-        app.state.redis_clients_manager = redis_clients_manager
-
-        yield
-    finally:
-        if redis_clients_manager:
-            await redis_clients_manager.shutdown()
-
-
-def configure_redis_clients(app_lifespan: LifespanManager) -> None:
-    """Configure Redis clients lifespan."""
-    app_lifespan.add(_redis_clients_lifespan)
+def configure_redis_clients(
+    app_lifespan: LifespanManager,
+    *,
+    settings: RedisSettings,
+) -> None:
+    configure_redis_clients_manager(
+        app_lifespan,
+        settings=settings,
+        databases_configs={
+            RedisManagerDBConfig(database=db)
+            for db in (
+                RedisDatabase.LOCKS,
+                RedisDatabase.CELERY_TASKS,
+            )
+        },
+        client_name=APP_NAME,
+    )
 
 
 def get_redis_client_manager(app: FastAPI) -> RedisClientsManager:

--- a/services/storage/src/simcore_service_storage/modules/redis.py
+++ b/services/storage/src/simcore_service_storage/modules/redis.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from typing import cast
 
 from fastapi import FastAPI
-from servicelib.fastapi.lifespan_utils import LifespanManager
+from fastapi_lifespan_manager import LifespanManager
 from servicelib.redis import RedisClientsManager, RedisManagerDBConfig
 from settings_library.redis import RedisDatabase
 
@@ -35,7 +35,6 @@ async def _redis_clients_lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
         yield
     finally:
-        redis_clients_manager: RedisClientsManager = app.state.redis_clients_manager
         if redis_clients_manager:
             await redis_clients_manager.shutdown()
 

--- a/services/storage/src/simcore_service_storage/modules/redis.py
+++ b/services/storage/src/simcore_service_storage/modules/redis.py
@@ -1,6 +1,9 @@
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import cast
 
 from fastapi import FastAPI
+from servicelib.fastapi.lifespan_utils import LifespanManager
 from servicelib.redis import RedisClientsManager, RedisManagerDBConfig
 from settings_library.redis import RedisDatabase
 
@@ -8,11 +11,15 @@ from .._meta import APP_NAME
 from ..core.settings import get_application_settings
 
 
-def setup(app: FastAPI) -> None:
-    async def on_startup() -> None:
+@asynccontextmanager
+async def _redis_clients_lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """Lifespan context manager for Redis clients."""
+    app.state.redis_clients_manager = None
+
+    try:
         redis_settings = get_application_settings(app).STORAGE_REDIS
 
-        app.state.redis_clients_manager = redis_clients_manager = RedisClientsManager(
+        redis_clients_manager = RedisClientsManager(
             databases_configs={
                 RedisManagerDBConfig(database=db)
                 for db in (
@@ -24,13 +31,18 @@ def setup(app: FastAPI) -> None:
             client_name=APP_NAME,
         )
         await redis_clients_manager.setup()
+        app.state.redis_clients_manager = redis_clients_manager
 
-    async def on_shutdown() -> None:
+        yield
+    finally:
         redis_clients_manager: RedisClientsManager = app.state.redis_clients_manager
-        await redis_clients_manager.shutdown()
+        if redis_clients_manager:
+            await redis_clients_manager.shutdown()
 
-    app.add_event_handler("startup", on_startup)
-    app.add_event_handler("shutdown", on_shutdown)
+
+def configure_redis_clients(app_lifespan: LifespanManager) -> None:
+    """Configure Redis clients lifespan."""
+    app_lifespan.add(_redis_clients_lifespan)
 
 
 def get_redis_client_manager(app: FastAPI) -> RedisClientsManager:

--- a/services/storage/src/simcore_service_storage/modules/s3.py
+++ b/services/storage/src/simcore_service_storage/modules/s3.py
@@ -1,12 +1,15 @@
 """Module to access s3 service"""
 
 import logging
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import Literal, cast
 
 from aws_library.s3 import SimcoreS3API
 from common_library.json_serialization import json_dumps
 from fastapi import FastAPI
 from pydantic import TypeAdapter
+from servicelib.fastapi.lifespan_utils import LifespanManager
 from tenacity import retry, wait_random_exponential
 from tenacity.asyncio import AsyncRetrying
 from tenacity.before_sleep import before_sleep_log
@@ -41,9 +44,13 @@ async def _ensure_s3_bucket(client: SimcoreS3API, settings: ApplicationSettings)
     )
 
 
-def setup_s3(app: FastAPI) -> None:
-    async def _on_startup() -> None:
-        app.state.s3_client = None
+@asynccontextmanager
+async def _s3_client_lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """Lifespan context manager for S3 client."""
+    app.state.s3_client = None
+    client = None
+
+    try:
         settings = get_application_settings(app)
 
         async for attempt in AsyncRetrying(
@@ -66,13 +73,15 @@ def setup_s3(app: FastAPI) -> None:
         app.state.s3_client = client
 
         await _ensure_s3_bucket(client, settings)
-
-    async def _on_shutdown() -> None:
+        yield
+    finally:
         if app.state.s3_client:
             await cast(SimcoreS3API, app.state.s3_client).close()
 
-    app.add_event_handler("startup", _on_startup)
-    app.add_event_handler("shutdown", _on_shutdown)
+
+def configure_s3_client(app_lifespan: LifespanManager) -> None:
+    """Configure S3 client lifespan."""
+    app_lifespan.add(_s3_client_lifespan)
 
 
 def get_s3_client(app: FastAPI) -> SimcoreS3API:

--- a/services/storage/src/simcore_service_storage/modules/s3.py
+++ b/services/storage/src/simcore_service_storage/modules/s3.py
@@ -8,8 +8,8 @@ from typing import Literal, cast
 from aws_library.s3 import SimcoreS3API
 from common_library.json_serialization import json_dumps
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager
 from pydantic import TypeAdapter
-from servicelib.fastapi.lifespan_utils import LifespanManager
 from tenacity import retry, wait_random_exponential
 from tenacity.asyncio import AsyncRetrying
 from tenacity.before_sleep import before_sleep_log
@@ -71,7 +71,7 @@ async def _s3_client_lifespan(app: FastAPI) -> AsyncGenerator[None]:
                 )
                 assert client  # nosec
         app.state.s3_client = client
-
+        assert client  # nosec
         await _ensure_s3_bucket(client, settings)
         yield
     finally:

--- a/services/storage/tests/conftest.py
+++ b/services/storage/tests/conftest.py
@@ -176,8 +176,7 @@ async def storage_s3_bucket(app_settings: ApplicationSettings) -> str:
 
 @pytest.fixture
 async def mock_rabbit_setup(mocker: MockerFixture) -> MockerFixture:
-    mocker.patch("simcore_service_storage.core.application.setup_rabbitmq")
-    mocker.patch("simcore_service_storage.core.application.setup_rpc_api_routes")
+    mocker.patch("simcore_service_storage.modules.rabbitmq.configure_rabbitmq_client")
     return mocker
 
 

--- a/services/storage/tests/unit/test_dsm_cleaner.py
+++ b/services/storage/tests/unit/test_dsm_cleaner.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from pytest_mock import MockerFixture
 from simcore_service_storage.dsm_cleaner import _TASK_NAME_PERIODICALLY_CLEAN_DSM
 
-pytest_simcore_core_services_selection = ["postgres"]
+pytest_simcore_core_services_selection = ["postgres", "rabbit"]
 pytest_simcore_ops_services_selection = ["adminer"]
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
♻️Storage now follows lifespan pattern for application startup.


### Bonuses
♻️ :exclamation: refactors usage of redis lifespan for all lifespan-enabled fastapi services (use servicelib module everywhere instead of duplicated code in each service)
♻️ :exclamation: refactors usage of rabbitmq lifespan for all lifespan-enabled fastapi services (use servicelib module everywhere instead of duplicated code in each service)
♻️ :exclamation: refactors usage of ssm lifespan for all lifespan-enabled fastapi services (use aws-library module everywhere instead of duplicated code in each service)
♻️ :exclamation: refactors usage of ec2 lifespan for all lifespan-enabled fastapi services (use aws-library module everywhere instead of duplicated code in each service)
♻️ :skull: removed event-based httpx client code

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/4678
- relates to https://github.com/ITISFoundation/private-issues/issues/463
## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->
```bash
cd services/storage
make install-dev
make test-dev-unit
```
## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
