### PR TITLE
🐛 fix: Scope user search and group listings to current product

### DIFF
--- a/services/web/server/src/simcore_service_webserver/groups/_groups_repository.py
+++ b/services/web/server/src/simcore_service_webserver/groups/_groups_repository.py
@@ -16,7 +16,9 @@ from models_library.groups import (
     StandardGroupCreate,
     StandardGroupUpdate,
 )
+from models_library.products import ProductName
 from models_library.users import UserID, UserNameID
+from simcore_postgres_database.models.products import products
 from simcore_postgres_database.models.users import users
 from simcore_postgres_database.utils_products import get_or_create_product_group
 from simcore_postgres_database.utils_repos import pass_or_acquire_connection, transaction_context
@@ -161,14 +163,33 @@ async def get_group_by_gid(
 #
 
 
-def _list_user_groups_with_read_access_query(*group_selection, user_id: UserID):
-    return (
+def _list_user_groups_with_read_access_query(
+    *group_selection,
+    user_id: UserID,
+    product_name: ProductName | None = None,
+):
+    base_query = (
         sa.select(*group_selection, user_to_groups.c.access_rights)
         .select_from(
             user_to_groups.join(groups, user_to_groups.c.gid == groups.c.gid),
         )
         .where((user_to_groups.c.uid == user_id) & (user_to_groups.c.access_rights["read"].astext == "true"))
     )
+    if product_name is None:
+        return base_query
+
+    # Exclude standard groups that are system groups (group_id or support_standard_group_id)
+    # of a *different* product. Such groups are product-internal and must not leak across products.
+    other_product_system_gids = (
+        sa.select(products.c.group_id)
+        .where((products.c.name != product_name) & (products.c.group_id.isnot(None)))
+        .union(
+            sa.select(products.c.support_standard_group_id).where(
+                (products.c.name != product_name) & (products.c.support_standard_group_id.isnot(None))
+            )
+        )
+    )
+    return base_query.where((groups.c.type != GroupType.STANDARD) | groups.c.gid.notin_(other_product_system_gids))
 
 
 async def get_all_user_groups_with_read_access(
@@ -176,15 +197,19 @@ async def get_all_user_groups_with_read_access(
     connection: AsyncConnection | None = None,
     *,
     user_id: UserID,
+    product_name: ProductName | None = None,
 ) -> GroupsByTypeTuple:
     """
-    Returns the user primary group, standard groups and the all group
+    Returns the user primary group, standard groups and the all group.
+
+    When product_name is provided, standard groups that are system groups
+    (group_id or support_standard_group_id) of a different product are excluded.
     """
     primary_group: GroupInfoTuple | None = None
     standard_groups: list[GroupInfoTuple] = []
     everyone_group: GroupInfoTuple | None = None
 
-    query = _list_user_groups_with_read_access_query(groups, user_id=user_id)
+    query = _list_user_groups_with_read_access_query(groups, user_id=user_id, product_name=product_name)
 
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
         result = await conn.stream(query)

--- a/services/web/server/src/simcore_service_webserver/groups/_groups_repository.py
+++ b/services/web/server/src/simcore_service_webserver/groups/_groups_repository.py
@@ -178,18 +178,16 @@ def _list_user_groups_with_read_access_query(
     if product_name is None:
         return base_query
 
-    # Exclude standard groups that are system groups (group_id or support_standard_group_id)
-    # of a *different* product. Such groups are product-internal and must not leak across products.
-    other_product_system_gids = (
-        sa.select(products.c.group_id)
-        .where((products.c.name != product_name) & (products.c.group_id.isnot(None)))
-        .union(
-            sa.select(products.c.support_standard_group_id).where(
-                (products.c.name != product_name) & (products.c.support_standard_group_id.isnot(None))
-            )
+    # Exclude standard groups linked by another product row as either the
+    # product group or the product support group. These groups are
+    # product-internal and must not leak across products.
+    other_product_group_or_support_group_exists = sa.exists(
+        sa.select(sa.literal(1)).where(
+            (products.c.name != product_name)
+            & ((products.c.group_id == groups.c.gid) | (products.c.support_standard_group_id == groups.c.gid))
         )
     )
-    return base_query.where((groups.c.type != GroupType.STANDARD) | groups.c.gid.notin_(other_product_system_gids))
+    return base_query.where((groups.c.type != GroupType.STANDARD) | ~other_product_group_or_support_group_exists)
 
 
 async def get_all_user_groups_with_read_access(
@@ -202,8 +200,8 @@ async def get_all_user_groups_with_read_access(
     """
     Returns the user primary group, standard groups and the all group.
 
-    When product_name is provided, standard groups that are system groups
-    (group_id or support_standard_group_id) of a different product are excluded.
+    When product_name is provided, standard groups linked by another product
+    row as product group or product support group are excluded.
     """
     primary_group: GroupInfoTuple | None = None
     standard_groups: list[GroupInfoTuple] = []

--- a/services/web/server/src/simcore_service_webserver/groups/_groups_service.py
+++ b/services/web/server/src/simcore_service_webserver/groups/_groups_service.py
@@ -38,14 +38,24 @@ async def get_group_by_gid(app: web.Application, group_id: GroupID) -> Group | N
 #
 
 
-async def list_user_groups_with_read_access(app: web.Application, *, user_id: UserID) -> GroupsByTypeTuple:
+async def list_user_groups_with_read_access(
+    app: web.Application,
+    *,
+    user_id: UserID,
+    product_name: ProductName | None = None,
+) -> GroupsByTypeTuple:
     """
-    Returns the user primary group, standard groups and the all group
+    Returns the user primary group, standard groups and the all group.
+
+    When product_name is provided, standard groups that are system groups
+    (group_id or support_standard_group_id) of a different product are excluded.
     """
     # NOTE: Careful! It seems we are filtering out groups, such as Product Groups,
     # because they do not have read access. I believe this was done because the
     # frontend did not want to display them.
-    return await _groups_repository.get_all_user_groups_with_read_access(app, user_id=user_id)
+    return await _groups_repository.get_all_user_groups_with_read_access(
+        app, user_id=user_id, product_name=product_name
+    )
 
 
 async def list_user_groups_ids_with_read_access(app: web.Application, *, user_id: UserID) -> list[GroupID]:
@@ -91,7 +101,7 @@ async def get_user_profile_groups(
     Returns:
         Tuple of (groups_by_type, my_product_group, product_support_group)
     """
-    groups_by_type = await list_user_groups_with_read_access(app, user_id=user_id)
+    groups_by_type = await list_user_groups_with_read_access(app, user_id=user_id, product_name=product.name)
 
     my_product_group = None
     if product.group_id:  # Product group is optional

--- a/services/web/server/src/simcore_service_webserver/users/_controller/rest/users_rest.py
+++ b/services/web/server/src/simcore_service_webserver/users/_controller/rest/users_rest.py
@@ -179,6 +179,7 @@ async def search_users(request: web.Request) -> web.Response:
     found = await _users_service.search_public_users(
         request.app,
         caller_id=req_ctx.user_id,
+        product_name=req_ctx.product_name,
         match_=search_params.match_,
         limit=search_params.limit,
     )

--- a/services/web/server/src/simcore_service_webserver/users/_users_repository.py
+++ b/services/web/server/src/simcore_service_webserver/users/_users_repository.py
@@ -91,19 +91,31 @@ async def search_public_user(
     connection: AsyncConnection | None = None,
     *,
     caller_id: UserID,
+    product_name: ProductName,
     search_pattern: str,
     limit: int,
 ) -> list:
     _pattern = f"%{search_pattern}%"
 
+    # Only return users who belong to the current product's group
+    in_product_subq = (
+        sa.select(sa.literal(1))
+        .select_from(user_to_groups.join(products, products.c.group_id == user_to_groups.c.gid))
+        .where((user_to_groups.c.uid == users.c.id) & (products.c.name == product_name))
+        .exists()
+    )
+
     query = (
         sa.select(*_public_user_cols(caller_id=caller_id))
         .where(
-            (is_public(users.c.privacy_hide_username, caller_id) & users.c.name.ilike(_pattern))
-            | (is_public(users.c.privacy_hide_email, caller_id) & users.c.email.ilike(_pattern))
-            | (
-                is_public(users.c.privacy_hide_fullname, caller_id)
-                & (users.c.first_name.ilike(_pattern) | users.c.last_name.ilike(_pattern))
+            in_product_subq
+            & (
+                (is_public(users.c.privacy_hide_username, caller_id) & users.c.name.ilike(_pattern))
+                | (is_public(users.c.privacy_hide_email, caller_id) & users.c.email.ilike(_pattern))
+                | (
+                    is_public(users.c.privacy_hide_fullname, caller_id)
+                    & (users.c.first_name.ilike(_pattern) | users.c.last_name.ilike(_pattern))
+                )
             )
         )
         .limit(limit)

--- a/services/web/server/src/simcore_service_webserver/users/_users_service.py
+++ b/services/web/server/src/simcore_service_webserver/users/_users_service.py
@@ -48,10 +48,13 @@ async def get_public_user(app: web.Application, *, caller_id: UserID, user_id: U
     )
 
 
-async def search_public_users(app: web.Application, *, caller_id: UserID, match_: str, limit: int) -> list:
+async def search_public_users(
+    app: web.Application, *, caller_id: UserID, product_name: ProductName, match_: str, limit: int
+) -> list:
     return await _users_repository.search_public_user(
         get_asyncpg_engine(app),
         caller_id=caller_id,
+        product_name=product_name,
         search_pattern=match_,
         limit=limit,
     )

--- a/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_crud.py
+++ b/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_crud.py
@@ -6,20 +6,26 @@
 
 
 import operator
+from contextlib import AsyncExitStack
 
 import pytest
 from aiohttp.test_utils import TestClient
 from models_library.api_schemas_webserver.groups import GroupGet, MyGroupsGet
 from pydantic import TypeAdapter
 from pytest_simcore.helpers.assert_checks import assert_status
+from pytest_simcore.helpers.faker_factories import random_product
+from pytest_simcore.helpers.postgres_tools import insert_and_get_row_lifespan
 from pytest_simcore.helpers.webserver_parametrizations import (
     ExpectedResponse,
     standard_role_response,
 )
 from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
+from simcore_postgres_database.models.groups import groups, user_to_groups
+from simcore_postgres_database.models.products import products
 from simcore_postgres_database.models.users import UserRole
 from simcore_service_webserver._meta import API_VTAG
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 
 @pytest.mark.parametrize(*standard_role_response(), ids=str)
@@ -92,12 +98,7 @@ async def test_list_user_groups_and_try_modify_organizations(
         # try to add some user in the group
         url = client.app.router["add_group_user"].url_for(gid=f"{group['gid']}")
 
-        if i % 2 == 0:
-            # by user-id
-            params = {"uid": logged_user["id"]}
-        else:
-            # by user name
-            params = {"userName": logged_user["name"]}
+        params = {"uid": logged_user["id"]} if i % 2 == 0 else {"userName": logged_user["name"]}
 
         response = await client.post(f"{url}", json=params)
         await assert_status(response, status.HTTP_403_FORBIDDEN)
@@ -202,3 +203,81 @@ async def test_group_creation_workflow(
     _, error = await assert_status(resp, status.HTTP_404_NOT_FOUND)
 
     assert f"{group.gid}" in error["message"]
+
+
+@pytest.mark.parametrize("user_role", [UserRole.USER])
+async def test_list_user_groups_excludes_other_product_support_group(
+    client: TestClient,
+    user_role: UserRole,
+    logged_user: UserInfoDict,
+    asyncpg_engine: AsyncEngine,
+):
+    assert client.app
+    assert logged_user["role"] == user_role
+
+    async with AsyncExitStack() as stack:
+        other_product_group = await stack.enter_async_context(
+            insert_and_get_row_lifespan(
+                asyncpg_engine,
+                table=groups,
+                values={
+                    "name": "other-product-membership-group",
+                    "description": "Membership group for another product",
+                    "type": "STANDARD",
+                },
+                pk_col=groups.c.gid,
+            )
+        )
+        other_product_group_gid = other_product_group["gid"]
+
+        other_product_support_group = await stack.enter_async_context(
+            insert_and_get_row_lifespan(
+                asyncpg_engine,
+                table=groups,
+                values={
+                    "name": "other-product-support-group",
+                    "description": "Support group for another product",
+                    "type": "STANDARD",
+                },
+                pk_col=groups.c.gid,
+            )
+        )
+        other_product_support_group_gid = other_product_support_group["gid"]
+
+        await stack.enter_async_context(
+            insert_and_get_row_lifespan(
+                asyncpg_engine,
+                table=user_to_groups,
+                values={
+                    "uid": logged_user["id"],
+                    "gid": other_product_support_group_gid,
+                    "access_rights": {"read": True, "write": False, "delete": False},
+                },
+                pk_cols=[user_to_groups.c.uid, user_to_groups.c.gid],
+            )
+        )
+
+        other_product_data = random_product(
+            name="other-product",
+            priority=999,
+            group_id=other_product_group_gid,
+            support_standard_group_id=other_product_support_group_gid,
+        )
+        await stack.enter_async_context(
+            insert_and_get_row_lifespan(
+                asyncpg_engine,
+                table=products,
+                values=other_product_data,
+                pk_col=products.c.name,
+            )
+        )
+
+        # ACT
+        url = client.app.router["list_groups"].url_for()
+        response = await client.get(f"{url}")
+        data, _ = await assert_status(response, status.HTTP_200_OK)
+        my_groups = MyGroupsGet.model_validate(data)
+
+        # ASSERT
+        organization_ids = {group.gid for group in my_groups.organizations or []}
+        assert other_product_support_group_gid not in organization_ids


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

These changes make **sharing** behave consistently within the current **product**. When a user searches for a person to share with, **the frontend should only suggest sharees that belong to the same product**, and when it lists groups it should **only expose the product-relevant groups** that the user is meant to share with. 


Propagating `product_name` from the REST layer down to the query layer keeps the API scoped to the active product, avoids cross-product leakage, and matches the product-bound sharing model.

### Changed:
- `POST /v2/users:search` now only returns users that belong to the current product’s group.
- `GET /v2/groups` now threads `product_name` down into the groups service/repository so product-specific system groups from other products are excluded from the visible standard-group list.
- The product context is now propagated from REST controllers through the service layer into the repository queries, following the web-server design.


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- closes #9222 

## How to test

```
cd services/web/server/
make install-dev
pytest -vv tests/unit/with_dbs/01/groups/test_groups_handlers_crud.py
```

## Dev-ops
None

---
🤖  Assisted-by: GitHub Copilot:GPT-5.3-Codex [read_file] [run_in_terminal] [get_errors] [get_changed_files]