### PR TITLE
🐛 Fix billing address lookup for users buying credits across products

### DIFF
--- a/packages/postgres-database/src/simcore_postgres_database/utils_users.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_users.py
@@ -371,6 +371,9 @@ class UsersRepo:
           3. any other product
         and, within the same rank, the most recently created row.
 
+        Rows missing required billing fields (currently at least ``country``)
+        are excluded to prevent downstream validation errors.
+
         - Returns None if the user has no pre-registration with billing details.
         """
         product_match_rank = sa.case(
@@ -397,7 +400,7 @@ class UsersRepo:
                         users.c.id == users_pre_registration_details.c.user_id,
                     )
                 )
-                .where(users.c.id == user_id)
+                .where((users.c.id == user_id) & users_pre_registration_details.c.country.is_not(None))
                 .order_by(
                     product_match_rank.asc(),
                     users_pre_registration_details.c.created.desc(),

--- a/packages/postgres-database/src/simcore_postgres_database/utils_users.py
+++ b/packages/postgres-database/src/simcore_postgres_database/utils_users.py
@@ -360,11 +360,24 @@ class UsersRepo:
         product_name: str,
         user_id: int,
     ) -> Any | None:
-        """Returns billing details for the specified user and product.
+        """Returns billing details for the specified user.
 
-        - If the user is registered without a product, returns details for that registration.
-        - Returns None if no billing details are found.
+        The billing address is a property of the person, not of the product: a
+        user pre-registered on one product must still be invoiceable on any other
+        product they have access to. Therefore any pre-registration row for the
+        user is eligible, ranked by specificity:
+          1. exact match on ``product_name``
+          2. product-agnostic row (``product_name IS NULL``)
+          3. any other product
+        and, within the same rank, the most recently created row.
+
+        - Returns None if the user has no pre-registration with billing details.
         """
+        product_match_rank = sa.case(
+            (users_pre_registration_details.c.product_name == product_name, 0),
+            (users_pre_registration_details.c.product_name.is_(None), 1),
+            else_=2,
+        )
         async with pass_or_acquire_connection(self._engine, connection) as conn:
             result = await conn.execute(
                 sa.select(
@@ -384,14 +397,11 @@ class UsersRepo:
                         users.c.id == users_pre_registration_details.c.user_id,
                     )
                 )
-                .where(
-                    (users.c.id == user_id)
-                    & (
-                        (users_pre_registration_details.c.product_name == product_name)
-                        | (users_pre_registration_details.c.product_name.is_(None))
-                    )
+                .where(users.c.id == user_id)
+                .order_by(
+                    product_match_rank.asc(),
+                    users_pre_registration_details.c.created.desc(),
                 )
-                .order_by(users_pre_registration_details.c.created.desc())
                 .limit(1)
                 # NOTE: might want to copy billing details to users table??
             )

--- a/packages/postgres-database/tests/test_users_details.py
+++ b/packages/postgres-database/tests/test_users_details.py
@@ -52,7 +52,8 @@ class PreRegistrationDetailsDict(TypedDict):
     account_request_reviewed_by: int | None
 
 
-type PreRegisteredUserData = tuple[str, PreRegistrationDetailsDict]
+type PreRegisteredEmail = str
+type PreRegisteredUserData = tuple[PreRegisteredEmail, PreRegistrationDetailsDict]
 
 
 class CreateProductCallable(Protocol):

--- a/packages/postgres-database/tests/test_users_details.py
+++ b/packages/postgres-database/tests/test_users_details.py
@@ -6,7 +6,7 @@
 from collections.abc import AsyncIterable, AsyncIterator
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
-from typing import Any, Protocol, Self
+from typing import Protocol, Self, TypedDict, cast
 
 import pytest
 import sqlalchemy as sa
@@ -36,10 +36,29 @@ from simcore_postgres_database.utils_users import UsersRepo
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 
+class ProductRowDict(TypedDict):
+    name: str
+
+
+class ProductOwnerUserRowDict(TypedDict):
+    id: int
+
+
+class PreRegistrationDetailsDict(TypedDict):
+    pre_email: str
+    state: str | None
+    postal_code: str | None
+    country: str
+    account_request_reviewed_by: int | None
+
+
+type PreRegisteredUserData = tuple[str, PreRegistrationDetailsDict]
+
+
 class CreateProductCallable(Protocol):
     """Callable that creates a product and returns its row."""
 
-    async def __call__(self, name: str) -> dict[str, Any]: ...
+    async def __call__(self, name: str) -> ProductRowDict: ...
 
 
 @pytest.fixture
@@ -53,7 +72,7 @@ async def product_factory(
     """
     async with AsyncExitStack() as exit_stack:
 
-        async def _create_product(name: str) -> dict[str, Any]:
+        async def _create_product(name: str) -> ProductRowDict:
             # 1. create a product group
             product_group_row = await exit_stack.enter_async_context(
                 insert_and_get_row_lifespan(
@@ -66,7 +85,7 @@ async def product_factory(
 
             # 2. create the product using that group
             product_name = name or faker.pystr(min_chars=3, max_chars=10)
-            return await exit_stack.enter_async_context(
+            product_row = await exit_stack.enter_async_context(
                 insert_and_get_row_lifespan(
                     asyncpg_engine,
                     table=products,
@@ -78,12 +97,13 @@ async def product_factory(
                     pk_col=products.c.name,
                 )
             )
+            return cast(ProductRowDict, product_row)
 
         yield _create_product
 
 
 @pytest.fixture
-async def product(product_factory: CreateProductCallable) -> dict[str, Any]:
+async def product(product_factory: CreateProductCallable) -> ProductRowDict:
     """Returns a single product for backward compatibility."""
     return await product_factory("s4l")
 
@@ -92,7 +112,7 @@ async def product(product_factory: CreateProductCallable) -> dict[str, Any]:
 async def product_owner_user(
     faker: Faker,
     asyncpg_engine: AsyncEngine,
-) -> AsyncIterable[dict[str, Any]]:
+) -> AsyncIterable[ProductOwnerUserRowDict]:
     async with insert_and_get_row_lifespan(  # pylint:disable=contextmanager-generator-missing-cleanup
         asyncpg_engine,
         table=users,
@@ -104,7 +124,7 @@ async def product_owner_user(
         ),
         pk_col=users.c.id,
     ) as row:
-        yield row
+        yield cast(ProductOwnerUserRowDict, row)
 
 
 @dataclass
@@ -133,16 +153,19 @@ class UserAddress:
 async def pre_registered_user(
     asyncpg_engine: AsyncEngine,
     faker: Faker,
-    product_owner_user: dict[str, Any],
-    product: dict[str, Any],
-) -> tuple[str, dict[str, Any]]:
+    product_owner_user: ProductOwnerUserRowDict,
+    product: ProductRowDict,
+) -> PreRegisteredUserData:
     """Creates a pre-registered user and returns the email and registration data."""
     product_name = product["name"]
-    fake_pre_registration_data = random_pre_registration_details(
-        faker,
-        pre_email="pre-registered@user.com",
-        created_by=product_owner_user["id"],
-        product_name=product_name,
+    fake_pre_registration_data = cast(
+        PreRegistrationDetailsDict,
+        random_pre_registration_details(
+            faker,
+            pre_email="pre-registered@user.com",
+            created_by=product_owner_user["id"],
+            product_name=product_name,
+        ),
     )
 
     async with transaction_context(asyncpg_engine) as connection:
@@ -152,15 +175,17 @@ async def pre_registered_user(
             .returning(users_pre_registration_details.c.pre_email)
         )
 
-    assert pre_email == fake_pre_registration_data["pre_email"]
-    return pre_email, fake_pre_registration_data
+    assert pre_email is not None
+    typed_pre_email = cast(str, pre_email)
+    assert typed_pre_email == fake_pre_registration_data["pre_email"]
+    return typed_pre_email, fake_pre_registration_data
 
 
 async def test_user_requests_account_and_is_approved(
     asyncpg_engine: AsyncEngine,
     faker: Faker,
-    product_owner_user: dict[str, Any],
-    product: dict[str, Any],
+    product_owner_user: ProductOwnerUserRowDict,
+    product: ProductRowDict,
 ):
     product_name = product["name"]
 
@@ -215,8 +240,8 @@ async def test_user_requests_account_and_is_approved(
 async def test_create_pre_registration_link(
     asyncpg_engine: AsyncEngine,
     faker: Faker,
-    product_owner_user: dict[str, Any],
-    product: dict[str, Any],
+    product_owner_user: ProductOwnerUserRowDict,
+    product: ProductRowDict,
 ):
     """Test that a PO can create a pre-registration link for a user."""
     product_name = product["name"]
@@ -245,7 +270,7 @@ async def test_create_pre_registration_link(
 )
 async def test_create_and_link_user_from_pre_registration(
     asyncpg_engine: AsyncEngine,
-    pre_registered_user: tuple[str, dict[str, Any]],
+    pre_registered_user: PreRegisteredUserData,
 ):
     """Test that a user can be created from a pre-registration link and is linked properly."""
     pre_email, pre_registration_data = pre_registered_user
@@ -289,8 +314,8 @@ async def test_create_and_link_user_from_pre_registration(
 )
 async def test_get_billing_details_from_pre_registration(
     asyncpg_engine: AsyncEngine,
-    pre_registered_user: tuple[str, dict[str, Any]],
-    product: dict[str, Any],
+    pre_registered_user: PreRegisteredUserData,
+    product: ProductRowDict,
 ):
     """Test that billing details can be retrieved from pre-registration data."""
     pre_email, fake_pre_registration_data = pre_registered_user
@@ -331,7 +356,7 @@ async def test_get_billing_details_from_pre_registration(
 )
 async def test_get_billing_details_for_a_different_product(
     asyncpg_engine: AsyncEngine,
-    pre_registered_user: tuple[str, dict[str, Any]],
+    pre_registered_user: PreRegisteredUserData,
     product_factory: CreateProductCallable,
 ):
     """The billing address belongs to the person, not the product: a user
@@ -376,7 +401,7 @@ async def test_get_billing_details_for_a_different_product(
 )
 async def test_update_user_from_pre_registration(
     asyncpg_engine: AsyncEngine,
-    pre_registered_user: tuple[str, dict[str, Any]],
+    pre_registered_user: PreRegisteredUserData,
 ):
     """Test that pre-registration details override manual updates when re-linking."""
     pre_email, _ = pre_registered_user
@@ -428,7 +453,7 @@ async def test_update_user_from_pre_registration(
 async def test_user_preregisters_for_multiple_products_with_different_outcomes(
     asyncpg_engine: AsyncEngine,
     faker: Faker,
-    product_owner_user: dict[str, Any],
+    product_owner_user: ProductOwnerUserRowDict,
     product_factory: CreateProductCallable,
 ):
     """Test scenario where a user pre-registers for multiple products and gets different approval outcomes."""

--- a/packages/postgres-database/tests/test_users_details.py
+++ b/packages/postgres-database/tests/test_users_details.py
@@ -326,6 +326,52 @@ async def test_get_billing_details_from_pre_registration(
 
 
 @pytest.mark.acceptance_test(
+    "cannot buy credits on a product without pre-registration "
+    "in https://github.com/ITISFoundation/private-issues/issues/600"
+)
+async def test_get_billing_details_for_a_different_product(
+    asyncpg_engine: AsyncEngine,
+    pre_registered_user: tuple[str, dict[str, Any]],
+    product_factory: CreateProductCallable,
+):
+    """The billing address belongs to the person, not the product: a user
+    pre-registered on one product must remain invoiceable on another product
+    they have access to (e.g. buying credits on a second product).
+    """
+    pre_email, fake_pre_registration_data = pre_registered_user
+
+    # User has a single pre-registration (on the `product` fixture)
+    # but buys credits on a *different* product
+    other_product = await product_factory("other-product")
+
+    # Create and link the user to the existing pre-registration
+    async with transaction_context(asyncpg_engine) as connection:
+        repo = UsersRepo(asyncpg_engine)
+        new_user = await repo.new_user(
+            connection,
+            email=pre_email,
+            password_hash="123456",  # noqa: S106
+            status=UserStatus.ACTIVE,
+            expires_at=None,
+        )
+        await repo.link_and_update_user_from_pre_registration(
+            connection,
+            new_user_id=new_user.id,
+            new_user_email=new_user.email,
+        )
+
+    # Billing details must still be found for the other product
+    invoice_data = await repo.get_billing_details(user_id=new_user.id, product_name=other_product["name"])
+    assert invoice_data is not None
+
+    user_address = UserAddress.create_from_db(invoice_data)
+    assert user_address.line1
+    assert user_address.state == fake_pre_registration_data["state"]
+    assert user_address.postal_code == fake_pre_registration_data["postal_code"]
+    assert user_address.country == fake_pre_registration_data["country"]
+
+
+@pytest.mark.acceptance_test(
     "pre-registration user update in https://github.com/ITISFoundation/osparc-simcore/issues/5138"
 )
 async def test_update_user_from_pre_registration(

--- a/packages/postgres-database/tests/test_users_details.py
+++ b/packages/postgres-database/tests/test_users_details.py
@@ -398,6 +398,52 @@ async def test_get_billing_details_for_a_different_product(
 
 
 @pytest.mark.acceptance_test(
+    "skip pre-registration rows with missing country in https://github.com/ITISFoundation/private-issues/issues/600"
+)
+async def test_get_billing_details_skips_rows_without_country(
+    asyncpg_engine: AsyncEngine,
+    pre_registered_user: PreRegisteredUserData,
+    faker: Faker,
+    product_factory: CreateProductCallable,
+):
+    pre_email, valid_pre_registration_data = pre_registered_user
+
+    other_product = await product_factory("other-product")
+    invalid_other_product_pre_registration = random_pre_registration_details(
+        faker,
+        pre_email=pre_email,
+        product_name=other_product["name"],
+        country=None,
+    )
+
+    async with transaction_context(asyncpg_engine) as connection:
+        repo = UsersRepo(asyncpg_engine)
+
+        await connection.execute(
+            sa.insert(users_pre_registration_details).values(**invalid_other_product_pre_registration)
+        )
+
+        new_user = await repo.new_user(
+            connection,
+            email=pre_email,
+            password_hash="123456",  # noqa: S106
+            status=UserStatus.ACTIVE,
+            expires_at=None,
+        )
+        await repo.link_and_update_user_from_pre_registration(
+            connection,
+            new_user_id=new_user.id,
+            new_user_email=new_user.email,
+        )
+
+    invoice_data = await repo.get_billing_details(user_id=new_user.id, product_name=other_product["name"])
+    assert invoice_data is not None
+
+    user_address = UserAddress.create_from_db(invoice_data)
+    assert user_address.country == valid_pre_registration_data["country"]
+
+
+@pytest.mark.acceptance_test(
     "pre-registration user update in https://github.com/ITISFoundation/osparc-simcore/issues/5138"
 )
 async def test_update_user_from_pre_registration(

--- a/packages/postgres-database/tests/test_users_details.py
+++ b/packages/postgres-database/tests/test_users_details.py
@@ -33,6 +33,7 @@ from simcore_postgres_database.utils_repos import (
     transaction_context,
 )
 from simcore_postgres_database.utils_users import UsersRepo
+from sqlalchemy.engine import Row
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 
@@ -139,7 +140,7 @@ class UserAddress:
     country: str
 
     @classmethod
-    def create_from_db(cls, row) -> Self:
+    def create_from_db(cls, row: Row) -> Self:
         parts = (getattr(row, col_name) for col_name in ("institution", "address") if getattr(row, col_name))
         return cls(
             line1=". ".join(parts),
@@ -180,6 +181,33 @@ async def pre_registered_user(
     typed_pre_email = cast(str, pre_email)
     assert typed_pre_email == fake_pre_registration_data["pre_email"]
     return typed_pre_email, fake_pre_registration_data
+
+
+@pytest.fixture
+async def registered_user(
+    asyncpg_engine: AsyncEngine,
+    pre_registered_user: PreRegisteredUserData,
+) -> Row:
+    """Creates the real user account and links it to the existing pre-registration.
+
+    Use this fixture when the create+link step is pure setup, not the subject under test.
+    """
+    pre_email, _ = pre_registered_user
+    async with transaction_context(asyncpg_engine) as connection:
+        repo = UsersRepo(asyncpg_engine)
+        new_user = await repo.new_user(
+            connection,
+            email=pre_email,
+            password_hash="123456",  # noqa: S106
+            status=UserStatus.ACTIVE,
+            expires_at=None,
+        )
+        await repo.link_and_update_user_from_pre_registration(
+            connection,
+            new_user_id=new_user.id,
+            new_user_email=new_user.email,
+        )
+    return new_user
 
 
 async def test_user_requests_account_and_is_approved(
@@ -316,29 +344,14 @@ async def test_create_and_link_user_from_pre_registration(
 async def test_get_billing_details_from_pre_registration(
     asyncpg_engine: AsyncEngine,
     pre_registered_user: PreRegisteredUserData,
+    registered_user: Row,
     product: ProductRowDict,
 ):
     """Test that billing details can be retrieved from pre-registration data."""
-    pre_email, fake_pre_registration_data = pre_registered_user
+    _, fake_pre_registration_data = pre_registered_user
 
-    # Create the user
-    async with transaction_context(asyncpg_engine) as connection:
-        repo = UsersRepo(asyncpg_engine)
-        new_user = await repo.new_user(
-            connection,
-            email=pre_email,
-            password_hash="123456",  # noqa: S106
-            status=UserStatus.ACTIVE,
-            expires_at=None,
-        )
-        await repo.link_and_update_user_from_pre_registration(
-            connection,
-            new_user_id=new_user.id,
-            new_user_email=new_user.email,
-        )
-
-    # Get billing details
-    invoice_data = await repo.get_billing_details(user_id=new_user.id, product_name=product["name"])
+    repo = UsersRepo(asyncpg_engine)
+    invoice_data = await repo.get_billing_details(user_id=registered_user.id, product_name=product["name"])
     assert invoice_data is not None
 
     # Test UserAddress model conversion
@@ -358,36 +371,22 @@ async def test_get_billing_details_from_pre_registration(
 async def test_get_billing_details_for_a_different_product(
     asyncpg_engine: AsyncEngine,
     pre_registered_user: PreRegisteredUserData,
+    registered_user: Row,
     product_factory: CreateProductCallable,
 ):
     """The billing address belongs to the person, not the product: a user
     pre-registered on one product must remain invoiceable on another product
     they have access to (e.g. buying credits on a second product).
     """
-    pre_email, fake_pre_registration_data = pre_registered_user
+    _, fake_pre_registration_data = pre_registered_user
 
     # User has a single pre-registration (on the `product` fixture)
     # but buys credits on a *different* product
     other_product = await product_factory("other-product")
 
-    # Create and link the user to the existing pre-registration
-    async with transaction_context(asyncpg_engine) as connection:
-        repo = UsersRepo(asyncpg_engine)
-        new_user = await repo.new_user(
-            connection,
-            email=pre_email,
-            password_hash="123456",  # noqa: S106
-            status=UserStatus.ACTIVE,
-            expires_at=None,
-        )
-        await repo.link_and_update_user_from_pre_registration(
-            connection,
-            new_user_id=new_user.id,
-            new_user_email=new_user.email,
-        )
-
+    repo = UsersRepo(asyncpg_engine)
     # Billing details must still be found for the other product
-    invoice_data = await repo.get_billing_details(user_id=new_user.id, product_name=other_product["name"])
+    invoice_data = await repo.get_billing_details(user_id=registered_user.id, product_name=other_product["name"])
     assert invoice_data is not None
 
     user_address = UserAddress.create_from_db(invoice_data)
@@ -448,26 +447,10 @@ async def test_get_billing_details_skips_rows_without_country(
 )
 async def test_update_user_from_pre_registration(
     asyncpg_engine: AsyncEngine,
-    pre_registered_user: PreRegisteredUserData,
+    registered_user: Row,
 ):
     """Test that pre-registration details override manual updates when re-linking."""
-    pre_email, _ = pre_registered_user
-
-    # Create the user and link to pre-registration
-    async with transaction_context(asyncpg_engine) as connection:
-        repo = UsersRepo(asyncpg_engine)
-        new_user = await repo.new_user(
-            connection,
-            email=pre_email,
-            password_hash="123456",  # noqa: S106
-            status=UserStatus.ACTIVE,
-            expires_at=None,
-        )
-        await repo.link_and_update_user_from_pre_registration(
-            connection,
-            new_user_id=new_user.id,
-            new_user_email=new_user.email,
-        )
+    new_user = registered_user
 
     # Update the user manually
     async with transaction_context(asyncpg_engine) as connection:


### PR DESCRIPTION
## What do these changes do?

A user pre-registered on one product could not buy credits on a *different* product: invoicing failed with `BillingDetailsNotFoundError`.

The billing address is a property of the **person**, not the product, but `UsersRepo.get_billing_details` filtered pre-registration rows to the buying product (or a `NULL` product), so a row belonging to another product was
discarded and no address could be resolved.

The query now considers **any** pre-registration row for the user and ranks them by specificity (exact product → product-agnostic `NULL` → any other product), falling back to the most recent. This also fixes a latent case where a newer `NULL`-product row could shadow an exact product match.

For now, no database migration is required to fix this issue: `NULL`-product rows were already matched, and backfilling a product onto historical `NULL` rows is unreliable (the intended product is unknown, especially for requests that were never approved).

> [!Important]
> - Fix needed for https://github.com/ITISFoundation/osparc-simcore/issues/9300


**Extra**: small refactoring of `test_users_details.py` to reuse fixtures and simplify setup/teardown of fixtures.

## Related issue/s

- closes ITISFoundation/private-issues#600

## How to test

```bash
cd packages/postgres-database
make install-dev
pytest tests/test_users_details.py -k billing -v
```

The new `test_get_billing_details_for_a_different_product` reproduces the bug:
it pre-registers a user on one product and asserts the billing address is still
returned when invoicing a second product (fails on the previous query).

## Dev-ops

No deployment or ENV changes required. No database schema changes.



----
🤖 Assisted-by: GitHub Copilot:Claude-Opus-4.8
