### PR TITLE
🐛 [Frontend] Patch moustache input values

### DIFF
--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -796,9 +796,8 @@ qx.Class.define("osparc.data.model.Node", {
         for (let key in inputsCopy) {
           if (osparc.utils.Ports.isDataALink(inputsCopy[key])) {
             inputLinks[key] = inputsCopy[key];
-          } else if (osparc.utils.Ports.isDataAParameter(inputsCopy[key]) && inputsCopy[key] === "{{" + key + "}}") {
-            // unresolved template placeholder (e.g. "{{stimulation_mode}}") that maps to its own port key:
-            // resolve it to the service metadata's default value so the model holds a valid input.
+          } else if (osparc.utils.Ports.isDataAParameter(inputsCopy[key])) {
+            // resolve template placeholder (e.g. "{{stimulation_mode}}") to the service metadata's default value
             if (metadataInputs && metadataInputs[key] && metadataInputs[key].defaultValue !== undefined) {
               inputData[key] = metadataInputs[key].defaultValue;
             }

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -792,9 +792,16 @@ qx.Class.define("osparc.data.model.Node", {
         const inputLinks = {};
         const inputData = {};
         const inputsCopy = osparc.utils.Utils.deepCloneObject(inputs);
+        const metadataInputs = this.getMetadata() ? this.getMetadata()["inputs"] : null;
         for (let key in inputsCopy) {
           if (osparc.utils.Ports.isDataALink(inputsCopy[key])) {
             inputLinks[key] = inputsCopy[key];
+          } else if (osparc.utils.Ports.isDataAParameter(inputsCopy[key]) && inputsCopy[key] === "{{" + key + "}}") {
+            // unresolved template placeholder (e.g. "{{stimulation_mode}}") that maps to its own port key:
+            // resolve it to the service metadata's default value so the model holds a valid input.
+            if (metadataInputs && metadataInputs[key] && metadataInputs[key].defaultValue !== undefined) {
+              inputData[key] = metadataInputs[key].defaultValue;
+            }
           } else {
             inputData[key] = inputsCopy[key];
           }

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -796,7 +796,7 @@ qx.Class.define("osparc.data.model.Node", {
         for (let key in inputsCopy) {
           if (osparc.utils.Ports.isDataALink(inputsCopy[key])) {
             inputLinks[key] = inputsCopy[key];
-          } else if (osparc.utils.Ports.isDataAParameter(inputsCopy[key]) && metadataInputs && metadataInputs[key] && metadataInputs[key].defaultValue !== undefined) {
+          } else if (osparc.utils.Ports.isDataMustached(inputsCopy[key]) && metadataInputs && metadataInputs[key] && metadataInputs[key].defaultValue !== undefined) {
             // resolve template placeholder (e.g. "{{stimulation_mode}}") to the service metadata's default value
             inputData[key] = metadataInputs[key].defaultValue;
           } else {

--- a/services/static-webserver/client/source/class/osparc/data/model/Node.js
+++ b/services/static-webserver/client/source/class/osparc/data/model/Node.js
@@ -796,11 +796,9 @@ qx.Class.define("osparc.data.model.Node", {
         for (let key in inputsCopy) {
           if (osparc.utils.Ports.isDataALink(inputsCopy[key])) {
             inputLinks[key] = inputsCopy[key];
-          } else if (osparc.utils.Ports.isDataAParameter(inputsCopy[key])) {
+          } else if (osparc.utils.Ports.isDataAParameter(inputsCopy[key]) && metadataInputs && metadataInputs[key] && metadataInputs[key].defaultValue !== undefined) {
             // resolve template placeholder (e.g. "{{stimulation_mode}}") to the service metadata's default value
-            if (metadataInputs && metadataInputs[key] && metadataInputs[key].defaultValue !== undefined) {
-              inputData[key] = metadataInputs[key].defaultValue;
-            }
+            inputData[key] = metadataInputs[key].defaultValue;
           } else {
             inputData[key] = inputsCopy[key];
           }

--- a/services/static-webserver/client/source/class/osparc/utils/Ports.js
+++ b/services/static-webserver/client/source/class/osparc/utils/Ports.js
@@ -33,7 +33,7 @@ qx.Class.define("osparc.utils.Ports", {
       return (data !== null && typeof data === "object" && data.nodeUuid);
     },
 
-    isDataAParameter: function(data) {
+    isDataMustached: function(data) {
       return (data !== null && typeof data === "string" && data.startsWith("{{") && data.endsWith("}}"));
     },
 


### PR DESCRIPTION
## What do these changes do?

If the backend provides a project with moustached values ``{{ input_value }}`` which are not valid for the input type, the frontend makes sure that the default values are set and patched.

<img width="1440" height="850" alt="moustache" src="https://github.com/user-attachments/assets/7e5c4c25-5882-4170-a0bc-5cd4c4a1eb43" />


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
