### PR TITLE
🔨 Autoscaling Monitoring CLI: Add auto-wait for termination on computational clusters

### DIFF
--- a/scripts/maintenance/autoscaled-monitor/README.md
+++ b/scripts/maintenance/autoscaled-monitor/README.md
@@ -66,9 +66,17 @@ autoscaled-monitor --deploy-config PATH/TO/DEPLOYMENT computational cancel-jobs
 
 #### `computational terminate` — terminate computational instances
 
+Triggers a graceful termination process for a computational cluster with the following phases:
+
+1. **Phase 1 - Graceful Termination**: Cancels all running jobs and sets the heartbeat tag to 1 hour ago
+2. **Phase 2 - Graceful Wait**: Waits up to 2x `CLUSTERS_KEEPER_TASK_INTERVAL` for clusters-keeper to remove the cluster
+3. **Phase 3 - Direct Fallback**: If the cluster is still present after the grace period, directly terminates the EC2 instances
+
 ```bash
-autoscaled-monitor --deploy-config PATH/TO/DEPLOYMENT computational terminate
+autoscaled-monitor --deploy-config PATH/TO/DEPLOYMENT computational terminate --user-id 123 --wallet-id 456
 ```
+
+The command provides real-time feedback during each phase and shows the countdown timer during the graceful wait period.
 
 #### `db check` — test database connectivity
 
@@ -78,15 +86,15 @@ autoscaled-monitor --deploy-config PATH/TO/DEPLOYMENT db check
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
+| Option                 | Description                                                                                                                                     |
+|------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--deploy-config PATH` | **(required)** Path to the deployment configuration directory (must contain `repo.config`, `ansible/inventory.ini`, and an SSH key `.pem` file) |
 
 ### Command-specific options
 
-| Option | Available on | Description |
-|--------|-------------|-------------|
-| `--user-id INT` | `summary`, `dynamic summary`, `computational summary` | Filter by user ID |
-| `--wallet-id INT` | `summary`, `computational summary` | Filter by wallet ID |
-| `--as-json` | `summary`, `dynamic summary`, `computational summary` | Output as JSON |
-| `--output PATH` | `summary`, `dynamic summary`, `computational summary` | Write output to file |
+| Option            | Available on                                          | Description          |
+|-------------------|-------------------------------------------------------|----------------------|
+| `--user-id INT`   | `summary`, `dynamic summary`, `computational summary` | Filter by user ID    |
+| `--wallet-id INT` | `summary`, `computational summary`                    | Filter by wallet ID  |
+| `--as-json`       | `summary`, `dynamic summary`, `computational summary` | Output as JSON       |
+| `--output PATH`   | `summary`, `dynamic summary`, `computational summary` | Write output to file |

--- a/scripts/maintenance/autoscaled-monitor/src/autoscaled_monitor/commands/computational/terminate.py
+++ b/scripts/maintenance/autoscaled-monitor/src/autoscaled_monitor/commands/computational/terminate.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import datetime
+import time
 from typing import Annotated
 
 import arrow
@@ -9,18 +10,20 @@ import rich
 import typer
 from mypy_boto3_ec2.type_defs import TagTypeDef
 
-from ... import analysis, db, rendering, ssh
+from ... import analysis, db, ec2, rendering, ssh
 from ..._helpers import load_computational_clusters
 from ..._state import state
 from ...models import AppState
 
 
-async def _run(
+async def _run(  # noqa: PLR0915
     state: AppState,
     user_id: int,
     wallet_id: int | None,
     *,
     force: bool,
+    intervals_to_wait: int,
+    skip_wait: bool,
 ) -> None:
     assert state.ec2_resource_clusters_keeper
     computational_clusters = await load_computational_clusters(state, user_id, wallet_id)
@@ -39,6 +42,10 @@ async def _run(
     if (force is True) or typer.confirm("Are you sure you want to trigger termination of that cluster?"):
         the_cluster = computational_clusters[0]
 
+        # ===== PHASE 1: Graceful termination - cancel jobs and set stale heartbeat =====
+        rich.print("\n[bold]Phase 1: Graceful termination[/bold]")
+        rich.print("Canceling running jobs...")
+
         async with db.db_engine(state) as engine:
             task_to_dask_job = await analysis.resolve_cluster_tasks(engine, the_cluster)
             assert state.ssh_key_path  # nosec
@@ -52,15 +59,70 @@ async def _run(
                     bastion_conn=bastion_conn,
                 )
 
+        rich.print("[green]✓ Jobs cancelled[/green]")
+
+        # Set heartbeat tag to trigger clusters-keeper termination
         new_heartbeat_tag: TagTypeDef = {
             "Key": "last_heartbeat",
             "Value": f"{arrow.utcnow().datetime - datetime.timedelta(hours=1)}",
         }
         the_cluster.primary.ec2_instance.create_tags(Tags=[new_heartbeat_tag])
-        rich.print(
-            f"heartbeat tag on cluster of {user_id=}/{wallet_id=} changed,"
-            " clusters-keeper will terminate that cluster soon."
-        )
+        rich.print("[green]✓ Stale heartbeat tag set[/green]")
+
+        original_primary_id = the_cluster.primary.ec2_instance.id
+        original_worker_ids = {w.ec2_instance.id for w in the_cluster.workers}
+
+        if skip_wait:
+            # Skip Phase 2 and go directly to fallback
+            rich.print("\n[yellow]Skipping wait phase, proceeding to direct EC2 termination...[/yellow]")
+            assert state.ec2_resource_clusters_keeper
+            await ec2.terminate_cluster_instances_forcefully(
+                state.ec2_resource_clusters_keeper,
+                original_primary_id,
+                original_worker_ids,
+            )
+            rich.print("[bold green]✓ Cluster termination complete (direct EC2 termination)[/bold green]")
+        else:
+            # ===== PHASE 2: Wait for clusters-keeper to remove the cluster =====
+            rich.print("\n[bold]Phase 2: Waiting for clusters-keeper termination[/bold]")
+            task_interval = ec2.get_clusters_keeper_task_interval(state)
+            wait_budget_seconds = int(task_interval.total_seconds() * intervals_to_wait)
+            rich.print(f"Waiting up to {wait_budget_seconds} seconds for clusters-keeper to terminate the cluster...")
+
+            start_time = time.time()
+            poll_interval = 5  # seconds between checks
+            cluster_removed = False
+
+            while time.time() - start_time < wait_budget_seconds:
+                cluster_still_up = await ec2.cluster_is_running(
+                    state,
+                    user_id,
+                    wallet_id,
+                    original_primary_id,
+                    original_worker_ids,
+                )
+
+                if not cluster_still_up:
+                    cluster_removed = True
+                    break
+
+                elapsed = int(time.time() - start_time)
+                remaining = wait_budget_seconds - elapsed
+                rich.print(f"  Cluster still present... {remaining}s remaining", end="\r")
+                await asyncio.sleep(poll_interval)
+
+            if cluster_removed:
+                rich.print("\n[green]✓ Cluster removed by clusters-keeper (termination successful)[/green]")
+            else:
+                # ===== PHASE 3: Fallback to direct EC2 termination =====
+                rich.print(f"\n[yellow]Graceful termination window ({wait_budget_seconds}s) expired.[/yellow]")
+                assert state.ec2_resource_clusters_keeper
+                await ec2.terminate_cluster_instances_forcefully(
+                    state.ec2_resource_clusters_keeper,
+                    original_primary_id,
+                    original_worker_ids,
+                )
+                rich.print("[bold green]✓ Cluster termination complete (direct EC2 fallback)[/bold green]")
     else:
         rich.print("not deleting anything")
 
@@ -70,11 +132,17 @@ def terminate(
     wallet_id: Annotated[int | None, typer.Option(help="the wallet ID")] = None,
     *,
     force: Annotated[bool, typer.Option(help="will not ask for confirmation (VERY RISKY!)")] = False,
+    intervals_to_wait: Annotated[
+        int, typer.Option(help="number of CLUSTERS_KEEPER_TASK_INTERVAL periods to wait")
+    ] = 10,
+    skip_wait: Annotated[bool, typer.Option(help="skip wait phase and go directly to EC2 termination")] = False,
 ) -> None:
     """Trigger termination of a computational cluster.
 
-    Sets the heartbeat tag on the primary machine to 1 hour ago,
-    ensuring the clusters-keeper will properly terminate it.
+    The command follows three phases (unless --skip-wait is used):
+    1. Cancel all running jobs and set stale heartbeat tag
+    2. Wait up to N x CLUSTERS_KEEPER_TASK_INTERVAL for graceful removal
+    3. If still present, directly terminate EC2 instances as fallback
     """
 
-    asyncio.run(_run(state, user_id, wallet_id, force=force))
+    asyncio.run(_run(state, user_id, wallet_id, force=force, intervals_to_wait=intervals_to_wait, skip_wait=skip_wait))

--- a/scripts/maintenance/autoscaled-monitor/src/autoscaled_monitor/ec2.py
+++ b/scripts/maintenance/autoscaled-monitor/src/autoscaled_monitor/ec2.py
@@ -1,11 +1,14 @@
+from datetime import timedelta
 from typing import Any, Final
 
 import boto3
 import orjson
+import rich
 from aiocache import cached
 from mypy_boto3_ec2 import EC2ServiceResource
 from mypy_boto3_ec2.service_resource import Instance, ServiceResourceInstancesCollection
 from mypy_boto3_ec2.type_defs import FilterTypeDef
+from pydantic import TypeAdapter
 
 from .models import AppState
 from .utils import get_instance_name, to_async
@@ -192,3 +195,105 @@ def _describe_instance_type(ec2_resource: EC2ServiceResource, instance_type: str
 
 async def get_instance_type_info(ec2_resource: EC2ServiceResource, instance_type: str) -> dict[str, Any]:
     return await _describe_instance_type(ec2_resource, instance_type)
+
+
+def get_clusters_keeper_task_interval(state: AppState) -> timedelta:
+    """Parse CLUSTERS_KEEPER_TASK_INTERVAL from environment and return as timedelta."""
+    task_interval_str = state.environment.get("CLUSTERS_KEEPER_TASK_INTERVAL", "30")
+    return TypeAdapter(timedelta).validate_python(task_interval_str)
+
+
+@to_async
+def _check_cluster_instances_exist(
+    ec2_resource: EC2ServiceResource,
+    key_name: str,
+    custom_tags: dict[str, str],
+    user_id: int,
+    wallet_id: int | None,
+    original_primary_id: str,
+    original_worker_ids: set[str],
+) -> bool:
+    """
+    Check if the original cluster instances still exist in EC2.
+
+    Returns True if any of the original instances are still in running/pending state.
+    """
+    ec2_filters: list[FilterTypeDef] = [
+        {"Name": "instance-state-name", "Values": ["running", "pending"]},
+        {"Name": "key-name", "Values": [key_name]},
+    ]
+    if custom_tags:
+        ec2_filters.extend([{"Name": f"tag:{key}", "Values": [f"{value}"]} for key, value in custom_tags.items()])
+    ec2_filters.append({"Name": "tag:user_id", "Values": [f"{user_id}"]})
+    if wallet_id:
+        ec2_filters.append({"Name": "tag:wallet_id", "Values": [f"{wallet_id}"]})
+
+    instances = ec2_resource.instances.filter(Filters=ec2_filters)
+    running_ids = {inst.id for inst in instances}
+
+    # Check if original primary or any workers are still running
+    return original_primary_id in running_ids or bool(original_worker_ids & running_ids)
+
+
+async def cluster_is_running(
+    state: AppState,
+    user_id: int,
+    wallet_id: int | None,
+    original_primary_instance_id: str,
+    original_worker_instance_ids: set[str],
+) -> bool:
+    """Check if the original cluster instances still exist in EC2."""
+    assert state.environment["PRIMARY_EC2_INSTANCES_KEY_NAME"]
+    custom_tags = {}
+    if state.environment["PRIMARY_EC2_INSTANCES_CUSTOM_TAGS"]:
+        custom_tags = orjson.loads(state.environment["PRIMARY_EC2_INSTANCES_CUSTOM_TAGS"])
+    assert state.ec2_resource_clusters_keeper
+
+    return await _check_cluster_instances_exist(
+        state.ec2_resource_clusters_keeper,
+        state.environment["PRIMARY_EC2_INSTANCES_KEY_NAME"],
+        custom_tags,
+        user_id,
+        wallet_id,
+        original_primary_instance_id,
+        original_worker_instance_ids,
+    )
+
+
+@to_async
+def _terminate_instances_by_ids(ec2_resource: EC2ServiceResource, instance_ids: list[str]) -> None:
+    instances_by_id = {inst.id: inst for inst in ec2_resource.instances.filter(InstanceIds=instance_ids)}
+    if not instances_by_id:
+        rich.print("[yellow]No matching instances found in EC2 for forceful termination.[/yellow]")
+        return
+
+    terminateable_ids: list[str] = []
+    for instance_id in instance_ids:
+        instance = instances_by_id.get(instance_id)
+        if instance is None:
+            rich.print(f"[yellow]Instance {instance_id} not found, skipping[/yellow]")
+            continue
+
+        state_name = instance.state["Name"]
+        if state_name in ("running", "pending", "stopping", "stopped"):
+            rich.print(f"Terminating instance {instance.id} ({get_instance_name(instance)})")
+            terminateable_ids.append(instance.id)
+        else:
+            rich.print(f"Instance {instance.id} already {state_name}, skipping")
+
+    if not terminateable_ids:
+        rich.print("[yellow]No instances in a terminateable state.[/yellow]")
+        return
+
+    ec2_resource.meta.client.terminate_instances(InstanceIds=terminateable_ids)
+
+
+async def terminate_cluster_instances_forcefully(
+    ec2_resource: EC2ServiceResource,
+    primary_instance_id: str,
+    worker_instance_ids: set[str],
+) -> None:
+    rich.print("\n[bold yellow]Initiating direct EC2 termination as fallback...[/bold yellow]")
+    instance_ids = [primary_instance_id, *sorted(worker_instance_ids)]
+    await _terminate_instances_by_ids(ec2_resource, instance_ids)
+    rich.print("[green]Direct EC2 termination initiated.[/green]")


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
modified the behavior of the "trigger termination" used to real "terminate" behavior for computational clusters:

now
```bash
autoscaled-monitor --deploy-config XXX computational terminate --user-id 23
```
<img width="1963" height="523" alt="image" src="https://github.com/user-attachments/assets/365c0ee9-b0b7-402f-80c3-f5c36bcee8bf" />

It will by default wait 10x the CLUSTERS_KEEPER_TASK_INTERVAL and then forcefully terminate the EC2 instances of the cluster.

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/private-issues/issues/463

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
