### PR TITLE
🎨 [Frontend] Locale: sync with Preferences instead of localStorage

### DIFF
--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -516,6 +516,16 @@ qx.Class.define("osparc.Application", {
                       preferencesSettings.setPreferredWalletId(parseInt(value));
                     }
                     break;
+                  case "userLocale":
+                    if (osparc.product.isLocaleEnabled()) {
+                      if (value) {
+                        preferencesSettings.setUserLocale(value);
+                      } else {
+                        // if the user has not set a locale yet, default to the browser language
+                        osparc.utils.LanguageManager.applyLocale(osparc.utils.LanguageManager.getBrowserLocale());
+                      }
+                    }
+                    break;
                   default:
                     if (fePreferences.includes(key)) {
                       preferencesSettings.set(key, value);

--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -517,12 +517,11 @@ qx.Class.define("osparc.Application", {
                     }
                     break;
                   case "userLocale":
-                    if (osparc.product.isLocaleEnabled()) {
+                    if (osparc.product.Utils.isLocaleEnabled()) {
                       if (value) {
                         preferencesSettings.setUserLocale(value);
                       } else {
-                        // if the user has not set a locale yet, default to the browser language
-                        osparc.utils.LanguageManager.applyLocale(osparc.utils.LanguageManager.getBrowserLocale());
+                        osparc.utils.LanguageManager.setDefaultLocale();
                       }
                     }
                     break;

--- a/services/static-webserver/client/source/class/osparc/Application.js
+++ b/services/static-webserver/client/source/class/osparc/Application.js
@@ -54,7 +54,6 @@ qx.Class.define("osparc.Application", {
       this.__loadCommonCss();
       this.__updateTabName();
       if (osparc.utils.Utils.isDevelopmentPlatform()) {
-        osparc.utils.LanguageManager.applyStoredLocale();
         this.__updateMetaTags();
         this.__setDeviceSpecificIcons();
       }

--- a/services/static-webserver/client/source/class/osparc/Preferences.js
+++ b/services/static-webserver/client/source/class/osparc/Preferences.js
@@ -145,6 +145,14 @@ qx.Class.define("osparc.Preferences", {
       check: "Array",
       event: "changeBillingCenterUsageColumnOrder",
       apply: "__patchPreference"
+    },
+
+    userLocale: {
+      nullable: true,
+      init: null,
+      check: "String",
+      event: "changeUserLocale",
+      apply: "__applyUserLocale"
     }
   },
 
@@ -216,6 +224,16 @@ qx.Class.define("osparc.Preferences", {
         return;
       }
       this.self().patchPreference(propName, value);
+    },
+
+    __applyUserLocale: function(value, old, propName) {
+      if (value === old) {
+        return;
+      }
+      osparc.utils.LanguageManager.applyLocale(value);
+      if (osparc.auth.Manager.getInstance().isLoggedIn()) {
+        this.self().patchPreference(propName, value);
+      }
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/filter/DateFilters.js
+++ b/services/static-webserver/client/source/class/osparc/filter/DateFilters.js
@@ -26,10 +26,10 @@ qx.Class.define("osparc.filter.DateFilters", {
       const defaultFrom = new Date();
       const defaultTo = new Date();
 
-      this.__from = this.__addDateInput("From", defaultFrom);
-      this.__until = this.__addDateInput("Until", defaultTo);
+      this.__from = this.__addDateInput(this.tr("From"), defaultFrom);
+      this.__until = this.__addDateInput(this.tr("Until"), defaultTo);
 
-      const todayBtn = new qx.ui.form.Button("Today").set({
+      const todayBtn = new qx.ui.form.Button(this.tr("Today")).set({
         allowStretchY: false,
         alignY: "bottom"
       });
@@ -40,7 +40,7 @@ qx.Class.define("osparc.filter.DateFilters", {
       });
       this._add(todayBtn);
 
-      const lastWeekBtn = new qx.ui.form.Button("Last week").set({
+      const lastWeekBtn = new qx.ui.form.Button(this.tr("Last week")).set({
         allowStretchY: false,
         alignY: "bottom"
       });
@@ -53,7 +53,7 @@ qx.Class.define("osparc.filter.DateFilters", {
       });
       this._add(lastWeekBtn);
 
-      const lastMonthBtn = new qx.ui.form.Button("Last month").set({
+      const lastMonthBtn = new qx.ui.form.Button(this.tr("Last month")).set({
         allowStretchY: false,
         alignY: "bottom"
       });
@@ -66,7 +66,7 @@ qx.Class.define("osparc.filter.DateFilters", {
       });
       this._add(lastMonthBtn);
 
-      const lastYearBtn = new qx.ui.form.Button("Last year").set({
+      const lastYearBtn = new qx.ui.form.Button(this.tr("Last year")).set({
         allowStretchY: false,
         alignY: "bottom"
       });

--- a/services/static-webserver/client/source/class/osparc/product/Utils.js
+++ b/services/static-webserver/client/source/class/osparc/product/Utils.js
@@ -452,6 +452,10 @@ qx.Class.define("osparc.product.Utils", {
       return osparc.utils.Utils.isDevelopmentPlatform();
     },
 
+    isLocaleEnabled: function() {
+      return osparc.utils.Utils.isDevelopmentPlatform();
+    },
+
     getOsparcOImageSource: function() {
       const colorManager = qx.theme.manager.Color.getInstance();
       const textColor = colorManager.resolve("text");

--- a/services/static-webserver/client/source/class/osparc/utils/LanguageManager.js
+++ b/services/static-webserver/client/source/class/osparc/utils/LanguageManager.js
@@ -40,12 +40,24 @@ qx.Class.define("osparc.utils.LanguageManager", {
       return osparc.Preferences.getInstance().getUserLocale();
     },
 
+    setLocale: function(localeCode) {
+      if (!this.getAvailableLocales().includes(localeCode)) {
+        return;
+      }
+      osparc.Preferences.getInstance().setUserLocale(localeCode);
+    },
+
+    setDefaultLocale: function() {
+      const browserLocale = this.__getBrowserLocale();
+      this.setLocale(browserLocale);
+    },
+
     /**
      * Resolves the best available locale for the user's browser language,
      * falling back to English ("en_US") when there is no match.
      * @return {String} e.g. "es_ES"
      */
-    getBrowserLocale: function() {
+    __getBrowserLocale: function() {
       const available = this.getAvailableLocales();
       const fallback = available.includes("en_US") ? "en_US" : available[0];
 
@@ -72,12 +84,5 @@ qx.Class.define("osparc.utils.LanguageManager", {
         qx.locale.Manager.getInstance().setLocale(localeCode);
       }
     },
-
-    setLocale: function(localeCode) {
-      if (!this.getAvailableLocales().includes(localeCode)) {
-        return;
-      }
-      osparc.Preferences.getInstance().setUserLocale(localeCode);
-    }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/utils/LanguageManager.js
+++ b/services/static-webserver/client/source/class/osparc/utils/LanguageManager.js
@@ -13,15 +13,12 @@ qx.Class.define("osparc.utils.LanguageManager", {
   type: "static",
 
   statics: {
-    LOCALE_KEY: "osparc.locale",
-
     // Display names for the locales we want to expose
     __localeLabels: {
       "en_US": "English",
       "es_ES": "Español [Spanish]",
       "zh": "中文 [Chinese]",
     },
-
 
     /**
      * Returns the locales for which translations were compiled (see compile.json).
@@ -40,26 +37,20 @@ qx.Class.define("osparc.utils.LanguageManager", {
     },
 
     getStoredLocale: function() {
-      return osparc.utils.Utils.localCache.getLocalStorageItem(this.LOCALE_KEY);
+      return osparc.Preferences.getInstance().getUserLocale();
+    },
+
+    applyLocale: function(localeCode) {
+      if (localeCode && this.getAvailableLocales().includes(localeCode)) {
+        qx.locale.Manager.getInstance().setLocale(localeCode);
+      }
     },
 
     setLocale: function(localeCode) {
       if (!this.getAvailableLocales().includes(localeCode)) {
         return;
       }
-      osparc.utils.Utils.localCache.setLocalStorageItem(this.LOCALE_KEY, localeCode);
-      qx.locale.Manager.getInstance().setLocale(localeCode);
-    },
-
-    /**
-     * Applies the locale stored in localStorage (if any and still available).
-     * Meant to be called early during application startup.
-     */
-    applyStoredLocale: function() {
-      const storedLocale = this.getStoredLocale();
-      if (storedLocale && this.getAvailableLocales().includes(storedLocale)) {
-        qx.locale.Manager.getInstance().setLocale(storedLocale);
-      }
+      osparc.Preferences.getInstance().setUserLocale(localeCode);
     }
   }
 });

--- a/services/static-webserver/client/source/class/osparc/utils/LanguageManager.js
+++ b/services/static-webserver/client/source/class/osparc/utils/LanguageManager.js
@@ -40,6 +40,33 @@ qx.Class.define("osparc.utils.LanguageManager", {
       return osparc.Preferences.getInstance().getUserLocale();
     },
 
+    /**
+     * Resolves the best available locale for the user's browser language,
+     * falling back to English ("en_US") when there is no match.
+     * @return {String} e.g. "es_ES"
+     */
+    getBrowserLocale: function() {
+      const available = this.getAvailableLocales();
+      const fallback = available.includes("en_US") ? "en_US" : available[0];
+
+      const language = qx.bom.client.Locale.getLocale(); // e.g. "es"
+      if (!language) {
+        return fallback;
+      }
+      const variant = qx.bom.client.Locale.getVariant(); // e.g. "ES"
+      const full = variant ? `${language}_${variant}` : language; // e.g. "es_ES"
+      // exact match (e.g. "es_ES") or language-only match (e.g. "zh")
+      if (available.includes(full)) {
+        return full;
+      }
+      if (available.includes(language)) {
+        return language;
+      }
+      // match by language prefix (e.g. "es" -> "es_ES")
+      const byPrefix = available.find(localeCode => localeCode.split("_")[0] === language);
+      return byPrefix || fallback;
+    },
+
     applyLocale: function(localeCode) {
       if (localeCode && this.getAvailableLocales().includes(localeCode)) {
         qx.locale.Manager.getInstance().setLocale(localeCode);


### PR DESCRIPTION
## What do these changes do?

- sync with preferences
- user's browser default if not set

## Related issue/s
- related to ITISFoundation/private-issues#590


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
