### PR TITLE
🎨 [Frontend] Enh: Prettify dispatching project workflow

### DIFF
--- a/services/static-webserver/client/source/class/osparc/desktop/MainPageHandler.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPageHandler.js
@@ -92,13 +92,7 @@ qx.Class.define("osparc.desktop.MainPageHandler", {
       this.setLoadingPageHeader(qx.locale.Manager.tr("Preparing ") + osparc.product.Utils.getStudyAlias());
       this.showLoadingPage();
 
-      const title = qx.locale.Manager.tr("CREATING ") + osparc.product.Utils.getStudyAlias({allUpperCase: true}) + " ...";
-      const progressSequence = new osparc.widget.ProgressSequence(title).set({
-        minHeight: 180 // four tasks
-      });
-      progressSequence.addOverallProgressBar();
-      this.__loadingPage.clearMessages();
-      this.__loadingPage.addWidgetToMessages(progressSequence);
+      const progressSequence = osparc.widget.ProgressSequence.createCreatingStudyProgress(this.__loadingPage);
 
       const params = {
         url: {
@@ -115,34 +109,7 @@ qx.Class.define("osparc.desktop.MainPageHandler", {
       pollTasks.createPollingTask(pollPromise, interval)
         .then(task => {
           task.addListener("updateReceived", e => {
-            const updateData = e.getData();
-            if ("task_progress" in updateData) {
-              const taskProgress = updateData["task_progress"];
-              const message = taskProgress["message"];
-              const percent = osparc.data.PollTask.extractProgress(updateData);
-              progressSequence.setOverallProgress(percent);
-              const existingTask = message ? progressSequence.getTask(message) : null;
-              if (existingTask) {
-                // update task
-                osparc.widget.ProgressSequence.updateTaskProgress(existingTask, {
-                  value: percent,
-                  progressLabel: osparc.utils.Utils.safeToFixed(percent * 100, 2) + "%"
-                });
-              } else if (message) {
-                // new task
-                // all the previous steps to 100%
-                progressSequence.getTasks().forEach(tsk => osparc.widget.ProgressSequence.updateTaskProgress(tsk, {
-                  value: 1,
-                  progressLabel: "100%"
-                }));
-                // and move to the next new task
-                const subTask = progressSequence.addNewTask(message);
-                osparc.widget.ProgressSequence.updateTaskProgress(subTask, {
-                  value: percent,
-                  progressLabel: "0%"
-                });
-              }
-            }
+            progressSequence.applyPollTaskUpdate(e.getData());
           }, this);
 
           task.addListener("resultReceived", e => {
@@ -151,12 +118,7 @@ qx.Class.define("osparc.desktop.MainPageHandler", {
             if (!projectId) {
               throw new Error(qx.locale.Manager.tr("Missing project id in dispatch result"));
             }
-            // all the steps to 100%
-            progressSequence.setOverallProgress(1);
-            progressSequence.getTasks().forEach(tsk => osparc.widget.ProgressSequence.updateTaskProgress(tsk, {
-              value: 1,
-              progressLabel: "100%"
-            }));
+            progressSequence.completeAllTasks();
             osparc.store.Store.getInstance().setCurrentStudyId(projectId);
             this.__loadingPage.clearMessages();
             this.startStudy(projectId);

--- a/services/static-webserver/client/source/class/osparc/desktop/MainPageHandler.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/MainPageHandler.js
@@ -91,9 +91,14 @@ qx.Class.define("osparc.desktop.MainPageHandler", {
     dispatchStudy: function(studyId) {
       this.setLoadingPageHeader(qx.locale.Manager.tr("Preparing ") + osparc.product.Utils.getStudyAlias());
       this.showLoadingPage();
-      this.__loadingPage.setMessages([
-        qx.locale.Manager.tr("Starting dispatch task...")
-      ]);
+
+      const title = qx.locale.Manager.tr("CREATING ") + osparc.product.Utils.getStudyAlias({allUpperCase: true}) + " ...";
+      const progressSequence = new osparc.widget.ProgressSequence(title).set({
+        minHeight: 180 // four tasks
+      });
+      progressSequence.addOverallProgressBar();
+      this.__loadingPage.clearMessages();
+      this.__loadingPage.addWidgetToMessages(progressSequence);
 
       const params = {
         url: {
@@ -114,8 +119,28 @@ qx.Class.define("osparc.desktop.MainPageHandler", {
             if ("task_progress" in updateData) {
               const taskProgress = updateData["task_progress"];
               const message = taskProgress["message"];
-              if (message) {
-                this.__loadingPage.setMessages([message]);
+              const percent = osparc.data.PollTask.extractProgress(updateData);
+              progressSequence.setOverallProgress(percent);
+              const existingTask = message ? progressSequence.getTask(message) : null;
+              if (existingTask) {
+                // update task
+                osparc.widget.ProgressSequence.updateTaskProgress(existingTask, {
+                  value: percent,
+                  progressLabel: osparc.utils.Utils.safeToFixed(percent * 100, 2) + "%"
+                });
+              } else if (message) {
+                // new task
+                // all the previous steps to 100%
+                progressSequence.getTasks().forEach(tsk => osparc.widget.ProgressSequence.updateTaskProgress(tsk, {
+                  value: 1,
+                  progressLabel: "100%"
+                }));
+                // and move to the next new task
+                const subTask = progressSequence.addNewTask(message);
+                osparc.widget.ProgressSequence.updateTaskProgress(subTask, {
+                  value: percent,
+                  progressLabel: "0%"
+                });
               }
             }
           }, this);
@@ -126,8 +151,14 @@ qx.Class.define("osparc.desktop.MainPageHandler", {
             if (!projectId) {
               throw new Error(qx.locale.Manager.tr("Missing project id in dispatch result"));
             }
+            // all the steps to 100%
+            progressSequence.setOverallProgress(1);
+            progressSequence.getTasks().forEach(tsk => osparc.widget.ProgressSequence.updateTaskProgress(tsk, {
+              value: 1,
+              progressLabel: "100%"
+            }));
             osparc.store.Store.getInstance().setCurrentStudyId(projectId);
-            this.__loadingPage.setMessages([]);
+            this.__loadingPage.clearMessages();
             this.startStudy(projectId);
           }, this);
 

--- a/services/static-webserver/client/source/class/osparc/study/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/study/Utils.js
@@ -121,41 +121,10 @@ qx.Class.define("osparc.study.Utils", {
             const interval = 1000;
             pollTasks.createPollingTask(pollPromise, interval)
               .then(task => {
-                const title = qx.locale.Manager.tr("CREATING ") + osparc.product.Utils.getStudyAlias({allUpperCase: true}) + " ...";
-                const progressSequence = new osparc.widget.ProgressSequence(title).set({
-                  minHeight: 180 // four tasks
-                });
-                progressSequence.addOverallProgressBar();
-                loadingPage.clearMessages();
-                loadingPage.addWidgetToMessages(progressSequence);
+                const progressSequence = osparc.widget.ProgressSequence.createCreatingStudyProgress(loadingPage);
                 task.addListener("updateReceived", e => {
-                  const updateData = e.getData();
-                  if ("task_progress" in updateData && loadingPage) {
-                    const taskProgress = updateData["task_progress"];
-                    const message = taskProgress["message"];
-                    const percent = osparc.data.PollTask.extractProgress(updateData);
-                    progressSequence.setOverallProgress(percent);
-                    const existingTask = progressSequence.getTask(message);
-                    if (existingTask) {
-                      // update task
-                      osparc.widget.ProgressSequence.updateTaskProgress(existingTask, {
-                        value: percent,
-                        progressLabel: osparc.utils.Utils.safeToFixed(percent * 100, 2) + "%"
-                      });
-                    } else {
-                      // new task
-                      // all the previous steps to 100%
-                      progressSequence.getTasks().forEach(tsk => osparc.widget.ProgressSequence.updateTaskProgress(tsk, {
-                        value: 1,
-                        progressLabel: "100%"
-                      }));
-                      // and move to the next new task
-                      const subTask = progressSequence.addNewTask(message);
-                      osparc.widget.ProgressSequence.updateTaskProgress(subTask, {
-                        value: percent,
-                        progressLabel: "0%"
-                      });
-                    }
+                  if (loadingPage) {
+                    progressSequence.applyPollTaskUpdate(e.getData());
                   }
                 }, this);
                 task.addListener("resultReceived", e => {

--- a/services/static-webserver/client/source/class/osparc/task/TaskUI.js
+++ b/services/static-webserver/client/source/class/osparc/task/TaskUI.js
@@ -136,7 +136,7 @@ qx.Class.define("osparc.task.TaskUI", {
         if ("message" in data["task_progress"] && !this.getChildControl("subtitle").getValue()) {
           this.getChildControl("subtitle").setValue(data["task_progress"]["message"]);
         }
-        this.getChildControl("progress").setValue((osparc.data.PollTask.extractProgress(data) * 100) + "%");
+        this.getChildControl("progress").setValue(osparc.utils.Utils.safeToFixed(osparc.data.PollTask.extractProgress(data) * 100, 2) + "%");
       }
     },
 

--- a/services/static-webserver/client/source/class/osparc/widget/ProgressSequence.js
+++ b/services/static-webserver/client/source/class/osparc/widget/ProgressSequence.js
@@ -128,6 +128,17 @@ qx.Class.define("osparc.widget.ProgressSequence", {
           visibility: (value >= 0) ? "visible" : "excluded"
         });
       }
+    },
+
+    createCreatingStudyProgress: function(loadingPage) {
+      const title = qx.locale.Manager.tr("CREATING ") + osparc.product.Utils.getStudyAlias({allUpperCase: true}) + " ...";
+      const progressSequence = new osparc.widget.ProgressSequence(title).set({
+        minHeight: 180 // four tasks
+      });
+      progressSequence.addOverallProgressBar();
+      loadingPage.clearMessages();
+      loadingPage.addWidgetToMessages(progressSequence);
+      return progressSequence;
     }
   },
 
@@ -187,6 +198,51 @@ qx.Class.define("osparc.widget.ProgressSequence", {
       this._add(newTask);
       this.__tasks.push(newTask);
       return newTask;
+    },
+
+    /**
+     * Applies a long-running-task update ("updateReceived"): updates the overall progress and the per-step task progress.
+     */
+    applyPollTaskUpdate: function(updateData) {
+      if (!("task_progress" in updateData)) {
+        return;
+      }
+      const message = updateData["task_progress"]["message"];
+      const percent = osparc.data.PollTask.extractProgress(updateData);
+      this.setOverallProgress(percent);
+      if (!message) {
+        return;
+      }
+      const existingTask = this.getTask(message);
+      if (existingTask) {
+        // update existing task
+        osparc.widget.ProgressSequence.updateTaskProgress(existingTask, {
+          value: percent,
+          progressLabel: osparc.utils.Utils.safeToFixed(percent * 100, 2) + "%"
+        });
+      } else {
+        // complete the previous steps and move on to the new one
+        this.getTasks().forEach(tsk => osparc.widget.ProgressSequence.updateTaskProgress(tsk, {
+          value: 1,
+          progressLabel: "100%"
+        }));
+        const subTask = this.addNewTask(message);
+        osparc.widget.ProgressSequence.updateTaskProgress(subTask, {
+          value: percent,
+          progressLabel: "0%"
+        });
+      }
+    },
+
+    /**
+     * Forces the overall progress and every task to 100%.
+     */
+    completeAllTasks: function() {
+      this.setOverallProgress(1);
+      this.getTasks().forEach(tsk => osparc.widget.ProgressSequence.updateTaskProgress(tsk, {
+        value: 1,
+        progressLabel: "100%"
+      }));
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/widget/ProgressSequence.js
+++ b/services/static-webserver/client/source/class/osparc/widget/ProgressSequence.js
@@ -229,7 +229,7 @@ qx.Class.define("osparc.widget.ProgressSequence", {
         const subTask = this.addNewTask(message);
         osparc.widget.ProgressSequence.updateTaskProgress(subTask, {
           value: percent,
-          progressLabel: "0%"
+          progressLabel: osparc.utils.Utils.safeToFixed(percent * 100, 2) + "%"
         });
       }
     },


### PR DESCRIPTION
## What do these changes do?

Follow-up to #9282 (💅 as promised).

The async study-dispatch flow (anonymous template access) previously reported its cloning progress as plain text lines in the loading page. This PR makes that feedback match the regular **"Creating" / "Loading"** pages used when a study is created from a template.

<img width="1440" height="850" alt="dispatching" src="https://github.com/user-attachments/assets/3582e97b-15a7-47a6-88a9-d8ac90b7b4ee" />

## Related issue/s

- follow-up of #9282
- relates to #9275


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
