### PR TITLE
Fix project duplication  🐛🤖

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/utils/dags.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dags.py
@@ -119,7 +119,11 @@ async def _compute_node_states(graph_data: nx.classes.reportviews.NodeDataView, 
 
 
 def _node_needs_computation(graph_data: nx.classes.reportviews.NodeDataView, node_id: NodeID) -> bool:
-    node = graph_data[f"{node_id}"]
+    node = graph_data.get(f"{node_id}")
+    if node is None:
+        # node_id is referenced via a PortLink but is not part of this graph
+        # (e.g. dangling reference to a deleted or non-computational node)
+        return False
     needs_computation: bool = node.get(_NODE_MODIFIED_STATE, False) or node.get(_NODE_DEPENDENCIES_TO_COMPUTE, None)
     return needs_computation
 

--- a/services/director-v2/src/simcore_service_director_v2/utils/dags.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dags.py
@@ -119,12 +119,7 @@ async def _compute_node_states(graph_data: nx.classes.reportviews.NodeDataView, 
 
 
 def _node_needs_computation(graph_data: nx.classes.reportviews.NodeDataView, node_id: NodeID) -> bool:
-    node_key = f"{node_id}"
-    if node_key not in graph_data:
-        # node_id is referenced via a PortLink but is not part of this graph
-        # (e.g. dangling reference to a deleted or non-computational node)
-        return False
-    node = graph_data[node_key]
+    node = graph_data[f"{node_id}"]
     needs_computation: bool = node.get(_NODE_MODIFIED_STATE, False) or node.get(_NODE_DEPENDENCIES_TO_COMPUTE, None)
     return needs_computation
 

--- a/services/director-v2/src/simcore_service_director_v2/utils/dags.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/dags.py
@@ -119,11 +119,12 @@ async def _compute_node_states(graph_data: nx.classes.reportviews.NodeDataView, 
 
 
 def _node_needs_computation(graph_data: nx.classes.reportviews.NodeDataView, node_id: NodeID) -> bool:
-    node = graph_data.get(f"{node_id}")
-    if node is None:
+    node_key = f"{node_id}"
+    if node_key not in graph_data:
         # node_id is referenced via a PortLink but is not part of this graph
         # (e.g. dangling reference to a deleted or non-computational node)
         return False
+    node = graph_data[node_key]
     needs_computation: bool = node.get(_NODE_MODIFIED_STATE, False) or node.get(_NODE_DEPENDENCIES_TO_COMPUTE, None)
     return needs_computation
 

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
@@ -174,7 +174,7 @@ async def _copy_project_nodes_from_source_project(
         if "inputs" in node_data:
             node_data["inputs"] = _remap_port_links(node_data["inputs"], nodes_map)
         if node_data.get("input_nodes"):
-            node_data["input_nodes"] = [NodeID(nodes_map.get(str(nid), str(nid))) for nid in node_data["input_nodes"]]
+            node_data["input_nodes"] = [nodes_map.get(str(nid), str(nid)) for nid in node_data["input_nodes"]]
         new_node_id = _mapped_node_id(node)
         result[new_node_id] = ProjectNodeCreate(node_id=new_node_id, **node_data)
     return result

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
@@ -134,7 +134,7 @@ def _remap_port_links(inputs: dict | None, nodes_map: NodesMap) -> dict | None:
     """Remap PortLink node_uuid references in inputs using nodes_map (old UUID -> new UUID)."""
     if not inputs:
         return inputs
-    remapped = {}
+    remapped: dict[str, Any] = {}
     for port_key, port_value in inputs.items():
         if isinstance(port_value, dict) and "nodeUuid" in port_value:
             old_uuid = str(port_value["nodeUuid"])

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
@@ -137,11 +137,11 @@ def _remap_port_links(inputs: dict | None, nodes_map: NodesMap) -> dict | None:
     remapped: dict[str, Any] = {}
     for port_key, port_value in inputs.items():
         if isinstance(port_value, dict) and "nodeUuid" in port_value:
-            old_uuid = str(port_value["nodeUuid"])
+            old_uuid = f"{port_value['nodeUuid']}"
             new_uuid = nodes_map.get(old_uuid, old_uuid)
             remapped[port_key] = {**port_value, "nodeUuid": new_uuid}
         elif isinstance(port_value, PortLink):
-            old_uuid = str(port_value.node_uuid)
+            old_uuid = f"{port_value.node_uuid}"
             new_uuid = nodes_map.get(old_uuid, old_uuid)
             remapped[port_key] = port_value.model_copy(update={"node_uuid": NodeID(new_uuid)})
         else:
@@ -174,7 +174,7 @@ async def _copy_project_nodes_from_source_project(
         if "inputs" in node_data:
             node_data["inputs"] = _remap_port_links(node_data["inputs"], nodes_map)
         if node_data.get("input_nodes"):
-            node_data["input_nodes"] = [nodes_map.get(str(nid), str(nid)) for nid in node_data["input_nodes"]]
+            node_data["input_nodes"] = [nodes_map.get(f"{nid}", f"{nid}") for nid in node_data["input_nodes"]]
         new_node_id = _mapped_node_id(node)
         result[new_node_id] = ProjectNodeCreate(node_id=new_node_id, **node_data)
     return result

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
@@ -11,7 +11,7 @@ from models_library.api_schemas_webserver.projects import ProjectGet
 from models_library.products import ProductName
 from models_library.projects import ProjectID
 from models_library.projects_access import Owner
-from models_library.projects_nodes_io import NodeID
+from models_library.projects_nodes_io import NodeID, PortLink
 from models_library.projects_state import ProjectStatus
 from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
@@ -36,10 +36,7 @@ from ..director_v2 import director_v2_service
 from ..dynamic_scheduler import api as dynamic_scheduler_service
 from ..folders import _folders_repository as folders_folders_repository
 from ..redis import get_redis_lock_manager_client_sdk
-from ..storage.api import (
-    copy_data_folders_from_project,
-    get_project_total_size_simcore_s3,
-)
+from ..storage.api import copy_data_folders_from_project, get_project_total_size_simcore_s3
 from ..workspaces.errors import WorkspaceAccessForbiddenError
 from ..workspaces.workspaces_service import check_user_workspace_access, get_user_workspace
 from . import _folders_repository, _projects_repository, _projects_service
@@ -133,6 +130,25 @@ async def _prepare_project_copy(
 _NODE_FIELDS_TO_CLEAN_ON_COPY = {"outputs", "progress", "run_hash"}
 
 
+def _remap_port_links(inputs: dict | None, nodes_map: NodesMap) -> dict | None:
+    """Remap PortLink node_uuid references in inputs using nodes_map (old UUID -> new UUID)."""
+    if not inputs:
+        return inputs
+    remapped = {}
+    for port_key, port_value in inputs.items():
+        if isinstance(port_value, dict) and "nodeUuid" in port_value:
+            old_uuid = str(port_value["nodeUuid"])
+            new_uuid = nodes_map.get(old_uuid, old_uuid)
+            remapped[port_key] = {**port_value, "nodeUuid": new_uuid}
+        elif isinstance(port_value, PortLink):
+            old_uuid = str(port_value.node_uuid)
+            new_uuid = nodes_map.get(old_uuid, old_uuid)
+            remapped[port_key] = port_value.model_copy(update={"node_uuid": NodeID(new_uuid)})
+        else:
+            remapped[port_key] = port_value
+    return remapped
+
+
 async def _copy_project_nodes_from_source_project(
     app: web.Application,
     source_project: ProjectDict,
@@ -147,17 +163,21 @@ async def _copy_project_nodes_from_source_project(
 
     valid_fields = ProjectNodeCreate.get_field_names(exclude={"node_id"})
 
-    return {
-        _mapped_node_id(node): ProjectNodeCreate(
-            node_id=_mapped_node_id(node),
-            **{
-                k: v
-                for k, v in node.model_dump().items()
-                if k in valid_fields and not (clean_output_data and k in _NODE_FIELDS_TO_CLEAN_ON_COPY)
-            },
-        )
-        for node in await db.list_project_nodes(ProjectID(source_project["uuid"]))
-    }
+    result = {}
+    for node in await db.list_project_nodes(ProjectID(source_project["uuid"])):
+        node_data = {
+            k: v
+            for k, v in node.model_dump().items()
+            if k in valid_fields and not (clean_output_data and k in _NODE_FIELDS_TO_CLEAN_ON_COPY)
+        }
+        # Remap PortLink references in inputs and input_nodes to use new node UUIDs
+        if "inputs" in node_data:
+            node_data["inputs"] = _remap_port_links(node_data["inputs"], nodes_map)
+        if node_data.get("input_nodes"):
+            node_data["input_nodes"] = [NodeID(nodes_map.get(str(nid), str(nid))) for nid in node_data["input_nodes"]]
+        new_node_id = _mapped_node_id(node)
+        result[new_node_id] = ProjectNodeCreate(node_id=new_node_id, **node_data)
+    return result
 
 
 async def _copy_files_from_source_project(

--- a/services/web/server/tests/unit/isolated/test_projects_utils.py
+++ b/services/web/server/tests/unit/isolated/test_projects_utils.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from models_library.projects import Project
 from models_library.projects_nodes_io import NodeID
+from simcore_service_webserver.projects._crud_api_create import _remap_port_links
 from simcore_service_webserver.projects.models import ProjectDict
 from simcore_service_webserver.projects.nodes_utils import project_get_depending_nodes
 from simcore_service_webserver.projects.utils import (
@@ -139,7 +140,37 @@ def test_default_copy_project_name(original_name: str, expected_copy_suffix: str
 def test_validate_project_json_schema():
     CURRENT_DIR = Path(__file__).resolve().parent
 
-    with open(CURRENT_DIR / "data/project-data.json") as f:
+    with (CURRENT_DIR / "data/project-data.json").open() as f:
         project: ProjectDict = json.load(f)
 
     Project.model_validate(project)
+
+
+def test_remap_port_links_remaps_node_uuid():
+    old_uuid = "b4b20476-e7c0-47c2-8cc4-f66ac21a13bf"
+    new_uuid = "aaaaaaaa-0000-0000-0000-000000000001"
+    nodes_map = {old_uuid: new_uuid}
+
+    inputs = {
+        "in_1": {"nodeUuid": old_uuid, "output": "outFile"},
+        "in_2": 42,
+    }
+
+    result = _remap_port_links(inputs, nodes_map)
+    assert result is not None
+    assert result["in_1"]["nodeUuid"] == new_uuid
+    assert result["in_1"]["output"] == "outFile"
+    assert result["in_2"] == 42
+
+
+def test_remap_port_links_unknown_uuid_is_preserved():
+    unknown = "cccccccc-0000-0000-0000-000000000099"
+    inputs = {"in_1": {"nodeUuid": unknown, "output": "x"}}
+    result = _remap_port_links(inputs, nodes_map={})
+    assert result is not None
+    assert result["in_1"]["nodeUuid"] == unknown
+
+
+def test_remap_port_links_none_and_empty():
+    assert _remap_port_links(None, {}) is None
+    assert _remap_port_links({}, {}) == {}

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone.py
@@ -113,12 +113,12 @@ async def test_clone_project(
     original_node_ids = set(project["workbench"].keys())
     for new_node in cloned_project.workbench.values():
         for ref_id in new_node.input_nodes or []:
-            assert str(ref_id) not in original_node_ids, (
+            assert f"{ref_id}" not in original_node_ids, (
                 f"Cloned input_nodes still references original node ID {ref_id}"
             )
         for port_val in (new_node.inputs or {}).values():
             if isinstance(port_val, PortLink):
-                assert str(port_val.node_uuid) not in original_node_ids, (
+                assert f"{port_val.node_uuid}" not in original_node_ids, (
                     f"Cloned PortLink still references original node UUID {port_val.node_uuid}"
                 )
 

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone.py
@@ -14,11 +14,9 @@ from aiohttp.web_exceptions import HTTPNotFound
 from faker import Faker
 from models_library.api_schemas_webserver.projects import ProjectGet
 from models_library.projects import ProjectID
+from models_library.projects_nodes_io import PortLink
 from pydantic import TypeAdapter
-from pytest_simcore.helpers.webserver_parametrizations import (
-    MockedStorageSubsystem,
-    standard_role_response,
-)
+from pytest_simcore.helpers.webserver_parametrizations import MockedStorageSubsystem, standard_role_response
 from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from servicelib.aiohttp.long_running_tasks.client import long_running_task_request
@@ -69,14 +67,13 @@ async def test_clone_project_user_permissions(
     url = client.app.router["clone_project"].url_for(project_id=project["uuid"])
     assert f"/v0/projects/{project['uuid']}:clone" == url.path
 
-    try:
-        cloned_project = await _request_clone_project(client, url)
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        assert exc.status == expected.ok  # pylint: disable=no-member
-
     if expected.ok == status.HTTP_200_OK:
-        # check whether it's a clone
+        cloned_project = await _request_clone_project(client, url)
         assert ProjectID(project["uuid"]) != cloned_project.uuid
+    else:
+        with pytest.raises(ClientResponseError) as exc_info:
+            await _request_clone_project(client, url)
+        assert exc_info.value.status == expected.ok
 
 
 @pytest.mark.parametrize(
@@ -111,6 +108,19 @@ async def test_clone_project(
 
     assert len(project["workbench"]) == len(cloned_project.workbench)
     assert set(project["workbench"].keys()) != set(cloned_project.workbench.keys()), "clone does NOT preserve node ids"
+
+    # Verify PortLink references and input_nodes are remapped to new cloned node IDs
+    original_node_ids = set(project["workbench"].keys())
+    for new_node in cloned_project.workbench.values():
+        for ref_id in new_node.input_nodes or []:
+            assert str(ref_id) not in original_node_ids, (
+                f"Cloned input_nodes still references original node ID {ref_id}"
+            )
+        for port_val in (new_node.inputs or {}).values():
+            if isinstance(port_val, PortLink):
+                assert str(port_val.node_uuid) not in original_node_ids, (
+                    f"Cloned PortLink still references original node UUID {port_val.node_uuid}"
+                )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This fixes an issue that was failing the MMUX e2e / Project duplication. From our french friend:

## What do these changes do?

### What
When cloning a project, `inputs` (PortLinks) and `input_nodes` in the
`projects_nodes` table were copied verbatim — i.e. the `nodeUuid` references
still pointed to the **old** node UUIDs from the source project.

This caused director-v2 to build a DAG where a PortLink referenced a UUID that
didn't exist in the workbench, raising a `KeyError` in `dags.py` and ultimately
returning HTTP 503 on `POST /computations`.

### Root cause
Introduced by #8141 (`0d8fce40e`), which switched from reading the
`projects.workbench` JSON column (where `clone_project_document` had already
remapped all UUIDs) to reading from the `projects_nodes` table (where no
remapping was done).

### Changes
- **`_crud_api_create.py`**: Added `_remap_port_links()` helper. When copying
  nodes from source project, remap `inputs` PortLink `nodeUuid` values and
  `input_nodes` UUID list using the clone's `nodes_map` (old → new UUID).
- improved tests in services/web/server/tests/unit/with_dbs/02/test_projects_crud_handlers__clone.py to catch this in the future


## How to test
Run the mmux RSM e2e test against osparc-master: