### PR TITLE
✨ [Frontend] Send email: bcc textfield when approving/rejecting user

### DIFF
--- a/services/static-webserver/client/source/class/osparc/po/EmailEditor.js
+++ b/services/static-webserver/client/source/class/osparc/po/EmailEditor.js
@@ -80,6 +80,27 @@ qx.Class.define("osparc.po.EmailEditor", {
           });
           break;
         }
+        case "options-container": {
+          control = new qx.ui.container.Composite(new qx.ui.layout.HBox(6).set({
+            alignY: "middle",
+          })).set({
+            marginBottom: 10,
+          });
+          const formContainer = this.getChildControl("form-container");
+          formContainer.add(control, {
+            row: 1,
+            column: 1
+          });
+          break;
+        }
+        case "bcc-myself-checkbox": {
+          control = new qx.ui.form.CheckBox(this.tr("Send me a copy (Bcc)")).set({
+            value: false,
+            visibility: "excluded",
+          });
+          this.getChildControl("options-container").add(control);
+          break;
+        }
         case "subject-field": {
           control = new qx.ui.form.TextField().set({
             marginBottom: 10
@@ -88,11 +109,11 @@ qx.Class.define("osparc.po.EmailEditor", {
           formContainer.add(new qx.ui.basic.Label(this.tr("Subject")).set({
             paddingTop: 5,
           }), {
-            row: 1,
+            row: 2,
             column: 0
           });
           formContainer.add(control, {
-            row: 1,
+            row: 2,
             column: 1
           });
           break;
@@ -113,6 +134,8 @@ qx.Class.define("osparc.po.EmailEditor", {
     __buildLayout: function() {
       this.getChildControl("add-recipient-button");
       this.getChildControl("recipients-chips");
+      this.getChildControl("options-container");
+      this.getChildControl("bcc-myself-checkbox");
       this.getChildControl("subject-field");
       this.getChildControl("email-content-editor-and-preview");
     },
@@ -173,6 +196,14 @@ qx.Class.define("osparc.po.EmailEditor", {
 
     getSelectedGroupIds: function() {
       return this.__selectedGroupIds;
+    },
+
+    showBccMyselfOption: function() {
+      this.getChildControl("bcc-myself-checkbox").show();
+    },
+
+    isBccMyself: function() {
+      return this.getChildControl("bcc-myself-checkbox").getValue();
     },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/po/EmailEditor.js
+++ b/services/static-webserver/client/source/class/osparc/po/EmailEditor.js
@@ -21,7 +21,7 @@ qx.Class.define("osparc.po.EmailEditor", {
   construct: function() {
     this.base(arguments);
 
-    this._setLayout(new qx.ui.layout.VBox(5));
+    this._setLayout(new qx.ui.layout.VBox(4));
 
     this.__selectedGroupIds = [];
 
@@ -35,7 +35,7 @@ qx.Class.define("osparc.po.EmailEditor", {
       let control;
       switch (id) {
         case "form-container": {
-          control = new qx.ui.container.Composite(new qx.ui.layout.Grid(10, 5));
+          control = new qx.ui.container.Composite(new qx.ui.layout.Grid(10, 4));
           control.getLayout().setColumnFlex(1, 1);
           this._add(control);
           break;
@@ -80,25 +80,28 @@ qx.Class.define("osparc.po.EmailEditor", {
           });
           break;
         }
-        case "options-container": {
-          control = new qx.ui.container.Composite(new qx.ui.layout.HBox(6).set({
-            alignY: "middle",
-          })).set({
+        case "bcc-label": {
+          control = new qx.ui.basic.Label(this.tr("Bcc")).set({
+            paddingTop: 5,
+            visibility: "excluded",
+          });
+          break;
+        }
+        case "bcc-field": {
+          control = new qx.ui.form.TextField().set({
             marginBottom: 10,
+            placeholder: this.tr("Comma-separated email addresses"),
+            visibility: "excluded",
           });
           const formContainer = this.getChildControl("form-container");
+          formContainer.add(this.getChildControl("bcc-label"), {
+            row: 1,
+            column: 0
+          });
           formContainer.add(control, {
             row: 1,
             column: 1
           });
-          break;
-        }
-        case "bcc-myself-checkbox": {
-          control = new qx.ui.form.CheckBox(this.tr("Send me a copy (Bcc)")).set({
-            value: false,
-            visibility: "excluded",
-          });
-          this.getChildControl("options-container").add(control);
           break;
         }
         case "subject-field": {
@@ -134,8 +137,7 @@ qx.Class.define("osparc.po.EmailEditor", {
     __buildLayout: function() {
       this.getChildControl("add-recipient-button");
       this.getChildControl("recipients-chips");
-      this.getChildControl("options-container");
-      this.getChildControl("bcc-myself-checkbox");
+      this.getChildControl("bcc-field");
       this.getChildControl("subject-field");
       this.getChildControl("email-content-editor-and-preview");
     },
@@ -198,12 +200,17 @@ qx.Class.define("osparc.po.EmailEditor", {
       return this.__selectedGroupIds;
     },
 
-    showBccMyselfOption: function() {
-      this.getChildControl("bcc-myself-checkbox").show();
+    showBccField: function() {
+      this.getChildControl("bcc-label").show();
+      this.getChildControl("bcc-field").show();
     },
 
-    isBccMyself: function() {
-      return this.getChildControl("bcc-myself-checkbox").getValue();
+    getBccEmails: function() {
+      const value = this.getChildControl("bcc-field").getValue();
+      if (!value) {
+        return [];
+      }
+      return value.split(",").map(email => email.trim()).filter(email => email.length);
     },
   }
 });

--- a/services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js
+++ b/services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js
@@ -236,12 +236,12 @@ qx.Class.define("osparc.po.PreviewApprovalRejection", {
       const emailContentEditor = emailEditor.getChildControl("email-content-editor-and-preview");
       const bodyHtml = emailContentEditor.composeWholeHtml();
       const bodyText = emailContentEditor.getBodyText();
-      const bcc = emailEditor.getBccEmails();
+      const bccEmails = emailEditor.getBccEmails();
       const params = {
         data: {
           email,
+          bccEmails,
           invitationUrl,
-          bcc,
           messageContent: {
             subject,
             bodyHtml,
@@ -265,11 +265,11 @@ qx.Class.define("osparc.po.PreviewApprovalRejection", {
       const emailContentEditor = emailEditor.getChildControl("email-content-editor-and-preview");
       const bodyHtml = emailContentEditor.composeWholeHtml();
       const bodyText = emailContentEditor.getBodyText();
-      const bcc = emailEditor.getBccEmails();
+      const bccEmails = emailEditor.getBccEmails();
       const params = {
         data: {
           email,
-          bcc,
+          bccEmails,
           messageContent: {
             subject,
             bodyHtml,

--- a/services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js
+++ b/services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js
@@ -74,7 +74,7 @@ qx.Class.define("osparc.po.PreviewApprovalRejection", {
       switch (id) {
         case "email-editor": {
           control = new osparc.po.EmailEditor();
-          control.showBccMyselfOption();
+          control.showBccField();
           this._add(control, {
             flex: 1
           });
@@ -236,12 +236,12 @@ qx.Class.define("osparc.po.PreviewApprovalRejection", {
       const emailContentEditor = emailEditor.getChildControl("email-content-editor-and-preview");
       const bodyHtml = emailContentEditor.composeWholeHtml();
       const bodyText = emailContentEditor.getBodyText();
-      const bccApprover = emailEditor.isBccMyself();
+      const bcc = emailEditor.getBccEmails();
       const params = {
         data: {
           email,
           invitationUrl,
-          bccApprover,
+          bcc,
           messageContent: {
             subject,
             bodyHtml,
@@ -265,11 +265,11 @@ qx.Class.define("osparc.po.PreviewApprovalRejection", {
       const emailContentEditor = emailEditor.getChildControl("email-content-editor-and-preview");
       const bodyHtml = emailContentEditor.composeWholeHtml();
       const bodyText = emailContentEditor.getBodyText();
-      const bccApprover = emailEditor.isBccMyself();
+      const bcc = emailEditor.getBccEmails();
       const params = {
         data: {
           email,
-          bccApprover,
+          bcc,
           messageContent: {
             subject,
             bodyHtml,

--- a/services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js
+++ b/services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js
@@ -74,6 +74,7 @@ qx.Class.define("osparc.po.PreviewApprovalRejection", {
       switch (id) {
         case "email-editor": {
           control = new osparc.po.EmailEditor();
+          control.showBccMyselfOption();
           this._add(control, {
             flex: 1
           });
@@ -235,10 +236,12 @@ qx.Class.define("osparc.po.PreviewApprovalRejection", {
       const emailContentEditor = emailEditor.getChildControl("email-content-editor-and-preview");
       const bodyHtml = emailContentEditor.composeWholeHtml();
       const bodyText = emailContentEditor.getBodyText();
+      const bccApprover = emailEditor.isBccMyself();
       const params = {
         data: {
           email,
           invitationUrl,
+          bccApprover,
           messageContent: {
             subject,
             bodyHtml,
@@ -262,9 +265,11 @@ qx.Class.define("osparc.po.PreviewApprovalRejection", {
       const emailContentEditor = emailEditor.getChildControl("email-content-editor-and-preview");
       const bodyHtml = emailContentEditor.composeWholeHtml();
       const bodyText = emailContentEditor.getBodyText();
+      const bccApprover = emailEditor.isBccMyself();
       const params = {
         data: {
           email,
+          bccApprover,
           messageContent: {
             subject,
             bodyHtml,


### PR DESCRIPTION
## What do these changes do?

requested by @mminana 

This PR adds a BCC input to the user-approval/rejection email preview flow so product owners can include additional recipients when sending those emails.

<img width="1440" height="850" alt="SendMeACopy" src="https://github.com/user-attachments/assets/b4680a02-27cc-4183-be05-ed5066976f0d" />


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
