### PR TITLE
🐛 [Frontend] Cropped chat message

### DIFF
--- a/services/static-webserver/client/source/class/osparc/conversation/AddMessage.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/AddMessage.js
@@ -101,7 +101,9 @@ qx.Class.define("osparc.conversation.AddMessage", {
             if (e.getKeyIdentifier() === "Enter" && !e.isShiftPressed() && !e.isCtrlPressed()) {
               e.preventDefault();
               e.stopPropagation();
-              this.__addCommentPressed();
+              if (this.getChildControl("add-comment-button").getEnabled()) {
+                this.__addCommentPressed();
+              }
             }
           }, this);
           textArea.addListener("appear", () => {

--- a/services/static-webserver/client/source/class/osparc/conversation/AddMessage.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/AddMessage.js
@@ -96,6 +96,14 @@ qx.Class.define("osparc.conversation.AddMessage", {
           textArea.set({
             maxLength: osparc.data.model.Conversation.MAX_CONTENT_LENGTH,
           });
+          // Enter posts the message, Shift+Enter inserts a new line
+          textArea.addListener("keydown", e => {
+            if (e.getKeyIdentifier() === "Enter" && !e.isShiftPressed() && !e.isCtrlPressed()) {
+              e.preventDefault();
+              e.stopPropagation();
+              this.__addCommentPressed();
+            }
+          }, this);
           textArea.addListener("appear", () => {
             textArea.focus();
             textArea.activate();
@@ -116,7 +124,7 @@ qx.Class.define("osparc.conversation.AddMessage", {
         }
         case "add-comment-button": {
           control = new qx.ui.form.Button(null, "@FontAwesomeSolid/arrow-up/16").set({
-            toolTipText: this.tr("Ctrl+Enter"),
+            toolTipText: this.tr("Enter"),
             backgroundColor: "input-background",
             allowGrowX: false,
             alignX: "right",

--- a/services/static-webserver/client/source/class/osparc/conversation/MessageList.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/MessageList.js
@@ -60,6 +60,8 @@ qx.Class.define("osparc.conversation.MessageList", {
   },
 
   members: {
+    __atBottom: true,
+
     _createChildControlImpl: function(id) {
       let control;
       switch (id) {
@@ -71,6 +73,7 @@ qx.Class.define("osparc.conversation.MessageList", {
           break;
         case "messages-container-scroll":
           control = new qx.ui.container.Scroll();
+          control.getChildControl("pane").addListener("scrollY", () => this.__updateAtBottom(), this);
           this._addAt(control, this.self().POS.MESSAGES_CONTAINER, {
             flex: 1
           });
@@ -178,6 +181,12 @@ qx.Class.define("osparc.conversation.MessageList", {
         case "MESSAGE":
           control = this._createMessageUI(message);
           control.addListener("messageDeleted", e => this.__messageDeleted(e.getData()));
+          // markdown content resizes asynchronously (images, reflow); keep pinned to bottom
+          control.addListener("resized", () => {
+            if (this.__atBottom) {
+              this.__scrollToBottom();
+            }
+          });
           break;
         case "NOTIFICATION":
           control = new osparc.conversation.NotificationUI(message);
@@ -192,12 +201,21 @@ qx.Class.define("osparc.conversation.MessageList", {
 
       // scroll to bottom
       // add timeout to ensure the scroll happens after the UI is updated
-      setTimeout(() => {
-        const messagesScroll = this.getChildControl("messages-container-scroll");
-        messagesScroll.scrollToY(messagesScroll.getChildControl("pane").getScrollMaxY());
-      }, 50);
+      this.__atBottom = true;
+      setTimeout(() => this.__scrollToBottom(), 50);
 
       this.fireEvent("messagesChanged");
+    },
+
+    __scrollToBottom: function() {
+      const messagesScroll = this.getChildControl("messages-container-scroll");
+      messagesScroll.scrollToY(messagesScroll.getChildControl("pane").getScrollMaxY());
+    },
+
+    __updateAtBottom: function() {
+      const pane = this.getChildControl("messages-container-scroll").getChildControl("pane");
+      // consider "at bottom" when within a small threshold to absorb sub-pixel rounding
+      this.__atBottom = pane.getScrollMaxY() - pane.getScrollY() <= 20;
     },
 
     __messageDeleted: function(message) {

--- a/services/static-webserver/client/source/class/osparc/conversation/MessageList.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/MessageList.js
@@ -141,7 +141,8 @@ qx.Class.define("osparc.conversation.MessageList", {
       loadMoreMessages.setFetching(true);
       this.getConversation().getNextMessages()
         .then(resp => {
-          if (resp["_links"]["next"] === null && loadMoreMessages) {
+          const next = resp && resp["_links"] ? resp["_links"]["next"] : null;
+          if (next === null && loadMoreMessages) {
             loadMoreMessages.exclude();
           }
         })

--- a/services/static-webserver/client/source/class/osparc/conversation/MessageList.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/MessageList.js
@@ -209,6 +209,8 @@ qx.Class.define("osparc.conversation.MessageList", {
     },
 
     __scrollToBottom: function() {
+      // ensure pending layout changes (e.g. image-driven resize) are applied before measuring
+      qx.ui.core.queue.Manager.flush();
       const messagesScroll = this.getChildControl("messages-container-scroll");
       messagesScroll.scrollToY(messagesScroll.getChildControl("pane").getScrollMaxY());
     },

--- a/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
@@ -119,6 +119,7 @@ qx.Class.define("osparc.conversation.MessageUI", {
             allowGrowY: false,
             marginTop: 4,
             alignY: "top",
+            center: true,
             icon: "@FontAwesomeSolid/ellipsis-v/12",
             focusable: false
           });

--- a/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
+++ b/services/static-webserver/client/source/class/osparc/conversation/MessageUI.js
@@ -41,6 +41,7 @@ qx.Class.define("osparc.conversation.MessageUI", {
   events: {
     "messageUpdated": "qx.event.type.Data",
     "messageDeleted": "qx.event.type.Data",
+    "resized": "qx.event.type.Event",
   },
 
   properties: {
@@ -106,6 +107,7 @@ qx.Class.define("osparc.conversation.MessageUI", {
         }
         case "message-content":
           control = new osparc.ui.markdown.MarkdownChat();
+          control.addListener("resized", () => this.fireEvent("resized"));
           this.getChildControl("message-bubble").add(control);
           break;
         case "menu-button": {

--- a/services/static-webserver/client/source/class/osparc/support/ConversationListItem.js
+++ b/services/static-webserver/client/source/class/osparc/support/ConversationListItem.js
@@ -104,19 +104,7 @@ qx.Class.define("osparc.support.ConversationListItem", {
           this.getChildControl("badges-layout").add(control);
           break;
         case "menu-button": {
-          const buttonSize = 22;
-          control = new qx.ui.form.MenuButton().set({
-            appearance: "form-button-outlined",
-            width: buttonSize,
-            height: buttonSize,
-            padding: [0, 7],
-            allowGrowX: false,
-            allowGrowY: false,
-            alignX: "center",
-            alignY: "middle",
-            icon: "@FontAwesomeSolid/ellipsis-v/12",
-            focusable: false,
-          });
+          control = osparc.support.ConversationOptionsMenu.createMenuButton();
           this.getChildControl("bottom-right-layout").add(control);
           break;
         }

--- a/services/static-webserver/client/source/class/osparc/support/ConversationOptionsMenu.js
+++ b/services/static-webserver/client/source/class/osparc/support/ConversationOptionsMenu.js
@@ -27,6 +27,30 @@ qx.Class.define("osparc.support.ConversationOptionsMenu", {
     });
   },
 
+  statics: {
+    /**
+     * Factory for the "three dots" options button so all conversation entry points share the same look and alignment.
+     */
+    createMenuButton: function() {
+      const buttonSize = 22;
+      return new qx.ui.form.MenuButton().set({
+        appearance: "form-button-outlined",
+        backgroundColor: "background-main-3",
+        width: buttonSize,
+        height: buttonSize,
+        maxWidth: buttonSize,
+        maxHeight: buttonSize,
+        allowGrowX: false,
+        allowGrowY: false,
+        alignX: "center",
+        alignY: "middle",
+        center: true,
+        icon: "@FontAwesomeSolid/ellipsis-v/12",
+        focusable: false,
+      });
+    },
+  },
+
   properties: {
     conversation: {
       check: "osparc.data.model.Conversation",

--- a/services/static-webserver/client/source/class/osparc/support/ConversationOptionsMenu.js
+++ b/services/static-webserver/client/source/class/osparc/support/ConversationOptionsMenu.js
@@ -215,7 +215,9 @@ qx.Class.define("osparc.support.ConversationOptionsMenu", {
         confirmAction: "delete",
       });
       const supportCenter = osparc.ui.window.SingletonWindow.getWindowById("support-center");
-      win.setCenterOnElement(supportCenter);
+      if (supportCenter) {
+        win.setCenterOnElement(supportCenter);
+      }
       win.center();
       win.open();
       win.addListener("close", () => {

--- a/services/static-webserver/client/source/class/osparc/support/ConversationOptionsMenu.js
+++ b/services/static-webserver/client/source/class/osparc/support/ConversationOptionsMenu.js
@@ -190,6 +190,9 @@ qx.Class.define("osparc.support.ConversationOptionsMenu", {
         confirmText: this.tr("Delete"),
         confirmAction: "delete",
       });
+      const supportCenter = osparc.ui.window.SingletonWindow.getWindowById("support-center");
+      win.setCenterOnElement(supportCenter);
+      win.center();
       win.open();
       win.addListener("close", () => {
         if (win.getConfirmed()) {

--- a/services/static-webserver/client/source/class/osparc/support/ConversationPage.js
+++ b/services/static-webserver/client/source/class/osparc/support/ConversationPage.js
@@ -103,19 +103,7 @@ qx.Class.define("osparc.support.ConversationPage", {
           this.getChildControl("conversation-header-center-layout").addAt(control, 1);
           break;
         case "menu-button": {
-          const buttonSize = 22;
-          control = new qx.ui.form.MenuButton().set({
-            appearance: "form-button-outlined",
-            backgroundColor: "background-main-3",
-            width: buttonSize,
-            height: buttonSize,
-            allowGrowX: false,
-            allowGrowY: false,
-            alignX: "center",
-            alignY: "middle",
-            icon: "@FontAwesomeSolid/ellipsis-v/14",
-            focusable: false
-          });
+          control = osparc.support.ConversationOptionsMenu.createMenuButton();
           this.getChildControl("conversation-header-layout").addAt(control, 2);
           break;
         }


### PR DESCRIPTION
## What do these changes do?

This PR targets a UI issue where chat content can appear cropped (mostly due to asynchronous markdown reflow/image loading) by keeping the message list pinned to the bottom when appropriate.

<img width="1440" height="850" alt="scrollDown" src="https://github.com/user-attachments/assets/0cd2bd56-bf4e-46c0-b57a-2f6547d46b95" />


## Related issue/s
- related to https://z43.fogbugz.com/f/cases/232820/AI-support-center-improvements


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
