### PR TITLE
🐛 fix(dask-sidecar): unzip error for input files with spaces in name

### DIFF
--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
@@ -14,7 +14,7 @@ import aiofiles
 import aiofiles.tempfile
 import fsspec  # type: ignore[import-untyped]
 import repro_zipfile
-from pydantic import ByteSize, FileUrl, TypeAdapter
+from pydantic import ByteSize
 from pydantic.networks import AnyUrl
 from servicelib.logging_utils import LogLevelInt, LogMessageStr
 from settings_library.s3 import S3Settings
@@ -96,8 +96,8 @@ def _file_chunk_streamer(src: IOBase, dst: IOBase):
 
 
 async def _copy_file(
-    src_url: AnyUrl,
-    dst_url: AnyUrl,
+    src_url: AnyUrl | Path,
+    dst_url: AnyUrl | Path,
     *,
     log_publishing_cb: LogPublishingCB,
     text_prefix: str,
@@ -187,7 +187,7 @@ async def pull_file_from_remote(
 
         await _copy_file(
             src_url,
-            TypeAdapter(FileUrl).validate_python(f"{download_dst_path.as_uri()}"),
+            download_dst_path,
             src_storage_cfg=cast(dict[str, Any], storage_kwargs),
             log_publishing_cb=log_publishing_cb,
             text_prefix=f"Downloading '{src_location_str}':",
@@ -250,7 +250,7 @@ async def _push_file_to_remote(
         storage_kwargs = _s3fs_settings_from_s3_settings(s3_settings)
 
     await _copy_file(
-        TypeAdapter(FileUrl).validate_python(file_to_upload.as_uri()),
+        file_to_upload,
         dst_url,
         dst_storage_cfg=cast(dict[str, Any], storage_kwargs),
         log_publishing_cb=log_publishing_cb,

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
@@ -180,7 +180,7 @@ async def pull_file_from_remote(
             # we need to extract the file, so we create a temporary directory
             # where the file will be downloaded and extracted
             tmp_dir = await exit_stack.enter_async_context(aiofiles.tempfile.TemporaryDirectory())
-            download_dst_path = Path(f"{tmp_dir}") / Path(src_url.path).name
+            download_dst_path = Path(f"{tmp_dir}") / Path(URL(f"{src_url}").path).name
         else:
             # no extraction needed, so we can use the provided dst_path directly
             download_dst_path = dst_path

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
@@ -180,8 +180,7 @@ async def pull_file_from_remote(
             # we need to extract the file, so we create a temporary directory
             # where the file will be downloaded and extracted
             tmp_dir = await exit_stack.enter_async_context(aiofiles.tempfile.TemporaryDirectory())
-            # NOTE: the URL path is percent-encoded (spaces -> '%20'); decode it via yarl
-            # so the local file name matches the real name and can be unzipped
+            # NOTE: the URL path is percent-encoded
             download_dst_path = Path(tmp_dir) / Path(URL(f"{src_url}").path).name
         else:
             # no extraction needed, so we can use the provided dst_path directly

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/utils/files.py
@@ -180,7 +180,9 @@ async def pull_file_from_remote(
             # we need to extract the file, so we create a temporary directory
             # where the file will be downloaded and extracted
             tmp_dir = await exit_stack.enter_async_context(aiofiles.tempfile.TemporaryDirectory())
-            download_dst_path = Path(f"{tmp_dir}") / Path(URL(f"{src_url}").path).name
+            # NOTE: the URL path is percent-encoded (spaces -> '%20'); decode it via yarl
+            # so the local file name matches the real name and can be unzipped
+            download_dst_path = Path(tmp_dir) / Path(URL(f"{src_url}").path).name
         else:
             # no extraction needed, so we can use the provided dst_path directly
             download_dst_path = dst_path

--- a/services/dask-sidecar/tests/unit/test_utils_files.py
+++ b/services/dask-sidecar/tests/unit/test_utils_files.py
@@ -6,7 +6,7 @@ import asyncio
 import hashlib
 import mimetypes
 import zipfile
-from collections.abc import AsyncIterable, Mapping
+from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -367,21 +367,6 @@ async def test_pull_file_from_remote_s3_presigned_link_invalid_file(
     mocked_log_publishing_cb.assert_called()
 
 
-def _upload_file_to_remote(local_file: Path, remote_url: AnyUrl, storage_kwargs: Mapping[str, Any]) -> None:
-    with (
-        cast(
-            fsspec.core.OpenFile,
-            fsspec.open(
-                f"{remote_url}",
-                mode="wb",
-                **storage_kwargs,
-            ),
-        ) as dest_fp,
-        local_file.open("rb") as src_fp,
-    ):
-        dest_fp.write(src_fp.read())
-
-
 async def test_pull_compressed_zip_file_from_remote(
     remote_parameters: StorageParameters,
     tmp_path: Path,
@@ -404,7 +389,18 @@ async def test_pull_compressed_zip_file_from_remote(
     if remote_parameters.s3_settings:
         storage_kwargs = _s3fs_settings_from_s3_settings(remote_parameters.s3_settings)
 
-    _upload_file_to_remote(local_zip_file_path, destination_url, storage_kwargs)
+    with (
+        cast(
+            fsspec.core.OpenFile,
+            fsspec.open(
+                f"{destination_url}",
+                mode="wb",
+                **storage_kwargs,
+            ),
+        ) as dest_fp,
+        local_zip_file_path.open("rb") as src_fp,
+    ):
+        dest_fp.write(src_fp.read())
 
     # now we want to download that file so it becomes the source
     src_url = destination_url
@@ -492,7 +488,18 @@ async def test_pull_compressed_zip_file_with_spaces_in_name_from_remote(
     if remote_parameters.s3_settings:
         storage_kwargs = _s3fs_settings_from_s3_settings(remote_parameters.s3_settings)
 
-    _upload_file_to_remote(local_zip_file_path, destination_url, storage_kwargs)
+    with (
+        cast(
+            fsspec.core.OpenFile,
+            fsspec.open(
+                f"{destination_url}",
+                mode="wb",
+                **storage_kwargs,
+            ),
+        ) as dest_fp,
+        local_zip_file_path.open("rb") as src_fp,
+    ):
+        dest_fp.write(src_fp.read())
 
     # now we want to download that file so it becomes the source
     src_url = destination_url

--- a/services/dask-sidecar/tests/unit/test_utils_files.py
+++ b/services/dask-sidecar/tests/unit/test_utils_files.py
@@ -481,9 +481,8 @@ async def test_pull_compressed_zip_file_with_spaces_in_name_from_remote(
         s3_settings=remote_parameters.s3_settings,
     )
     assert not dst_path.exists()
-    for file in download_folder.glob("*"):
-        assert file.exists()
-        assert file.name in file_names_within_zip_file
+    extracted_file_names = {file.name for file in download_folder.glob("*")}
+    assert extracted_file_names == file_names_within_zip_file
     mocked_log_publishing_cb.assert_called()
 
 

--- a/services/dask-sidecar/tests/unit/test_utils_files.py
+++ b/services/dask-sidecar/tests/unit/test_utils_files.py
@@ -424,6 +424,68 @@ async def test_pull_compressed_zip_file_from_remote(
     mocked_log_publishing_cb.assert_called()
 
 
+async def test_pull_compressed_zip_file_with_spaces_in_name_from_remote(
+    remote_parameters: StorageParameters,
+    tmp_path: Path,
+    faker: Faker,
+    mocked_log_publishing_cb: mock.AsyncMock,
+):
+    # regression test for zip files whose name contains spaces (e.g. 'IXI025-Guys-0852-MRI (2) (3).zip')
+    # the URL path percent-encodes the spaces and the local download name must be decoded back
+    # so that the archive can be found and uncompressed
+    local_zip_file_path = tmp_path / "archive with spaces (2) (3).zip"
+    file_names_within_zip_file = set()
+    with zipfile.ZipFile(local_zip_file_path, compression=zipfile.ZIP_DEFLATED, mode="w") as zfp:
+        for file_number in range(5):
+            local_test_file = tmp_path / f"{file_number}_{faker.file_name()}"
+            local_test_file.write_text(faker.text())
+            assert local_test_file.exists()
+            zfp.write(local_test_file, local_test_file.name)
+            file_names_within_zip_file.add(local_test_file.name)
+
+    # NOTE: the remote file name contains spaces, which get percent-encoded in the URL
+    destination_url = TypeAdapter(AnyUrl).validate_python(
+        f"{remote_parameters.remote_file_url} with spaces (2) (3).zip"
+    )
+    storage_kwargs = {}
+    if remote_parameters.s3_settings:
+        storage_kwargs = _s3fs_settings_from_s3_settings(remote_parameters.s3_settings)
+
+    with (
+        cast(
+            fsspec.core.OpenFile,
+            fsspec.open(
+                f"{destination_url}",
+                mode="wb",
+                **storage_kwargs,
+            ),
+        ) as dest_fp,
+        local_zip_file_path.open("rb") as src_fp,
+    ):
+        dest_fp.write(src_fp.read())
+
+    # now we want to download that file so it becomes the source
+    src_url = destination_url
+
+    # if destination is not a zip, then we decompress
+    download_folder = tmp_path / "download"
+    download_folder.mkdir(parents=True, exist_ok=True)
+    assert download_folder.exists()
+    dst_path = download_folder / faker.file_name()
+    await pull_file_from_remote(
+        src_url=src_url,
+        target_mime_type=None,
+        dst_path=dst_path,
+        log_publishing_cb=mocked_log_publishing_cb,
+        s3_settings=remote_parameters.s3_settings,
+    )
+    assert not dst_path.exists()
+    for file in download_folder.glob("*"):
+        assert file.exists()
+        assert file.name in file_names_within_zip_file
+    mocked_log_publishing_cb.assert_called()
+
+
 def _compute_hash(file_path: Path) -> str:
     with file_path.open("rb") as file_to_hash:
         file_hash = hashlib.sha256()

--- a/services/dask-sidecar/tests/unit/test_utils_files.py
+++ b/services/dask-sidecar/tests/unit/test_utils_files.py
@@ -126,6 +126,42 @@ async def test_push_file_to_remote(
     mocked_log_publishing_cb.assert_called()
 
 
+async def test_push_file_with_spaces_in_name_to_remote(
+    remote_parameters: StorageParameters,
+    tmp_path: Path,
+    faker: Faker,
+    mocked_log_publishing_cb: mock.AsyncMock,
+):
+    # let's create some file with spaces/parentheses in its local name
+    src_path = tmp_path / "some file with spaces (1) (2).txt"
+    TEXT_IN_FILE = faker.text()
+    src_path.write_text(TEXT_IN_FILE)
+    assert src_path.exists()
+    # push it to the remote
+    await push_file_to_remote(
+        src_path,
+        remote_parameters.remote_file_url,
+        mocked_log_publishing_cb,
+        remote_parameters.s3_settings,
+    )
+
+    # check the remote is actually having the file in
+    storage_kwargs = {}
+    if remote_parameters.s3_settings:
+        storage_kwargs = _s3fs_settings_from_s3_settings(remote_parameters.s3_settings)
+
+    with cast(
+        fsspec.core.OpenFile,
+        fsspec.open(
+            f"{remote_parameters.remote_file_url}",
+            mode="rt",
+            **storage_kwargs,
+        ),
+    ) as fp:
+        assert fp.read() == TEXT_IN_FILE
+    mocked_log_publishing_cb.assert_called()
+
+
 async def test_push_file_to_remote_s3_http_presigned_link(
     s3_presigned_link_remote_file_url: AnyUrl,
     s3_settings: S3Settings,

--- a/services/dask-sidecar/tests/unit/test_utils_files.py
+++ b/services/dask-sidecar/tests/unit/test_utils_files.py
@@ -3,10 +3,11 @@
 # pylint: disable=unused-variable
 
 import asyncio
+import contextlib
 import hashlib
 import mimetypes
 import zipfile
-from collections.abc import AsyncIterable
+from collections.abc import AsyncIterable, Callable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -88,6 +89,32 @@ def remote_parameters(
     }[
         request.param  # type: ignore
     ]
+
+
+@pytest.fixture
+def upload_file_to_remote(
+    remote_parameters: StorageParameters,
+) -> Iterator[Callable[[Path, AnyUrl], None]]:
+    storage_kwargs: dict[str, Any] = {}
+    if remote_parameters.s3_settings:
+        storage_kwargs = _s3fs_settings_from_s3_settings(remote_parameters.s3_settings)
+
+    uploaded_files: list[fsspec.core.OpenFile] = []
+
+    def _upload(local_path: Path, remote_url: AnyUrl) -> None:
+        open_file = cast(
+            fsspec.core.OpenFile,
+            fsspec.open(f"{remote_url}", mode="wb", **storage_kwargs),
+        )
+        with open_file as dest_fp, local_path.open("rb") as src_fp:
+            dest_fp.write(src_fp.read())
+        uploaded_files.append(open_file)
+
+    yield _upload
+
+    for open_file in uploaded_files:
+        with contextlib.suppress(Exception):
+            open_file.fs.rm(open_file.path)
 
 
 async def test_push_file_to_remote(
@@ -369,6 +396,7 @@ async def test_pull_file_from_remote_s3_presigned_link_invalid_file(
 
 async def test_pull_compressed_zip_file_from_remote(
     remote_parameters: StorageParameters,
+    upload_file_to_remote: Callable[[Path, AnyUrl], None],
     tmp_path: Path,
     faker: Faker,
     mocked_log_publishing_cb: mock.AsyncMock,
@@ -385,22 +413,7 @@ async def test_pull_compressed_zip_file_from_remote(
             file_names_within_zip_file.add(local_test_file.name)
 
     destination_url = TypeAdapter(AnyUrl).validate_python(f"{remote_parameters.remote_file_url}.zip")
-    storage_kwargs = {}
-    if remote_parameters.s3_settings:
-        storage_kwargs = _s3fs_settings_from_s3_settings(remote_parameters.s3_settings)
-
-    with (
-        cast(
-            fsspec.core.OpenFile,
-            fsspec.open(
-                f"{destination_url}",
-                mode="wb",
-                **storage_kwargs,
-            ),
-        ) as dest_fp,
-        local_zip_file_path.open("rb") as src_fp,
-    ):
-        dest_fp.write(src_fp.read())
+    upload_file_to_remote(local_zip_file_path, destination_url)
 
     # now we want to download that file so it becomes the source
     src_url = destination_url
@@ -462,6 +475,7 @@ async def test_pull_compressed_zip_file_from_remote(
 
 async def test_pull_compressed_zip_file_with_spaces_in_name_from_remote(
     remote_parameters: StorageParameters,
+    upload_file_to_remote: Callable[[Path, AnyUrl], None],
     tmp_path: Path,
     faker: Faker,
     mocked_log_publishing_cb: mock.AsyncMock,
@@ -484,22 +498,7 @@ async def test_pull_compressed_zip_file_with_spaces_in_name_from_remote(
     assert "%20" in f"{destination_url}"
     assert " " not in f"{destination_url}"
 
-    storage_kwargs = {}
-    if remote_parameters.s3_settings:
-        storage_kwargs = _s3fs_settings_from_s3_settings(remote_parameters.s3_settings)
-
-    with (
-        cast(
-            fsspec.core.OpenFile,
-            fsspec.open(
-                f"{destination_url}",
-                mode="wb",
-                **storage_kwargs,
-            ),
-        ) as dest_fp,
-        local_zip_file_path.open("rb") as src_fp,
-    ):
-        dest_fp.write(src_fp.read())
+    upload_file_to_remote(local_zip_file_path, destination_url)
 
     # now we want to download that file so it becomes the source
     src_url = destination_url

--- a/services/dask-sidecar/tests/unit/test_utils_files.py
+++ b/services/dask-sidecar/tests/unit/test_utils_files.py
@@ -6,7 +6,7 @@ import asyncio
 import hashlib
 import mimetypes
 import zipfile
-from collections.abc import AsyncIterable
+from collections.abc import AsyncIterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -331,6 +331,21 @@ async def test_pull_file_from_remote_s3_presigned_link_invalid_file(
     mocked_log_publishing_cb.assert_called()
 
 
+def _upload_file_to_remote(local_file: Path, remote_url: AnyUrl, storage_kwargs: Mapping[str, Any]) -> None:
+    with (
+        cast(
+            fsspec.core.OpenFile,
+            fsspec.open(
+                f"{remote_url}",
+                mode="wb",
+                **storage_kwargs,
+            ),
+        ) as dest_fp,
+        local_file.open("rb") as src_fp,
+    ):
+        dest_fp.write(src_fp.read())
+
+
 async def test_pull_compressed_zip_file_from_remote(
     remote_parameters: StorageParameters,
     tmp_path: Path,
@@ -353,18 +368,7 @@ async def test_pull_compressed_zip_file_from_remote(
     if remote_parameters.s3_settings:
         storage_kwargs = _s3fs_settings_from_s3_settings(remote_parameters.s3_settings)
 
-    with (
-        cast(
-            fsspec.core.OpenFile,
-            fsspec.open(
-                f"{destination_url}",
-                mode="wb",
-                **storage_kwargs,
-            ),
-        ) as dest_fp,
-        local_zip_file_path.open("rb") as src_fp,
-    ):
-        dest_fp.write(src_fp.read())
+    _upload_file_to_remote(local_zip_file_path, destination_url, storage_kwargs)
 
     # now we want to download that file so it becomes the source
     src_url = destination_url
@@ -452,18 +456,7 @@ async def test_pull_compressed_zip_file_with_spaces_in_name_from_remote(
     if remote_parameters.s3_settings:
         storage_kwargs = _s3fs_settings_from_s3_settings(remote_parameters.s3_settings)
 
-    with (
-        cast(
-            fsspec.core.OpenFile,
-            fsspec.open(
-                f"{destination_url}",
-                mode="wb",
-                **storage_kwargs,
-            ),
-        ) as dest_fp,
-        local_zip_file_path.open("rb") as src_fp,
-    ):
-        dest_fp.write(src_fp.read())
+    _upload_file_to_remote(local_zip_file_path, destination_url, storage_kwargs)
 
     # now we want to download that file so it becomes the source
     src_url = destination_url

--- a/services/dask-sidecar/tests/unit/test_utils_files.py
+++ b/services/dask-sidecar/tests/unit/test_utils_files.py
@@ -430,10 +430,7 @@ async def test_pull_compressed_zip_file_with_spaces_in_name_from_remote(
     faker: Faker,
     mocked_log_publishing_cb: mock.AsyncMock,
 ):
-    # regression test for zip files whose name contains spaces (e.g. 'IXI025-Guys-0852-MRI (2) (3).zip')
-    # the URL path percent-encodes the spaces and the local download name must be decoded back
-    # so that the archive can be found and uncompressed
-    local_zip_file_path = tmp_path / "archive with spaces (2) (3).zip"
+    local_zip_file_path = tmp_path / "archive with spaces (1) (2).zip"
     file_names_within_zip_file = set()
     with zipfile.ZipFile(local_zip_file_path, compression=zipfile.ZIP_DEFLATED, mode="w") as zfp:
         for file_number in range(5):
@@ -445,8 +442,12 @@ async def test_pull_compressed_zip_file_with_spaces_in_name_from_remote(
 
     # NOTE: the remote file name contains spaces, which get percent-encoded in the URL
     destination_url = TypeAdapter(AnyUrl).validate_python(
-        f"{remote_parameters.remote_file_url} with spaces (2) (3).zip"
+        f"{remote_parameters.remote_file_url} with spaces (1) (2).zip"
     )
+
+    assert "%20" in f"{destination_url}"
+    assert " " not in f"{destination_url}"
+
     storage_kwargs = {}
     if remote_parameters.s3_settings:
         storage_kwargs = _s3fs_settings_from_s3_settings(remote_parameters.s3_settings)


### PR DESCRIPTION
## What do these changes do?

Fixes the computational backend (`dask-sidecar`) failing to **unzip input files whose name contains spaces** (or other special characters), e.g. `IXI025-Guys-0852-MRI (2) (3).zip`.

### Root cause

`pydantic`/`yarl` URL types percent-encode paths (spaces → `%20`), while `fsspec`'s local filesystem does **not** decode `file://` URIs. The sidecar built local file paths from the percent-encoded `AnyUrl.path` and passed them to `fsspec` as `file://` URIs via `Path.as_uri()`. As a result `fsspec` created/read a file literally named with `%20`, so the subsequent unzip (which used the real, decoded name) failed with:

```
[Errno 2] No such file or directory: '.../inputs/IXI025-Guys-0852-MRI (2) (3).zip'
```

### Fix

- Derive the local download filename from the **decoded** URL path (via `yarl.URL`), so it matches the real name used for extraction.
- Pass local files to `_copy_file` as plain `Path` objects (formatted as plain paths) instead of `file://` URIs, since `fsspec` does not percent-decode them. This centralizes the fix for both **download** and **upload** of files with special characters.
- `_copy_file` now accepts `AnyUrl | Path` for `src_url`/`dst_url`.
- Removed now-unused `FileUrl`/`TypeAdapter` imports.

Added a regression test covering filenames with spaces and parentheses.

## Related issue/s

- fixes ITISFoundation/osparc-simcore#7201

## How to test

```bash
cd services/dask-sidecar && make install-dev
pytest -vv tests/unit/test_utils_files.py
```

## Dev-ops

No changes.
