### PR TITLE
⬆️ SQLAlchemy 2.x upgrade :champagne: 🚨 🚨

### DIFF
--- a/packages/models-library/src/models_library/functions.py
+++ b/packages/models-library/src/models_library/functions.py
@@ -426,6 +426,7 @@ class FunctionAccessRights(BaseModel):
         alias_generator=snake_to_camel,
         populate_by_name=True,
         extra="forbid",
+        from_attributes=True,
     )
 
 

--- a/packages/postgres-database/requirements/_base.txt
+++ b/packages/postgres-database/requirements/_base.txt
@@ -34,7 +34,7 @@ pydantic-core==2.33.2
     # via pydantic
 pydantic-extra-types==2.11.1
     # via -r requirements/../../../packages/common-library/requirements/_base.in
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_base.in
@@ -45,6 +45,7 @@ typing-extensions==4.15.0
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic

--- a/packages/postgres-database/requirements/_migration.txt
+++ b/packages/postgres-database/requirements/_migration.txt
@@ -31,7 +31,7 @@ markupsafe==3.0.3
     #   mako
 requests==2.32.5
     # via docker
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
@@ -42,6 +42,7 @@ typing-extensions==4.15.0
     # via
     #   -c requirements/_base.txt
     #   alembic
+    #   sqlalchemy
 urllib3==2.7.0
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/packages/postgres-database/requirements/_test.txt
+++ b/packages/postgres-database/requirements/_test.txt
@@ -67,14 +67,12 @@ pyyaml==6.0.3
     #   -r requirements/_test.in
 six==1.17.0
     # via python-dateutil
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -c requirements/_migration.txt
     #   -r requirements/_test.in
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 types-docker==7.1.0.20260109
     # via -r requirements/_test.in
 types-paramiko==4.0.0.20250822
@@ -88,7 +86,7 @@ typing-extensions==4.15.0
     #   -c requirements/_base.txt
     #   -c requirements/_migration.txt
     #   mypy
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 tzdata==2025.3
     # via arrow
 urllib3==2.7.0

--- a/packages/postgres-database/src/simcore_postgres_database/migration/env.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/env.py
@@ -1,4 +1,5 @@
 from logging.config import fileConfig
+from typing import Any, cast
 
 from alembic import context
 from simcore_postgres_database.settings import target_metadatas
@@ -23,7 +24,7 @@ target_metadata = target_metadatas
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
+# my_important_option = config.get_main_option("my_important_option")  # noqa: ERA001
 # ... etc.
 
 
@@ -55,8 +56,10 @@ def run_migrations_online():
 
     """
     # pylint: disable=no-member
+    section = config.get_section(config.config_ini_section)
+    assert section is not None  # nosec
     connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
+        cast(dict[str, Any], section),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/10b293fdcd56_alters_product_login_settings.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/10b293fdcd56_alters_product_login_settings.py
@@ -22,18 +22,15 @@ depends_on = None
 def upgrade():
     # Reassign items from two_factor_enabled -> LOGIN_2FA_REQUIRED
     conn = op.get_bind()
-    rows = conn.execute(sa.DDL("SELECT name, login_settings FROM products")).fetchall()
+    rows = conn.execute(sa.text("SELECT name, login_settings FROM products")).mappings().all()
     for row in rows:
         data = row["login_settings"] or {}
         if "two_factor_enabled" in data:
             data["LOGIN_2FA_REQUIRED"] = data.pop("two_factor_enabled")
             data = json.dumps(data)
             conn.execute(
-                sa.DDL(
-                    "UPDATE products SET login_settings = '{}' WHERE name = '{}'".format(  # nosec
-                        data, row["name"]
-                    )
-                )
+                sa.text("UPDATE products SET login_settings = CAST(:login_settings AS jsonb) WHERE name = :name"),
+                {"login_settings": data, "name": row["name"]},
             )
 
     # change to nullable=True and remove the server default to
@@ -48,17 +45,14 @@ def upgrade():
 def downgrade():
     # Reassign items from LOGIN_2FA_REQUIRED -> two_factor_enabled=false
     conn = op.get_bind()
-    rows = conn.execute(sa.DDL("SELECT name, login_settings FROM products")).fetchall()
+    rows = conn.execute(sa.text("SELECT name, login_settings FROM products")).mappings().all()
     for row in rows:
         data = row["login_settings"] or {}
         data["two_factor_enabled"] = data.pop("LOGIN_2FA_REQUIRED", False)  # back to default
         data = json.dumps(data)
         conn.execute(
-            sa.DDL(
-                "UPDATE products SET login_settings = '{}' WHERE name = '{}'".format(  # nosec
-                    data, row["name"]
-                )
-            )
+            sa.text("UPDATE products SET login_settings = CAST(:login_settings AS jsonb) WHERE name = :name"),
+            {"login_settings": data, "name": row["name"]},
         )
 
     # revert to nullable=False and add default

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/5679165336c8_new_users_secrets.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/5679165336c8_new_users_secrets.py
@@ -71,6 +71,18 @@ def downgrade():
         )
     )
 
+    # users created without local credentials have no users_secrets row.
+    # Backfill a non-empty placeholder before restoring the legacy NOT NULL column.
+    op.execute(
+        sa.DDL(
+            """
+        UPDATE users
+        SET password_hash = '__MIGRATED_NO_PASSWORD__'
+        WHERE password_hash IS NULL
+    """
+        )
+    )
+
     # Now make the column NOT NULL
     op.alter_column("users", "password_hash", nullable=False)
 

--- a/packages/postgres-database/src/simcore_postgres_database/utils.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils.py
@@ -76,6 +76,6 @@ def hide_dict_pass(data: dict) -> dict:
 def as_postgres_sql_query_str(statement) -> str:
     compiled = statement.compile(
         compile_kwargs={"literal_binds": True},
-        dialect=postgresql.dialect(),  # type: ignore[misc]
+        dialect=postgresql.dialect(),
     )
     return f"{compiled}"

--- a/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 
 
 type PaymentID = str
-PaymentTransactionRow: TypeAlias = Row  # this is used in isintance calls. so it cannot be a type alias  # noqa: UP040
+PaymentTransactionRow: TypeAlias = Row  # used in isinstance(...) checks; keep as a runtime class alias (do not convert to a PEP 695 `type ... = ...` alias)  # noqa: UP040
 
 
 UNSET: Final[str] = "__UNSET__"

--- a/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Final, TypeAlias
+from typing import Final
 
 import sqlalchemy as sa
 import sqlalchemy.exc
@@ -14,8 +14,8 @@ from .models.payments_transactions import PaymentTransactionState, payments_tran
 _logger = logging.getLogger(__name__)
 
 
-PaymentID: TypeAlias = str
-PaymentTransactionRow: TypeAlias = Row
+type PaymentID = str
+type PaymentTransactionRow = Row
 
 
 UNSET: Final[str] = "__UNSET__"
@@ -157,5 +157,5 @@ async def get_user_payments_transactions(
         stmt = stmt.limit(limit)
 
     result = await connection.execute(stmt)
-    rows = result.fetchall()
+    rows = list(result.fetchall())
     return total_number_of_items, rows

--- a/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_payments.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Final
+from typing import Final, TypeAlias
 
 import sqlalchemy as sa
 import sqlalchemy.exc
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 
 
 type PaymentID = str
-type PaymentTransactionRow = Row
+PaymentTransactionRow: TypeAlias = Row  # this is used in isintance calls. so it cannot be a type alias  # noqa: UP040
 
 
 UNSET: Final[str] = "__UNSET__"

--- a/packages/postgres-database/src/simcore_postgres_database/utils_projects_metadata.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_projects_metadata.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 import sqlalchemy.exc as sa_exc
 from common_library.errors_classes import OsparcErrorMixin
 from pydantic import BaseModel, ConfigDict
+from sqlalchemy.dialects.postgresql import Insert as PostgresInsert
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncConnection
 
@@ -177,8 +178,8 @@ async def set_project_ancestors(
         "root_parent_project_uuid": (f"{root_parent_project_uuid}" if root_parent_project_uuid is not None else None),
         "root_parent_node_id": (f"{root_parent_node_id}" if root_parent_node_id is not None else None),
     }
-    insert_stmt = pg_insert(projects_metadata).values(**data)
-    upsert_stmt = insert_stmt.on_conflict_do_update(
+    insert_stmt: PostgresInsert = pg_insert(projects_metadata).values(**data)
+    upsert_stmt: Any = insert_stmt.on_conflict_do_update(
         index_elements=[projects_metadata.c.project_uuid],
         set_=data,
     ).returning(sa.literal_column("*"))
@@ -225,8 +226,8 @@ async def set_project_custom_metadata(
         "project_uuid": f"{project_uuid}",
         "custom": custom_metadata,
     }
-    insert_stmt = pg_insert(projects_metadata).values(**data)
-    upsert_stmt = insert_stmt.on_conflict_do_update(
+    insert_stmt: PostgresInsert = pg_insert(projects_metadata).values(**data)
+    upsert_stmt: Any = insert_stmt.on_conflict_do_update(
         index_elements=[projects_metadata.c.project_uuid],
         set_=data,
     ).returning(sa.literal_column("*"))

--- a/packages/postgres-database/src/simcore_postgres_database/utils_tags_sql.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_tags_sql.py
@@ -145,13 +145,18 @@ def update_tag_stmt(*, user_id: int, tag_id: int, **updates):
 
 
 def delete_tag_stmt(*, user_id: int, tag_id: int):
-    return (
-        tags.delete()
-        .where(tags.c.id == tag_id)
+    user_can_delete_tag = sa.exists(
+        sa.select(sa.literal(1))
+        .select_from(
+            tags_access_rights.join(
+                user_to_groups,
+                (tags_access_rights.c.group_id == user_to_groups.c.gid) & (user_to_groups.c.uid == user_id),
+            )
+        )
         .where((tags_access_rights.c.tag_id == tag_id) & (tags_access_rights.c.delete.is_(True)))
-        .where((tags_access_rights.c.group_id == user_to_groups.c.gid) & (user_to_groups.c.uid == user_id))
-        .returning(tags_access_rights.c.delete)
     )
+
+    return tags.delete().where(tags.c.id == tag_id).where(user_can_delete_tag).returning(tags.c.id)
 
 
 #

--- a/packages/postgres-database/src/simcore_postgres_database/utils_user_preferences.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_user_preferences.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import Insert as PostgresInsert
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncConnection
 
@@ -33,8 +34,8 @@ class BasePreferencesRepo:
             "payload": payload,
         }
 
-        insert_stmt = pg_insert(cls.model).values(**data)
-        upsert_stmt = insert_stmt.on_conflict_do_update(
+        insert_stmt: PostgresInsert = pg_insert(cls.model).values(**data)
+        upsert_stmt: Any = insert_stmt.on_conflict_do_update(
             index_elements=[
                 cls.model.c.user_id,
                 cls.model.c.product_name,

--- a/packages/postgres-database/src/simcore_postgres_database/utils_users.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_users.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from common_library.users_enums import AccountRequestStatus
 from sqlalchemy import Column
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.engine.result import Row
+from sqlalchemy.engine import Row
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio.engine import AsyncConnection, AsyncEngine
 from sqlalchemy.sql import Select

--- a/packages/postgres-database/tests/conftest.py
+++ b/packages/postgres-database/tests/conftest.py
@@ -6,6 +6,7 @@
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator
 from pathlib import Path
+from urllib.parse import quote_plus
 
 import pytest
 import simcore_postgres_database.cli
@@ -49,9 +50,11 @@ def postgres_service(docker_services, docker_ip, docker_compose_file) -> str:
         config = yaml.safe_load(fh)
     environ = config["services"]["postgres"]["environment"]
 
-    dsn = "postgresql://{user}:{password}@{host}:{port}/{database}".format(
-        user=environ["POSTGRES_USER"],
-        password=environ["POSTGRES_PASSWORD"],
+    user = quote_plus(environ["POSTGRES_USER"])
+    password = quote_plus(environ["POSTGRES_PASSWORD"])
+    dsn = "postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}".format(
+        user=user,
+        password=password,
         host=docker_ip,
         port=docker_services.port_for("postgres", 5432),
         database=environ["POSTGRES_DB"],
@@ -76,7 +79,7 @@ def sync_engine(postgres_service: str) -> Iterable[sqlalchemy.engine.Engine]:
 @pytest.fixture
 def _make_asyncpg_engine(postgres_service: str) -> Callable[[bool], AsyncEngine]:
     # NOTE: users is responsible of `await engine.dispose()`
-    dsn = postgres_service.replace("postgresql://", "postgresql+asyncpg://")
+    dsn = postgres_service.replace("postgresql+psycopg2://", "postgresql+asyncpg://")
     minsize = 2
     maxsize = 50
 

--- a/packages/postgres-database/tests/test_models_projects_to_jobs.py
+++ b/packages/postgres-database/tests/test_models_projects_to_jobs.py
@@ -84,6 +84,7 @@ def test_populate_projects_to_jobs_during_migration(sync_engine: sqlalchemy.engi
         with pytest.raises(sqlalchemy.exc.ProgrammingError) as exc_info:
             conn.execute(sa.select(sa.func.count()).select_from(projects_to_jobs)).scalar()
         assert "psycopg2.errors.UndefinedTable" in f"{exc_info.value}"
+        conn.rollback()
 
         # INSERT data (emulates data in-place)
         user_data = random_user(
@@ -146,7 +147,7 @@ def test_populate_projects_to_jobs_during_migration(sync_engine: sqlalchemy.engi
                     "inputs_checksum": "015ba4cd5cf00c511a8217deb65c242e3b15dc6ae4b1ecf94982d693887d9e8a",
                     "created_at": "2025-01-27T13:12:58.676564Z"
                     }
-                    """
+                    """  # noqa: E501
                 ),
                 prj_owner=user_id,
             ),
@@ -202,6 +203,8 @@ def test_populate_projects_to_jobs_during_migration(sync_engine: sqlalchemy.engi
                 """
             ).bindparams(project_uuid=prj_prepared["uuid"], product_name=product_name)
             conn.execute(stmt)
+
+        conn.commit()
 
     # MIGRATE UPGRADE: this should populate
     simcore_postgres_database.cli.upgrade.callback("head")

--- a/packages/postgres-database/tests/test_users.py
+++ b/packages/postgres-database/tests/test_users.py
@@ -135,7 +135,7 @@ async def test_new_user(asyncpg_engine: AsyncEngine, faker: Faker, clean_users_d
         "email": faker.email(),
         "password_hash": "foo",
         "status": UserStatus.ACTIVE,
-        "expires_at": datetime.now(tz=UTC),
+        "expires_at": datetime.utcnow(),  # noqa: DTZ003
     }
     repo = UsersRepo(asyncpg_engine)
     new_user = await repo.new_user(**data)
@@ -162,7 +162,7 @@ async def test_trial_accounts(asyncpg_engine: AsyncEngine, clean_users_db_table:
     EXPIRATION_INTERVAL = timedelta(minutes=5)
 
     # creates trial user
-    client_now = datetime.now(tz=UTC)
+    client_now = datetime.utcnow()  # noqa: DTZ003
     async with transaction_context(asyncpg_engine) as connection:
         user_id: int | None = await connection.scalar(
             users.insert()

--- a/packages/postgres-database/tests/test_users.py
+++ b/packages/postgres-database/tests/test_users.py
@@ -6,7 +6,7 @@
 
 import json
 from collections.abc import Iterator
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import simcore_postgres_database.cli
@@ -545,7 +545,7 @@ def test_pre_registration_reconciliation_migration_upgrade_downgrade(  # noqa: P
                 "pre_email": "rejected@example.com",
                 "status": "REJECTED",
                 "reviewed_by": po_user_id,
-                "reviewed_at": datetime.utcnow(),  # noqa: DTZ003
+                "reviewed_at": datetime.now(tz=UTC),
                 "product_name": "osparc",
                 "created_by": po_user_id,
                 "extras": "{}",
@@ -560,7 +560,7 @@ def test_pre_registration_reconciliation_migration_upgrade_downgrade(  # noqa: P
                 "pre_email": "approved@example.com",
                 "status": "APPROVED",
                 "reviewed_by": po_user_id,
-                "reviewed_at": datetime.utcnow(),  # noqa: DTZ003
+                "reviewed_at": datetime.now(tz=UTC),
                 "product_name": "osparc",
                 "created_by": po_user_id,
                 "extras": "{}",

--- a/packages/postgres-database/tests/test_users.py
+++ b/packages/postgres-database/tests/test_users.py
@@ -247,6 +247,7 @@ def test_users_secrets_migration_upgrade_downgrade(sync_engine_with_migration: s
         with pytest.raises(sqlalchemy.exc.ProgrammingError) as exc_info:
             conn.execute(sa.select(sa.func.count()).select_from(sa.table("users_secrets"))).scalar()
         assert "psycopg2.errors.UndefinedTable" in f"{exc_info.value}"
+        conn.rollback()
 
         # INSERT users with password hashes (emulates data in-place before migration)
         users_data_with_hashed_password = [
@@ -294,6 +295,7 @@ def test_users_secrets_migration_upgrade_downgrade(sync_engine_with_migration: s
         assert len(password_hashes_before) == 2
         assert password_hashes_before[inserted_user_ids[0]] == "hashed_password_1"
         assert password_hashes_before[inserted_user_ids[1]] == "hashed_password_2"
+        conn.commit()
 
     # MIGRATE UPGRADE: this should move password hashes to users_secrets
     # packages/postgres-database/src/simcore_postgres_database/migration/versions/5679165336c8_new_users_secrets.py
@@ -313,6 +315,7 @@ def test_users_secrets_migration_upgrade_downgrade(sync_engine_with_migration: s
         with pytest.raises(sqlalchemy.exc.ProgrammingError) as exc_info:
             conn.execute(sa.text("SELECT password_hash FROM users"))
         assert "psycopg2.errors.UndefinedColumn" in f"{exc_info.value}"
+        conn.rollback()
 
     # MIGRATE DOWNGRADE: this should move password hashes back to users
     simcore_postgres_database.cli.downgrade.callback("61b98a60e934")
@@ -322,6 +325,7 @@ def test_users_secrets_migration_upgrade_downgrade(sync_engine_with_migration: s
         with pytest.raises(sqlalchemy.exc.ProgrammingError) as exc_info:
             conn.execute(sa.text("SELECT COUNT(*) FROM users_secrets")).scalar()
         assert "psycopg2.errors.UndefinedTable" in f"{exc_info.value}"
+        conn.rollback()
 
         # Verify password hashes are back in users table
         result = conn.execute(
@@ -562,6 +566,7 @@ def test_pre_registration_reconciliation_migration_upgrade_downgrade(  # noqa: P
                 "extras": "{}",
             },
         ).scalar_one()
+        conn.commit()
 
     # --- ACT: run migration upgrade ---
     simcore_postgres_database.cli.upgrade.callback("7f8d9b1c2e4f")

--- a/packages/postgres-database/tests/test_users.py
+++ b/packages/postgres-database/tests/test_users.py
@@ -6,7 +6,7 @@
 
 import json
 from collections.abc import Iterator
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
 import pytest
 import simcore_postgres_database.cli
@@ -545,7 +545,7 @@ def test_pre_registration_reconciliation_migration_upgrade_downgrade(  # noqa: P
                 "pre_email": "rejected@example.com",
                 "status": "REJECTED",
                 "reviewed_by": po_user_id,
-                "reviewed_at": datetime.now(tz=UTC),
+                "reviewed_at": datetime.utcnow(),  # noqa: DTZ003
                 "product_name": "osparc",
                 "created_by": po_user_id,
                 "extras": "{}",
@@ -560,7 +560,7 @@ def test_pre_registration_reconciliation_migration_upgrade_downgrade(  # noqa: P
                 "pre_email": "approved@example.com",
                 "status": "APPROVED",
                 "reviewed_by": po_user_id,
-                "reviewed_at": datetime.now(tz=UTC),
+                "reviewed_at": datetime.utcnow(),  # noqa: DTZ003
                 "product_name": "osparc",
                 "created_by": po_user_id,
                 "extras": "{}",

--- a/packages/postgres-database/tests/test_users.py
+++ b/packages/postgres-database/tests/test_users.py
@@ -135,7 +135,7 @@ async def test_new_user(asyncpg_engine: AsyncEngine, faker: Faker, clean_users_d
         "email": faker.email(),
         "password_hash": "foo",
         "status": UserStatus.ACTIVE,
-        "expires_at": datetime.utcnow(),  # noqa: DTZ003
+        "expires_at": datetime.now(tz=UTC),
     }
     repo = UsersRepo(asyncpg_engine)
     new_user = await repo.new_user(**data)
@@ -162,7 +162,7 @@ async def test_trial_accounts(asyncpg_engine: AsyncEngine, clean_users_db_table:
     EXPIRATION_INTERVAL = timedelta(minutes=5)
 
     # creates trial user
-    client_now = datetime.utcnow()  # noqa: DTZ003
+    client_now = datetime.now(tz=UTC)
     async with transaction_context(asyncpg_engine) as connection:
         user_id: int | None = await connection.scalar(
             users.insert()

--- a/packages/pytest-simcore/requirements/_test.txt
+++ b/packages/pytest-simcore/requirements/_test.txt
@@ -144,12 +144,10 @@ simple-websocket==1.1.0
     # via python-engineio
 six==1.17.0
     # via python-dateutil
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 starlette==0.52.1
     # via
     #   -c requirements/../../../requirements/constraints.txt
@@ -168,7 +166,7 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   pydantic-extra-types
     #   pyee
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/postgres_tools.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/postgres_tools.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncIterator, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from typing import Any, TypedDict
+from urllib.parse import quote_plus
 
 import simcore_postgres_database.cli
 import sqlalchemy as sa
@@ -44,7 +45,15 @@ def migrated_pg_tables_context(
     using migration upgrade/downgrade routines
     """
 
-    dsn = "postgresql://{user}:{password}@{host}:{port}/{database}".format(**postgres_config)
+    user = quote_plus(postgres_config["user"])
+    password = quote_plus(postgres_config["password"])
+    dsn = "postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}".format(
+        user=user,
+        password=password,
+        host=postgres_config["host"],
+        port=postgres_config["port"],
+        database=postgres_config["database"],
+    )
 
     assert simcore_postgres_database.cli.discover.callback
     assert simcore_postgres_database.cli.upgrade.callback

--- a/packages/pytest-simcore/src/pytest_simcore/postgres_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/postgres_service.py
@@ -5,6 +5,7 @@
 import json
 from collections.abc import AsyncIterator, Iterator
 from typing import Final
+from urllib.parse import quote_plus
 
 import docker
 import pytest
@@ -91,7 +92,13 @@ def postgres_with_template_db(
 def drop_db_engine(postgres_dsn: PostgresTestConfig) -> sa.engine.Engine:
     postgres_dsn_copy = postgres_dsn.copy()  # make a copy to change these parameters
     postgres_dsn_copy["database"] = "postgres"
-    dsn = "postgresql://{user}:{password}@{host}:{port}/{database}".format(**postgres_dsn_copy)
+    dsn = "postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}".format(
+        user=quote_plus(postgres_dsn_copy["user"]),
+        password=quote_plus(postgres_dsn_copy["password"]),
+        host=postgres_dsn_copy["host"],
+        port=postgres_dsn_copy["port"],
+        database=postgres_dsn_copy["database"],
+    )
     return sa.create_engine(dsn, isolation_level="AUTOCOMMIT")
 
 
@@ -146,7 +153,13 @@ _MINUTE: Final[int] = 60
 
 @pytest.fixture(scope="module")
 def postgres_engine(postgres_dsn: PostgresTestConfig) -> Iterator[sa.engine.Engine]:
-    dsn = "postgresql://{user}:{password}@{host}:{port}/{database}".format(**postgres_dsn)
+    dsn = "postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}".format(
+        user=quote_plus(postgres_dsn["user"]),
+        password=quote_plus(postgres_dsn["password"]),
+        host=postgres_dsn["host"],
+        port=postgres_dsn["port"],
+        database=postgres_dsn["database"],
+    )
 
     engine = sa.create_engine(dsn, isolation_level="AUTOCOMMIT")
     assert isinstance(engine, sa.engine.Engine)  # nosec
@@ -188,7 +201,8 @@ async def sqlalchemy_async_engine(
 ) -> AsyncIterator[AsyncEngine]:
     # NOTE: prevent having to import this if latest sqlalchemy not installed
 
-    engine = create_async_engine(f"{postgres_db.url}".replace("postgresql", "postgresql+asyncpg"))
+    sync_dsn = postgres_db.url.render_as_string(hide_password=False)
+    engine = create_async_engine(sync_dsn.replace("postgresql+psycopg2://", "postgresql+asyncpg://"))
     assert engine
     yield engine
 

--- a/packages/pytest-simcore/src/pytest_simcore/postgres_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/postgres_service.py
@@ -35,13 +35,16 @@ def _execute_queries(
         for statement in sql_statements:
             try:
                 with connection.begin():
-                    connection.execute(statement)
+                    connection.execute(sa.text(statement))
 
             except Exception as e:  # pylint: disable=broad-except
-                # when running tests initially the TEMPLATE_DB_TO_RESTORE dose not exist and will cause an error
-                # which can safely be ignored. The debug message is here to catch future errors which and
-                # avoid time wasting
-                print(f"SQL error which can be ignored {e}")
+                if ignore_errors:
+                    # when running tests initially the TEMPLATE_DB_TO_RESTORE does not exist and will cause an error
+                    # which can safely be ignored. The debug message is here to catch future errors and
+                    # avoid time wasting
+                    print(f"SQL error which can be ignored: {e}")
+                else:
+                    raise
 
 
 def _create_template_db(postgres_dsn: PostgresTestConfig, postgres_engine: sa.engine.Engine) -> None:

--- a/packages/pytest-simcore/src/pytest_simcore/postgres_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/postgres_service.py
@@ -11,7 +11,9 @@ import docker
 import pytest
 import sqlalchemy as sa
 import tenacity
+from sqlalchemy import exc as sa_exc
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from tenacity import retry_if_exception, stop_after_attempt
 from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
 
@@ -24,6 +26,15 @@ from .helpers.typing_env import EnvVarsDict
 _TEMPLATE_DB_TO_RESTORE = "template_simcore_db"
 
 
+def _is_server_connection_drop(error: sa_exc.OperationalError) -> bool:
+    error_msg = str(error).lower()
+    return "server closed the connection unexpectedly" in error_msg
+
+
+def _is_retryable_operational_error(error: BaseException) -> bool:
+    return isinstance(error, sa_exc.OperationalError) and _is_server_connection_drop(error)
+
+
 def _execute_queries(
     postgres_engine: sa.engine.Engine,
     sql_statements: list[str],
@@ -31,20 +42,30 @@ def _execute_queries(
     ignore_errors: bool = False,
 ) -> None:
     """runs the queries in the list in order"""
-    with postgres_engine.connect() as connection:
-        for statement in sql_statements:
-            try:
-                with connection.begin():
-                    connection.execute(sa.text(statement))
-
-            except Exception as e:  # pylint: disable=broad-except
-                if ignore_errors:
-                    # when running tests initially the TEMPLATE_DB_TO_RESTORE does not exist and will cause an error
-                    # which can safely be ignored. The debug message is here to catch future errors and
-                    # avoid time wasting
-                    print(f"SQL error which can be ignored: {e}")
-                else:
-                    raise
+    for statement in sql_statements:
+        try:
+            for attempt in tenacity.Retrying(
+                retry=retry_if_exception(_is_retryable_operational_error),
+                stop=stop_after_attempt(2),
+                reraise=True,
+            ):
+                with attempt:
+                    try:
+                        with postgres_engine.connect() as connection, connection.begin():
+                            connection.execute(sa.text(statement))
+                    except sa_exc.OperationalError as e:
+                        if _is_server_connection_drop(e):
+                            # Recreate stale pooled connections before the retry.
+                            postgres_engine.dispose()
+                        raise
+        except Exception as e:  # pylint: disable=broad-except
+            if ignore_errors:
+                # when running tests initially the TEMPLATE_DB_TO_RESTORE does not exist and will cause an error
+                # which can safely be ignored. The debug message is here to catch future errors and
+                # avoid time wasting
+                print(f"SQL error which can be ignored: {e}")
+                continue
+            raise
 
 
 def _create_template_db(postgres_dsn: PostgresTestConfig, postgres_engine: sa.engine.Engine) -> None:
@@ -72,6 +93,7 @@ def _create_template_db(postgres_dsn: PostgresTestConfig, postgres_engine: sa.en
 
 def _drop_template_db(postgres_engine: sa.engine.Engine) -> None:
     # remove the template db
+    postgres_engine.dispose()
     queries = [
         # drop template database
         f"ALTER DATABASE {_TEMPLATE_DB_TO_RESTORE} is_template false;",
@@ -145,7 +167,7 @@ def postgres_dsn(docker_stack: dict, env_vars_for_docker_compose: EnvVarsDict) -
         "password": env_vars_for_docker_compose["POSTGRES_PASSWORD"],
         "database": env_vars_for_docker_compose["POSTGRES_DB"],
         "host": get_localhost_ip(),
-        "port": get_service_published_port("postgres", env_vars_for_docker_compose["POSTGRES_PORT"]),
+        "port": get_service_published_port("postgres", int(env_vars_for_docker_compose["POSTGRES_PORT"])),
     }
 
     return pg_config

--- a/packages/service-library/requirements/_test.txt
+++ b/packages/service-library/requirements/_test.txt
@@ -263,12 +263,10 @@ sniffio==1.3.1
     #   pyleak
 sortedcontainers==2.4.0
     # via fakeredis
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 termcolor==3.3.0
     # via pytest-sugar
 types-aiofiles==25.1.0.20251011
@@ -287,7 +285,7 @@ typing-extensions==4.15.0
     #   -c requirements/_base.txt
     #   -c requirements/_fastapi.txt
     #   mypy
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 urllib3==2.7.0
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -287,7 +287,7 @@ shellingham==1.5.4
     # via typer
 six==1.17.0
     # via python-dateutil
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -325,6 +325,7 @@ typing-extensions==4.15.0
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic

--- a/packages/simcore-sdk/requirements/_test.txt
+++ b/packages/simcore-sdk/requirements/_test.txt
@@ -313,14 +313,12 @@ six==1.17.0
     #   -c requirements/_base.txt
     #   python-dateutil
     #   rfc3339-validator
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   alembic
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 sympy==1.14.0
     # via cfn-lint
 termcolor==3.3.0
@@ -346,7 +344,7 @@ typing-extensions==4.15.0
     #   mypy
     #   pydantic
     #   pydantic-core
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/dbmanager.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/dbmanager.py
@@ -33,6 +33,7 @@ async def _get_node_from_db(project_id: str, node_uuid: str, connection: AsyncCo
             (comp_tasks.c.node_id == node_uuid) & (comp_tasks.c.project_id == project_id),
         )
     )
+    assert rows_count is not None  # nosec
     if rows_count > 1:
         _logger.error("the node id %s is not unique", node_uuid)
     result = await connection.execute(

--- a/packages/simcore-sdk/tests/integration/conftest.py
+++ b/packages/simcore-sdk/tests/integration/conftest.py
@@ -43,7 +43,7 @@ def user_id(postgres_db: sa.engine.Engine) -> Iterable[UserID]:
         postgres_db,
         table=users,
         values=random_user(
-            name="test",
+            name=f"test_{uuid4().hex}",
         ),
         pk_col=users.c.id,
     ) as user_row:
@@ -240,7 +240,7 @@ def create_task(postgres_db: sa.engine.Engine) -> Iterator[Callable[..., str]]:
             )
             row = result.first()
             assert row
-            new_task_id = row[comp_tasks.c.task_id]
+            new_task_id = row.task_id
         created_task_ids.append(new_task_id)
         return node_uuid
 

--- a/packages/simcore-sdk/tests/integration/conftest.py
+++ b/packages/simcore-sdk/tests/integration/conftest.py
@@ -61,7 +61,7 @@ def project_id(user_id: int, postgres_db: sa.engine.Engine) -> Iterable[str]:
         result = conn.execute(stmt)
         row = result.first()
         assert row
-        prj_uuid = row[projects.c.uuid]
+        prj_uuid = row.uuid
 
     yield prj_uuid
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -33,10 +33,6 @@ urllib3>=1.26.5                               # https://github.com/advisories/GH
 # Breaking changes -----------------------------------------------------------------------------------------
 #
 
-# with new released version 1.0.0 (https://github.com/aio-libs/aiozipkin/releases).
-# TODO: includes async features https://docs.sqlalchemy.org/en/14/changelog/migration_20.html
-sqlalchemy<2.0
-
 
 
 #

--- a/scripts/maintenance/migrate_project/src/db.py
+++ b/scripts/maintenance/migrate_project/src/db.py
@@ -2,6 +2,7 @@ from collections import deque
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
+from urllib.parse import quote_plus
 from uuid import UUID
 
 import typer
@@ -16,8 +17,10 @@ from sqlalchemy.engine.cursor import ResultProxy
 
 @contextmanager
 def db_connection(db_config: DBConfig) -> Iterator[Connection]:
+    user = quote_plus(db_config.user)
+    password = quote_plus(db_config.password)
     engine = create_engine(
-        f"postgresql://{db_config.user}:{db_config.password}@{db_config.address}/{db_config.database}",
+        f"postgresql+psycopg2://{user}:{password}@{db_config.address}/{db_config.database}",
         echo=True,
     )
     with engine.connect() as con:
@@ -26,14 +29,12 @@ def db_connection(db_config: DBConfig) -> Iterator[Connection]:
 
 def _project_uuid_exists_in_destination(connection: Connection, project_id: str) -> bool:
     query = select(projects.c.id).where(projects.c.uuid == f"{project_id}")
-    exists = len(list(connection.execute(query))) > 0
-    return exists
+    return len(list(connection.execute(query))) > 0
 
 
 def _meta_data_exists_in_destination(connection: Connection, file_id: str) -> bool:
     query = select(file_meta_data.c.file_id).where(file_meta_data.c.file_id == f"{file_id}")
-    exists = len(list(connection.execute(query))) > 0
-    return exists
+    return len(list(connection.execute(query))) > 0
 
 
 def _get_project(connection: Connection, project_uuid: UUID) -> ResultProxy:

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -394,7 +394,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -445,6 +445,7 @@ typing-extensions==4.14.1
     #   pydantic-core
     #   pydantic-extra-types
     #   rich-toolkit
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1

--- a/services/api-server/requirements/_test.txt
+++ b/services/api-server/requirements/_test.txt
@@ -390,14 +390,12 @@ sniffio==1.3.1
     #   asgi-lifespan
 sortedcontainers==2.4.0
     # via fakeredis
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   alembic
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 sshpubkeys==3.3.1
     # via moto
 tenacity==9.0.0
@@ -419,7 +417,7 @@ typing-extensions==4.14.1
     #   -c requirements/_base.txt
     #   alembic
     #   mypy
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 tzdata==2025.2
     # via
     #   -c requirements/_base.txt

--- a/services/api-server/tests/unit/_with_db/conftest.py
+++ b/services/api-server/tests/unit/_with_db/conftest.py
@@ -11,6 +11,7 @@ import sys
 from collections.abc import AsyncGenerator, Callable, Iterable
 from pathlib import Path
 from typing import TypedDict
+from urllib.parse import quote_plus
 
 import httpx
 import pytest
@@ -95,7 +96,15 @@ def postgres_service(docker_services, docker_ip, docker_compose_file: Path) -> P
         "database": environ["POSTGRES_DB"],
     }
 
-    dsn = "postgresql://{user}:{password}@{host}:{port}/{database}".format(**config)
+    user = quote_plus(config["user"])
+    password = quote_plus(config["password"])
+    dsn = "postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}".format(
+        user=user,
+        password=password,
+        host=config["host"],
+        port=config["port"],
+        database=config["database"],
+    )
 
     def _create_checker() -> Callable:
         def is_postgres_responsive() -> bool:

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -347,7 +347,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -389,6 +389,7 @@ typing-extensions==4.14.1
     #   pydantic-core
     #   pydantic-extra-types
     #   rich-toolkit
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1

--- a/services/catalog/requirements/_test.txt
+++ b/services/catalog/requirements/_test.txt
@@ -178,14 +178,12 @@ sniffio==1.3.1
     #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   alembic
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 types-psycopg2==2.9.21.20260223
     # via -r requirements/_test.in
 types-pyyaml==6.0.12.20250915
@@ -195,7 +193,7 @@ typing-extensions==4.14.1
     #   -c requirements/_base.txt
     #   alembic
     #   mypy
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 urllib3==2.7.0
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/catalog/src/simcore_service_catalog/repository/_services_sql.py
+++ b/services/catalog/src/simcore_service_catalog/repository/_services_sql.py
@@ -17,6 +17,7 @@ from simcore_postgres_database.models.services_compatibility import (
 )
 from simcore_postgres_database.models.users import users
 from simcore_postgres_database.utils_repos import get_columns_from_db_model
+from sqlalchemy import ColumnElement
 from sqlalchemy.dialects.postgresql import ARRAY, INTEGER, array_agg
 from sqlalchemy.sql import and_, or_
 from sqlalchemy.sql.expression import func
@@ -40,12 +41,11 @@ def list_services_stmt(
         conditions: list[Any] = []
 
         # access rights
-        logic_operator = and_ if combine_access_with_and else or_
-        default = bool(combine_access_with_and)
+        execute_clause = services_access_rights.c.execute_access if execute_access else sa.true()
+        write_clause = services_access_rights.c.write_access if write_access else sa.true()
 
-        access_query_part = logic_operator(  # type: ignore[type-var]
-            services_access_rights.c.execute_access if execute_access else default,
-            services_access_rights.c.write_access if write_access else default,
+        access_query_part = (
+            and_(execute_clause, write_clause) if combine_access_with_and else or_(execute_clause, write_clause)
         )
         conditions.append(access_query_part)
 
@@ -131,7 +131,7 @@ def apply_services_filters(
     if filters.version_display_pattern:
         # Convert glob pattern to SQL LIKE pattern and handle NULL values
         sql_pattern = filters.version_display_pattern.replace("*", "%")
-        version_display_condition = services_meta_data.c.version_display.like(sql_pattern)
+        version_display_condition: ColumnElement[bool] = services_meta_data.c.version_display.like(sql_pattern)
 
         if sql_pattern == "%":
             conditions.append(
@@ -139,10 +139,10 @@ def apply_services_filters(
                     version_display_condition,
                     # If pattern==*, also match NULL when rest is empty
                     services_meta_data.c.version_display.is_(None),
-                )
+                )  # type: ignore[arg-type]
             )
         else:
-            conditions.append(version_display_condition)
+            conditions.append(version_display_condition)  # type: ignore[arg-type]
 
     if conditions:
         stmt = stmt.where(sa.and_(*conditions))
@@ -170,7 +170,7 @@ def latest_services_total_count_stmt(
                 (user_to_groups.c.gid == services_access_rights.c.gid) & (user_to_groups.c.uid == user_id),
             )
         )
-        .where(access_rights)
+        .where(access_rights)  # type: ignore[arg-type]
     )
 
     if filters:
@@ -206,7 +206,7 @@ def list_latest_services_stmt(
                 (user_to_groups.c.gid == services_access_rights.c.gid) & (user_to_groups.c.uid == user_id),
             )
         )
-        .where(access_rights)
+        .where(access_rights)  # type: ignore[arg-type]
         .order_by(
             services_meta_data.c.key,
             sa.desc(by_version(services_meta_data.c.version)),  # latest first

--- a/services/catalog/src/simcore_service_catalog/repository/groups.py
+++ b/services/catalog/src/simcore_service_catalog/repository/groups.py
@@ -59,5 +59,7 @@ class GroupsRepository(BaseRepository):
             async for row in await conn.stream(
                 sa.select(users.c.primary_gid, users.c.email).where(users.c.primary_gid.in_(gids))
             ):
-                service_owners[row[0]] = TypeAdapter(LowerCaseEmailStr).validate_python(row[1]) if row[1] else None
+                service_owners[row.primary_gid] = (
+                    TypeAdapter(LowerCaseEmailStr).validate_python(row.email) if row.email else None
+                )
         return service_owners

--- a/services/catalog/src/simcore_service_catalog/repository/groups.py
+++ b/services/catalog/src/simcore_service_catalog/repository/groups.py
@@ -57,9 +57,7 @@ class GroupsRepository(BaseRepository):
         service_owners: dict[PositiveInt, LowerCaseEmailStr | None] = {}
         async with self.db_engine.connect() as conn:
             async for row in await conn.stream(
-                sa.select([users.c.primary_gid, users.c.email]).where(users.c.primary_gid.in_(gids))
+                sa.select(users.c.primary_gid, users.c.email).where(users.c.primary_gid.in_(gids))
             ):
-                service_owners[row[users.c.primary_gid]] = (
-                    TypeAdapter(LowerCaseEmailStr).validate_python(row[users.c.email]) if row[users.c.email] else None
-                )
+                service_owners[row[0]] = TypeAdapter(LowerCaseEmailStr).validate_python(row[1]) if row[1] else None
         return service_owners

--- a/services/catalog/src/simcore_service_catalog/repository/services.py
+++ b/services/catalog/src/simcore_service_catalog/repository/services.py
@@ -29,7 +29,7 @@ from simcore_postgres_database.models.services_specifications import (
 )
 from simcore_postgres_database.utils_repos import pass_or_acquire_connection
 from simcore_postgres_database.utils_services import create_select_latest_services_query
-from sqlalchemy import sql
+from sqlalchemy import ColumnElement, sql
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 
@@ -619,16 +619,12 @@ class ServicesRepository(BaseRepository):
         Returns only found. If None found, then None
         """
         service_to_access_rights = defaultdict(list)
-        query = (
-            sa.select(services_access_rights)
-            .select_from(services_access_rights)
-            .where(
-                sql.tuple_(services_access_rights.c.key, services_access_rights.c.version).in_(key_versions)
-                & (services_access_rights.c.product_name == product_name)
-                if product_name
-                else True
-            )
-        )
+        where_clause: ColumnElement[bool] = sql.tuple_(
+            services_access_rights.c.key, services_access_rights.c.version
+        ).in_(key_versions)
+        if product_name:
+            where_clause = where_clause & (services_access_rights.c.product_name == product_name)
+        query = sa.select(services_access_rights).select_from(services_access_rights).where(where_clause)
         async with self.db_engine.connect() as conn:
             async for row in await conn.stream(query):
                 service_to_access_rights[(row.key, row.version)].append(ServiceAccessRightsDB.model_validate(row))

--- a/services/catalog/src/simcore_service_catalog/repository/services.py
+++ b/services/catalog/src/simcore_service_catalog/repository/services.py
@@ -29,7 +29,7 @@ from simcore_postgres_database.models.services_specifications import (
 )
 from simcore_postgres_database.utils_repos import pass_or_acquire_connection
 from simcore_postgres_database.utils_services import create_select_latest_services_query
-from sqlalchemy import ColumnElement, sql
+from sqlalchemy import sql
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 
@@ -619,11 +619,11 @@ class ServicesRepository(BaseRepository):
         Returns only found. If None found, then None
         """
         service_to_access_rights = defaultdict(list)
-        where_clause: ColumnElement[bool] = sql.tuple_(
-            services_access_rights.c.key, services_access_rights.c.version
-        ).in_(key_versions)
-        if product_name:
-            where_clause = where_clause & (services_access_rights.c.product_name == product_name)
+        where_clause = sql.tuple_(
+            services_access_rights.c.key,
+            services_access_rights.c.version,
+        ).in_(key_versions) & (services_access_rights.c.product_name == product_name if product_name else sql.true())
+
         query = sa.select(services_access_rights).select_from(services_access_rights).where(where_clause)
         async with self.db_engine.connect() as conn:
             async for row in await conn.stream(query):

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -442,7 +442,7 @@ sortedcontainers==2.4.0
     # via
     #   -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
     #   distributed
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -503,6 +503,7 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   pydantic-extra-types
     #   rich-toolkit
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.2

--- a/services/director-v2/requirements/_test.txt
+++ b/services/director-v2/requirements/_test.txt
@@ -238,14 +238,12 @@ sortedcontainers==2.4.0
     #   -c requirements/_base.txt
     #   distributed
     #   fakeredis
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   alembic
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 tblib==3.2.2
     # via
     #   -c requirements/_base.txt
@@ -272,7 +270,7 @@ typing-extensions==4.15.0
     #   -c requirements/_base.txt
     #   alembic
     #   mypy
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 urllib3==2.7.0
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -22,10 +22,11 @@ from simcore_postgres_database.utils_repos import (
     pass_or_acquire_connection,
     transaction_context,
 )
+from sqlalchemy import CursorResult
 from sqlalchemy.dialects.postgresql.asyncpg import AsyncAdapt_asyncpg_dbapi
 from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.sql import or_
-from sqlalchemy.sql.elements import literal_column
+from sqlalchemy.sql.elements import ColumnElement, literal_column
 from sqlalchemy.sql.expression import desc
 
 from ....core.errors import (
@@ -171,11 +172,11 @@ class CompRunsRepository(BaseRepository):
                                 which are not processed since then (default: {None})
         """
 
-        conditions = []
+        conditions: list[ColumnElement[bool]] = []
         if filter_by_state:
             conditions.append(or_(*[comp_runs.c.result == RUNNING_STATE_TO_DB[s] for s in filter_by_state]))
 
-        scheduling_or_conditions = []
+        scheduling_or_conditions: list[ColumnElement[bool]] = []
         if never_scheduled:
             scheduling_or_conditions.append(comp_runs.c.scheduled.is_(None))
         if scheduled_since is not None:
@@ -464,7 +465,7 @@ class CompRunsRepository(BaseRepository):
                 if iteration is None:
                     iteration = await _get_next_iteration(conn, user_id, project_id)
 
-                result = await conn.execute(
+                result: CursorResult = await conn.execute(
                     comp_runs.insert()
                     .values(
                         user_id=user_id,
@@ -488,7 +489,7 @@ class CompRunsRepository(BaseRepository):
         self, user_id: UserID, project_id: ProjectID, iteration: PositiveInt, **values
     ) -> CompRunsAtDB | None:
         async with transaction_context(self.db_engine) as conn:
-            result = await conn.execute(
+            result: CursorResult = await conn.execute(
                 sa.update(comp_runs)
                 .where(
                     (comp_runs.c.project_uuid == f"{project_id}")

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -15,7 +15,7 @@ from pydantic import PositiveInt
 from servicelib.logging_utils import log_context
 from servicelib.rabbitmq import RabbitMQRPCClient
 from servicelib.utils import logged_gather
-from sqlalchemy import literal_column
+from sqlalchemy import CursorResult, literal_column
 from sqlalchemy.dialects.postgresql import insert
 
 from .....core.errors import ComputationalTaskNotFoundError
@@ -197,11 +197,12 @@ class CompTasksRepository(BaseRepository):
                     exclusion_rule.add("outputs")
                 else:
                     update_values = {}
-                on_update_stmt = insert_stmt.on_conflict_do_update(
-                    index_elements=[comp_tasks.c.project_id, comp_tasks.c.node_id],
-                    set_=comp_task_db.to_db_model(exclude=exclusion_rule) | update_values,
-                ).returning(literal_column("*"))
-                result = await conn.execute(on_update_stmt)
+                result = await conn.execute(
+                    insert_stmt.on_conflict_do_update(
+                        index_elements=[comp_tasks.c.project_id, comp_tasks.c.node_id],
+                        set_=comp_task_db.to_db_model(exclude=exclusion_rule) | update_values,
+                    ).returning(literal_column("*"))
+                )
                 row = result.one()
                 inserted_comp_tasks_db.append(CompTaskAtDB.model_validate(row))
                 _logger.debug(
@@ -219,7 +220,7 @@ class CompTasksRepository(BaseRepository):
             msg=f"update task {project_id=}:{task=} with '{task_kwargs}'",
         ):
             async with self.db_engine.begin() as conn:
-                result = await conn.execute(
+                result: CursorResult = await conn.execute(
                     sa.update(comp_tasks)
                     .where((comp_tasks.c.project_id == f"{project_id}") & (comp_tasks.c.node_id == f"{task}"))
                     .values(**task_kwargs)

--- a/services/director-v2/tests/unit/with_dbs/test_modules_db_repositories_groups_extra_properties.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_db_repositories_groups_extra_properties.py
@@ -56,7 +56,7 @@ def mock_env(
     # NOTE: drops the default internet policy added by the migration to test
     # otherwise any user will always have access to the internet
     with postgres_db.connect() as con:
-        con.execute(groups_extra_properties.delete(groups_extra_properties.c.group_id == 1))
+        con.execute(groups_extra_properties.delete().where(groups_extra_properties.c.group_id == 1))
     return env_vars
 
 
@@ -66,7 +66,7 @@ def give_internet_to_group(
 ) -> Iterator[Callable[..., dict]]:
     to_remove = []
 
-    def creator(group_id: int, has_internet_access: bool, product_name: str = None) -> dict[str, Any]:
+    def creator(group_id: int, has_internet_access: bool, product_name: str | None = None) -> dict[str, Any]:
         with postgres_db.connect() as con:
             groups_extra_properties_config = {
                 "group_id": group_id,
@@ -84,7 +84,7 @@ def give_internet_to_group(
             result = con.execute(
                 sa.select(groups_extra_properties).where(groups_extra_properties.c.group_id == group_id)
             )
-            entry = result.first()
+            entry = result.mappings().first()
             assert entry
             print(f"--> created {entry=}")
             to_remove.append(group_id)
@@ -137,7 +137,7 @@ async def test_regression_group_id_is_not_unique(mock_env: EnvVarsDict, postgres
         result = con.execute(groups.insert().values(groups_config).returning(sa.literal_column("*")))
         return result.first()[0]
 
-    def _insert_product(con: sa.engine.Connection, group_id: int, name: str) -> int:
+    def _insert_product(con: sa.engine.Connection, group_id: int, name: str) -> None:
         product_config = {
             "name": name,
             "group_id": group_id,
@@ -146,7 +146,7 @@ async def test_regression_group_id_is_not_unique(mock_env: EnvVarsDict, postgres
         }
         con.execute(products.insert().values(product_config))
 
-    def _insert_groups_extra_properties(con: sa.engine.Connection, group_id: int, product_name: str) -> int:
+    def _insert_groups_extra_properties(con: sa.engine.Connection, group_id: int, product_name: str) -> None:
         groups_extra_properties_config = {
             "product_name": product_name,
             "group_id": group_id,

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -377,7 +377,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -420,6 +420,7 @@ typing-extensions==4.14.1
     #   pydantic-core
     #   pydantic-extra-types
     #   rich-toolkit
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1

--- a/services/dynamic-scheduler/requirements/_test.txt
+++ b/services/dynamic-scheduler/requirements/_test.txt
@@ -145,13 +145,11 @@ sniffio==1.3.1
     #   asgi-lifespan
 sortedcontainers==2.4.0
     # via fakeredis
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 termcolor==3.3.0
     # via pytest-sugar
 types-psycopg2==2.9.21.20260223
@@ -161,7 +159,7 @@ typing-extensions==4.14.1
     #   -c requirements/_base.txt
     #   mypy
     #   pyee
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 urllib3==2.7.0
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -375,7 +375,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -423,6 +423,7 @@ typing-extensions==4.14.1
     #   pydantic-core
     #   pydantic-extra-types
     #   rich-toolkit
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1

--- a/services/dynamic-sidecar/requirements/_test.txt
+++ b/services/dynamic-sidecar/requirements/_test.txt
@@ -155,13 +155,11 @@ sniffio==1.3.1
     #   asgi-lifespan
 sortedcontainers==2.4.0
     # via fakeredis
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 types-aiobotocore-s3==3.2.1
     # via -r requirements/_test.in
 types-aiofiles==25.1.0.20251011
@@ -174,7 +172,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/_base.txt
     #   mypy
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 urllib3==2.7.0
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/dynamic-sidecar/tests/integration/test_modules_long_running_tasks.py
+++ b/services/dynamic-sidecar/tests/integration/test_modules_long_running_tasks.py
@@ -75,7 +75,7 @@ def project_id(user_id: int, postgres_db: sa.engine.Engine) -> Iterable[ProjectI
         result = conn.execute(stmt)
         row = result.first()
         assert row
-        prj_uuid = row[projects.c.uuid]
+        prj_uuid = row.uuid
 
     yield prj_uuid
 

--- a/services/efs-guardian/requirements/_base.txt
+++ b/services/efs-guardian/requirements/_base.txt
@@ -384,7 +384,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -434,6 +434,7 @@ typing-extensions==4.14.1
     #   pydantic-core
     #   pydantic-extra-types
     #   rich-toolkit
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1

--- a/services/migration/requirements/_test.txt
+++ b/services/migration/requirements/_test.txt
@@ -73,18 +73,16 @@ rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/_test.in
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 tenacity==9.1.4
     # via -r requirements/_test.in
 typing-extensions==4.15.0
     # via
     #   mypy
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 urllib3==2.7.0
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/notifications/requirements/_base.txt
+++ b/services/notifications/requirements/_base.txt
@@ -366,7 +366,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -406,6 +406,7 @@ typing-extensions==4.14.1
     #   pydantic-core
     #   pydantic-extra-types
     #   rich-toolkit
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.0

--- a/services/notifications/requirements/_test.txt
+++ b/services/notifications/requirements/_test.txt
@@ -171,13 +171,11 @@ sniffio==1.3.1
     #   asgi-lifespan
 sortedcontainers==2.4.0
     # via fakeredis
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 tenacity==9.0.0
     # via
     #   -c requirements/_base.txt
@@ -186,7 +184,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/_base.txt
     #   mypy
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 tzdata==2025.2
     # via
     #   -c requirements/_base.txt

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -371,7 +371,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -412,6 +412,7 @@ typing-extensions==4.14.1
     #   pydantic-core
     #   pydantic-extra-types
     #   rich-toolkit
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1

--- a/services/payments/requirements/_test.txt
+++ b/services/payments/requirements/_test.txt
@@ -163,13 +163,11 @@ sniffio==1.3.1
     #   -c requirements/_base.txt
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 termcolor==3.3.0
     # via pytest-sugar
 types-aiofiles==25.1.0.20251011
@@ -184,7 +182,7 @@ typing-extensions==4.14.1
     # via
     #   -c requirements/_base.txt
     #   mypy
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
 urllib3==2.7.0
     # via
     #   -c requirements/../../../requirements/constraints.txt

--- a/services/payments/src/simcore_service_payments/db/payments_methods_repo.py
+++ b/services/payments/src/simcore_service_payments/db/payments_methods_repo.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Any
 
 import sqlalchemy as sa
 from arrow import utcnow
@@ -78,7 +79,7 @@ class PaymentsMethodsRepo(BaseRepository):
             if row.completed_at is not None:
                 raise PaymentMethodAlreadyAckedError(payment_method_id=payment_method_id)
 
-            result = await conn.execute(
+            result: Any = await conn.execute(
                 payments_methods.update()
                 .values(completed_at=sa.func.now(), state=completion_state, **optional)
                 .where(payments_methods.c.payment_method_id == payment_method_id)
@@ -177,7 +178,7 @@ class PaymentsMethodsRepo(BaseRepository):
         wallet_id: WalletID,
     ) -> PaymentsMethodsDB | None:
         async with self.db_engine.begin() as conn:
-            result = await conn.execute(
+            result: Any = await conn.execute(
                 payments_methods.delete()
                 .where(
                     (payments_methods.c.user_id == user_id)

--- a/services/payments/src/simcore_service_payments/db/payments_transactions_repo.py
+++ b/services/payments/src/simcore_service_payments/db/payments_transactions_repo.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import Any
 
 import sqlalchemy as sa
 from models_library.api_schemas_payments.errors import (
@@ -109,7 +110,7 @@ class PaymentsTransactionsRepo(BaseRepository):
 
             assert row.initiated_at  # nosec
 
-            result = await connection.execute(
+            result: Any = await connection.execute(
                 payments_transactions.update()
                 .values(
                     completed_at=sa.func.now(),

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -430,7 +430,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -483,6 +483,7 @@ typing-extensions==4.14.1
     #   pydantic-core
     #   pydantic-extra-types
     #   rich-toolkit
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1

--- a/services/resource-usage-tracker/requirements/_test.txt
+++ b/services/resource-usage-tracker/requirements/_test.txt
@@ -300,14 +300,12 @@ sniffio==1.3.1
     #   asgi-lifespan
 sortedcontainers==2.4.0
     # via fakeredis
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   alembic
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 sympy==1.14.0
     # via cfn-lint
 termcolor==3.3.0
@@ -323,7 +321,7 @@ typing-extensions==4.14.1
     #   mypy
     #   pydantic
     #   pydantic-core
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.1
     # via

--- a/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/modules/db/licensed_items_checkouts_db.py
+++ b/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/modules/db/licensed_items_checkouts_db.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 from datetime import datetime
 from typing import cast
 
@@ -129,7 +130,7 @@ async def list_(
         result = await conn.stream(list_query)
         items: list[LicensedItemCheckoutDB] = [LicensedItemCheckoutDB.model_validate(row) async for row in result]
 
-        return cast(int, total_count), items
+        return total_count, items
 
 
 async def get(
@@ -164,23 +165,23 @@ async def update(
     product_name: ProductName,
     stopped_at: datetime,
 ) -> LicensedItemCheckoutDB:
-    update_stmt = (
-        resource_tracker_licensed_items_checkouts.update()
-        .values(
-            modified=sa.func.now(),
-            stopped_at=stopped_at,
-        )
-        .where(
-            (resource_tracker_licensed_items_checkouts.c.licensed_item_checkout_id == licensed_item_checkout_id)
-            & (resource_tracker_licensed_items_checkouts.c.product_name == product_name)
-            & (resource_tracker_licensed_items_checkouts.c.stopped_at.is_(None))
-        )
-        .returning(sa.literal_column("*"))
-    )
-
+    row: object | None
     async with transaction_context(engine, connection) as conn:
-        result = await conn.execute(update_stmt)
-        row = result.first()
+        row = (
+            await conn.execute(
+                resource_tracker_licensed_items_checkouts.update()
+                .values(
+                    modified=sa.func.now(),
+                    stopped_at=stopped_at,
+                )
+                .where(
+                    (resource_tracker_licensed_items_checkouts.c.licensed_item_checkout_id == licensed_item_checkout_id)
+                    & (resource_tracker_licensed_items_checkouts.c.product_name == product_name)
+                    & (resource_tracker_licensed_items_checkouts.c.stopped_at.is_(None))
+                )
+                .returning(sa.literal_column("*"))
+            )
+        ).first()
         if row is None:
             raise LicensedItemCheckoutNotFoundError(licensed_item_checkout_id=licensed_item_checkout_id)
         return LicensedItemCheckoutDB.model_validate(row)
@@ -224,21 +225,21 @@ async def force_release_license_seats_by_run_id(
     the unhealthy service.
     Currently, this functionality is primarily used to handle the release of a single seat allocated to the VIP model.
     """
-    update_stmt = (
-        resource_tracker_licensed_items_checkouts.update()
-        .values(
-            modified=sa.func.now(),
-            stopped_at=sa.func.now(),
-        )
-        .where(
-            (resource_tracker_licensed_items_checkouts.c.service_run_id == service_run_id)
-            & (resource_tracker_licensed_items_checkouts.c.stopped_at.is_(None))
-        )
-        .returning(sa.literal_column("*"))
-    )
-
+    released_seats: Sequence[object]
     async with transaction_context(engine, connection) as conn:
-        result = await conn.execute(update_stmt)
-        released_seats = result.fetchall()
+        released_seats = (
+            await conn.execute(
+                resource_tracker_licensed_items_checkouts.update()
+                .values(
+                    modified=sa.func.now(),
+                    stopped_at=sa.func.now(),
+                )
+                .where(
+                    (resource_tracker_licensed_items_checkouts.c.service_run_id == service_run_id)
+                    & (resource_tracker_licensed_items_checkouts.c.stopped_at.is_(None))
+                )
+                .returning(sa.literal_column("*"))
+            )
+        ).fetchall()
         if released_seats:
             _logger.error("Force release of %s seats: %s", len(released_seats), released_seats)

--- a/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/modules/db/licensed_items_purchases_db.py
+++ b/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/modules/db/licensed_items_purchases_db.py
@@ -123,7 +123,7 @@ async def list_(
         result = await conn.stream(list_query)
         items: list[LicensedItemsPurchasesDB] = [LicensedItemsPurchasesDB.model_validate(row) async for row in result]
 
-        return cast(int, total_count), items
+        return total_count, items
 
 
 async def get(

--- a/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/modules/db/pricing_plans_db.py
+++ b/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/modules/db/pricing_plans_db.py
@@ -1,5 +1,4 @@
 import logging
-from typing import cast
 
 import sqlalchemy as sa
 from models_library.products import ProductName
@@ -206,7 +205,7 @@ async def list_pricing_plans_by_product(
         result = await conn.execute(list_query.offset(offset).limit(limit))
 
     items = [PricingPlansDB.model_validate(row) for row in result.fetchall()]
-    return cast(int, total_count), items
+    return total_count, items
 
 
 async def create_pricing_plan(

--- a/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/modules/db/service_runs_db.py
+++ b/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/modules/db/service_runs_db.py
@@ -113,23 +113,24 @@ async def update_service_run_last_heartbeat(
     *,
     data: ServiceRunLastHeartbeatUpdate,
 ) -> ServiceRunDB | None:
+    row: object | None
     async with transaction_context(engine, connection) as conn:
-        update_stmt = (
-            resource_tracker_service_runs.update()
-            .values(
-                modified=sa.func.now(),
-                last_heartbeat_at=data.last_heartbeat_at,
-                missed_heartbeat_counter=0,
+        row = (
+            await conn.execute(
+                resource_tracker_service_runs.update()
+                .values(
+                    modified=sa.func.now(),
+                    last_heartbeat_at=data.last_heartbeat_at,
+                    missed_heartbeat_counter=0,
+                )
+                .where(
+                    (resource_tracker_service_runs.c.service_run_id == data.service_run_id)
+                    & (resource_tracker_service_runs.c.service_run_status == ServiceRunStatus.RUNNING)
+                    & (resource_tracker_service_runs.c.last_heartbeat_at <= data.last_heartbeat_at)
+                )
+                .returning(sa.literal_column("*"))
             )
-            .where(
-                (resource_tracker_service_runs.c.service_run_id == data.service_run_id)
-                & (resource_tracker_service_runs.c.service_run_status == ServiceRunStatus.RUNNING)
-                & (resource_tracker_service_runs.c.last_heartbeat_at <= data.last_heartbeat_at)
-            )
-            .returning(sa.literal_column("*"))
-        )
-        result = await conn.execute(update_stmt)
-    row = result.first()
+        ).first()
     if row is None:
         return None
     return ServiceRunDB.model_validate(row)
@@ -141,23 +142,24 @@ async def update_service_run_stopped_at(
     *,
     data: ServiceRunStoppedAtUpdate,
 ) -> ServiceRunDB | None:
+    row: object | None
     async with transaction_context(engine, connection) as conn:
-        update_stmt = (
-            resource_tracker_service_runs.update()
-            .values(
-                modified=sa.func.now(),
-                stopped_at=data.stopped_at,
-                service_run_status=data.service_run_status,
-                service_run_status_msg=data.service_run_status_msg,
+        row = (
+            await conn.execute(
+                resource_tracker_service_runs.update()
+                .values(
+                    modified=sa.func.now(),
+                    stopped_at=data.stopped_at,
+                    service_run_status=data.service_run_status,
+                    service_run_status_msg=data.service_run_status_msg,
+                )
+                .where(
+                    (resource_tracker_service_runs.c.service_run_id == data.service_run_id)
+                    & (resource_tracker_service_runs.c.service_run_status == ServiceRunStatus.RUNNING)
+                )
+                .returning(sa.literal_column("*"))
             )
-            .where(
-                (resource_tracker_service_runs.c.service_run_id == data.service_run_id)
-                & (resource_tracker_service_runs.c.service_run_status == ServiceRunStatus.RUNNING)
-            )
-            .returning(sa.literal_column("*"))
-        )
-        result = await conn.execute(update_stmt)
-    row = result.first()
+        ).first()
     if row is None:
         return None
     return ServiceRunDB.model_validate(row)
@@ -312,7 +314,7 @@ async def list_service_runs_by_product_and_user_and_wallet(
         result = await conn.stream(list_query.offset(offset).limit(limit))
         items: list[ServiceRunWithCreditsDB] = [ServiceRunWithCreditsDB.model_validate(row) async for row in result]
 
-        return cast(int, total_count), items
+        return total_count, items
 
 
 async def get_osparc_credits_aggregated_by_service(
@@ -404,7 +406,7 @@ async def get_osparc_credits_aggregated_by_service(
         list_result = await conn.execute(list_query)
 
     return (
-        cast(int, count_result),
+        count_result,
         [OsparcCreditsAggregatedByServiceKeyDB.model_validate(row) for row in list_result.fetchall()],
     )
 
@@ -638,23 +640,23 @@ async def update_service_missed_heartbeat_counter(
     last_heartbeat_at: datetime,
     missed_heartbeat_counter: int,
 ) -> ServiceRunDB | None:
+    row: object | None
     async with transaction_context(engine, connection) as conn:
-        update_stmt = (
-            resource_tracker_service_runs.update()
-            .values(
-                modified=sa.func.now(),
-                missed_heartbeat_counter=missed_heartbeat_counter,
+        row = (
+            await conn.execute(
+                resource_tracker_service_runs.update()
+                .values(
+                    modified=sa.func.now(),
+                    missed_heartbeat_counter=missed_heartbeat_counter,
+                )
+                .where(
+                    (resource_tracker_service_runs.c.service_run_id == service_run_id)
+                    & (resource_tracker_service_runs.c.service_run_status == ServiceRunStatus.RUNNING)
+                    & (resource_tracker_service_runs.c.last_heartbeat_at == last_heartbeat_at)
+                )
+                .returning(sa.literal_column("*"))
             )
-            .where(
-                (resource_tracker_service_runs.c.service_run_id == service_run_id)
-                & (resource_tracker_service_runs.c.service_run_status == ServiceRunStatus.RUNNING)
-                & (resource_tracker_service_runs.c.last_heartbeat_at == last_heartbeat_at)
-            )
-            .returning(sa.literal_column("*"))
-        )
-
-        result = await conn.execute(update_stmt)
-    row = result.first()
+        ).first()
     if row is None:
         return None
     return ServiceRunDB.model_validate(row)

--- a/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/service_runs.py
+++ b/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/service_runs.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-arguments
 from datetime import UTC, datetime, timedelta
 
-import shortuuid  # type: ignore[import-not-found]
+import shortuuid
 from aws_library.s3 import SimcoreS3API
 from models_library.api_schemas_resource_usage_tracker.credit_transactions import (
     WalletTotalCredits,
@@ -32,7 +32,7 @@ from .modules.db import service_runs_db
 _PRESIGNED_LINK_EXPIRATION_SEC = 7200
 
 
-async def list_service_runs(
+async def list_service_runs(  # noqa: PLR0913
     db_engine: AsyncEngine,
     *,
     user_id: UserID,

--- a/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/service_runs.py
+++ b/services/resource-usage-tracker/src/simcore_service_resource_usage_tracker/services/service_runs.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-arguments
 from datetime import UTC, datetime, timedelta
 
-import shortuuid
+import shortuuid  # type: ignore[import-not-found]
 from aws_library.s3 import SimcoreS3API
 from models_library.api_schemas_resource_usage_tracker.credit_transactions import (
     WalletTotalCredits,

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -430,7 +430,7 @@ sniffio==1.3.1
     # via
     #   anyio
     #   asgi-lifespan
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/postgres-database/requirements/_base.in
@@ -486,6 +486,7 @@ typing-extensions==4.14.1
     #   pydantic-core
     #   pydantic-extra-types
     #   rich-toolkit
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1

--- a/services/storage/requirements/_test.txt
+++ b/services/storage/requirements/_test.txt
@@ -391,13 +391,11 @@ sniffio==1.3.1
     #   anyio
 sortedcontainers==2.4.0
     # via fakeredis
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 sympy==1.14.0
     # via cfn-lint
 tenacity==9.0.0
@@ -417,7 +415,7 @@ typing-extensions==4.14.1
     #   mypy
     #   pydantic
     #   pydantic-core
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.1
     # via

--- a/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
+++ b/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
@@ -129,14 +129,14 @@ class FileMetaDataRepository(BaseRepository):
         # NOTE: upsert file_meta_data, if the file already exists, we update the whole row
         # so we get the correct time stamps
         fmd_db = FileMetaDataAtDB.model_validate(fmd) if isinstance(fmd, FileMetaData) else fmd
-        insert_statement = pg_insert(file_meta_data).values(**fmd_db.model_dump())
         async with transaction_context(self.db_engine, connection) as conn:
             return FileMetaDataAtDB.model_validate(
                 (
                     await conn.execute(
-                        insert_statement.on_conflict_do_update(
-                            index_elements=[file_meta_data.c.file_id], set_=fmd_db.model_dump()
-                        ).returning(literal_column("*"))
+                        pg_insert(file_meta_data)
+                        .values(**fmd_db.model_dump())
+                        .on_conflict_do_update(index_elements=[file_meta_data.c.file_id], set_=fmd_db.model_dump())
+                        .returning(literal_column("*"))
                     )
                 ).one()
             )

--- a/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
+++ b/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
@@ -2,7 +2,7 @@ import contextlib
 import datetime
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Annotated, TypeAlias
+from typing import Annotated
 
 import sqlalchemy as sa
 from models_library.basic_types import SHA256Str
@@ -31,7 +31,7 @@ from ...models import (
 )
 from ._base import BaseRepository
 
-TotalChildren: TypeAlias = int
+type TotalChildren = int
 
 
 class _PathsCursorParameters(BaseModel):
@@ -74,7 +74,7 @@ def _list_filter_with_partial_file_id_stmt(
     limit: int | None = None,
     offset: int | None = None,
 ):
-    conditions: list = []
+    conditions: list[sa.ColumnElement[bool]] = []
 
     # Checks access rights (project can be owned or shared)
     user_id = user_or_project_filter.user_id
@@ -83,7 +83,7 @@ def _list_filter_with_partial_file_id_stmt(
         conditions.append(
             sa.or_(
                 file_meta_data.c.user_id == user_id,
-                (file_meta_data.c.project_id.in_(f"{_}" for _ in project_ids) if project_ids else False),
+                (file_meta_data.c.project_id.in_(f"{_}" for _ in project_ids) if project_ids else sa.false()),
             )
         )
     else:
@@ -130,22 +130,27 @@ class FileMetaDataRepository(BaseRepository):
         # so we get the correct time stamps
         fmd_db = FileMetaDataAtDB.model_validate(fmd) if isinstance(fmd, FileMetaData) else fmd
         insert_statement = pg_insert(file_meta_data).values(**fmd_db.model_dump())
-        on_update_statement = insert_statement.on_conflict_do_update(
-            index_elements=[file_meta_data.c.file_id], set_=fmd_db.model_dump()
-        ).returning(literal_column("*"))
         async with transaction_context(self.db_engine, connection) as conn:
-            result = await conn.execute(on_update_statement)
-            row = result.one()
-        return FileMetaDataAtDB.model_validate(row)
+            return FileMetaDataAtDB.model_validate(
+                (
+                    await conn.execute(
+                        insert_statement.on_conflict_do_update(
+                            index_elements=[file_meta_data.c.file_id], set_=fmd_db.model_dump()
+                        ).returning(literal_column("*"))
+                    )
+                ).one()
+            )
 
     async def insert(self, *, connection: AsyncConnection | None = None, fmd: FileMetaData) -> FileMetaDataAtDB:
         fmd_db = FileMetaDataAtDB.model_validate(fmd)
         async with transaction_context(self.db_engine, connection) as conn:
-            result = await conn.execute(
-                file_meta_data.insert().values(jsonable_encoder(fmd_db)).returning(literal_column("*"))
+            return FileMetaDataAtDB.model_validate(
+                (
+                    await conn.execute(
+                        file_meta_data.insert().values(jsonable_encoder(fmd_db)).returning(literal_column("*"))
+                    )
+                ).one()
             )
-            row = result.one()
-        return FileMetaDataAtDB.model_validate(row)
 
     async def get(self, *, connection: AsyncConnection | None = None, file_id: SimcoreS3FileID) -> FileMetaDataAtDB:
         async with pass_or_acquire_connection(self.db_engine, connection) as conn:
@@ -245,7 +250,7 @@ class FileMetaDataRepository(BaseRepository):
                         (
                             file_meta_data.c.project_id.in_([f"{_}" for _ in filter_by_project_ids])
                             if filter_by_project_ids
-                            else True
+                            else sa.true()
                         ),
                     )
                 )
@@ -266,7 +271,7 @@ class FileMetaDataRepository(BaseRepository):
                 .where(
                     file_meta_data.c.project_id.in_([f"{_}" for _ in filter_by_project_ids])
                     if filter_by_project_ids
-                    else True
+                    else sa.true()
                 )
                 .cte("ranked_files")
             )
@@ -286,9 +291,11 @@ class FileMetaDataRepository(BaseRepository):
             .offset(cursor_params.offset)
         )
         async with pass_or_acquire_connection(self.db_engine, connection) as conn:
-            total_count = await conn.scalar(
-                sa.select(sa.func.count()).select_from(ranked_files).where(ranked_files.c.row_num == 1)
-            )
+            total_count = (
+                await conn.scalar(
+                    sa.select(sa.func.count()).select_from(ranked_files).where(ranked_files.c.row_num == 1)
+                )
+            ) or 0
 
             items = [
                 PathMetaData(
@@ -328,10 +335,10 @@ class FileMetaDataRepository(BaseRepository):
     ) -> list[FileMetaDataAtDB]:
         stmt = sa.select(file_meta_data).where(
             and_(
-                (file_meta_data.c.user_id == f"{user_id}") if user_id else True,
-                ((file_meta_data.c.project_id.in_([f"{p}" for p in project_ids])) if project_ids else True),
-                (file_meta_data.c.file_id.in_(file_ids)) if file_ids else True,
-                ((file_meta_data.c.upload_expires_at < expired_after) if expired_after else True),
+                (file_meta_data.c.user_id == f"{user_id}") if user_id else sa.true(),
+                ((file_meta_data.c.project_id.in_([f"{p}" for p in project_ids])) if project_ids else sa.true()),
+                (file_meta_data.c.file_id.in_(file_ids)) if file_ids else sa.true(),
+                ((file_meta_data.c.upload_expires_at < expired_after) if expired_after else sa.true()),
             )
         )
         async with pass_or_acquire_connection(self.db_engine, connection) as conn:

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -427,7 +427,7 @@ six==1.16.0
     # via python-dateutil
 sniffio==1.3.1
     # via anyio
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -r requirements/../../../../packages/postgres-database/requirements/_base.in
@@ -472,6 +472,7 @@ typing-extensions==4.14.1
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1

--- a/services/web/server/requirements/_test.txt
+++ b/services/web/server/requirements/_test.txt
@@ -341,14 +341,12 @@ sortedcontainers==2.4.0
     # via
     #   fakeredis
     #   hypothesis
-sqlalchemy==1.4.54
+sqlalchemy==2.0.51
     # via
     #   -c requirements/../../../../requirements/constraints.txt
     #   -c requirements/_base.txt
     #   -r requirements/_test.in
     #   alembic
-sqlalchemy2-stubs==0.0.2a38
-    # via sqlalchemy
 starlette==0.47.3
     # via
     #   -c requirements/../../../../requirements/constraints.txt
@@ -384,7 +382,7 @@ typing-extensions==4.14.1
     #   pydantic
     #   pydantic-core
     #   rich-toolkit
-    #   sqlalchemy2-stubs
+    #   sqlalchemy
     #   typer
     #   typing-inspection
 typing-inspection==0.4.1

--- a/services/web/server/src/simcore_service_webserver/application_keys.py
+++ b/services/web/server/src/simcore_service_webserver/application_keys.py
@@ -14,14 +14,19 @@ if TYPE_CHECKING:
     from .application_settings import ApplicationSettings
 
     APP_SETTINGS_APPKEY: Final = web.AppKey("APP_SETTINGS", ApplicationSettings)
+    APP_PUBLIC_CONFIG_PER_PRODUCT_APPKEY: Final = web.AppKey(
+        "APP_PUBLIC_CONFIG_PER_PRODUCT", dict[str, dict[str, object]]
+    )
 else:
     APP_SETTINGS_APPKEY: Final = web.AppKey("APP_SETTINGS", None)
+    APP_PUBLIC_CONFIG_PER_PRODUCT_APPKEY: Final = web.AppKey("APP_PUBLIC_CONFIG_PER_PRODUCT", dict)
 
 
 __all__: tuple[str, ...] = (
     "APP_CLIENT_SESSION_KEY",
     "APP_CONFIG_KEY",
     "APP_FIRE_AND_FORGET_TASKS_KEY",
+    "APP_PUBLIC_CONFIG_PER_PRODUCT_APPKEY",
     "APP_SETTINGS_APPKEY",
 )
 

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -559,7 +559,7 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
     def public_dict(self) -> dict[str, Any]:
         """Config publicly available"""
 
-        config = {"invitation_required": False}  # SEE APP_PUBLIC_CONFIG_PER_PRODUCT
+        config = {"invitation_required": False}  # SEE APP_PUBLIC_CONFIG_PER_PRODUCT_APPKEY
         config.update(
             self._export_by_alias(
                 include={

--- a/services/web/server/src/simcore_service_webserver/constants.py
+++ b/services/web/server/src/simcore_service_webserver/constants.py
@@ -13,9 +13,6 @@ from servicelib.aiohttp.request_keys import RQT_USERID_KEY
 assert APP_CLIENT_SESSION_KEY  # nosec
 assert APP_CONFIG_KEY  # nosec
 
-# Public config per product returned in /config
-APP_PUBLIC_CONFIG_PER_PRODUCT: Final[str] = f"{__name__}.APP_PUBLIC_CONFIG_PER_PRODUCT"
-
 FRONTEND_APPS_AVAILABLE = frozenset(
     # These are the apps built right now by static-webserver/client
     {

--- a/services/web/server/src/simcore_service_webserver/functions/_function_job_collections_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_function_job_collections_repository.py
@@ -195,8 +195,11 @@ async def list_function_job_collections(
             function_job_collections_table.c.uuid.in_(access_subquery),
         )
 
-        total_count_result = await conn.scalar(
-            func.count().select().select_from(function_job_collections_table).where(filter_and_access_condition)
+        total_count_result = (
+            await conn.scalar(
+                func.count().select().select_from(function_job_collections_table).where(filter_and_access_condition)
+            )
+            or 0
         )
         if total_count_result == 0:
             return [], PageMetaInfoLimitOffset(total=0, offset=pagination_offset, limit=pagination_limit, count=0)

--- a/services/web/server/src/simcore_service_webserver/functions/_function_jobs_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_function_jobs_repository.py
@@ -238,8 +238,8 @@ async def list_function_jobs_with_status(
                 function_jobs_table.c.uuid.in_(collection_subquery),
             )
 
-        total_count_result = await conn.scalar(
-            func.count().select().select_from(function_jobs_table).where(filter_conditions)
+        total_count_result = (
+            await conn.scalar(func.count().select().select_from(function_jobs_table).where(filter_conditions)) or 0
         )
         if total_count_result == 0:
             return [], PageMetaInfoLimitOffset(total=0, offset=pagination_offset, limit=pagination_limit, count=0)

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
@@ -280,10 +280,11 @@ async def _internal_set_group_permissions(
                 access_rights_list.append((object_id, FunctionGroupAccessRights(**row)))
             else:
                 # Update existing access rights only for non-None values
+                row_mapping = row._mapping
                 update_values = {
-                    "read": read if read is not None else row["read"],
-                    "write": write if write is not None else row["write"],
-                    "execute": execute if execute is not None else row["execute"],
+                    "read": read if read is not None else row_mapping["read"],
+                    "write": write if write is not None else row_mapping["write"],
+                    "execute": execute if execute is not None else row_mapping["execute"],
                 }
 
                 update_result = await transaction.execute(

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
@@ -97,21 +97,18 @@ async def _internal_get_group_permissions(
             rows = [
                 row
                 async for row in await conn.stream(
-                    access_rights_table.select().where(
+                    sa.select(
+                        access_rights_table.c.group_id,
+                        access_rights_table.c.read,
+                        access_rights_table.c.write,
+                        access_rights_table.c.execute,
+                    ).where(
                         getattr(access_rights_table.c, field_name) == object_id,
                         access_rights_table.c.product_name == product_name,
                     )
                 )
             ]
-            group_permissions = [
-                FunctionGroupAccessRights(
-                    group_id=row.group_id,
-                    read=row.read,
-                    write=row.write,
-                    execute=row.execute,
-                )
-                for row in rows
-            ]
+            group_permissions = [FunctionGroupAccessRights.model_validate(row) for row in rows]
             access_rights_list.append((object_id, group_permissions))
 
         return access_rights_list
@@ -282,7 +279,12 @@ async def _internal_set_group_permissions(
                     )
                 )
                 row = result.one()
-                access_rights_list.append((object_id, FunctionGroupAccessRights(**dict(row))))
+                access_rights_list.append(
+                    (
+                        object_id,
+                        FunctionGroupAccessRights.model_validate(row),
+                    )
+                )
             else:
                 # Update existing access rights only for non-None values
                 update_values = {
@@ -306,7 +308,12 @@ async def _internal_set_group_permissions(
                     )
                 )
                 updated_row = update_result.one()
-                access_rights_list.append((object_id, FunctionGroupAccessRights(**dict(updated_row))))
+                access_rights_list.append(
+                    (
+                        object_id,
+                        FunctionGroupAccessRights.model_validate(updated_row),
+                    )
+                )
 
         return access_rights_list
 

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
@@ -1,6 +1,7 @@
 from typing import Literal
 from uuid import UUID
 
+import sqlalchemy as sa
 from aiohttp import web
 from models_library.functions import (
     FunctionAccessRightsDB,
@@ -250,7 +251,11 @@ async def _internal_set_group_permissions(
         for object_id in object_ids:
             # Check if the group already has access rights for the function
             result = await transaction.execute(
-                access_rights_table.select().where(
+                sa.select(
+                    access_rights_table.c.read,
+                    access_rights_table.c.write,
+                    access_rights_table.c.execute,
+                ).where(
                     getattr(access_rights_table.c, field_name) == object_id,
                     access_rights_table.c.group_id == permission_group_id,
                 )
@@ -277,13 +282,13 @@ async def _internal_set_group_permissions(
                     )
                 )
                 row = result.one()
-                access_rights_list.append((object_id, FunctionGroupAccessRights(**row)))
+                access_rights_list.append((object_id, FunctionGroupAccessRights(**dict(row))))
             else:
                 # Update existing access rights only for non-None values
                 update_values = {
-                    "read": read if read is not None else row["read"],
-                    "write": write if write is not None else row["write"],
-                    "execute": execute if execute is not None else row["execute"],
+                    "read": read if read is not None else row.read,
+                    "write": write if write is not None else row.write,
+                    "execute": execute if execute is not None else row.execute,
                 }
 
                 update_result = await transaction.execute(
@@ -301,7 +306,7 @@ async def _internal_set_group_permissions(
                     )
                 )
                 updated_row = update_result.one()
-                access_rights_list.append((object_id, FunctionGroupAccessRights(**updated_row)))
+                access_rights_list.append((object_id, FunctionGroupAccessRights(**dict(updated_row))))
 
         return access_rights_list
 

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_permissions_repository.py
@@ -280,11 +280,10 @@ async def _internal_set_group_permissions(
                 access_rights_list.append((object_id, FunctionGroupAccessRights(**row)))
             else:
                 # Update existing access rights only for non-None values
-                row_mapping = row._mapping
                 update_values = {
-                    "read": read if read is not None else row_mapping["read"],
-                    "write": write if write is not None else row_mapping["write"],
-                    "execute": execute if execute is not None else row_mapping["execute"],
+                    "read": read if read is not None else row["read"],
+                    "write": write if write is not None else row["write"],
+                    "execute": execute if execute is not None else row["execute"],
                 }
 
                 update_result = await transaction.execute(

--- a/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
+++ b/services/web/server/src/simcore_service_webserver/functions/_functions_repository.py
@@ -208,7 +208,7 @@ async def list_functions(  # noqa: PLR0913
         )
 
         # Get total count
-        total_count = await conn.scalar(func.count().select().select_from(base_query.subquery()))
+        total_count = await conn.scalar(func.count().select().select_from(base_query.subquery())) or 0
         if total_count == 0:
             return [], PageMetaInfoLimitOffset(total=0, offset=pagination_offset, limit=pagination_limit, count=0)
 

--- a/services/web/server/src/simcore_service_webserver/groups/_groups_repository.py
+++ b/services/web/server/src/simcore_service_webserver/groups/_groups_repository.py
@@ -831,12 +831,12 @@ async def auto_add_user_to_groups(
     async with transaction_context(get_asyncpg_engine(app), connection) as conn:
         result = await conn.stream(query)
         async for row in result:
-            inclusion_rules = row[groups.c.inclusion_rules]
+            inclusion_rules = row.inclusion_rules
             for prop, rule_pattern in inclusion_rules.items():
                 if prop not in user:
                     continue
                 if re.search(rule_pattern, user[prop]):
-                    possible_group_ids.add(row[groups.c.gid])
+                    possible_group_ids.add(row.gid)
 
         # now add the user to these groups if possible
         for gid in possible_group_ids:

--- a/services/web/server/src/simcore_service_webserver/licenses/_licensed_items_repository.py
+++ b/services/web/server/src/simcore_service_webserver/licenses/_licensed_items_repository.py
@@ -272,7 +272,7 @@ async def get_licensed_item_by_key_version(
         row = result.one_or_none()
         if row is None:
             raise LicensedKeyVersionNotFoundError(key=key, version=version)
-        return LicensedItem.model_validate(dict(row))
+        return LicensedItem.model_validate(row, from_attributes=True)
 
 
 async def list_licensed_items(
@@ -337,6 +337,6 @@ async def list_licensed_items(
         total_count = await conn.scalar(count_query)
 
         result = await conn.stream(list_query)
-        items: list[LicensedItem] = [LicensedItem.model_validate(dict(row)) async for row in result]
+        items: list[LicensedItem] = [LicensedItem.model_validate(row, from_attributes=True) async for row in result]
 
         return cast(int, total_count), items

--- a/services/web/server/src/simcore_service_webserver/login/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/login/plugin.py
@@ -3,16 +3,16 @@ import logging
 from aiohttp import web
 from pydantic import ValidationError
 
-from ..application_keys import APP_SETTINGS_APPKEY
+from ..application_keys import (
+    APP_PUBLIC_CONFIG_PER_PRODUCT_APPKEY,
+    APP_SETTINGS_APPKEY,
+)
 from ..application_setup import (
     ModuleCategory,
     app_setup_func,
     ensure_single_setup,
 )
-from ..constants import (
-    APP_PUBLIC_CONFIG_PER_PRODUCT,
-    INDEX_RESOURCE_NAME,
-)
+from ..constants import INDEX_RESOURCE_NAME
 from ..db.plugin import setup_db
 from ..invitations.plugin import setup_invitations
 from ..login_accounts.plugin import setup_login_account
@@ -87,7 +87,7 @@ async def _resolve_login_settings_per_product(app: web.Application):
     for product_name, settings in login_settings_per_product.items():
         public_data_per_product[product_name] = {"invitation_required": settings.LOGIN_REGISTRATION_INVITATION_REQUIRED}
 
-    app.setdefault(APP_PUBLIC_CONFIG_PER_PRODUCT, public_data_per_product)
+    app.setdefault(APP_PUBLIC_CONFIG_PER_PRODUCT_APPKEY, public_data_per_product)
 
 
 @app_setup_func(

--- a/services/web/server/src/simcore_service_webserver/products/_models.py
+++ b/services/web/server/src/simcore_service_webserver/products/_models.py
@@ -235,7 +235,7 @@ class Product(BaseModel):
                         },
                         # defaults from sqlalchemy table
                         **{
-                            str(c.name): c.server_default.arg
+                            f"{c.name}": c.server_default.arg
                             for c in products.columns
                             if isinstance(c, Column)
                             and isinstance(c.server_default, DefaultClause)

--- a/services/web/server/src/simcore_service_webserver/products/_models.py
+++ b/services/web/server/src/simcore_service_webserver/products/_models.py
@@ -33,7 +33,7 @@ from simcore_postgres_database.models.products import (
     WebFeedback,
     products,
 )
-from sqlalchemy import Column
+from sqlalchemy import Column, DefaultClause
 
 from ..constants import FRONTEND_APPS_AVAILABLE
 
@@ -235,9 +235,11 @@ class Product(BaseModel):
                         },
                         # defaults from sqlalchemy table
                         **{
-                            str(c.name): c.server_default.arg  # type: ignore[union-attr]
+                            str(c.name): c.server_default.arg
                             for c in products.columns
-                            if isinstance(c, Column) and c.server_default and isinstance(c.server_default.arg, str)  # type: ignore[union-attr]
+                            if isinstance(c, Column)
+                            and isinstance(c.server_default, DefaultClause)
+                            and isinstance(c.server_default.arg, str)
                         },
                     },
                     # Example of data in the database with a url set with blanks

--- a/services/web/server/src/simcore_service_webserver/projects/_folders_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_folders_repository.py
@@ -42,18 +42,23 @@ async def insert_project_to_folder(
     private_workspace_user_id_or_none: UserID | None,
 ) -> ProjectToFolderDB:
     async with transaction_context(get_asyncpg_engine(app)) as conn:
-        result = await conn.execute(
-            projects_to_folders.insert()
-            .values(
-                project_uuid=f"{project_id}",
-                folder_id=folder_id,
-                user_id=private_workspace_user_id_or_none,
-                created=func.now(),
-                modified=func.now(),
+        row = (
+            (
+                await conn.execute(
+                    projects_to_folders.insert()
+                    .values(
+                        project_uuid=f"{project_id}",
+                        folder_id=folder_id,
+                        user_id=private_workspace_user_id_or_none,
+                        created=func.now(),
+                        modified=func.now(),
+                    )
+                    .returning(literal_column("*"))
+                )
             )
-            .returning(literal_column("*"))
+            .mappings()
+            .one()
         )
-        row = result.mappings().one()
         return ProjectToFolderDB.model_validate(row)
 
 

--- a/services/web/server/src/simcore_service_webserver/projects/_groups_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_groups_repository.py
@@ -28,23 +28,25 @@ async def create_project_group(
     write: bool,
     delete: bool,
 ) -> ProjectGroupGetDB:
-    query = (
-        project_to_groups.insert()
-        .values(
-            project_uuid=f"{project_id}",
-            gid=group_id,
-            read=read,
-            write=write,
-            delete=delete,
-            created=func.now(),
-            modified=func.now(),
-        )
-        .returning(literal_column("*"))
-    )
-
+    row: object | None
     async with transaction_context(get_asyncpg_engine(app), connection) as conn:
-        result = await conn.stream(query)
-        row = await result.first()
+        row = await (
+            await conn.stream(
+                project_to_groups.insert()
+                .values(
+                    project_uuid=f"{project_id}",
+                    gid=group_id,
+                    read=read,
+                    write=write,
+                    delete=delete,
+                    created=func.now(),
+                    modified=func.now(),
+                )
+                .returning(literal_column("*"))
+            )
+        ).first()
+        if row is None:
+            raise ProjectGroupNotFoundError(details=f"Project {project_id} group {group_id} not found")
         return ProjectGroupGetDB.model_validate(row)
 
 
@@ -111,20 +113,20 @@ async def replace_project_group(
     write: bool,
     delete: bool,
 ) -> ProjectGroupGetDB:
-    query = (
-        project_to_groups.update()
-        .values(
-            read=read,
-            write=write,
-            delete=delete,
-        )
-        .where((project_to_groups.c.project_uuid == f"{project_id}") & (project_to_groups.c.gid == group_id))
-        .returning(literal_column("*"))
-    )
-
+    row: object | None
     async with transaction_context(get_asyncpg_engine(app), connection) as conn:
-        result = await conn.stream(query)
-        row = await result.first()
+        row = await (
+            await conn.stream(
+                project_to_groups.update()
+                .values(
+                    read=read,
+                    write=write,
+                    delete=delete,
+                )
+                .where((project_to_groups.c.project_uuid == f"{project_id}") & (project_to_groups.c.gid == group_id))
+                .returning(literal_column("*"))
+            )
+        ).first()
         if row is None:
             raise ProjectGroupNotFoundError(details=f"Project {project_id} group {group_id} not found")
         return ProjectGroupGetDB.model_validate(row)

--- a/services/web/server/src/simcore_service_webserver/projects/_metadata_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_metadata_repository.py
@@ -166,5 +166,5 @@ async def list_project_uuids_by_root_parent_project_id(
     )
 
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
-        result = await conn.stream(stmt)
-        return [ProjectID(row._mapping["project_uuid"]) async for row in result]
+        result = await conn.stream_scalars(stmt)
+        return [ProjectID(project_uuid) async for project_uuid in result]

--- a/services/web/server/src/simcore_service_webserver/projects/_metadata_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_metadata_repository.py
@@ -167,4 +167,4 @@ async def list_project_uuids_by_root_parent_project_id(
 
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
         result = await conn.stream(stmt)
-        return [ProjectID(row["project_uuid"]) async for row in result]
+        return [ProjectID(row._mapping["project_uuid"]) async for row in result]

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_nodes_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_nodes_repository.py
@@ -100,7 +100,7 @@ async def delete(
                 (projects_nodes.c.project_uuid == f"{project_id}") & (projects_nodes.c.node_id == f"{node_id}")
             )
         )
-        if result.rowcount == 0:  # type: ignore[attr-defined]
+        if result.rowcount == 0:
             raise NodeNotFoundError(project_uuid=f"{project_id}", node_uuid=f"{node_id}")
 
 

--- a/services/web/server/src/simcore_service_webserver/rest/_handlers.py
+++ b/services/web/server/src/simcore_service_webserver/rest/_handlers.py
@@ -10,8 +10,10 @@ from servicelib.aiohttp import status
 from servicelib.aiohttp.rest_responses import create_http_error, exception_to_response
 
 from .._meta import API_VTAG
-from ..application_keys import APP_SETTINGS_APPKEY
-from ..constants import APP_PUBLIC_CONFIG_PER_PRODUCT
+from ..application_keys import (
+    APP_PUBLIC_CONFIG_PER_PRODUCT_APPKEY,
+    APP_SETTINGS_APPKEY,
+)
 from ..login.decorators import login_required
 from ..products import products_web
 from ..redis import get_redis_scheduled_maintenance_client
@@ -83,7 +85,7 @@ async def get_config(request: web.Request):
     app_public_config: dict[str, Any] = request.app[APP_SETTINGS_APPKEY].public_dict()
 
     product_name = products_web.get_product_name(request=request)
-    product_public_config = request.app.get(APP_PUBLIC_CONFIG_PER_PRODUCT, {}).get(product_name, {})
+    product_public_config = request.app.get(APP_PUBLIC_CONFIG_PER_PRODUCT_APPKEY, {}).get(product_name, {})
 
     return envelope_json_response(app_public_config | product_public_config)
 

--- a/services/web/server/src/simcore_service_webserver/scicrunch/_repository.py
+++ b/services/web/server/src/simcore_service_webserver/scicrunch/_repository.py
@@ -32,7 +32,7 @@ class ScicrunchResourcesRepository(BaseRepository):
                 scicrunch_resources.c.description,
             )
             result = await conn.execute(stmt)
-            return result.fetchall()
+            return list(result.fetchall())
 
     async def get_resource_by_rrid(self, rrid: str, connection: AsyncConnection | None = None) -> Row | None:
         """Get a research resource by RRID."""

--- a/services/web/server/src/simcore_service_webserver/user_tokens/_repository.py
+++ b/services/web/server/src/simcore_service_webserver/user_tokens/_repository.py
@@ -9,7 +9,7 @@ from simcore_postgres_database.utils_repos import (
     pass_or_acquire_connection,
     transaction_context,
 )
-from sqlalchemy import and_, literal_column
+from sqlalchemy import and_
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from ..db.base_repository import BaseRepository
@@ -83,16 +83,16 @@ class UserTokensRepository(BaseRepository):
             if not row:
                 raise TokenNotFoundError(service_id=service_id)
 
-            data = dict(row["token_data"])
-            tid = row["token_id"]
+            data = dict(row.token_data)
+            tid = row.token_id
             data.update(token_data)
 
             result = await conn.execute(
-                tokens.update().where(tokens.c.token_id == tid).values(token_data=data).returning(literal_column("*"))
+                tokens.update().where(tokens.c.token_id == tid).values(token_data=data).returning(tokens.c.token_data)
             )
             updated_token = result.one()
             assert updated_token  # nosec
-            return UserThirdPartyToken.model_construct(**updated_token["token_data"])
+            return UserThirdPartyToken.model_construct(**updated_token.token_data)
 
     async def delete_token(
         self,

--- a/services/web/server/src/simcore_service_webserver/user_tokens/_repository.py
+++ b/services/web/server/src/simcore_service_webserver/user_tokens/_repository.py
@@ -43,7 +43,7 @@ class UserTokensRepository(BaseRepository):
     ) -> list[UserThirdPartyToken]:
         async with pass_or_acquire_connection(self.engine, connection) as conn:
             result = await conn.execute(sa.select(tokens.c.token_data).where(tokens.c.user_id == user_id))
-            return [UserThirdPartyToken.model_construct(**row["token_data"]) for row in result.fetchall()]
+            return [UserThirdPartyToken.model_construct(**row._mapping["token_data"]) for row in result.fetchall()]
 
     async def get_token(
         self,
@@ -62,7 +62,7 @@ class UserTokensRepository(BaseRepository):
                 )
             )
             if row := result.one_or_none():
-                return UserThirdPartyToken.model_construct(**row["token_data"])
+                return UserThirdPartyToken.model_construct(**row._mapping["token_data"])
             raise TokenNotFoundError(service_id=service_id)
 
     async def update_token(
@@ -83,8 +83,8 @@ class UserTokensRepository(BaseRepository):
             if not row:
                 raise TokenNotFoundError(service_id=service_id)
 
-            data = dict(row["token_data"])
-            tid = row["token_id"]
+            data = dict(row._mapping["token_data"])
+            tid = row._mapping["token_id"]
             data.update(token_data)
 
             result = await conn.execute(
@@ -92,7 +92,7 @@ class UserTokensRepository(BaseRepository):
             )
             updated_token = result.one()
             assert updated_token  # nosec
-            return UserThirdPartyToken.model_construct(**updated_token["token_data"])
+            return UserThirdPartyToken.model_construct(**updated_token._mapping["token_data"])
 
     async def delete_token(
         self,

--- a/services/web/server/src/simcore_service_webserver/user_tokens/_repository.py
+++ b/services/web/server/src/simcore_service_webserver/user_tokens/_repository.py
@@ -43,7 +43,7 @@ class UserTokensRepository(BaseRepository):
     ) -> list[UserThirdPartyToken]:
         async with pass_or_acquire_connection(self.engine, connection) as conn:
             result = await conn.execute(sa.select(tokens.c.token_data).where(tokens.c.user_id == user_id))
-            return [UserThirdPartyToken.model_construct(**row._mapping["token_data"]) for row in result.fetchall()]
+            return [UserThirdPartyToken.model_construct(**token_data) for token_data in result.scalars().all()]
 
     async def get_token(
         self,
@@ -61,8 +61,8 @@ class UserTokensRepository(BaseRepository):
                     )
                 )
             )
-            if row := result.one_or_none():
-                return UserThirdPartyToken.model_construct(**row._mapping["token_data"])
+            if token_data := result.scalar_one_or_none():
+                return UserThirdPartyToken.model_construct(**token_data)
             raise TokenNotFoundError(service_id=service_id)
 
     async def update_token(
@@ -83,8 +83,8 @@ class UserTokensRepository(BaseRepository):
             if not row:
                 raise TokenNotFoundError(service_id=service_id)
 
-            data = dict(row._mapping["token_data"])
-            tid = row._mapping["token_id"]
+            data = dict(row["token_data"])
+            tid = row["token_id"]
             data.update(token_data)
 
             result = await conn.execute(
@@ -92,7 +92,7 @@ class UserTokensRepository(BaseRepository):
             )
             updated_token = result.one()
             assert updated_token  # nosec
-            return UserThirdPartyToken.model_construct(**updated_token._mapping["token_data"])
+            return UserThirdPartyToken.model_construct(**updated_token["token_data"])
 
     async def delete_token(
         self,

--- a/services/web/server/src/simcore_service_webserver/users/_accounts_repository.py
+++ b/services/web/server/src/simcore_service_webserver/users/_accounts_repository.py
@@ -142,7 +142,7 @@ async def list_user_pre_registrations(
         Tuple of (list of pre-registration records, total count)
     """
     # Base query conditions
-    where_conditions = []
+    where_conditions: list[sa.ColumnElement[bool]] = []
 
     # Apply filters if provided
     if filter_by_pre_email is not None:
@@ -424,7 +424,7 @@ def _build_left_outer_join_query(
     product_name: ProductName | None,
     columns: tuple,
 ) -> sa.sql.Select | None:
-    left_where_conditions = []
+    left_where_conditions: list[sa.ColumnElement[bool]] = []
     if email_like is not None:
         left_where_conditions.append(users_pre_registration_details.c.pre_email.like(email_like))
     if product_name:
@@ -442,7 +442,7 @@ def _build_right_outer_join_query(
     product_name: ProductName | None,
     columns: tuple,
 ) -> sa.sql.Select | None:
-    right_where_conditions = []
+    right_where_conditions: list[sa.ColumnElement[bool]] = []
     if email_like is not None:
         right_where_conditions.append(users.c.email.like(email_like))
     if user_name_like is not None:
@@ -543,7 +543,7 @@ async def search_merged_pre_and_registered_users(
 
     async with pass_or_acquire_connection(engine, connection) as conn:
         result = await conn.execute(final_query)
-        return result.fetchall()
+        return list(result.fetchall())
 
 
 async def list_merged_pre_and_registered_users(

--- a/services/web/server/src/simcore_service_webserver/users/_users_repository.py
+++ b/services/web/server/src/simcore_service_webserver/users/_users_repository.py
@@ -211,12 +211,12 @@ async def get_active_users_email_data_by_ids(
 
 async def get_user_id_from_pgid(app: web.Application, *, primary_gid: int) -> UserID:
     async with pass_or_acquire_connection(engine=get_asyncpg_engine(app)) as conn:
-        user_id: UserID = await conn.scalar(
+        user_id = await conn.scalar(
             sa.select(
                 users.c.id,
             ).where(users.c.primary_gid == primary_gid)
         )
-        return user_id
+        return _parse_as_user(user_id)
 
 
 async def get_user_email_legacy(engine: AsyncEngine, *, user_id: UserID | None) -> str:

--- a/services/web/server/src/simcore_service_webserver/wallets/_db.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_db.py
@@ -31,21 +31,26 @@ async def create_wallet(
     thumbnail: str | None,
 ) -> WalletDB:
     async with transaction_context(get_asyncpg_engine(app)) as conn:
-        result = await conn.execute(
-            wallets.insert()
-            .values(
-                name=wallet_name,
-                description=description,
-                owner=owner,
-                thumbnail=thumbnail,
-                status=WalletStatus.ACTIVE,
-                created=func.now(),
-                modified=func.now(),
-                product_name=product_name,
+        row = (
+            (
+                await conn.execute(
+                    wallets.insert()
+                    .values(
+                        name=wallet_name,
+                        description=description,
+                        owner=owner,
+                        thumbnail=thumbnail,
+                        status=WalletStatus.ACTIVE,
+                        created=func.now(),
+                        modified=func.now(),
+                        product_name=product_name,
+                    )
+                    .returning(literal_column("*"))
+                )
             )
-            .returning(literal_column("*"))
+            .mappings()
+            .one()
         )
-        row = result.mappings().one()
         return WalletDB.model_validate(row)
 
 
@@ -194,19 +199,24 @@ async def update_wallet(
     product_name: ProductName,
 ) -> WalletDB:
     async with transaction_context(get_asyncpg_engine(app)) as conn:
-        result = await conn.execute(
-            wallets.update()
-            .values(
-                name=name,
-                description=description,
-                thumbnail=thumbnail,
-                status=status,
-                modified=func.now(),
+        row = (
+            (
+                await conn.execute(
+                    wallets.update()
+                    .values(
+                        name=name,
+                        description=description,
+                        thumbnail=thumbnail,
+                        status=status,
+                        modified=func.now(),
+                    )
+                    .where((wallets.c.wallet_id == wallet_id) & (wallets.c.product_name == product_name))
+                    .returning(literal_column("*"))
+                )
             )
-            .where((wallets.c.wallet_id == wallet_id) & (wallets.c.product_name == product_name))
-            .returning(literal_column("*"))
+            .mappings()
+            .one_or_none()
         )
-        row = result.mappings().one_or_none()
         if row is None:
             raise WalletNotFoundError(details=f"Wallet {wallet_id} not found.")
         return WalletDB.model_validate(row)

--- a/services/web/server/src/simcore_service_webserver/wallets/_groups_db.py
+++ b/services/web/server/src/simcore_service_webserver/wallets/_groups_db.py
@@ -32,20 +32,25 @@ async def create_wallet_group(
     delete: bool,
 ) -> WalletGroupGetDB:
     async with transaction_context(get_asyncpg_engine(app)) as conn:
-        result = await conn.execute(
-            wallet_to_groups.insert()
-            .values(
-                wallet_id=wallet_id,
-                gid=group_id,
-                read=read,
-                write=write,
-                delete=delete,
-                created=func.now(),
-                modified=func.now(),
+        row = (
+            (
+                await conn.execute(
+                    wallet_to_groups.insert()
+                    .values(
+                        wallet_id=wallet_id,
+                        gid=group_id,
+                        read=read,
+                        write=write,
+                        delete=delete,
+                        created=func.now(),
+                        modified=func.now(),
+                    )
+                    .returning(literal_column("*"))
+                )
             )
-            .returning(literal_column("*"))
+            .mappings()
+            .one()
         )
-        row = result.mappings().one()
         return WalletGroupGetDB.model_validate(row)
 
 
@@ -108,17 +113,22 @@ async def update_wallet_group(
     delete: bool,
 ) -> WalletGroupGetDB:
     async with transaction_context(get_asyncpg_engine(app)) as conn:
-        result = await conn.execute(
-            wallet_to_groups.update()
-            .values(
-                read=read,
-                write=write,
-                delete=delete,
+        row = (
+            (
+                await conn.execute(
+                    wallet_to_groups.update()
+                    .values(
+                        read=read,
+                        write=write,
+                        delete=delete,
+                    )
+                    .where((wallet_to_groups.c.wallet_id == wallet_id) & (wallet_to_groups.c.gid == group_id))
+                    .returning(literal_column("*"))
+                )
             )
-            .where((wallet_to_groups.c.wallet_id == wallet_id) & (wallet_to_groups.c.gid == group_id))
-            .returning(literal_column("*"))
+            .mappings()
+            .one_or_none()
         )
-        row = result.mappings().one_or_none()
         if row is None:
             raise WalletGroupNotFoundError(details=f"Wallet {wallet_id} group {group_id} not found")
         return WalletGroupGetDB.model_validate(row)

--- a/services/web/server/src/simcore_service_webserver/workspaces/_groups_repository.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_groups_repository.py
@@ -47,21 +47,25 @@ async def create_workspace_group(
     write: bool,
     delete: bool,
 ) -> WorkspaceGroupGetDB:
+    row: object | None
     async with transaction_context(get_asyncpg_engine(app), connection) as conn:
-        result = await conn.stream(
-            workspaces_access_rights.insert()
-            .values(
-                workspace_id=workspace_id,
-                gid=group_id,
-                read=read,
-                write=write,
-                delete=delete,
-                created=func.now(),
-                modified=func.now(),
+        row = await (
+            await conn.stream(
+                workspaces_access_rights.insert()
+                .values(
+                    workspace_id=workspace_id,
+                    gid=group_id,
+                    read=read,
+                    write=write,
+                    delete=delete,
+                    created=func.now(),
+                    modified=func.now(),
+                )
+                .returning(literal_column("*"))
             )
-            .returning(literal_column("*"))
-        )
-        row = await result.first()
+        ).first()
+        if row is None:
+            raise WorkspaceGroupNotFoundError(workspace_id=workspace_id, group_id=group_id)
         return WorkspaceGroupGetDB.model_validate(row)
 
 
@@ -127,20 +131,23 @@ async def update_workspace_group(
     write: bool,
     delete: bool,
 ) -> WorkspaceGroupGetDB:
+    row: object | None
     async with transaction_context(get_asyncpg_engine(app), connection) as conn:
-        result = await conn.stream(
-            workspaces_access_rights.update()
-            .values(
-                read=read,
-                write=write,
-                delete=delete,
+        row = await (
+            await conn.stream(
+                workspaces_access_rights.update()
+                .values(
+                    read=read,
+                    write=write,
+                    delete=delete,
+                )
+                .where(
+                    (workspaces_access_rights.c.workspace_id == workspace_id)
+                    & (workspaces_access_rights.c.gid == group_id)
+                )
+                .returning(literal_column("*"))
             )
-            .where(
-                (workspaces_access_rights.c.workspace_id == workspace_id) & (workspaces_access_rights.c.gid == group_id)
-            )
-            .returning(literal_column("*"))
-        )
-        row = await result.first()
+        ).first()
         if row is None:
             raise WorkspaceGroupNotFoundError(workspace_id=workspace_id, group_id=group_id)
         return WorkspaceGroupGetDB.model_validate(row)

--- a/services/web/server/tests/unit/with_dbs/03/test_project_db.py
+++ b/services/web/server/tests/unit/with_dbs/03/test_project_db.py
@@ -151,14 +151,14 @@ def _assert_project_db_row(postgres_db: sa.engine.Engine, project: dict[str, Any
     expected_db_entries.update(kwargs)
     assert row
     # Remove last_change_date from strict equality check
-    project_entries_in_db = {k: row[k] for k in expected_db_entries}
+    project_entries_in_db = {k: getattr(row, k) for k in expected_db_entries}
     project_last_change = project_entries_in_db.pop("last_change_date", None)
     expected_db_entries.pop("last_change_date", None)
     assert project_entries_in_db == expected_db_entries
     # last_change_date should be >= creation_date
     assert project_last_change is not None
-    assert row["creation_date"] is not None
-    assert project_last_change >= row["creation_date"]
+    assert row.creation_date is not None
+    assert project_last_change >= row.creation_date
 
 
 @pytest.fixture

--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -520,7 +520,7 @@ def postgres_dsn(docker_services: Services, docker_ip: str | Any, default_app_cf
 
 @pytest.fixture(scope="session")
 def postgres_service(docker_services: Services, postgres_dsn: dict) -> str:
-    DSN = "postgresql://{user}:{password}@{host}:{port}/{database}"
+    DSN = "postgresql+psycopg2://{user}:{password}@{host}:{port}/{database}"
     url = DSN.format(**postgres_dsn)
 
     # Wait until service is responsive.
@@ -561,7 +561,8 @@ def postgres_db(postgres_dsn: dict, postgres_service: str) -> Iterator[sa.engine
 @pytest.fixture
 async def asyncpg_engine(postgres_db: sa.engine.Engine, is_pdb_enabled: bool) -> AsyncIterable[AsyncEngine]:
     # NOTE: call to postgres BEFORE app starts
-    dsn = f"{postgres_db.url}".replace("postgresql://", "postgresql+asyncpg://")
+    sync_dsn = postgres_db.url.render_as_string(hide_password=False)
+    dsn = sync_dsn.replace("postgresql+psycopg2://", "postgresql+asyncpg://")
     minsize = 1
     maxsize = 50
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 2
- #packages after ~ 1

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | sqlalchemy                | 1.4.54          | 2.0.51     | **MAJOR**  | 29 | api-server⬆️🧪</br>catalog⬆️🧪</br>director-v2⬆️🧪</br>dynamic-scheduler⬆️🧪</br>dynamic-sidecar⬆️🧪</br>efs-guardian⬆️</br>migration🧪</br>notifications⬆️🧪</br>payments⬆️🧪</br>postgres-database🧪🧪🧪</br>pytest-simcore🧪</br>resource-usage-tracker⬆️🧪</br>service-library🧪</br>simcore-sdk🧪🧪</br>storage⬆️🧪</br>web⬆️🧪 |
|   2 | sqlalchemy2-stubs         | 0.0.2           | 🗑️ removed |  | 15 | api-server🧪</br>catalog🧪</br>director-v2🧪</br>dynamic-scheduler🧪</br>dynamic-sidecar🧪</br>migration🧪</br>notifications🧪</br>payments🧪</br>postgres-database🧪</br>pytest-simcore🧪</br>resource-usage-tracker🧪</br>service-library🧪</br>simcore-sdk🧪</br>storage🧪</br>web🧪 |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/3986

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
