### PR TITLE
♻️Autoscaling: reduce static typing pressure

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/utils/cluster_scaling.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/utils/cluster_scaling.py
@@ -112,6 +112,7 @@ def find_selected_instance_type_for_task(
 type DrainedNodes = list[AssociatedInstance]
 type HotBufferDrainedNodes = list[AssociatedInstance]
 type TerminatingNodes = list[AssociatedInstance]
+type _InstanceTypeKey = str
 
 
 def sort_drained_nodes(
@@ -119,8 +120,8 @@ def sort_drained_nodes(
     all_drained_nodes: list[AssociatedInstance],
 ) -> tuple[DrainedNodes, HotBufferDrainedNodes, TerminatingNodes]:
     assert app_settings.AUTOSCALING_EC2_INSTANCES  # nosec
-    hot_buffer_requirements: dict[InstanceTypeType, tuple[int, datetime.timedelta | None]] = {
-        typing.cast(InstanceTypeType, type_name): (config.hot_buffer_count, config.hot_buffer_max_inactivity_time)
+    hot_buffer_requirements: dict[_InstanceTypeKey, tuple[int, datetime.timedelta | None]] = {
+        type_name: (config.hot_buffer_count, config.hot_buffer_max_inactivity_time)
         for type_name, config in app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES.items()
         if config.hot_buffer_count > 0
     }
@@ -130,10 +131,11 @@ def sort_drained_nodes(
     ]
 
     remaining_drained_nodes = [n for n in all_drained_nodes if n not in terminating_nodes]
-    candidates_by_type: dict[InstanceTypeType, list[AssociatedInstance]] = {}
+    candidates_by_type: dict[_InstanceTypeKey, list[AssociatedInstance]] = {}
     now = datetime.datetime.now(datetime.UTC)
     for node in remaining_drained_nodes:
-        requirement = hot_buffer_requirements.get(node.ec2_instance.type)
+        instance_type_key = str(node.ec2_instance.type)
+        requirement = hot_buffer_requirements.get(instance_type_key)
         if not requirement:
             continue
         _, inactivity_limit = requirement
@@ -141,19 +143,17 @@ def sort_drained_nodes(
         if inactivity_limit is not None and (now - last_ready_update) >= inactivity_limit:
             # Too old to keep in buffer, let normal termination flow handle it
             continue
-        candidates_by_type.setdefault(node.ec2_instance.type, []).append(node)
+        candidates_by_type.setdefault(instance_type_key, []).append(node)
 
     hot_buffer_drained_nodes: list[AssociatedInstance] = []
     for ec2_type in app_settings.AUTOSCALING_EC2_INSTANCES.EC2_INSTANCES_ALLOWED_TYPES:
-        requirement = hot_buffer_requirements.get(typing.cast(InstanceTypeType, ec2_type))
+        requirement = hot_buffer_requirements.get(ec2_type)
         if not requirement:
             continue
         desired_count, _ = requirement
         if desired_count <= 0:
             continue
-        hot_buffer_drained_nodes.extend(
-            candidates_by_type.get(typing.cast(InstanceTypeType, ec2_type), [])[:desired_count]
-        )
+        hot_buffer_drained_nodes.extend(candidates_by_type.get(ec2_type, [])[:desired_count])
 
     hot_buffer_ids = {node.ec2_instance.id for node in hot_buffer_drained_nodes}
     other_drained_nodes = [node for node in remaining_drained_nodes if node.ec2_instance.id not in hot_buffer_ids]


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
static typing takes almost 1 minute on autoscaling due to dictionaries with large unions used as dictionary key.

This is a trial to reduce that without losing too much on typing.

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
