### PR TITLE
🎨Fastapi cancellation middleware shall properly return a 499 when a client disconnects

### DIFF
--- a/packages/service-library/src/servicelib/fastapi/cancellation_middleware.py
+++ b/packages/service-library/src/servicelib/fastapi/cancellation_middleware.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import NoReturn
+from typing import Final, NoReturn
 
 from starlette.requests import Request
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -8,6 +8,8 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from ..logging_utils import log_context
 
 _logger = logging.getLogger(__name__)
+
+_HTTP_499_CLIENT_CLOSED_REQUEST: Final[int] = 499
 
 
 class _ClientDisconnectedError(Exception):
@@ -55,10 +57,18 @@ class RequestCancellationMiddleware:
         queue: asyncio.Queue[Message] = asyncio.Queue()
         request = Request(scope)
 
+        response_started = False
+
+        async def _tracking_send(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
         with log_context(_logger, logging.DEBUG, f"cancellable request {request.url}"):
             try:
                 async with asyncio.TaskGroup() as tg:
-                    handler_task = tg.create_task(_handler(self.app, scope, queue, send))
+                    handler_task = tg.create_task(_handler(self.app, scope, queue, _tracking_send))
                     poller_task = tg.create_task(_message_poller(request, queue, receive))
                     await handler_task
                     poller_task.cancel("handler completed, cancelling poller")
@@ -68,3 +78,15 @@ class RequestCancellationMiddleware:
                         "The client disconnected. The request to %s was cancelled.",
                         request.url,
                     )
+                if not response_started:
+                    # Emit a synthetic 499 (Client Closed Request) response so that
+                    # outer middlewares (e.g. Prometheus, tracing) observe a real
+                    # response instead of raising RuntimeError("No response returned").
+                    await send(
+                        {
+                            "type": "http.response.start",
+                            "status": _HTTP_499_CLIENT_CLOSED_REQUEST,
+                            "headers": [],
+                        }
+                    )
+                    await send({"type": "http.response.body", "body": b""})

--- a/packages/service-library/src/servicelib/fastapi/cancellation_middleware.py
+++ b/packages/service-library/src/servicelib/fastapi/cancellation_middleware.py
@@ -61,9 +61,9 @@ class RequestCancellationMiddleware:
 
         async def _tracking_send(message: Message) -> None:
             nonlocal response_started
+            await send(message)
             if message["type"] == "http.response.start":
                 response_started = True
-            await send(message)
 
         with log_context(_logger, logging.DEBUG, f"cancellable request {request.url}"):
             try:

--- a/packages/service-library/tests/fastapi/test_cancellation_middleware.py
+++ b/packages/service-library/tests/fastapi/test_cancellation_middleware.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, BackgroundTasks, FastAPI
 from pytest_simcore.helpers.logging_tools import log_context
 from servicelib.fastapi.cancellation_middleware import RequestCancellationMiddleware
 from servicelib.utils import unused_port
+from starlette.types import Message, Receive, Scope, Send
 from tenacity import retry, stop_after_delay, wait_fixed
 from yarl import URL
 
@@ -168,3 +169,107 @@ async def test_server_cancels_when_client_disconnects(
         # request should have been cancelled after the ReadTimeout!
         server_done_event.wait(5)
         server_cancelled_mock.assert_called_once()
+
+
+async def test_middleware_emits_499_when_client_disconnects_before_response():
+    # When the client disconnects while the handler is still running (and no
+    # response has been sent yet), the middleware must emit a synthetic 499
+    # response so that outer middlewares observe a real response instead of
+    # raising RuntimeError("No response returned").
+
+    async def _never_responding_app(scope: Scope, receive: Receive, send: Send) -> None:
+        # Simulates a handler still working when the client disconnects
+        await asyncio.Event().wait()
+
+    middleware = RequestCancellationMiddleware(_never_responding_app)
+
+    sent_messages: list[Message] = []
+    initial_request_sent = False
+
+    async def _receive() -> Message:
+        nonlocal initial_request_sent
+        if not initial_request_sent:
+            initial_request_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        return {"type": "http.disconnect"}
+
+    async def _send(message: Message) -> None:
+        sent_messages.append(message)
+
+    scope: Scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "server": ("127.0.0.1", 8000),
+        "client": ("127.0.0.1", 12345),
+    }
+
+    await asyncio.wait_for(middleware(scope, _receive, _send), timeout=5)
+
+    start_messages = [m for m in sent_messages if m["type"] == "http.response.start"]
+    assert len(start_messages) == 1
+    assert start_messages[0]["status"] == 499
+
+    body_messages = [m for m in sent_messages if m["type"] == "http.response.body"]
+    assert len(body_messages) == 1
+
+
+async def test_middleware_does_not_inject_499_when_client_disconnects_mid_stream():
+    # When the client disconnects AFTER the response has already started
+    # streaming, the middleware must NOT inject a second http.response.start
+    # (which would violate the ASGI protocol). The already-committed status is
+    # preserved and the truncated stream simply ends.
+
+    streaming_started = asyncio.Event()
+
+    async def _streaming_app(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"chunk", "more_body": True})
+        streaming_started.set()
+        # still streaming when the client disconnects
+        await asyncio.Event().wait()
+
+    middleware = RequestCancellationMiddleware(_streaming_app)
+
+    sent_messages: list[Message] = []
+    initial_request_sent = False
+
+    async def _receive() -> Message:
+        nonlocal initial_request_sent
+        if not initial_request_sent:
+            initial_request_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        # only signal the disconnect once the response is actually streaming
+        await streaming_started.wait()
+        return {"type": "http.disconnect"}
+
+    async def _send(message: Message) -> None:
+        sent_messages.append(message)
+
+    scope: Scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "server": ("127.0.0.1", 8000),
+        "client": ("127.0.0.1", 12345),
+    }
+
+    # must complete without raising (no protocol violation, no leaked error)
+    await asyncio.wait_for(middleware(scope, _receive, _send), timeout=5)
+
+    start_messages = [m for m in sent_messages if m["type"] == "http.response.start"]
+    # exactly one start, with the status the handler already committed (NOT 499)
+    assert len(start_messages) == 1
+    assert start_messages[0]["status"] == 200

--- a/packages/service-library/tests/fastapi/test_cancellation_middleware.py
+++ b/packages/service-library/tests/fastapi/test_cancellation_middleware.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
 
 import asyncio
 import logging


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
In order to prevent following "dragons" in logs, the cancellation middleware was adjusted to properly return a 499 HTTP code when a client disconnected _before_ the response was even started instead of a 500 that shows as an error and make the lone debugger debug nonsense.


<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
