### PR TITLE
WIP: ✨ feat: add create-admin CLI bootstrap command

### DIFF
--- a/services/web/server/Makefile
+++ b/services/web/server/Makefile
@@ -20,3 +20,11 @@ openapi-specs: ## updates and validates openapi specifications
 	$(MAKE_C) $(REPO_BASE_DIR)/api/specs/web-server all
 	# validates OAS file: $(APP_OPENAPI_RELPATH)
 	$(call validate_openapi_specs,$(APP_OPENAPI_RELPATH))
+
+
+.PHONY: create-admin
+create-admin: ## bootstraps the first ADMIN user in the running stack. Usage: make create-admin email=admin@foo.com [product=osparc]
+	@$(if $(email),,$(error Missing 'email'. Usage: make create-admin email=admin@foo.com [product=osparc]))
+	@container_id=$$(docker ps --filter "name=webserver" --filter "status=running" --format "{{.ID}}" | head -n1); \
+	if [ -z "$$container_id" ]; then echo "ERROR: no running webserver container found"; exit 1; fi; \
+	docker exec -it "$$container_id" simcore-service-webserver create-admin $(email) --product-name $(or $(product),osparc)

--- a/services/web/server/docs/DESIGN.md
+++ b/services/web/server/docs/DESIGN.md
@@ -76,6 +76,18 @@ Each domain folder follows this layout. Modules prefixed with `_` are **private*
   - Calls its own domain's service or an aggregation service; never a repository or client directly.
   - Maps domain models ⇄ transport schemas (REST/RPC).
 
+#### CLI / Entrypoints (`cli.py`)
+- **Responsibility:** a **driving adapter** — the same architectural role as a controller, but
+  driven by command-line arguments instead of HTTP. Parses args, invokes the service layer, renders output.
+- **Invariants:**
+  - Thin: contains no business logic. Like a controller, it calls its domain's service or an
+    **aggregation service**; never a repository or client directly. Cross-domain orchestration belongs
+    in an aggregation service, not in the command body.
+  - Service functions take `app: web.Application`. A command therefore builds a **minimal app context**
+    with only the plugins it needs (e.g. `setup_settings` + `setup_db`), runs the app lifespan
+    (`web.AppRunner.setup()/cleanup()`) to wire resources, then calls services.
+  - Maps domain errors ⇄ process exit codes / console output.
+
 #### Service (`_service.py` + public facade `<domain>_service.py`)
 - **Responsibility:** the domain's business logic; orchestrates repository and client calls.
 - **Invariants:**

--- a/services/web/server/src/simcore_service_webserver/cli.py
+++ b/services/web/server/src/simcore_service_webserver/cli.py
@@ -32,7 +32,7 @@ from .login import cli as login_cli
 if os.environ.get("SC_BOOT_MODE") == "debug":
     import multiprocessing
 
-    multiprocessing.set_start_method("spawn", True)
+    multiprocessing.set_start_method("spawn", force=True)
 
 _logger = logging.getLogger(__name__)
 
@@ -41,9 +41,9 @@ def _setup_app_from_settings(
     settings: ApplicationSettings,
     tracing_config: TracingConfig,
 ) -> tuple[web.Application, dict]:
-    # NOTE: keeping imports here to reduce CLI load time
-    from .application import create_application
-    from .application_settings_utils import convert_to_app_config
+    # NOTE: keeping LAZY imports here to reduce CLI load time
+    from .application import create_application  # noqa: PLC0415
+    from .application_settings_utils import convert_to_app_config  # noqa: PLC0415
 
     # NOTE: By having an equivalent config allows us
     # to keep some of the code from the previous
@@ -61,8 +61,10 @@ async def app_factory() -> web.Application:
 
     Created to launch app from gunicorn (see docker/boot.sh)
     """
-    from .application import create_application_auth
-    from .log import setup_logging
+    # NOTE: keeping LAZY imports here to reduce CLI load time
+
+    from .application import create_application_auth  # noqa: PLC0415
+    from .log import setup_logging  # noqa: PLC0415
 
     app_settings = ApplicationSettings.create_from_envs()
     tracing_config = TracingConfig.create(app_settings.WEBSERVER_TRACING, service_name=APP_NAME)
@@ -114,10 +116,24 @@ def invitations(
 
 
 @main.command()
+def create_admin(
+    email: str,
+    password: Annotated[str, typer.Option(prompt=True, hide_input=True)],
+    product_name: str = "osparc",
+):
+    """Creates an ACTIVE ADMIN user (bootstraps the first privileged user)"""
+    login_cli.create_admin(
+        email=email,
+        password=password,
+        product_name=product_name,
+    )
+
+
+@main.command()
 def run():
     """Runs web server"""
     # NOTE: keeping imports here to reduce CLI load time
-    from .application import run_service
+    from .application import run_service  # noqa: PLC0415
 
     app_settings = ApplicationSettings.create_from_envs()
     app_tracing_config = TracingConfig.create(app_settings.WEBSERVER_TRACING, service_name=APP_NAME)

--- a/services/web/server/src/simcore_service_webserver/cli.py
+++ b/services/web/server/src/simcore_service_webserver/cli.py
@@ -19,6 +19,7 @@ from typing import Annotated, Final
 
 import typer
 from aiohttp import web
+from common_library.basic_types import BootModeEnum
 from common_library.json_serialization import json_dumps
 from servicelib.tracing import TracingConfig
 from settings_library.utils_cli import create_settings_command
@@ -115,18 +116,44 @@ def invitations(
     )
 
 
-@main.command()
+def _is_devel_deployment() -> bool:
+    """Whether the service was booted in a development mode.
+
+    Reads SC_BOOT_MODE, which is injected by the docker boot stage (e.g.
+    docker-compose.devel.yml sets it to 'debug' for 'make up-devel') and is NOT
+    read from the user-editable .env file. Unknown/undefined values are treated
+    as non-development (fail-closed).
+    """
+    boot_mode = os.environ.get("SC_BOOT_MODE")
+    try:
+        return boot_mode is not None and BootModeEnum(boot_mode).is_devel_mode()
+    except ValueError:
+        return False
+
+
 def create_admin(
     email: str,
     password: Annotated[str, typer.Option(prompt=True, hide_input=True)],
     product_name: str = "osparc",
 ):
-    """Creates an ACTIVE ADMIN user (bootstraps the first privileged user)"""
+    """Creates an ACTIVE ADMIN user (bootstraps the first privileged user).
+
+    DEVELOPMENT-ONLY: this command is only registered when the service boots in a
+    development mode (SC_BOOT_MODE), and is additionally guarded at runtime. See
+    login.cli.create_admin.
+    """
     login_cli.create_admin(
         email=email,
         password=password,
         product_name=product_name,
     )
+
+
+# Bootstrap tool: only expose the command in development deployments. It is
+# additionally guarded at runtime (see login.cli.create_admin) so a direct call
+# in a production deployment fails closed.
+if _is_devel_deployment():
+    main.command()(create_admin)
 
 
 @main.command()

--- a/services/web/server/src/simcore_service_webserver/login/_account_aggregation_service.py
+++ b/services/web/server/src/simcore_service_webserver/login/_account_aggregation_service.py
@@ -1,0 +1,50 @@
+"""Aggregation service (login domain).
+
+Glues the login, groups and products domains to create a ready-to-use user
+account in a single operation. Used e.g. by the CLI to bootstrap the first
+privileged user in an empty deployment.
+"""
+
+from aiohttp import web
+from common_library.users_enums import UserRole
+from models_library.products import ProductName
+from simcore_postgres_database.models.users import UserStatus
+
+from ..groups.groups_service import (
+    auto_add_user_to_groups,
+    auto_add_user_to_product_group,
+)
+from . import _auth_service
+from .errors import UserAlreadyRegisteredError
+
+
+async def create_account(
+    app: web.Application,
+    *,
+    email: str,
+    password: str,
+    role: UserRole,
+    product_name: ProductName,
+    status_upon_creation: UserStatus = UserStatus.ACTIVE,
+) -> _auth_service.UserInfoDict:
+    """Creates a user account and wires its group and product memberships.
+
+    Raises:
+        UserAlreadyRegisteredError: if a user with this email already exists
+    """
+    if await _auth_service.get_user_or_none(app, email=email) is not None:
+        raise UserAlreadyRegisteredError(email=email)
+
+    user = await _auth_service.create_user(
+        app,
+        email=email,
+        password=password,
+        status_upon_creation=status_upon_creation,
+        expires_at=None,
+        role=role,
+    )
+
+    await auto_add_user_to_groups(app, user_id=user["id"])
+    await auto_add_user_to_product_group(app, user_id=user["id"], product_name=product_name)
+
+    return user

--- a/services/web/server/src/simcore_service_webserver/login/_auth_service.py
+++ b/services/web/server/src/simcore_service_webserver/login/_auth_service.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import TypedDict
 
 from aiohttp import web
+from common_library.users_enums import UserRole
 from servicelib.mimetype_constants import MIMETYPE_APPLICATION_JSON
 from simcore_postgres_database.models.users import UserStatus
 from simcore_postgres_database.utils_repos import transaction_context
@@ -65,6 +66,7 @@ async def create_user(
     password: str,
     status_upon_creation: UserStatus,
     expires_at: datetime | None,
+    role: UserRole = UserRole.USER,
 ) -> UserInfoDict:
     asyncpg_engine = get_asyncpg_engine(app)
     repo = UsersRepo(asyncpg_engine)
@@ -75,6 +77,7 @@ async def create_user(
             password_hash=security_service.encrypt_password(password),
             status=status_upon_creation,
             expires_at=expires_at,
+            role=role,
         )
         await repo.link_and_update_user_from_pre_registration(
             conn,

--- a/services/web/server/src/simcore_service_webserver/login/cli.py
+++ b/services/web/server/src/simcore_service_webserver/login/cli.py
@@ -1,12 +1,20 @@
+import asyncio
 import sys
 from datetime import UTC, datetime
 
 import typer
+from aiohttp import web
+from common_library.users_enums import UserRole
+from servicelib.aiohttp.application import create_safe_application
 from servicelib.utils_secrets import generate_password
 from simcore_postgres_database.models.confirmations import ConfirmationAction
 from yarl import URL
 
+from ..application_settings import setup_settings
+from ..db.plugin import setup_db
+from . import _account_aggregation_service
 from ._invitations_service import ConfirmedInvitationData, get_invitation_url
+from .errors import UserAlreadyRegisteredError
 
 
 def invitations(
@@ -66,3 +74,52 @@ def invitations(
         "-" * 100,
         fg=typer.colors.BLUE,
     )
+
+
+def _build_db_cli_app() -> web.Application:
+    """Minimal aiohttp app exposing only the postgres engine.
+
+    The login/groups/products service functions used below reach the database
+    exclusively through `get_asyncpg_engine(app)`, which is wired by `setup_db`.
+    """
+    app = create_safe_application()
+    setup_settings(app)
+    setup_db(app)
+    return app
+
+
+def create_admin(
+    email: str,
+    password: str,
+    product_name: str,
+) -> None:
+    """Creates an ACTIVE ADMIN user account.
+
+    Bootstraps the first privileged user in an empty deployment so that
+    invitations and account approvals become possible.
+    """
+
+    async def _run() -> None:
+        app = _build_db_cli_app()
+        runner = web.AppRunner(app)
+        await runner.setup()  # enters cleanup_ctx -> creates the postgres engine
+        try:
+            user = await _account_aggregation_service.create_account(
+                app,
+                email=email,
+                password=password,
+                role=UserRole.ADMIN,
+                product_name=product_name,
+            )
+            typer.secho(
+                f"Created ADMIN account id={user['id']} email={user['email']} in product '{product_name}'",
+                fg=typer.colors.GREEN,
+            )
+        finally:
+            await runner.cleanup()
+
+    try:
+        asyncio.run(_run())
+    except UserAlreadyRegisteredError as err:
+        typer.secho(f"{err}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1) from err

--- a/services/web/server/src/simcore_service_webserver/login/cli.py
+++ b/services/web/server/src/simcore_service_webserver/login/cli.py
@@ -10,7 +10,7 @@ from servicelib.utils_secrets import generate_password
 from simcore_postgres_database.models.confirmations import ConfirmationAction
 from yarl import URL
 
-from ..application_settings import setup_settings
+from ..application_settings import get_application_settings, setup_settings
 from ..db.plugin import setup_db
 from . import _account_aggregation_service
 from ._invitations_service import ConfirmedInvitationData, get_invitation_url
@@ -88,6 +88,25 @@ def _build_db_cli_app() -> web.Application:
     return app
 
 
+def _ensure_development_deployment(app: web.Application) -> None:
+    """Fail-closed guard: `create-admin` must never run in a production deployment.
+
+    The check relies on `SC_BOOT_MODE`, which is injected by the docker boot stage
+    (e.g. `docker-compose.devel.yml` sets it to `debug` for `make up-devel`) and is
+    NOT read from the user-editable `.env` file. Any non-development boot mode -- or
+    an undefined one -- is rejected.
+    """
+    boot_mode = get_application_settings(app).SC_BOOT_MODE
+    if boot_mode is None or not boot_mode.is_devel_mode():
+        typer.secho(
+            f"'create-admin' is disabled in this deployment (SC_BOOT_MODE={boot_mode}). "
+            "It is a development-only bootstrap tool (e.g. 'make build-devel up-devel').",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+
 def create_admin(
     email: str,
     password: str,
@@ -101,6 +120,7 @@ def create_admin(
 
     async def _run() -> None:
         app = _build_db_cli_app()
+        _ensure_development_deployment(app)
         runner = web.AppRunner(app)
         await runner.setup()  # enters cleanup_ctx -> creates the postgres engine
         try:

--- a/services/web/server/src/simcore_service_webserver/login/errors.py
+++ b/services/web/server/src/simcore_service_webserver/login/errors.py
@@ -14,3 +14,7 @@ class SendingVerificationEmailError(LoginError):
 
 class WrongPasswordError(LoginError):
     msg_template = "Invalid password provided for user {user_id}"
+
+
+class UserAlreadyRegisteredError(LoginError):
+    msg_template = "A user with email {email} is already registered"

--- a/services/web/server/src/simcore_service_webserver/users/_accounts_service.py
+++ b/services/web/server/src/simcore_service_webserver/users/_accounts_service.py
@@ -43,14 +43,13 @@ async def pre_register_user(
     ],
     product_name: ProductName,
 ) -> UserAccountGet:
-    found = await search_users_accounts(
-        app,
-        filter_by_email_glob=profile.email,
+    already_exists = await _accounts_repository.check_pre_registration_email_exists_in_product(
+        get_asyncpg_engine(app),
+        email=profile.email,
         product_name=product_name,
-        include_products=False,
     )
-    if found:
-        raise AlreadyPreRegisteredError(num_found=len(found), email=profile.email)
+    if already_exists:
+        raise AlreadyPreRegisteredError(num_found=1, email=profile.email)
 
     details = profile.model_dump(
         include={

--- a/services/web/server/tests/unit/isolated/test_login_cli_guards.py
+++ b/services/web/server/tests/unit/isolated/test_login_cli_guards.py
@@ -1,0 +1,66 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from types import SimpleNamespace
+
+import pytest
+import typer
+from aiohttp import web
+from common_library.basic_types import BootModeEnum
+from pytest_mock import MockerFixture
+from simcore_service_webserver import cli
+from simcore_service_webserver.login import cli as login_cli
+
+
+@pytest.mark.parametrize(
+    "boot_mode,expected",
+    [
+        (BootModeEnum.DEBUG.value, True),
+        (BootModeEnum.DEVELOPMENT.value, True),
+        (BootModeEnum.LOCAL.value, True),
+        (BootModeEnum.PRODUCTION.value, False),
+        (BootModeEnum.DEFAULT.value, False),
+        ("not-a-valid-mode", False),
+        (None, False),
+    ],
+)
+def test_is_devel_deployment(monkeypatch: pytest.MonkeyPatch, boot_mode: str | None, expected: bool):
+    if boot_mode is None:
+        monkeypatch.delenv("SC_BOOT_MODE", raising=False)
+    else:
+        monkeypatch.setenv("SC_BOOT_MODE", boot_mode)
+
+    assert cli._is_devel_deployment() is expected  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    "boot_mode",
+    [BootModeEnum.DEBUG, BootModeEnum.DEVELOPMENT, BootModeEnum.LOCAL],
+)
+def test_ensure_development_deployment_passes_in_devel(mocker: MockerFixture, boot_mode: BootModeEnum):
+    mocker.patch.object(
+        login_cli,
+        "get_application_settings",
+        return_value=SimpleNamespace(SC_BOOT_MODE=boot_mode),
+    )
+
+    # does not raise
+    login_cli._ensure_development_deployment(web.Application())  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    "boot_mode",
+    [BootModeEnum.PRODUCTION, BootModeEnum.DEFAULT, None],
+)
+def test_ensure_development_deployment_exits_otherwise(mocker: MockerFixture, boot_mode: BootModeEnum | None):
+    mocker.patch.object(
+        login_cli,
+        "get_application_settings",
+        return_value=SimpleNamespace(SC_BOOT_MODE=boot_mode),
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        login_cli._ensure_development_deployment(web.Application())  # noqa: SLF001
+
+    assert exc_info.value.exit_code == 1

--- a/services/web/server/tests/unit/with_dbs/03/login/test_login_account_aggregation.py
+++ b/services/web/server/tests/unit/with_dbs/03/login/test_login_account_aggregation.py
@@ -1,0 +1,73 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+import pytest
+from aiohttp.test_utils import TestClient
+from common_library.users_enums import UserRole, UserStatus
+from models_library.products import ProductName
+from simcore_service_webserver.groups import groups_service
+from simcore_service_webserver.login import (
+    _account_aggregation_service,
+    _auth_service,
+)
+from simcore_service_webserver.login.errors import UserAlreadyRegisteredError
+from simcore_service_webserver.products import products_service
+
+
+async def test_create_account_creates_active_admin_in_product_group(
+    client: TestClient,
+    default_product_name: ProductName,
+    user_email: str,
+    user_password: str,
+    cleanup_db_tables: None,
+):
+    assert client.app
+    app = client.app
+
+    user = await _account_aggregation_service.create_account(
+        app,
+        email=user_email,
+        password=user_password,
+        role=UserRole.ADMIN,
+        product_name=default_product_name,
+    )
+
+    created = await _auth_service.get_user_or_none(app, email=user_email)
+    assert created is not None
+    assert created["id"] == user["id"]
+    assert created["role"] == UserRole.ADMIN.value
+    assert created["status"] == UserStatus.ACTIVE.value
+
+    # is member of the product group
+    product = products_service.get_product(app, product_name=default_product_name)
+    assert product.group_id is not None
+    assert await groups_service.is_user_in_group(app, user_id=user["id"], group_id=product.group_id)
+
+
+async def test_create_account_with_existing_email_raises(
+    client: TestClient,
+    default_product_name: ProductName,
+    user_email: str,
+    user_password: str,
+    cleanup_db_tables: None,
+):
+    assert client.app
+    app = client.app
+
+    await _account_aggregation_service.create_account(
+        app,
+        email=user_email,
+        password=user_password,
+        role=UserRole.ADMIN,
+        product_name=default_product_name,
+    )
+
+    with pytest.raises(UserAlreadyRegisteredError):
+        await _account_aggregation_service.create_account(
+            app,
+            email=user_email,
+            password=user_password,
+            role=UserRole.ADMIN,
+            product_name=default_product_name,
+        )

--- a/services/web/server/tests/unit/with_dbs/03/users/test_users_accounts_service.py
+++ b/services/web/server/tests/unit/with_dbs/03/users/test_users_accounts_service.py
@@ -469,3 +469,81 @@ async def test_pre_register_user_on_second_product_after_reviewed_on_first(
                     sa.delete(users_pre_registration_details).where(users_pre_registration_details.c.pre_email == email)
                 )
                 await conn.commit()
+
+
+async def test_pre_register_existing_account_user_on_new_product(
+    app: web.Application,
+    product_name: ProductName,
+    product_owner_user: dict[str, Any],
+    asyncpg_engine: AsyncEngine,
+):
+    """A user with an existing account (row in `users`) that is pre-registered and
+    linked on product A must still be allowed to pre-register on a different product B.
+
+    Regression test for the bug where `pre_register_user`'s duplicate check relied on
+    `search_users_accounts`, whose right-outer-join query matched the registered user by
+    email regardless of `product_name`. This caused `AlreadyPreRegisteredError` to be
+    raised for product B even though no pre-registration existed there.
+    """
+    product_a = product_name
+    # Use the existing account's email so the pre-registration links to `users`
+    email = product_owner_user["email"]
+    user_id = product_owner_user["id"]
+
+    async with insert_and_get_product_lifespan(asyncpg_engine) as product_b_row:
+        product_b = ProductName(product_b_row["name"])
+
+        # 1. Pre-register the existing account on product A (auto-links user_id)
+        pre_registration_id = await create_user_pre_registration(
+            asyncpg_engine,
+            email=email,
+            created_by=user_id,
+            product_name=product_a,
+            pre_first_name="Existing",
+            pre_last_name="Account",
+            institution="Existing University",
+        )
+
+        # Sanity: the pre-registration is linked to the existing account
+        async with asyncpg_engine.connect() as conn:
+            linked_user_id = await conn.scalar(
+                sa.select(users_pre_registration_details.c.user_id).where(
+                    users_pre_registration_details.c.id == pre_registration_id
+                )
+            )
+        assert linked_user_id == user_id
+
+        # 2. Build a minimal profile for product B pre-registration
+        profile = UserAccountRestPreRegister.model_validate(
+            {
+                "firstName": "Existing",
+                "lastName": "Account",
+                "email": email,
+                "address": "1 Test St",
+                "city": "Testville",
+                "postalCode": "00000",
+                "country": "US",
+                "phone": None,
+            }
+        )
+
+        # 3. Pre-registering on product B must NOT raise AlreadyPreRegisteredError
+        try:
+            await _accounts_service.pre_register_user(
+                app,
+                profile=profile,
+                creator_user_id=user_id,
+                product_name=product_b,
+            )
+        except AlreadyPreRegisteredError:
+            pytest.fail(
+                f"pre_register_user raised AlreadyPreRegisteredError for product {product_b!r} "
+                f"even though the existing account has no pre-registration in that product"
+            )
+        finally:
+            # Clean up both rows — must run even if the test fails
+            async with asyncpg_engine.connect() as conn:
+                await conn.execute(
+                    sa.delete(users_pre_registration_details).where(users_pre_registration_details.c.pre_email == email)
+                )
+                await conn.commit()


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

Adds a `create-admin` CLI command to the web-server that mints the first `ACTIVE ADMIN` user directly via the database, solving the chicken-and-egg problem of bootstrapping a fresh deployment with no invitations or existing admin. The command is guarded by two layers keyed on `SC_BOOT_MODE` (injected by the docker boot stage, not the user-editable .env): it is only registered in the Typer CLI tree when the service boots in a development mode, and a 


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
