### PR TITLE
Treat transient storage/dask connectivity errors as retryable instead of abort pipeline

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from typing import Final
 
 import arrow
+import httpx
 import networkx as nx
 from common_library.logging.logging_errors import create_troubleshooting_log_kwargs
 from common_library.user_messages import user_message
@@ -856,15 +857,18 @@ class BaseCompScheduler(ABC):
             for task in tasks_ready_to_start:
                 comp_tasks[f"{task}"].state = RunningState.WAITING_FOR_CLUSTER
 
-        except OsparcVariableResolveTimeoutError as exc:
+        except (
+            httpx.RequestError,
+            httpx.HTTPStatusError,
+            OsparcVariableResolveTimeoutError,
+        ) as exc:
             _logger.warning(
                 **create_troubleshooting_log_kwargs(
-                    "Variable resolution timed out during task scheduling. "
+                    "Transient error during task scheduling. "
                     "Tasks are set back to WAITING_FOR_CLUSTER state and will be retried!",
                     error=exc,
                     error_context=log_error_context,
-                    tip="This is likely a transient issue. The variable resolution will be retried "
-                    "on the next scheduling cycle.",
+                    tip="This is likely a transient issue. The scheduler will retry on the next cycle.",
                 )
             )
             await publish_project_log(
@@ -872,7 +876,7 @@ class BaseCompScheduler(ABC):
                 user_id,
                 project_id,
                 log=user_message(
-                    "Variable resolution timed out during task scheduling, will retry.",
+                    "A transient error occurred during task scheduling, will retry.",
                     _version=1,
                 ),
                 log_level=logging.WARNING,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -496,6 +496,7 @@ class DaskClient:
         # process, and report when it is finished and properly cancelled.
         _logger.debug("cancelling task with %s", f"{job_id=}")
         try:
+            dask_utils.check_communication_with_scheduler_is_open(self.backend.client)
             task_future: distributed.Future = await dask_utils.wrap_client_async_routine(
                 self.backend.client.get_dataset(name=job_id)
             )
@@ -507,6 +508,8 @@ class DaskClient:
             _logger.debug("Dask task %s cancelled", task_future.key)
         except KeyError:
             _logger.warning("Unknown task cannot be aborted: %s", f"{job_id=}")
+        except AttributeError as exc:
+            raise ComputationalBackendNotConnectedError from exc
 
     async def get_task_result(self, job_id: str) -> TaskOutputData:
         _logger.debug("getting result of %s", f"{job_id=}")
@@ -533,6 +536,7 @@ class DaskClient:
     async def release_task_result(self, job_id: str) -> None:
         _logger.debug("releasing results for %s", f"{job_id=}")
         try:
+            dask_utils.check_communication_with_scheduler_is_open(self.backend.client)
             # first check if the key exists
             await dask_utils.wrap_client_async_routine(self.backend.client.get_dataset(name=job_id))
 
@@ -540,3 +544,5 @@ class DaskClient:
 
         except KeyError:
             _logger.warning("Unknown task cannot be unpublished: %s", f"{job_id=}")
+        except AttributeError as exc:
+            raise ComputationalBackendNotConnectedError from exc


### PR DESCRIPTION
… of aborting pipeline

<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
