### PR TITLE
🐛🎨 [p2e] Fix: get node id for given key

### DIFF
--- a/tests/e2e/portal-files/VTK_file.js
+++ b/tests/e2e/portal-files/VTK_file.js
@@ -34,12 +34,16 @@ async function runTutorial () {
 
   try {
     const page = await tutorial.beforeScript();
-    const studyData = await tutorial.openStudyLink();
+    const studyResp = await tutorial.openStudyLink();
+    const studyData = studyResp["data"];
+    const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData["data"]);
-    const nodeIdViewer = workbenchData["nodeIds"][1];
+    const nodeIdViewer = utils.getNodeIdFromServiceKey(studyData["workbench"], "3d-viewer-gpu");
+    if (!nodeIdViewer) {
+      throw new Error('Could not find node with service key "3d-viewer-gpu"');
+    }
     await tutorial.waitForServices(
-      workbenchData["studyId"],
+      studyId,
       [nodeIdViewer],
       startTimeout,
       false

--- a/tests/e2e/portal/2D_Plot.js
+++ b/tests/e2e/portal/2D_Plot.js
@@ -26,11 +26,10 @@ async function runTutorial () {
     const studyData = studyResp["data"];
     const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData);
-    const nodeIdViewer = workbenchData["nodeIds"][1];
+    const rawGraphsId = utils.getNodeIdFromServiceKey(studyData["workbench"], "raw-graphs");
     await tutorial.waitForServices(
       studyId,
-      [nodeIdViewer],
+      [rawGraphsId],
       startTimeout
     );
 
@@ -40,7 +39,7 @@ async function runTutorial () {
     await tutorial.waitFor(2000);
     await utils.takeScreenshot(page, screenshotPrefix + 'iFrame0');
 
-    const frame = await tutorial.getIframe(nodeIdViewer);
+    const frame = await tutorial.getIframe(rawGraphsId);
 
     // inside the iFrame, click on "oSPARC inputs"
     const oSPARCInputsSelector = '#load-data > div > div:nth-child(2) > div.col-lg-2 > ul > li:nth-child(5)';

--- a/tests/e2e/portal/2D_Plot.js
+++ b/tests/e2e/portal/2D_Plot.js
@@ -22,12 +22,14 @@ async function runTutorial () {
 
   try {
     const page = await tutorial.beforeScript();
-    const studyData = await tutorial.openStudyLink();
+    const studyResp = await tutorial.openStudyLink();
+    const studyData = studyResp["data"];
+    const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData["data"]);
+    const workbenchData = utils.extractWorkbenchData(studyData);
     const nodeIdViewer = workbenchData["nodeIds"][1];
     await tutorial.waitForServices(
-      workbenchData["studyId"],
+      studyId,
       [nodeIdViewer],
       startTimeout
     );

--- a/tests/e2e/portal/2D_Plot.js
+++ b/tests/e2e/portal/2D_Plot.js
@@ -26,10 +26,10 @@ async function runTutorial () {
     const studyData = studyResp["data"];
     const studyId = studyData["uuid"];
 
-    const rawGraphsId = utils.getNodeIdFromServiceKey(studyData["workbench"], "raw-graphs");
+    const nodeIdViewer = utils.getNodeIdFromServiceKey(studyData["workbench"], "raw-graphs");
     await tutorial.waitForServices(
       studyId,
-      [rawGraphsId],
+      [nodeIdViewer],
       startTimeout
     );
 
@@ -39,7 +39,7 @@ async function runTutorial () {
     await tutorial.waitFor(2000);
     await utils.takeScreenshot(page, screenshotPrefix + 'iFrame0');
 
-    const frame = await tutorial.getIframe(rawGraphsId);
+    const frame = await tutorial.getIframe(nodeIdViewer);
 
     // inside the iFrame, click on "oSPARC inputs"
     const oSPARCInputsSelector = '#load-data > div > div:nth-child(2) > div.col-lg-2 > ul > li:nth-child(5)';

--- a/tests/e2e/portal/2D_Plot.js
+++ b/tests/e2e/portal/2D_Plot.js
@@ -27,6 +27,9 @@ async function runTutorial () {
     const studyId = studyData["uuid"];
 
     const nodeIdViewer = utils.getNodeIdFromServiceKey(studyData["workbench"], "raw-graphs");
+    if (!nodeIdViewer) {
+      throw new Error('Could not find node with service key "raw-graphs"');
+    }
     await tutorial.waitForServices(
       studyId,
       [nodeIdViewer],

--- a/tests/e2e/portal/3D_Anatomical.js
+++ b/tests/e2e/portal/3D_Anatomical.js
@@ -22,12 +22,14 @@ async function runTutorial () {
 
   try {
     const page = await tutorial.beforeScript();
-    const studyData = await tutorial.openStudyLink();
+    const studyResp = await tutorial.openStudyLink();
+    const studyData = studyResp["data"];
+    const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData["data"]);
+    const workbenchData = utils.extractWorkbenchData(studyData);
     const vtkNodeId = workbenchData["nodeIds"][1];
     await tutorial.waitForServices(
-      workbenchData["studyId"],
+      studyId,
       [vtkNodeId],
       startTimeout,
       false

--- a/tests/e2e/portal/3D_Anatomical.js
+++ b/tests/e2e/portal/3D_Anatomical.js
@@ -26,8 +26,7 @@ async function runTutorial () {
     const studyData = studyResp["data"];
     const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData);
-    const vtkNodeId = workbenchData["nodeIds"][1];
+    const vtkNodeId = utils.getNodeIdFromServiceKey(studyData["workbench"], "3d-viewer-gpu");
     await tutorial.waitForServices(
       studyId,
       [vtkNodeId],

--- a/tests/e2e/portal/3D_Anatomical.js
+++ b/tests/e2e/portal/3D_Anatomical.js
@@ -27,6 +27,9 @@ async function runTutorial () {
     const studyId = studyData["uuid"];
 
     const vtkNodeId = utils.getNodeIdFromServiceKey(studyData["workbench"], "3d-viewer-gpu");
+    if (!vtkNodeId) {
+      throw new Error('Could not find node with service key "3d-viewer-gpu"');
+    }
     await tutorial.waitForServices(
       studyId,
       [vtkNodeId],

--- a/tests/e2e/portal/3D_EM.js
+++ b/tests/e2e/portal/3D_EM.js
@@ -26,8 +26,7 @@ async function runTutorial () {
     const studyData = studyResp["data"];
     const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData);
-    const vtkNodeId = workbenchData["nodeIds"][2];
+    const vtkNodeId = utils.getNodeIdFromServiceKey(studyData["workbench"], "3d-viewer-gpu");
     await tutorial.waitForServices(
       studyId,
       [vtkNodeId],

--- a/tests/e2e/portal/3D_EM.js
+++ b/tests/e2e/portal/3D_EM.js
@@ -22,12 +22,14 @@ async function runTutorial () {
 
   try {
     const page = await tutorial.beforeScript();
-    const studyData = await tutorial.openStudyLink();
+    const studyResp = await tutorial.openStudyLink();
+    const studyData = studyResp["data"];
+    const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData["data"]);
+    const workbenchData = utils.extractWorkbenchData(studyData);
     const vtkNodeId = workbenchData["nodeIds"][2];
     await tutorial.waitForServices(
-      workbenchData["studyId"],
+      studyId,
       [vtkNodeId],
       startTimeout,
       false

--- a/tests/e2e/portal/3D_EM.js
+++ b/tests/e2e/portal/3D_EM.js
@@ -27,6 +27,9 @@ async function runTutorial () {
     const studyId = studyData["uuid"];
 
     const vtkNodeId = utils.getNodeIdFromServiceKey(studyData["workbench"], "3d-viewer-gpu");
+    if (!vtkNodeId) {
+      throw new Error('Could not find node with service key "3d-viewer-gpu"');
+    }
     await tutorial.waitForServices(
       studyId,
       [vtkNodeId],

--- a/tests/e2e/portal/BIOS_VNS_Calibrator.js
+++ b/tests/e2e/portal/BIOS_VNS_Calibrator.js
@@ -27,6 +27,9 @@ async function runTutorial () {
     const studyId = studyData["uuid"];
 
     const BIOSIdViewer = utils.getNodeIdFromServiceKey(studyData["workbench"], "bios-health-vns-calibrator");
+    if (!BIOSIdViewer) {
+      throw new Error('Could not find node with service key "bios-health-vns-calibrator"');
+    }
     await tutorial.waitForServices(
       studyId,
       [BIOSIdViewer],

--- a/tests/e2e/portal/BIOS_VNS_Calibrator.js
+++ b/tests/e2e/portal/BIOS_VNS_Calibrator.js
@@ -26,9 +26,7 @@ async function runTutorial () {
     const studyData = studyResp["data"];
     const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData);
-    console.log("Workbench Data:", workbenchData);
-    const BIOSIdViewer = workbenchData["nodeIds"][0];
+    const BIOSIdViewer = utils.getNodeIdFromServiceKey(studyData["workbench"], "bios-health-vns-calibrator");
     await tutorial.waitForServices(
       studyId,
       [BIOSIdViewer],

--- a/tests/e2e/portal/BIOS_VNS_Calibrator.js
+++ b/tests/e2e/portal/BIOS_VNS_Calibrator.js
@@ -22,13 +22,15 @@ async function runTutorial () {
 
   try {
     const page = await tutorial.beforeScript();
-    const studyData = await tutorial.openStudyLink();
+    const studyResp = await tutorial.openStudyLink();
+    const studyData = studyResp["data"];
+    const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData["data"]);
+    const workbenchData = utils.extractWorkbenchData(studyData);
     console.log("Workbench Data:", workbenchData);
     const BIOSIdViewer = workbenchData["nodeIds"][0];
     await tutorial.waitForServices(
-      workbenchData["studyId"],
+      studyId,
       [BIOSIdViewer],
       startTimeout,
       false

--- a/tests/e2e/portal/Bornstein.js
+++ b/tests/e2e/portal/Bornstein.js
@@ -26,10 +26,10 @@ async function runTutorial () {
     const studyData = studyResp["data"];
     const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData);
+    const bornsteinViewerId = utils.getNodeIdFromServiceKey(studyData["workbench"], "bornstein-viewer");
     await tutorial.waitForServices(
       studyId,
-      [workbenchData["nodeIds"][0]],
+      [bornsteinViewerId],
       startTimeout
     );
 

--- a/tests/e2e/portal/Bornstein.js
+++ b/tests/e2e/portal/Bornstein.js
@@ -22,11 +22,13 @@ async function runTutorial () {
 
   try {
     const page = await tutorial.beforeScript();
-    const studyData = await tutorial.openStudyLink();
+    const studyResp = await tutorial.openStudyLink();
+    const studyData = studyResp["data"];
+    const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData["data"]);
+    const workbenchData = utils.extractWorkbenchData(studyData);
     await tutorial.waitForServices(
-      workbenchData["studyId"],
+      studyId,
       [workbenchData["nodeIds"][0]],
       startTimeout
     );

--- a/tests/e2e/portal/Bornstein.js
+++ b/tests/e2e/portal/Bornstein.js
@@ -27,6 +27,9 @@ async function runTutorial () {
     const studyId = studyData["uuid"];
 
     const bornsteinViewerId = utils.getNodeIdFromServiceKey(studyData["workbench"], "bornstein-viewer");
+    if (!bornsteinViewerId) {
+      throw new Error('Could not find node with service key "bornstein-viewer"');
+    }
     await tutorial.waitForServices(
       studyId,
       [bornsteinViewerId],

--- a/tests/e2e/portal/Kember.js
+++ b/tests/e2e/portal/Kember.js
@@ -22,10 +22,11 @@ async function runTutorial () {
 
   try {
     await tutorial.beforeScript();
-    const studyData = await tutorial.openStudyLink();
-    const studyId = studyData["data"]["uuid"];
+    const studyResp = await tutorial.openStudyLink();
+    const studyData = studyResp["data"];
+    const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData["data"]);
+    const workbenchData = utils.extractWorkbenchData(studyData);
     const kemberSolver = workbenchData["nodeIds"][0];
     const kemberIdViewer = workbenchData["nodeIds"][1];
 

--- a/tests/e2e/portal/Kember.js
+++ b/tests/e2e/portal/Kember.js
@@ -26,9 +26,8 @@ async function runTutorial () {
     const studyData = studyResp["data"];
     const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData);
-    const kemberSolver = workbenchData["nodeIds"][0];
-    const kemberIdViewer = workbenchData["nodeIds"][1];
+    const kemberSolver = utils.getNodeIdFromServiceKey(studyData["workbench"], "kember-cardiac-model");
+    const kemberIdViewer = utils.getNodeIdFromServiceKey(studyData["workbench"], "voila-viewer");
 
     await tutorial.takeScreenshot("template_started");
 

--- a/tests/e2e/portal/Kember.js
+++ b/tests/e2e/portal/Kember.js
@@ -27,7 +27,13 @@ async function runTutorial () {
     const studyId = studyData["uuid"];
 
     const kemberSolver = utils.getNodeIdFromServiceKey(studyData["workbench"], "kember-cardiac-model");
+    if (!kemberSolver) {
+      throw new Error('Could not find node with service key "kember-cardiac-model"');
+    }
     const kemberIdViewer = utils.getNodeIdFromServiceKey(studyData["workbench"], "voila-viewer");
+    if (!kemberIdViewer) {
+      throw new Error('Could not find node with service key "voila-viewer"');
+    }
 
     await tutorial.takeScreenshot("template_started");
 

--- a/tests/e2e/portal/Mattward.js
+++ b/tests/e2e/portal/Mattward.js
@@ -27,6 +27,9 @@ async function runTutorial () {
     const studyId = studyData["uuid"];
 
     const mattwardViewerId = utils.getNodeIdFromServiceKey(studyData["workbench"], "mattward-viewer");
+    if (!mattwardViewerId) {
+      throw new Error('Could not find node with service key "mattward-viewer"');
+    }
     await tutorial.waitForServices(
       studyId,
       [mattwardViewerId],

--- a/tests/e2e/portal/Mattward.js
+++ b/tests/e2e/portal/Mattward.js
@@ -26,10 +26,10 @@ async function runTutorial () {
     const studyData = studyResp["data"];
     const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData);
+    const mattwardViewerId = utils.getNodeIdFromServiceKey(studyData["workbench"], "mattward-viewer");
     await tutorial.waitForServices(
       studyId,
-      [workbenchData["nodeIds"][0]],
+      [mattwardViewerId],
       startTimeout
     );
 

--- a/tests/e2e/portal/Mattward.js
+++ b/tests/e2e/portal/Mattward.js
@@ -22,11 +22,13 @@ async function runTutorial () {
 
   try {
     const page = await tutorial.beforeScript();
-    const studyData = await tutorial.openStudyLink();
+    const studyResp = await tutorial.openStudyLink();
+    const studyData = studyResp["data"];
+    const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData["data"]);
+    const workbenchData = utils.extractWorkbenchData(studyData);
     await tutorial.waitForServices(
-      workbenchData["studyId"],
+      studyId,
       [workbenchData["nodeIds"][0]],
       startTimeout
     );

--- a/tests/e2e/publications/SarValidation.js
+++ b/tests/e2e/publications/SarValidation.js
@@ -31,13 +31,16 @@ async function runTutorial () {
 
   try {
     await tutorial.beforeScript();
-    const studyData = await tutorial.openStudyLink();
+    const studyResp = await tutorial.openStudyLink();
+    const studyData = studyResp["data"];
+    const studyId = studyData["uuid"];
 
-    const workbenchData = utils.extractWorkbenchData(studyData["data"]);
-    console.log("Workbench Data:", workbenchData);
-    const sarNodeId = workbenchData["nodeIds"][0];
+    const sarNodeId = utils.getNodeIdFromServiceKey(studyData["workbench"], "iec62209-web");
+    if (!sarNodeId) {
+      throw new Error('Could not find node with service key "iec62209-web"');
+    }
     await tutorial.waitForServices(
-      workbenchData["studyId"],
+      studyId,
       [sarNodeId],
       startTimeout,
       false

--- a/tests/e2e/utils/utils.js
+++ b/tests/e2e/utils/utils.js
@@ -579,15 +579,14 @@ function extractWorkbenchData(data) {
   return workbenchData;
 }
 
-function getNodeIdFromServiceKey(workbenchData, serviceKeyFragment) {
-  // Resolves a nodeId by matching the service key, instead of relying on the
-  // node's position in the workbench. The match is done on a substring of the
-  // service key so it is resilient to version changes.
-  const idx = workbenchData.keyVersions.findIndex(keyVersion => keyVersion.includes(serviceKeyFragment));
-  if (idx === -1) {
-    throw new Error(`No node found with service key matching "${serviceKeyFragment}". Available: ${workbenchData.keyVersions.join(", ")}`);
-  }
-  return workbenchData.nodeIds[idx];
+function getNodeIdFromServiceKey(workbench, serviceKeyFragment) {
+  let nodeId = null;
+  Object.entries(workbench).forEach(([nId, nodeData]) => {
+    if (nodeData["key"].includes(serviceKeyFragment)) {
+      nodeId = nId;
+    }
+  });
+  return nodeId;
 }
 
 function getGrayLogSnapshotUrl(targetUrl, since_secs = 30) {

--- a/tests/e2e/utils/utils.js
+++ b/tests/e2e/utils/utils.js
@@ -579,6 +579,17 @@ function extractWorkbenchData(data) {
   return workbenchData;
 }
 
+function getNodeIdFromServiceKey(workbenchData, serviceKeyFragment) {
+  // Resolves a nodeId by matching the service key, instead of relying on the
+  // node's position in the workbench. The match is done on a substring of the
+  // service key so it is resilient to version changes.
+  const idx = workbenchData.keyVersions.findIndex(keyVersion => keyVersion.includes(serviceKeyFragment));
+  if (idx === -1) {
+    throw new Error(`No node found with service key matching "${serviceKeyFragment}". Available: ${workbenchData.keyVersions.join(", ")}`);
+  }
+  return workbenchData.nodeIds[idx];
+}
+
 function getGrayLogSnapshotUrl(targetUrl, since_secs = 30) {
   let snapshotUrl = null;
 
@@ -695,6 +706,7 @@ module.exports = {
   createScreenshotsDir,
   takeScreenshot,
   extractWorkbenchData,
+  getNodeIdFromServiceKey,
   parseCommandLineArguments,
   parseCommandLineArgumentsAnonymous,
   parseCommandLineArgumentsStudyDispatcherParams,


### PR DESCRIPTION
## What do these changes do?

This PR updates p2e tests to reliably identify specific workbench nodes by service key (instead of relying on positional node ordering), improving resilience when template workbench node ordering changes.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
