### PR TITLE
🐛 Fix CI deploy: restore `build:` context so `docker compose push` stops skipping all services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,7 +582,13 @@ push-latest: tag-latest
 
 push-version: tag-version
 	# pushing '${DOCKER_REGISTRY}/{service}:${DOCKER_IMAGE_TAG}'
-	@docker compose --file services/docker-compose-deploy.yml push
+	# below BUILD_TARGET gets overwritten but is required when merging yaml files
+	# NOTE: services/docker-compose-build.yml is merged in only so each service carries
+	# a 'build:' section (docker compose push skips any service without one). The push
+	# is scoped to SERVICES_NAMES_TO_BUILD so the shared base images (simcore-runtime-base,
+	# simcore-build-base) defined there are never pushed by this target.
+	@export BUILD_TARGET=undefined; \
+	docker compose --file services/docker-compose-build.yml --file services/docker-compose-deploy.yml push $(SERVICES_NAMES_TO_BUILD)
 
 pull-externals: ## pulls non-simcore external images defined in docker-compose.yml
 	# Pulling external images


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->



## What
`push-version` no longer pushes any images to DockerHub — every service is reported `Skipped` during the deploy job, though the job exits green.

## Why
#9344 (a same-day hotfix for #9330) dropped the docker-compose-build.yml merge from `push-version`, leaving only docker-compose-deploy.yml. That file has no `build:` key for any service, and `docker compose push` unconditionally skips any service where `Build == nil`. Result: silent no-op deploys.

#9330 had added `simcore-runtime-base`/`simcore-build-base` to docker-compose-build.yml, which is what broke the original merged push (compose tried to push those too), prompting #9344's overly broad fix.

## Fix
Restore the docker-compose-build.yml merge (needed only to supply `build:` metadata), but scope `docker compose push` to `$(SERVICES_NAMES_TO_BUILD)` so the two new base images are excluded from push while the 21 real services get their `build:` section back.


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
