### PR TITLE
:nail_care: fix(notifications): use `product.display_name` as logo alt text

### DIFF
--- a/services/notifications/src/simcore_service_notifications/templates/email/_base/body_html.j2
+++ b/services/notifications/src/simcore_service_notifications/templates/email/_base/body_html.j2
@@ -57,7 +57,7 @@
           <tr>
             <td style="{{ header_style }}">
               <a href="{{ product.homepage_url | default(default_homepage) }}" target="_blank" rel="noopener noreferrer" style="display: inline-block; background-color: #ffffff; padding: 4px; border-radius: 8px;">
-                <img src="{{ product.ui.logo_url | default(default_logo) }}" alt="Logo" style="height: 40px; border: 0; display: block;">
+                <img src="{{ product.ui.logo_url | default(default_logo) }}" alt="{{ product.display_name }}" style="height: 40px; border: 0; display: block;">
               </a>
             </td>
           </tr>


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Updates the notifications service’s base HTML email template to improve accessibility and clarity when email clients block images by using the product’s display name as the logo’s alt text.

> [!NOTE]
> Reported by @calys  

### Current
<img width="424" height="131" alt="image" src="https://github.com/user-attachments/assets/963cf6d2-35ca-426a-afc5-e5ab5d1c45eb" />

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
No changes.