### PR TITLE
♻️Maintenance: All services use the same base image

### DIFF
--- a/.github/workflows/ci-arm-build.yml
+++ b/.github/workflows/ci-arm-build.yml
@@ -16,18 +16,17 @@ concurrency:
 jobs:
   build-and-push-arm64:
     timeout-minutes: 60 # intentionally long to allow for slow builds
-    runs-on: ubuntu-latest
+    # native arm64 runner: builds linux/arm64 without QEMU emulation
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-24.04-arm]
         python: ["3.13"]
     env:
       # secrets can be set in settings/secrets on github
       DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
     steps:
       - uses: actions/checkout@v7.0.0
-      - name: setup QEMU
-        uses: docker/setup-qemu-action@v4
       - name: setup docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v4

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ export SWARM_STACK_NAME_NO_HYPHEN = $(subst -,_,$(SWARM_STACK_NAME))
 export DOCKER_IMAGE_TAG ?= latest
 export DOCKER_REGISTRY  ?= itisfoundation
 
+# content-hash tag of the shared simcore base images (see services/_base_images/Dockerfile)
+export BASE_TAG ?= $(shell ci/helpers/compute_base_image_tag.bash)
+
 MAKEFILES_WITH_OPENAPI_SPECS := $(shell find . -mindepth 2 -type f -name 'Makefile' -not -path '*/.*' -exec grep -l '^openapi-specs:' {} \; | xargs realpath)
 
 # WSL 2 tricks
@@ -189,6 +192,11 @@ $(foreach service, $(SERVICES_NAMES_TO_BUILD),\
 	,) \
 )\
 docker buildx bake --allow=fs.read=.. \
+	--set *.args.BASE_TAG=$(BASE_TAG) \
+	--set *.args.DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
+	$(foreach service, $(if $(target),$(target),$(INCLUDED_SERVICES)),\
+		--set $(service).contexts.$(DOCKER_REGISTRY)/simcore-runtime-base:$(BASE_TAG)=target:simcore-runtime-base \
+		--set $(service).contexts.$(DOCKER_REGISTRY)/simcore-build-base:$(BASE_TAG)=target:simcore-build-base) \
 	$(if $(findstring -devel,$@),,\
 	--set *.platform=$(DOCKER_TARGET_PLATFORMS) \
 	)\

--- a/ci/helpers/compute_base_image_tag.bash
+++ b/ci/helpers/compute_base_image_tag.bash
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Usage: compute_base_image_tag.bash
+#
+# Echoes the content-hash tag for the shared simcore base images
+# (simcore-runtime-base / simcore-build-base).
+#
+# The tag is derived from the base image Dockerfile content, which fully
+# determines the produced images (it pins PYTHON_VERSION, UV_VERSION and the
+# installed apt packages). When the base Dockerfile is unchanged the tag is
+# stable, so the base images are rebuilt only when they actually change.
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -o errexit  # abort on nonzero exitstatus
+set -o nounset  # abort on unbound variable
+set -o pipefail # don't hide errors within pipes
+IFS=$'\n\t'
+
+repo_root="$(git rev-parse --show-toplevel)"
+base_dockerfile="${repo_root}/services/_base_images/Dockerfile"
+
+if [ ! -f "${base_dockerfile}" ]; then
+  echo "ERROR: base image Dockerfile not found at ${base_dockerfile}" >&2
+  exit 1
+fi
+
+content_hash="$(sha256sum "${base_dockerfile}" | cut -c1-16)"
+
+echo "base-${content_hash}"

--- a/packages/service-integration/Dockerfile
+++ b/packages/service-integration/Dockerfile
@@ -1,79 +1,43 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile) + git
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 
 LABEL maintainer=pcrespov
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
   git \
   && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && git --version
 
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
 
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
+# -------------------------- Build stage -------------------
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile) + git
+#
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+  set -eux \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+  git \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
 # https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy
-
-# Ensures that the python and pip executables used
-# in the image will be those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
-# -------------------------- Build stage -------------------
-
-FROM base AS build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
 
 WORKDIR /build/packages/service-integration
 
@@ -86,10 +50,12 @@ RUN \
   && uv pip list
 
 
-# -------------------------- Build stage -------------------
-
-FROM base AS development
+# --------------------------Development stage -------------------
 # NOTE: this is necessary to allow to build development images but is the same as production here
+FROM base AS development
+
+
+# --------------------------Production stage -------------------
 FROM base AS production
 
 WORKDIR /home/scu

--- a/services/_base_images/Dockerfile
+++ b/services/_base_images/Dockerfile
@@ -1,0 +1,104 @@
+# syntax=docker/dockerfile:1
+
+#
+# Shared base images for all python-based simcore services.
+#
+#  Produces two images, tagged with a content-hash (see ci/helpers/compute_base_image_tag.bash):
+#
+#   - ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG}
+#       minimal runtime: python + common apt deps + non-root `scu` user + venv env.
+#       Used as parent of every service `production` stage (small final image).
+#
+#   - ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG}
+#       runtime-base + build toolchain (build-essential, uv) + empty virtualenv.
+#       Used as parent of every service dependency-install / development stage.
+#
+#  USAGE:
+#     docker buildx build -f services/_base_images/Dockerfile --target runtime-base -t simcore-runtime-base .
+#     docker buildx build -f services/_base_images/Dockerfile --target build-base   -t simcore-build-base .
+#
+#  This image needs NO repository files in the build context (only apt + uv).
+#
+
+# Define arguments in the global scope
+ARG PYTHON_VERSION="3.13.9"
+ARG UV_VERSION="0.9"
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+
+FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
+# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
+# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
+ENV UV_CONCURRENT_INSTALLS=1
+
+FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
+
+
+# -------------------------- runtime-base -------------------
+# Minimal runtime shared by every service production stage
+#
+FROM base-${TARGETARCH} AS runtime-base
+
+LABEL maintainer="osparc-simcore"
+
+# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+  set -eux && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+  fd-find \
+  gosu \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
+  # verify that the binary works
+  && gosu nobody true
+
+# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
+ENV SC_USER_ID=8004 \
+  SC_USER_NAME=scu \
+  SC_BUILD_TARGET=base \
+  SC_BOOT_MODE=default
+
+RUN adduser \
+  --uid ${SC_USER_ID} \
+  --disabled-password \
+  --gecos "" \
+  --shell /bin/sh \
+  --home /home/${SC_USER_NAME} \
+  ${SC_USER_NAME}
+
+
+# Sets utf-8 encoding for Python et al
+ENV LANG=C.UTF-8
+
+# Turns off writing .pyc files; superfluous on an ephemeral container.
+ENV PYTHONDONTWRITEBYTECODE=1 \
+  VIRTUAL_ENV=/home/scu/.venv
+
+# Ensures that the python and pip executables used in the image will be
+# those from our virtualenv.
+ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
+
+
+# -------------------------- build-base -------------------
+# runtime-base + build toolchain shared by every service dependency-install stage
+#
+FROM runtime-base AS build-base
+
+ENV SC_BUILD_TARGET=build
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
+  set -eux \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+  build-essential
+
+# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
+COPY --from=uv_build /uv /uvx /bin/
+
+# NOTE: python virtualenv is used here such that installed
+# packages may be moved to production image easily by copying the venv
+RUN uv venv "${VIRTUAL_ENV}"
+
+WORKDIR /build

--- a/services/_base_images/Dockerfile
+++ b/services/_base_images/Dockerfile
@@ -25,18 +25,11 @@ ARG PYTHON_VERSION="3.13.9"
 ARG UV_VERSION="0.9"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
 
 # -------------------------- runtime-base -------------------
 # Minimal runtime shared by every service production stage
 #
-FROM base-${TARGETARCH} AS runtime-base
+FROM python:${PYTHON_VERSION}-slim-bookworm AS runtime-base
 
 LABEL maintainer="osparc-simcore"
 

--- a/services/_base_images/Dockerfile
+++ b/services/_base_images/Dockerfile
@@ -85,7 +85,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  build-essential
+  build-essential \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
 COPY --from=uv_build /uv /uvx /bin/

--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -1,24 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile) + curl + rclone
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/agent
+#     cd services/agent
 #     docker build -f Dockerfile -t agent:prod --target production ../../
 #     docker run agent:prod
 #
@@ -26,45 +18,14 @@ FROM base-${TARGETARCH} AS base
 
 LABEL maintainer=GitHK
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+# curl is needed at runtime
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
   curl \
   && apt-get clean -y \
-  # verify that the binary works
-  && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
+  && rm -rf /var/lib/apt/lists/*
 
 # rclone installation
 ARG TARGETARCH
@@ -73,36 +34,13 @@ RUN \
   --mount=type=bind,source=scripts/install_rclone.bash,target=/tmp/install_rclone.bash \
   ./tmp/install_rclone.bash
 
+EXPOSE 8000
+
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -169,10 +107,9 @@ HEALTHCHECK \
   --retries=5 \
   CMD ["python3", "-S", "docker/healthcheck.py", "http://localhost:8000/health"]
 
-EXPOSE 8000
-
 ENTRYPOINT [ "/bin/sh", "services/agent/docker/entrypoint.sh" ]
 CMD ["/bin/sh", "services/agent/docker/boot.sh"]
+
 
 # --------------------------Development stage -------------------
 # Source code accessible in host but runs in container

--- a/services/api-server/Dockerfile
+++ b/services/api-server/Dockerfile
@@ -1,21 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/api-server
+#     cd services/api-server
 #     docker build -f Dockerfile -t api-server:prod --target production ../../
 #     docker run api-server:prod
 #
@@ -23,79 +18,14 @@ FROM base-${TARGETARCH} AS base
 
 LABEL maintainer=pcrespov
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
 EXPOSE 8000
 EXPOSE 3000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -107,6 +37,7 @@ WORKDIR /build
 FROM build AS prod-only-deps
 
 ENV SC_BUILD_TARGET=prod-only-deps
+
 # https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy
@@ -120,7 +51,6 @@ RUN \
   uv pip sync \
   requirements/prod.txt \
   && uv pip list
-
 
 
 # --------------------------Production stage -------------------
@@ -153,7 +83,9 @@ COPY --chown=scu:scu \
   scripts/docker/docker_healthcheck.py \
   docker/healthcheck.py
 
-HEALTHCHECK --interval=10s \
+# https://docs.docker.com/reference/dockerfile/#healthcheck
+HEALTHCHECK \
+  --interval=10s \
   --timeout=5s \
   --start-period=20s \
   --start-interval=1s \
@@ -166,7 +98,7 @@ CMD ["/bin/sh", "services/api-server/docker/boot.sh"]
 
 # --------------------------Development stage -------------------
 # Source code accessible in host but runs in container
-# Runs as my with same gid/uid as host
+# Runs as "scu" with same gid/uid as host
 # Placed at the end to speed-up the build if images targeting production
 #
 #  + /devel         WORKDIR

--- a/services/autoscaling/Dockerfile
+++ b/services/autoscaling/Dockerfile
@@ -1,19 +1,13 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile) + docker-cli
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
 #     cd services/autoscaling
@@ -27,15 +21,11 @@ LABEL maintainer=sanderegg
 # NOTE: to list the latest version run `make` inside `scripts/apt-packages-versions`
 ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+# Installs the docker CLI (only the cli is needed) on top of the shared runtime base
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
   ca-certificates \
   curl \
   gnupg \
@@ -46,73 +36,25 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  # only the cli is needed and we remove the unnecessary stuff again
   docker-ce-cli=${DOCKER_APT_VERSION} \
-  && apt-get remove -y\
+  && apt-get remove -y \
   gnupg \
   curl \
   lsb-release \
-  && apt-get clean -y\
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 EXPOSE 8000
 EXPOSE 3000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
 
 # --------------------------Prod-depends-only stage -------------------
 # This stage is for production only dependencies that get partially wiped out afterwards (final docker image concerns)

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -1,22 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
 #
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/catalog
+#     cd services/catalog
 #     docker build -f Dockerfile -t catalog:prod --target production ../../
 #     docker run catalog:prod
 #
@@ -24,79 +18,14 @@ FROM base-${TARGETARCH} AS base
 
 LABEL maintainer=pcrespov
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
 EXPOSE 8000
 EXPOSE 3000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------

--- a/services/clusters-keeper/Dockerfile
+++ b/services/clusters-keeper/Dockerfile
@@ -1,22 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile) + docker-cli
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/clusters-keeper
+#     cd services/clusters-keeper
 #     docker build -f Dockerfile -t clusters-keeper:prod --target production ../../
 #     docker run clusters-keeper:prod
 #
@@ -27,15 +21,11 @@ LABEL maintainer=sanderegg
 # NOTE: to list the latest version run `make` inside `scripts/apt-packages-versions`
 ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+# Installs the docker CLI (only the cli is needed) on top of the shared runtime base
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
   ca-certificates \
   curl \
   gnupg \
@@ -46,75 +36,24 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  # only the cli is needed and we remove the unnecessary stuff again
   docker-ce-cli=${DOCKER_APT_VERSION} \
-  && apt-get remove -y\
+  && apt-get remove -y \
   gnupg \
   curl \
   lsb-release \
-  && apt-get clean -y\
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 EXPOSE 8000
 EXPOSE 3000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------

--- a/services/dask-sidecar/Dockerfile
+++ b/services/dask-sidecar/Dockerfile
@@ -1,17 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
-# we docker image is built based on debian
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /log
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
+
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile) + iputils-ping + curl
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/dask-sidecar
+#     cd services/dask-sidecar
 #     docker build -f Dockerfile -t dask-sidecar:prod --target production ../../
 #     docker run dask-sidecar:prod
 #
@@ -19,48 +18,14 @@ RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /log
 
 LABEL maintainer=sanderegg
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  fd-find \
   iputils-ping \
   curl \
-  gosu \
   && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
-
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-ENV LANG=C.UTF-8 \
-  PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
-# for ARM architecture this helps a lot VS building packages
-# NOTE: remove as this might create bad caching behaviour
-# ENV PIP_EXTRA_INDEX_URL=https://www.piwheels.org/simple
-
+  && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8080
 EXPOSE 8786
@@ -70,33 +35,11 @@ EXPOSE 8787
 RUN mkdir --parents /home/scu/.config/dask \
   && chown -R scu:scu /home/scu/.config
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -121,6 +64,7 @@ RUN \
   uv pip sync \
   requirements/prod.txt \
   && uv pip list
+
 
 # --------------------------Production stage -------------------
 # Final cleanup up to reduce image size and startup setup

--- a/services/datcore-adapter/Dockerfile
+++ b/services/datcore-adapter/Dockerfile
@@ -1,19 +1,13 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
 #     cd services/datcore-adapter
@@ -24,79 +18,14 @@ FROM base-${TARGETARCH} AS base
 
 LABEL maintainer=sanderegg
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
 EXPOSE 8000
 EXPOSE 3000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------

--- a/services/director-v2/Dockerfile
+++ b/services/director-v2/Dockerfile
@@ -1,102 +1,31 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/director-v2
-#     docker build -f Dockerfile -t director-v2 :prod --target production ../../
-#     docker run director-v2 :prod
+#     cd services/director-v2
+#     docker build -f Dockerfile -t director-v2:prod --target production ../../
+#     docker run director-v2:prod
 #
 #  REQUIRED: context expected at ``osparc-simcore/`` folder because we need access to osparc-simcore/packages
 
 LABEL maintainer=pcrespov
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
 EXPOSE 8000
 EXPOSE 3000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -108,6 +37,7 @@ WORKDIR /build
 FROM build AS prod-only-deps
 
 ENV SC_BUILD_TARGET=prod-only-deps
+
 # https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy

--- a/services/director/Dockerfile
+++ b/services/director/Dockerfile
@@ -1,22 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/director
+#     cd services/director
 #     docker build -f Dockerfile -t director:prod --target production ../../
 #     docker run director:prod
 #
@@ -24,76 +18,15 @@ FROM base-${TARGETARCH} AS base
 
 LABEL maintainer=sanderegg
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used
-# in the image will be those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
 EXPOSE 8000
 EXPOSE 3000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
 
 # --------------------------Prod-depends-only stage -------------------
 # This stage is for production only dependencies that get partially wiped out afterwards (final docker image concerns)
@@ -104,6 +37,7 @@ WORKDIR /build
 FROM build AS prod-only-deps
 
 ENV SC_BUILD_TARGET=prod-only-deps
+
 # https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy

--- a/services/docker-compose-build.yml
+++ b/services/docker-compose-build.yml
@@ -10,6 +10,29 @@
 # NOTE: the dask-scheduler uses the same image as the dask-sidecar. there is no need to build it twice!
 #
 services:
+  # Shared base images consumed by every python service Dockerfile via
+  # `FROM ${DOCKER_REGISTRY}/simcore-{runtime,build}-base:${BASE_TAG}`.
+  #
+  # - On local/test builds (no push) the Makefile links these targets in-memory as
+  #   build contexts, so no registry is needed (see scripts/common.Makefile / root Makefile).
+  # - On deploy (push) builds the service FROM pulls the pre-built & pushed base images.
+  #
+  # NOTE: these targets are NOT part of SERVICES_NAMES_TO_BUILD, they are only built
+  # when referenced (as a build context or explicitly via `make build-base`).
+  simcore-runtime-base:
+    image: ${DOCKER_REGISTRY:-itisfoundation}/simcore-runtime-base:${BASE_TAG:-latest}
+    build:
+      context: ../
+      dockerfile: services/_base_images/Dockerfile
+      target: runtime-base
+
+  simcore-build-base:
+    image: ${DOCKER_REGISTRY:-itisfoundation}/simcore-build-base:${BASE_TAG:-latest}
+    build:
+      context: ../
+      dockerfile: services/_base_images/Dockerfile
+      target: build-base
+
   service-integration:
     image: local/service-integration:${BUILD_TARGET:?build_target_required}
     build:

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -16,7 +16,7 @@ FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  REQUIRED: context expected at ``osparc-simcore/`` folder because we need access to osparc-simcore/packages
 
-LABEL maintainer=pcrespov
+LABEL maintainer=GitHK
 
 EXPOSE 8000
 

--- a/services/dynamic-scheduler/Dockerfile
+++ b/services/dynamic-scheduler/Dockerfile
@@ -1,99 +1,30 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/dynamic-scheduler
-#     docker build -f Dockerfile -t dynamic_scheduler:prod --target production ../../
-#     docker run dynamic_scheduler:prod
+#     cd services/dynamic-scheduler
+#     docker build -f Dockerfile -t dynamic-scheduler:prod --target production ../../
+#     docker run dynamic-scheduler:prod
 #
 #  REQUIRED: context expected at ``osparc-simcore/`` folder because we need access to osparc-simcore/packages
 
 LABEL maintainer=pcrespov
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
+EXPOSE 8000
 
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -105,6 +36,7 @@ WORKDIR /build
 FROM build AS prod-only-deps
 
 ENV SC_BUILD_TARGET=prod-only-deps
+
 # https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy
@@ -162,7 +94,6 @@ HEALTHCHECK \
 ENTRYPOINT [ "/bin/sh", "services/dynamic-scheduler/docker/entrypoint.sh" ]
 CMD ["/bin/sh", "services/dynamic-scheduler/docker/boot.sh"]
 
-EXPOSE 8000
 
 # --------------------------Development stage -------------------
 # Source code accessible in host but runs in container

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -1,21 +1,17 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#   + docker-cli + docker-compose-plugin + libmagic1 + xz-utils + rclone + 7zip
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/dynamic-sidecar
+#     cd services/dynamic-sidecar
 #     docker build -f Dockerfile -t dynamic-sidecar:prod --target production ../../
 #     docker run dynamic-sidecar:prod
 #
@@ -27,15 +23,12 @@ LABEL maintainer="Andrei Neagu <neagu@itis.swiss>"
 ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 ENV DOCKER_COMPOSE_APT_VERSION="2.27.1-1~debian.12~bookworm"
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN \
   --mount=type=cache,target=/var/cache/apt,mode=0755,sharing=private \
-  --mount=type=cache,target=/var/lib/apt,mode=0755,sharing=private \
   set -eux && \
   apt-get update && \
-  apt-get install -y --no-install-recommends\
+  apt-get install -y --no-install-recommends \
+  ca-certificates \
   curl \
   gnupg \
   lsb-release \
@@ -48,15 +41,13 @@ RUN \
   && apt-get install -y --no-install-recommends \
   docker-ce-cli=${DOCKER_APT_VERSION} \
   docker-compose-plugin=${DOCKER_COMPOSE_APT_VERSION} \
-  fd-find \
-  gosu \
-  ca-certificates \
   # required by python-magic
   libmagic1 \
-  && apt-get remove -y\
+  && apt-get remove -y \
   gnupg \
   lsb-release \
-  && apt-get clean -y\
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 
@@ -67,35 +58,10 @@ RUN \
   --mount=type=bind,source=scripts/install_rclone.bash,target=install_rclone.bash \
   ./install_rclone.bash
 # install 7zip
-ARG TARGETARCH
-ENV TARGETARCH=${TARGETARCH}
 RUN \
   --mount=type=bind,source=scripts/install_7zip.bash,target=install_7zip.bash \
   ./install_7zip.bash
 
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-# Ensures that the python and pip executables used
-# in the image will be those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 # directory where dynamic-sidecar stores creates and shares
 # volumes between itself and the spawned containers
 ENV DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR="/dy-volumes"
@@ -106,36 +72,21 @@ ENV DYNAMIC_SIDECAR_SHARED_STORE_DIR="${DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR}/sh
 RUN mkdir -p "${DYNAMIC_SIDECAR_SHARED_STORE_DIR}" && \
   chown -R scu:scu "${DYNAMIC_SIDECAR_SHARED_STORE_DIR}"
 
+EXPOSE 8000
+
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}" \
-  && mkdir -p "${DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR}"
-
-
-WORKDIR /build
-
+ENV DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR="/dy-volumes"
+RUN mkdir -p "${DYNAMIC_SIDECAR_DY_VOLUMES_MOUNT_DIR}"
 
 # copy utility devops scripts
 COPY --chown=scu:scu services/dynamic-sidecar/scripts/Makefile /home/scu
 COPY --chown=root:root services/dynamic-sidecar/scripts/Makefile /root
+
 
 # --------------------------Prod-depends-only stage -------------------
 # This stage is for production only dependencies that get partially wiped out afterwards (final docker image concerns)
@@ -159,6 +110,7 @@ RUN \
   uv pip sync \
   requirements/prod.txt \
   && uv pip list
+
 
 # --------------------------Production stage -------------------
 # Final cleanup up to reduce image size and startup setup
@@ -199,8 +151,6 @@ HEALTHCHECK \
   --start-interval=1s \
   --retries=5 \
   CMD ["python3", "-S", "docker/healthcheck.py", "http://localhost:8000/health"]
-
-EXPOSE 8000
 
 ENTRYPOINT [ "/bin/sh", "services/dynamic-sidecar/docker/entrypoint.sh" ]
 CMD ["/bin/sh", "services/dynamic-sidecar/docker/boot.sh"]

--- a/services/dynamic-sidecar/Dockerfile
+++ b/services/dynamic-sidecar/Dockerfile
@@ -17,7 +17,7 @@ FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  REQUIRED: context expected at ``osparc-simcore/`` folder because we need access to osparc-simcore/packages
 
-LABEL maintainer="Andrei Neagu <neagu@itis.swiss>"
+LABEL maintainer=GitHK
 
 # NOTE: to list the latest version run `make` inside `scripts/apt-packages-versions`
 ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"

--- a/services/efs-guardian/Dockerfile
+++ b/services/efs-guardian/Dockerfile
@@ -1,22 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile) + docker-cli + efs user
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/efs-guardian
+#     cd services/efs-guardian
 #     docker build -f Dockerfile -t efs-guardian:prod --target production ../../
 #     docker run efs-guardian:prod
 #
@@ -27,15 +21,11 @@ LABEL maintainer=sanderegg
 # NOTE: to list the latest version run `make` inside `scripts/apt-packages-versions`
 ENV DOCKER_APT_VERSION="5:26.1.4-1~debian.12~bookworm"
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+# Installs the docker CLI (only the cli is needed) on top of the shared runtime base
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
   ca-certificates \
   curl \
   gnupg \
@@ -46,13 +36,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  # only the cli is needed and we remove the unnecessary stuff again
   docker-ce-cli=${DOCKER_APT_VERSION} \
-  && apt-get remove -y\
+  && apt-get remove -y \
   gnupg \
   curl \
   lsb-release \
-  && apt-get clean -y\
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/* \
   # verify that the binary works
   && gosu nobody true
 
@@ -61,20 +51,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
 # Currently all simcore services run as user 8004. The Guardian needs to run as a different user 8006.
 # The Guardian has access to the root directory of the EFS distributed file system
 # and can change the file permissions of user 8004 if needed.
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  EFS_USER_ID=8006 \
-  EFS_USER_NAME=efs \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid 8004 \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/scu \
-  scu
+ENV EFS_USER_ID=8006 \
+  EFS_USER_NAME=efs
 
 RUN adduser \
   --uid 8006 \
@@ -89,50 +67,27 @@ RUN groupadd -g 8106 efs-group
 RUN usermod -a -G efs-group efs
 RUN usermod -a -G efs-group scu
 
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
 # Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/efs/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
+# NOTE: efs-guardian runs as the `efs` user, the virtualenv lives in its home
+ENV VIRTUAL_ENV=/home/efs/.venv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 EXPOSE 8000
 EXPOSE 3000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
+# NOTE: efs-guardian uses a dedicated virtualenv at /home/efs/.venv
 #
-# + /build             WORKDIR
-#
-FROM base AS build
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
-ENV SC_BUILD_TARGET=build
+ENV VIRTUAL_ENV=/home/efs/.venv
+ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
+# python virtualenv is created in the efs user home so it can be copied to production
+RUN mkdir -p /home/efs \
+  && uv venv "${VIRTUAL_ENV}"
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -161,10 +116,10 @@ RUN \
 
 # --------------------------Production stage -------------------
 # Final cleanup up to reduce image size and startup setup
-# Runs as scu (non-root user)
+# Runs as efs (non-root user)
 #
-#  + /home/scu     $HOME = WORKDIR
-#    + services/efs-guardian [scu:scu]
+#  + /home/efs     $HOME = WORKDIR
+#    + services/efs-guardian
 #
 FROM base AS production
 

--- a/services/invitations/Dockerfile
+++ b/services/invitations/Dockerfile
@@ -1,22 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/invitations
+#     cd services/invitations
 #     docker build -f Dockerfile -t invitations:prod --target production ../../
 #     docker run invitations:prod
 #
@@ -24,79 +18,13 @@ FROM base-${TARGETARCH} AS base
 
 LABEL maintainer=pcrespov
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
 EXPOSE 8000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -108,6 +36,7 @@ WORKDIR /build
 FROM build AS prod-only-deps
 
 ENV SC_BUILD_TARGET=prod-only-deps
+
 # https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy

--- a/services/migration/Dockerfile
+++ b/services/migration/Dockerfile
@@ -1,72 +1,33 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 
 LABEL maintainer=sanderegg
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
 
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-# Ensures that the python and pip executables used
-# in the image will be those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
-
-# --------------------------------------------
-FROM base AS build
+# -------------------------- Build stage -------------------
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile) + git
+#
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  build-essential \
-  git
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
+  git \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy
-
-
-
-
 
 WORKDIR /build/packages/postgres-database
 
@@ -79,7 +40,10 @@ RUN \
   && uv pip list
 
 
-# --------------------------------------------
+# --------------------------Production stage -------------------
+# Final cleanup up to reduce image size and startup setup
+# Runs as scu (non-root user)
+#
 FROM base AS production
 
 ENV PYTHONOPTIMIZE=TRUE

--- a/services/notifications/Dockerfile
+++ b/services/notifications/Dockerfile
@@ -16,7 +16,7 @@ FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  REQUIRED: context expected at ``osparc-simcore/`` folder because we need access to osparc-simcore/packages
 
-LABEL maintainer=GitHK
+LABEL maintainer=giancarloromeo
 
 EXPOSE 8000
 

--- a/services/notifications/Dockerfile
+++ b/services/notifications/Dockerfile
@@ -1,19 +1,13 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
 #     cd services/notifications
@@ -24,75 +18,13 @@ FROM base-${TARGETARCH} AS base
 
 LABEL maintainer=GitHK
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  # verify that the binary works
-  && gosu nobody true
+EXPOSE 8000
 
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -162,7 +94,6 @@ HEALTHCHECK \
 ENTRYPOINT [ "/bin/sh", "services/notifications/docker/entrypoint.sh" ]
 CMD ["/bin/sh", "services/notifications/docker/boot.sh"]
 
-EXPOSE 8000
 
 # --------------------------Development stage -------------------
 # Source code accessible in host but runs in container

--- a/services/payments/Dockerfile
+++ b/services/payments/Dockerfile
@@ -1,22 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/payments
+#     cd services/payments
 #     docker build -f Dockerfile -t payments:prod --target production ../../
 #     docker run payments:prod
 #
@@ -24,79 +18,13 @@ FROM base-${TARGETARCH} AS base
 
 LABEL maintainer=pcrespov
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
 EXPOSE 8000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -108,6 +36,7 @@ WORKDIR /build
 FROM build AS prod-only-deps
 
 ENV SC_BUILD_TARGET=prod-only-deps
+
 # https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy

--- a/services/resource-usage-tracker/Dockerfile
+++ b/services/resource-usage-tracker/Dockerfile
@@ -1,19 +1,13 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
-
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
 #     cd services/resource-usage-tracker
@@ -24,79 +18,14 @@ FROM base-${TARGETARCH} AS base
 
 LABEL maintainer=sanderegg
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used in the image will be
-# those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
 EXPOSE 8000
 EXPOSE 3000
 
+
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile)
 #
-# + /build             WORKDIR
-#
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends \
-  build-essential
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-# install base 3rd party dependencies
-
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -108,6 +37,7 @@ WORKDIR /build
 FROM build AS prod-only-deps
 
 ENV SC_BUILD_TARGET=prod-only-deps
+
 # https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -1,21 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile)
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/storage
+#     cd services/storage
 #     docker build -f Dockerfile -t storage:prod --target production ../../
 #     docker run storage:prod
 #
@@ -23,91 +18,21 @@ FROM base-${TARGETARCH} AS base
 
 LABEL maintainer=mguidon
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
-  set -eux && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-  fd-find \
-  gosu \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
-
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-
-# Ensures that the python and pip executables used
-# in the image will be those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
-
-ENV SC_BUILD_TARGET=base
-ENV SC_BOOT_MODE=default
-
 EXPOSE 8080
-# -------------------------- -------------------------------
-
 
 
 # -------------------------- Build stage -------------------
-# Installs build/package management tools and third party dependencies
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile) + git
 #
-# + /build             WORKDIR
-#
-
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  build-essential \
-  git
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
-
-
-# -------------------------- -------------------------------
-
-
+  git \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -133,8 +58,6 @@ RUN \
   uv pip sync \
   requirements/prod.txt \
   && uv pip list
-# -------------------------- -------------------------------
-
 
 
 # --------------------------Production stage -------------------
@@ -172,12 +95,8 @@ HEALTHCHECK \
   --retries=5 \
   CMD ["python3", "-S", "docker/healthcheck.py", "http://localhost:8080/v0/"]
 
-
 ENTRYPOINT [ "/bin/sh", "services/storage/docker/entrypoint.sh" ]
 CMD ["/bin/sh", "services/storage/docker/boot.sh"]
-# -------------------------- -------------------------------
-
-
 
 
 # --------------------------Development stage -------------------
@@ -199,4 +118,3 @@ RUN chown -R scu:scu "${VIRTUAL_ENV}"
 
 ENTRYPOINT [ "/bin/sh", "services/storage/docker/entrypoint.sh" ]
 CMD ["/bin/sh", "services/storage/docker/boot.sh"]
-# -------------------------- -------------------------------

--- a/services/storage/Dockerfile
+++ b/services/storage/Dockerfile
@@ -16,7 +16,7 @@ FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  REQUIRED: context expected at ``osparc-simcore/`` folder because we need access to osparc-simcore/packages
 
-LABEL maintainer=mguidon
+LABEL maintainer=sanderegg
 
 EXPOSE 8080
 

--- a/services/web/Dockerfile
+++ b/services/web/Dockerfile
@@ -1,46 +1,34 @@
 # syntax=docker/dockerfile:1
 
 # Define arguments in the global scope
-ARG PYTHON_VERSION="3.13.9"
-ARG UV_VERSION="0.9"
-FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_build
+ARG DOCKER_REGISTRY="itisfoundation"
+ARG BASE_TAG="latest"
 
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-arm64
-# These environment variables are necessary because of https://github.com/astral-sh/uv/issues/6105
-# and until https://gitlab.com/qemu-project/qemu/-/issues/2846 gets fixed
-ENV UV_CONCURRENT_INSTALLS=1
-
-FROM python:${PYTHON_VERSION}-slim-bookworm AS base-amd64
-
-FROM base-${TARGETARCH} AS base
+# -------------------------- Base stage -------------------
+# Shared minimal runtime (see services/_base_images/Dockerfile) + curl + libmagic1 + xz-utils + 7zip
+#
+FROM ${DOCKER_REGISTRY}/simcore-runtime-base:${BASE_TAG} AS base
 #
 #  USAGE:
-#     cd sercices/web
+#     cd services/web
 #     docker build -f Dockerfile -t web:prod --target production ../../
-#     docker run web:ci
+#     docker run web:prod
 #
 #  REQUIRED: context expected at ``osparc-simcore/`` folder because we need access to osparc-simcore/packages
 #  REQUIRED: client_qx:build image ready
 
-
 LABEL maintainer=pcrespov
 
-# for docker apt caching to work this needs to be added: [https://vsupalov.com/buildkit-cache-mount-dockerfile/]
-RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
-  echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
-  fd-find \
   curl \
-  gosu \
+  # required by python-magic
   libmagic1 \
   xz-utils \
   && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* \
-  # verify that the binary works
-  && gosu nobody true
+  && rm -rf /var/lib/apt/lists/*
 
 # install 7zip
 ARG TARGETARCH
@@ -49,70 +37,21 @@ RUN \
   --mount=type=bind,source=scripts/install_7zip.bash,target=install_7zip.bash \
   ./install_7zip.bash
 
-
-# simcore-user uid=8004(scu) gid=8004(scu) groups=8004(scu)
-ENV SC_USER_ID=8004 \
-  SC_USER_NAME=scu \
-  SC_BUILD_TARGET=base \
-  SC_BOOT_MODE=default
-
-RUN adduser \
-  --uid ${SC_USER_ID} \
-  --disabled-password \
-  --gecos "" \
-  --shell /bin/sh \
-  --home /home/${SC_USER_NAME} \
-  ${SC_USER_NAME}
-
-
-# Sets utf-8 encoding for Python et al
-ENV LANG=C.UTF-8
-# Turns off writing .pyc files; superfluous on an ephemeral container.
-ENV PYTHONDONTWRITEBYTECODE=1 \
-  VIRTUAL_ENV=/home/scu/.venv
-# Ensures that the python and pip executables used
-# in the image will be those from our virtualenv.
-ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
-
-
 EXPOSE 8080
 
+
 # -------------------------- Build stage -------------------
-# Creates and installs virtual environment
-# Contains all build tools
+# Shared build toolchain + empty virtualenv (see services/_base_images/Dockerfile) + libffi-dev
 #
-# + /build             WORKDIR
-#    + packages
-#    + services/web/server
-#       + src
-#       + tests
-
-FROM base AS build
-
-ENV SC_BUILD_TARGET=build
+FROM ${DOCKER_REGISTRY}/simcore-build-base:${BASE_TAG} AS build
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
   set -eux \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  build-essential \
-  libffi-dev
-
-# install UV https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=uv_build /uv /uvx /bin/
-
-
-# NOTE: python virtualenv is used here such that installed
-# packages may be moved to production image easily by copying the venv
-RUN uv venv "${VIRTUAL_ENV}"
-
-
-
-
-
-WORKDIR /build
-
+  libffi-dev \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
 
 # --------------------------Prod-depends-only stage -------------------
@@ -138,6 +77,7 @@ RUN \
   uv pip sync \
   requirements/prod.txt \
   && uv pip list
+
 
 # --------------------------Production stage -------------------
 # Final cleanup up to reduce image size and startup setup
@@ -187,11 +127,8 @@ ENV SC_BUILD_DATE=${BUILD_DATE} \
   SC_VCS_URL=${VCS_URL} \
   SC_VCS_REF=${VCS_REF}
 
-
-
 ENTRYPOINT [ "services/web/server/docker/entrypoint.sh" ]
 CMD ["services/web/server/docker/boot.sh"]
-
 
 
 # --------------------------Development stage -------------------


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Refactor of how the docker build process works for the backend images by de-duplicating building the same base parts in every single Dockerfile.

Make use of `-arm64` github runners so the hacks for building ARM images using qemu (multi-arch builders) are not necessary anymore and are removed.

This is a first change before adding ARM64 build back.

From a nose view, it looks like 1-2 minutes were spared in the build backend step (to be confirmed as this was not measured thoroughly). Also image sizes were slightly decreased.

- relates to https://github.com/ITISFoundation/osparc-simcore/issues/7087

<details><summary>Details</summary>
<p>

### The two shared base images

Both come from a single source, Dockerfile, and start from `python:3.13.9-slim-bookworm` (with a `TARGETARCH` split so the same Dockerfile builds amd64 or arm64 natively).

| Image | Built from | Adds | Purpose |
|---|---|---|---|
| `simcore-runtime-base` | `python-slim` | `fd-find`, `gosu`, non-root `scu` user (uid 8004), venv env (`VIRTUAL_ENV=/home/scu/.venv`, `PATH`, `LANG`, `PYTHONDONTWRITEBYTECODE`) | Parent of every service **`production`** stage → small final image, **no build tools** |
| `simcore-build-base` | `runtime-base` | `build-essential`, `uv`, empty `uv venv`, `WORKDIR /build` | Parent of every service **dependency-install / `development`** stage → has the toolchain |

Key idea: build tools live only in `build-base`, so they never reach the shipped runtime image.

### Per-service Dockerfile pattern (4 stages)

Every service Dockerfile now follows the same template:

```
FROM .../simcore-runtime-base AS base          # + service runtime extras, EXPOSE, healthcheck
FROM .../simcore-build-base   AS build         # + service build extras
FROM build AS prod-only-deps                   # uv pip sync requirements/prod.txt
FROM base  AS production                        # copy venv from prod-only-deps + boot scripts
FROM build AS development                       # devel mount
```

The **only** differences between services are the small "extras" each adds:

| Service(s) | Extra runtime deps added on top of base |
|---|---|
| api-server, catalog, director, director-v2, datcore-adapter, invitations, payments, notifications, dynamic-scheduler, resource-usage-tracker | none (pure base) — differ only in EXPOSE port + healthcheck path/timing |
| autoscaling, clusters-keeper | `docker-cli` (26.1.4) |
| efs-guardian | `docker-cli` + extra `efs` user/group, venv relocated to `/home/efs/.venv` |
| agent | `rclone`, `curl` |
| storage | `git` (build stage) |
| dask-sidecar | `iputils-ping`, `curl`, dask config dir; ports 8080/8786/8787 |
| migration | minimal: `git`, no `prod-only-deps`/`development` stages, custom healthcheck |
| web (webserver) | `7zip`, `libmagic1`, `xz-utils`, `libffi-dev` (build), build-metadata ARGs |
| service-integration | `git`, `ENTRYPOINT ooil` |
| **dynamic-sidecar** | the heaviest: `docker-cli` + `docker-compose-plugin` (2.27.1) + `rclone` + `7zip` + `libmagic1` + `xz-utils` + `/dy-volumes` env |

Excluded (not Python): `docker-api-proxy` (caddy), `static-webserver` (node).

### Build schematic

```mermaid
flowchart TD
    subgraph onebake["single 'docker buildx bake' call (per job/arch)"]
        P["python:3.13.9-slim-bookworm<br/>(TARGETARCH → amd64 / arm64)"]
        P --> RB["simcore-runtime-base<br/>fd-find · gosu · scu user · venv env"]
        RB --> BB["simcore-build-base<br/>build-essential · uv · uv venv"]

        RB -.->|FROM base| SVCprod
        BB -.->|FROM build| SVCdeps

        subgraph svc["each service (×19)"]
            SVCdeps["build / prod-only-deps stage<br/>uv pip sync requirements/prod.txt"]
            SVCprod["production stage<br/>COPY --from=prod-only-deps venv<br/>+ boot scripts, healthcheck"]
            SVCdeps -->|copy venv| SVCprod
        end
    end

    SVCprod --> OUT{output}
    OUT -->|local-dest / amd64| TAR["service .tar artifacts<br/>(retagged+pushed by deploy job)"]
    OUT -->|push=true / arm64| REG["pushed to registry<br/>service:TAG-latest-arm64"]

    RB -.->|cacheonly| X["base never pushed"]
    BB -.->|cacheonly| X
```

**How it runs:**
- buildx treats `runtime-base` / `build-base` as **dependencies (contexts)** of every service, so within one bake call it builds **base first → all services on top**, base built **once** and shared.
- Base targets resolve to `cacheonly` output → **built inline, never published**.
- **amd64** job exports each service to a `.tar` (`local-dest`), later retagged & pushed by the `deploy` job.
- **arm64** job (ci-arm-build.yml) builds natively and pushes `…-latest-arm64`; a separate fusing workflow merges amd64 + arm64 into a multi-arch manifest.
- gha layer cache keeps the per-job base rebuild cheap when nothing changed.
</p>
</details> 
