### PR TITLE
✨Encryption/Decryption - Dask-sidecar: encrypt sidecar log file

### DIFF
--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/encryption.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/encryption.py
@@ -10,7 +10,7 @@ from models_library.projects_nodes_io import NodeID
 from pydantic import BaseModel, ConfigDict, Field, SecretBytes
 from pydantic.config import JsonDict
 
-_SIDECAR_LOGS_FILE_ID: Final[str] = "logs"
+_SIDECAR_LOGS_FILE_ID: Final[str] = "service-logs"
 _ROOT_KEY_EXAMPLE: Final[str] = "0123456789abcdef0123456789abcdef"
 
 

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/encryption.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/encryption.py
@@ -86,10 +86,7 @@ class JobEncryptionContext(BaseModel):
         return TransferEncryptionSettings(root_key=self.root_key, file_id=output_key)
 
     def transfer_settings_for_logs(self) -> TransferEncryptionSettings | None:
-        """Returns the per-file transfer settings for the logs, or None when the task has no encrypted inputs."""
-        if not self.input_port_to_file_id:
-            return None
-        # use a fixed file_id for logs, as they are not tied to any input port
+        """Returns the per-file transfer settings for the logs (the file_id is fixed)."""
         return TransferEncryptionSettings(root_key=self.root_key, file_id=_SIDECAR_LOGS_FILE_ID)
 
     @staticmethod

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/encryption.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/encryption.py
@@ -14,7 +14,7 @@ _SIDECAR_LOGS_FILE_ID: Final[str] = "service-logs"
 _ROOT_KEY_EXAMPLE: Final[str] = "0123456789abcdef0123456789abcdef"
 
 
-_RootKeyType = Annotated[
+_RootKeySecretBytes = Annotated[
     SecretBytes,
     Field(
         min_length=AES_256_GCM_KEY_SIZE_BYTES,
@@ -25,7 +25,7 @@ _RootKeyType = Annotated[
 
 
 class TransferEncryptionSettings(BaseModel):
-    root_key: _RootKeyType
+    root_key: _RootKeySecretBytes
     file_id: Annotated[
         FileIDStr,
         Field(description="Per-file identifier mixed into key derivation"),
@@ -51,7 +51,7 @@ class TransferEncryptionSettings(BaseModel):
 
 
 class JobEncryptionContext(BaseModel):
-    root_key: _RootKeyType
+    root_key: _RootKeySecretBytes
     input_port_to_file_id: Annotated[
         dict[str, FileIDStr],
         Field(

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/encryption.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/encryption.py
@@ -1,5 +1,5 @@
 import base64
-from typing import Annotated, Final
+from typing import Annotated, Final, Self
 
 from models_library.api_schemas_directorv2.encryption import (
     AES_256_GCM_KEY_SIZE_BYTES,
@@ -10,6 +10,7 @@ from models_library.projects_nodes_io import NodeID
 from pydantic import BaseModel, ConfigDict, Field, SecretBytes
 from pydantic.config import JsonDict
 
+_SIDECAR_LOGS_FILE_ID: Final[str] = "logs"
 _ROOT_KEY_EXAMPLE: Final[str] = "0123456789abcdef0123456789abcdef"
 
 
@@ -21,60 +22,6 @@ _RootKeyType = Annotated[
         description="Secret root key used to derive every per-file key (HKDF over root_key/file_id)",
     ),
 ]
-
-
-class JobEncryptionContext(BaseModel):
-    root_key: _RootKeyType
-    input_port_to_file_id: Annotated[
-        dict[str, FileIDStr],
-        Field(
-            description=(
-                "Maps each encrypted input port key to the file_id the client used to derive its key "
-                "(may differ from the port key). Only listed inputs are decrypted."
-            ),
-        ),
-    ]
-
-    @classmethod
-    def from_metadata(cls, metadata: JobEncryptionContextMetadata, node_id: NodeID) -> "JobEncryptionContext":
-        """Builds the per-task context for ``node_id`` from the REST/storage transport form.
-
-        The shared base64 ``root_key`` is decoded back into raw bytes and only the input mapping
-        of the given node is kept (empty when the node has no encrypted inputs).
-        """
-        return cls(
-            root_key=SecretBytes(base64.b64decode(metadata.root_key.get_secret_value())),
-            input_port_to_file_id=metadata.input_port_to_file_id.get(NodeID(f"{node_id}"), {}),
-        )
-
-    def transfer_settings_for_input(self, input_key: str) -> "TransferEncryptionSettings | None":
-        """Returns the per-file transfer settings for an input port, or None when that port is not encrypted."""
-        file_id = self.input_port_to_file_id.get(input_key)
-        if file_id is None:
-            return None
-        return TransferEncryptionSettings(root_key=self.root_key, file_id=file_id)
-
-    def transfer_settings_for_output(self, output_key: str) -> "TransferEncryptionSettings":
-        """Returns the per-file transfer settings for an output (the file_id is the output key)."""
-        return TransferEncryptionSettings(root_key=self.root_key, file_id=output_key)
-
-    @staticmethod
-    def _update_json_schema_extra(schema: JsonDict) -> None:
-        schema.update(
-            {
-                "examples": [
-                    {
-                        "root_key": _ROOT_KEY_EXAMPLE,
-                        "input_port_to_file_id": {"input_1": "input_1"},
-                    },
-                ]
-            }
-        )
-
-    model_config = ConfigDict(
-        frozen=True,
-        json_schema_extra=_update_json_schema_extra,
-    )
 
 
 class TransferEncryptionSettings(BaseModel):
@@ -92,6 +39,67 @@ class TransferEncryptionSettings(BaseModel):
                     {
                         "root_key": _ROOT_KEY_EXAMPLE,
                         "file_id": "input_1",
+                    },
+                ]
+            }
+        )
+
+    model_config = ConfigDict(
+        frozen=True,
+        json_schema_extra=_update_json_schema_extra,
+    )
+
+
+class JobEncryptionContext(BaseModel):
+    root_key: _RootKeyType
+    input_port_to_file_id: Annotated[
+        dict[str, FileIDStr],
+        Field(
+            description=(
+                "Maps each encrypted input port key to the file_id the client used to derive its key "
+                "(may differ from the port key). Only listed inputs are decrypted."
+            ),
+        ),
+    ]
+
+    @classmethod
+    def from_metadata(cls, metadata: JobEncryptionContextMetadata, node_id: NodeID) -> Self:
+        """Builds the per-task context for ``node_id`` from the REST/storage transport form.
+
+        The shared base64 ``root_key`` is decoded back into raw bytes and only the input mapping
+        of the given node is kept (empty when the node has no encrypted inputs).
+        """
+        return cls(
+            root_key=SecretBytes(base64.b64decode(metadata.root_key.get_secret_value())),
+            input_port_to_file_id=metadata.input_port_to_file_id.get(NodeID(f"{node_id}"), {}),
+        )
+
+    def transfer_settings_for_input(self, input_key: str) -> TransferEncryptionSettings | None:
+        """Returns the per-file transfer settings for an input port, or None when that port is not encrypted."""
+        file_id = self.input_port_to_file_id.get(input_key)
+        if file_id is None:
+            return None
+        return TransferEncryptionSettings(root_key=self.root_key, file_id=file_id)
+
+    def transfer_settings_for_output(self, output_key: str) -> TransferEncryptionSettings:
+        """Returns the per-file transfer settings for an output (the file_id is the output key)."""
+        return TransferEncryptionSettings(root_key=self.root_key, file_id=output_key)
+
+    def transfer_settings_for_logs(self) -> TransferEncryptionSettings | None:
+        """Returns the per-file transfer settings for the logs, or None when the task has no encrypted inputs."""
+        if not self.input_port_to_file_id:
+            return None
+        # use a fixed file_id for logs, as they are not tied to any input port
+        return TransferEncryptionSettings(root_key=self.root_key, file_id=_SIDECAR_LOGS_FILE_ID)
+
+    @staticmethod
+    def _update_json_schema_extra(schema: JsonDict) -> None:
+        schema.update(
+            {
+                "examples": [
+                    {
+                        "root_key": _ROOT_KEY_EXAMPLE,
+                        "input_port_to_file_id": {"input_1": "input_1"},
                     },
                 ]
             }

--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/encryption.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/encryption.py
@@ -14,7 +14,7 @@ _SIDECAR_LOGS_FILE_ID: Final[str] = "service-logs"
 _ROOT_KEY_EXAMPLE: Final[str] = "0123456789abcdef0123456789abcdef"
 
 
-_RootKeySecretBytes = Annotated[
+type _RootKeySecretBytes = Annotated[
     SecretBytes,
     Field(
         min_length=AES_256_GCM_KEY_SIZE_BYTES,

--- a/packages/dask-task-models-library/tests/container_tasks/test_encryption.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_encryption.py
@@ -4,15 +4,17 @@ import pytest
 from dask_task_models_library.container_tasks.encryption import (
     JobEncryptionContext,
     TransferEncryptionSettings,
+    _RootKeySecretBytes,
 )
 from faker import Faker
 from models_library.api_schemas_directorv2.encryption import (
     AES_256_GCM_KEY_SIZE_BYTES,
     MAX_LP_STRING_BYTES,
     JobEncryptionContextMetadata,
+    RootKeyStr,
 )
 from models_library.projects_nodes_io import NodeID
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
 
 @pytest.mark.parametrize("model_cls", [JobEncryptionContext, TransferEncryptionSettings])
@@ -49,7 +51,7 @@ def test_from_metadata_extracts_node_input_mapping(faker: Faker):
     encrypted_node_id = NodeID(faker.uuid4())
     other_node_id = NodeID(faker.uuid4())
     metadata = JobEncryptionContextMetadata(
-        root_key=base64.b64encode(raw_root_key).decode("ascii"),  # type: ignore[arg-type]
+        root_key=TypeAdapter(RootKeyStr).validate_python(base64.b64encode(raw_root_key).decode("ascii")),
         input_port_to_file_id={
             encrypted_node_id: {"input_1": "input_1"},
             other_node_id: {"input_2": "some_file_id"},
@@ -64,7 +66,7 @@ def test_from_metadata_extracts_node_input_mapping(faker: Faker):
 def test_from_metadata_node_without_encrypted_inputs(faker: Faker):
     raw_root_key = b"0" * AES_256_GCM_KEY_SIZE_BYTES
     metadata = JobEncryptionContextMetadata(
-        root_key=base64.b64encode(raw_root_key).decode("ascii"),  # type: ignore[arg-type]
+        root_key=TypeAdapter(RootKeyStr).validate_python(base64.b64encode(raw_root_key).decode("ascii")),
         input_port_to_file_id={},
     )
 
@@ -72,3 +74,66 @@ def test_from_metadata_node_without_encrypted_inputs(faker: Faker):
     context = JobEncryptionContext.from_metadata(metadata, NodeID(faker.uuid4()))
     assert context.root_key.get_secret_value() == raw_root_key
     assert context.input_port_to_file_id == {}
+
+
+def test_transfer_settings_for_input_returns_settings_for_encrypted_input():
+    root_key = b"0" * AES_256_GCM_KEY_SIZE_BYTES
+    context = JobEncryptionContext(
+        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key),
+        input_port_to_file_id={"input_1": "file_1"},
+    )
+
+    settings = context.transfer_settings_for_input("input_1")
+
+    assert settings == TransferEncryptionSettings(
+        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key), file_id="file_1"
+    )
+
+
+def test_transfer_settings_for_input_returns_none_for_unencrypted_input():
+    context = JobEncryptionContext(
+        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(b"0" * AES_256_GCM_KEY_SIZE_BYTES),
+        input_port_to_file_id={"input_1": "file_1"},
+    )
+
+    settings = context.transfer_settings_for_input("missing_input")
+
+    assert settings is None
+
+
+def test_transfer_settings_for_output_uses_output_key_as_file_id():
+    root_key = b"0" * AES_256_GCM_KEY_SIZE_BYTES
+    context = JobEncryptionContext(
+        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key), input_port_to_file_id={}
+    )
+
+    settings = context.transfer_settings_for_output("output_1")
+
+    assert settings == TransferEncryptionSettings(
+        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key), file_id="output_1"
+    )
+
+
+def test_transfer_settings_for_logs_returns_none_without_encrypted_inputs():
+    context = JobEncryptionContext(
+        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(b"0" * AES_256_GCM_KEY_SIZE_BYTES),
+        input_port_to_file_id={},
+    )
+
+    settings = context.transfer_settings_for_logs()
+
+    assert settings is None
+
+
+def test_transfer_settings_for_logs_uses_fixed_logs_file_id_when_inputs_are_encrypted():
+    root_key = b"0" * AES_256_GCM_KEY_SIZE_BYTES
+    context = JobEncryptionContext(
+        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key),
+        input_port_to_file_id={"input_1": "file_1"},
+    )
+
+    settings = context.transfer_settings_for_logs()
+
+    assert settings == TransferEncryptionSettings(
+        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key), file_id="service-logs"
+    )

--- a/packages/dask-task-models-library/tests/container_tasks/test_encryption.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_encryption.py
@@ -4,7 +4,6 @@ import pytest
 from dask_task_models_library.container_tasks.encryption import (
     JobEncryptionContext,
     TransferEncryptionSettings,
-    _RootKeySecretBytes,
 )
 from faker import Faker
 from models_library.api_schemas_directorv2.encryption import (
@@ -14,7 +13,7 @@ from models_library.api_schemas_directorv2.encryption import (
     RootKeyStr,
 )
 from models_library.projects_nodes_io import NodeID
-from pydantic import TypeAdapter, ValidationError
+from pydantic import SecretBytes, TypeAdapter, ValidationError
 
 
 @pytest.mark.parametrize("model_cls", [JobEncryptionContext, TransferEncryptionSettings])
@@ -79,20 +78,20 @@ def test_from_metadata_node_without_encrypted_inputs(faker: Faker):
 def test_transfer_settings_for_input_returns_settings_for_encrypted_input():
     root_key = b"0" * AES_256_GCM_KEY_SIZE_BYTES
     context = JobEncryptionContext(
-        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key),
+        root_key=TypeAdapter(SecretBytes).validate_python(root_key),
         input_port_to_file_id={"input_1": "file_1"},
     )
 
     settings = context.transfer_settings_for_input("input_1")
 
     assert settings == TransferEncryptionSettings(
-        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key), file_id="file_1"
+        root_key=TypeAdapter(SecretBytes).validate_python(root_key), file_id="file_1"
     )
 
 
 def test_transfer_settings_for_input_returns_none_for_unencrypted_input():
     context = JobEncryptionContext(
-        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(b"0" * AES_256_GCM_KEY_SIZE_BYTES),
+        root_key=TypeAdapter(SecretBytes).validate_python(b"0" * AES_256_GCM_KEY_SIZE_BYTES),
         input_port_to_file_id={"input_1": "file_1"},
     )
 
@@ -104,25 +103,25 @@ def test_transfer_settings_for_input_returns_none_for_unencrypted_input():
 def test_transfer_settings_for_output_uses_output_key_as_file_id():
     root_key = b"0" * AES_256_GCM_KEY_SIZE_BYTES
     context = JobEncryptionContext(
-        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key), input_port_to_file_id={}
+        root_key=TypeAdapter(SecretBytes).validate_python(root_key), input_port_to_file_id={}
     )
 
     settings = context.transfer_settings_for_output("output_1")
 
     assert settings == TransferEncryptionSettings(
-        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key), file_id="output_1"
+        root_key=TypeAdapter(SecretBytes).validate_python(root_key), file_id="output_1"
     )
 
 
 def test_transfer_settings_for_logs_uses_fixed_logs_file_id_when_inputs_are_encrypted():
     root_key = b"0" * AES_256_GCM_KEY_SIZE_BYTES
     context = JobEncryptionContext(
-        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key),
+        root_key=TypeAdapter(SecretBytes).validate_python(root_key),
         input_port_to_file_id={"input_1": "file_1"},
     )
 
     settings = context.transfer_settings_for_logs()
 
     assert settings == TransferEncryptionSettings(
-        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(root_key), file_id="service-logs"
+        root_key=TypeAdapter(SecretBytes).validate_python(root_key), file_id="service-logs"
     )

--- a/packages/dask-task-models-library/tests/container_tasks/test_encryption.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_encryption.py
@@ -114,17 +114,6 @@ def test_transfer_settings_for_output_uses_output_key_as_file_id():
     )
 
 
-def test_transfer_settings_for_logs_returns_none_without_encrypted_inputs():
-    context = JobEncryptionContext(
-        root_key=TypeAdapter(_RootKeySecretBytes).validate_python(b"0" * AES_256_GCM_KEY_SIZE_BYTES),
-        input_port_to_file_id={},
-    )
-
-    settings = context.transfer_settings_for_logs()
-
-    assert settings is None
-
-
 def test_transfer_settings_for_logs_uses_fixed_logs_file_id_when_inputs_are_encrypted():
     root_key = b"0" * AES_256_GCM_KEY_SIZE_BYTES
     context = JobEncryptionContext(

--- a/packages/dask-task-models-library/tests/container_tasks/test_io.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_io.py
@@ -6,8 +6,6 @@ import pytest
 from cloudpickle import dumps, loads
 from dask_task_models_library.container_tasks.io import (
     FilePortSchema,
-    FileUrl,
-    PortSchema,
     TaskInputData,
     TaskOutputData,
     TaskOutputDataSchema,
@@ -15,29 +13,9 @@ from dask_task_models_library.container_tasks.io import (
 from faker import Faker
 
 
-@pytest.mark.parametrize(
-    "model_cls",
-    (
-        PortSchema,
-        FilePortSchema,
-        FileUrl,
-        TaskInputData,
-        TaskOutputDataSchema,
-        TaskOutputData,
-    ),
-)
-def test_io_models_examples(model_cls, model_cls_examples):
-    for name, example in model_cls_examples.items():
-        print(name, ":", pformat(example))
-
-        model_instance = model_cls.model_validate(example)
-
-        assert model_instance, f"Failed with {name}"
-        print(name, ":", model_instance)
-
-
 def _create_fake_outputs(
     schema: TaskOutputDataSchema,
+    *,
     output_folder: Path,
     set_optional_field: bool,
     faker: Faker,
@@ -69,7 +47,13 @@ def test_create_task_output_from_task_with_optional_fields_as_required(
 ):
     for schema_example in TaskOutputDataSchema.model_json_schema()["examples"]:
         task_output_schema = TaskOutputDataSchema.model_validate(schema_example)
-        outputs_file_name = _create_fake_outputs(task_output_schema, tmp_path, optional_fields_set, faker)
+        outputs_file_name = _create_fake_outputs(
+            task_output_schema,
+            output_folder=tmp_path,
+            set_optional_field=optional_fields_set,
+            faker=faker,
+        )
+        assert outputs_file_name
         task_output_data = TaskOutputData.from_task_output(
             schema=task_output_schema,
             output_folder=tmp_path,
@@ -95,7 +79,7 @@ def test_create_task_output_from_task_throws_when_there_are_missing_files(tmp_pa
         }
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Could not locate .+"):
         TaskOutputData.from_task_output(
             schema=task_output_schema,
             output_folder=tmp_path,
@@ -133,7 +117,7 @@ def test_create_task_output_from_task_throws_when_there_are_entries(tmp_path: Pa
         }
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Could not locate .+"):
         TaskOutputData.from_task_output(
             schema=task_output_schema,
             output_folder=tmp_path,
@@ -160,11 +144,11 @@ def test_create_task_output_from_task_does_not_throw_when_there_are_optional_ent
 
 @pytest.mark.parametrize(
     "model_cls",
-    (
+    [
         TaskInputData,
         TaskOutputDataSchema,
         TaskOutputData,
-    ),
+    ],
 )
 def test_objects_are_compatible_with_dask_requirements(model_cls, model_cls_examples):
     # NOTE: fcts could also be passed through the same test
@@ -187,7 +171,12 @@ def test_create_task_output_from_task_ignores_additional_entries(tmp_path: Path,
             },
         }
     )
-    output_file = _create_fake_outputs(task_output_schema, tmp_path, False, faker)
+    output_file = _create_fake_outputs(
+        task_output_schema,
+        output_folder=tmp_path,
+        set_optional_field=False,
+        faker=faker,
+    )
     assert output_file
     # Add more data to the output file to simulate additional entries
     file_path = tmp_path / output_file

--- a/services/api-server/src/simcore_service_api_server/services_http/webserver.py
+++ b/services/api-server/src/simcore_service_api_server/services_http/webserver.py
@@ -511,7 +511,8 @@ class AuthSession:
             body_input["encryption"] = encryption
 
         body: ComputationStart = ComputationStart(**body_input)
-        # NOTE: encryption keys are secrets and must be transmitted in plaintext (webserver -> director-v2), so we use model_dump_with_secrets with show_secrets=True
+        # NOTE: encryption keys are secrets and must be transmitted in plaintext (api-server -> webserver -> director-v2),
+        # so we use model_dump_with_secrets with show_secrets=True
         body_data = model_dump_with_secrets(
             body,
             show_secrets=True,

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/core.py
@@ -256,6 +256,7 @@ class ComputationalSidecar:
                     log_publishing_cb=self._publish_sidecar_log,
                     s3_settings=self.s3_settings,
                     progress_bar=processing_progress_bar,
+                    encryption=(self.encryption.transfer_settings_for_logs() if self.encryption else None),
                 ),
             ):
                 await container.start()

--- a/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
+++ b/services/dask-sidecar/src/simcore_service_dask_sidecar/computational_sidecar/docker_utils.py
@@ -24,6 +24,7 @@ from aiodocker.containers import DockerContainer
 from aiodocker.volumes import DockerVolume
 from common_library.async_tools import cancel_wait_task, iter_with_timeout
 from dask_task_models_library.container_tasks.docker import DockerBasicAuth
+from dask_task_models_library.container_tasks.encryption import TransferEncryptionSettings
 from dask_task_models_library.container_tasks.errors import ServiceTimeoutLoggingError
 from dask_task_models_library.container_tasks.protocol import (
     ContainerCommands,
@@ -200,6 +201,7 @@ async def _parse_container_log_file(  # noqa: PLR0913 # pylint: disable=too-many
     log_publishing_cb: LogPublishingCB,
     s3_settings: S3Settings | None,
     progress_bar: ProgressBarData,
+    encryption: TransferEncryptionSettings | None,
 ) -> None:
     log_file = task_volumes.logs_folder / LEGACY_SERVICE_LOG_FILE_NAME
     with log_context(
@@ -244,11 +246,11 @@ async def _parse_container_log_file(  # noqa: PLR0913 # pylint: disable=too-many
                     log_file_url,
                     log_publishing_cb=log_publishing_cb,
                     s3_settings=s3_settings,
-                    encryption=None,
+                    encryption=encryption,
                 )
 
 
-async def _parse_container_docker_logs(
+async def _parse_container_docker_logs(  # noqa: PLR0913 # pylint: disable=too-many-arguments
     *,
     container: DockerContainer,
     progress_regexp: re.Pattern[str],
@@ -260,6 +262,7 @@ async def _parse_container_docker_logs(
     log_publishing_cb: LogPublishingCB,
     s3_settings: S3Settings | None,
     progress_bar: ProgressBarData,
+    encryption: TransferEncryptionSettings | None,
 ) -> None:
     """
 
@@ -340,7 +343,7 @@ async def _parse_container_docker_logs(
                         log_file_url,
                         log_publishing_cb=log_publishing_cb,
                         s3_settings=s3_settings,
-                        encryption=None,
+                        encryption=encryption,
                     )
 
 
@@ -357,6 +360,7 @@ async def _monitor_container_logs(  # noqa: PLR0913 # pylint: disable=too-many-a
     log_publishing_cb: LogPublishingCB,
     s3_settings: S3Settings | None,
     progress_bar: ProgressBarData,
+    encryption: TransferEncryptionSettings | None,
 ) -> None:
     """Services running with integration version 0.0.0 are logging into a file
     that must be available in task_volumes.log / log.dat
@@ -386,6 +390,7 @@ async def _monitor_container_logs(  # noqa: PLR0913 # pylint: disable=too-many-a
                 log_publishing_cb=log_publishing_cb,
                 s3_settings=s3_settings,
                 progress_bar=progress_bar,
+                encryption=encryption,
             )
         else:
             await _parse_container_log_file(
@@ -400,6 +405,7 @@ async def _monitor_container_logs(  # noqa: PLR0913 # pylint: disable=too-many-a
                 log_publishing_cb=log_publishing_cb,
                 s3_settings=s3_settings,
                 progress_bar=progress_bar,
+                encryption=encryption,
             )
 
 
@@ -436,6 +442,7 @@ async def managed_monitor_container_log_task(  # noqa: PLR0913 # pylint: disable
     log_publishing_cb: LogPublishingCB,
     s3_settings: S3Settings | None,
     progress_bar: ProgressBarData,
+    encryption: TransferEncryptionSettings | None,
 ) -> AsyncIterator[Awaitable[None]]:
     """
     Raises:
@@ -463,6 +470,7 @@ async def managed_monitor_container_log_task(  # noqa: PLR0913 # pylint: disable
                 log_publishing_cb=log_publishing_cb,
                 s3_settings=s3_settings,
                 progress_bar=progress_bar,
+                encryption=encryption,
             )
 
         monitoring_task = asyncio.create_task(

--- a/services/dask-sidecar/tests/unit/computational_sidecar_tasks/test_computational_sidecar_tasks_encryption.py
+++ b/services/dask-sidecar/tests/unit/computational_sidecar_tasks/test_computational_sidecar_tasks_encryption.py
@@ -34,6 +34,7 @@ from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.s3 import S3Settings
 from simcore_service_dask_sidecar.utils.aes_gcm import (
     FORMAT_MAGIC,
+    AesGcmStreamAuthError,
     decrypt_stream,
     encrypt_stream,
     generate_key,
@@ -114,6 +115,9 @@ async def test_run_computational_sidecar_with_encryption(
         )
 
     output_url = s3_remote_file_url(file_path="encrypted_output.dat")
+    log_file_url = s3_remote_file_url(file_path="log.dat")
+    log_transfer_settings = job_encryption_context.transfer_settings_for_logs()
+    assert log_transfer_settings is not None
 
     # 2. run a task (through the dask subsystem) that copies the decrypted input to its
     #    output, appends some text and logs a marker line, with encryption enabled
@@ -197,6 +201,28 @@ async def test_run_computational_sidecar_with_encryption(
         f"text added during computation '{computation_marker}' missing from decrypted output"
     )
     mocked_get_image_labels.assert_called()
+
+    # 6. check the log file on S3 is encrypted and can be decrypted with the correct key
+    with fsspec.open(f"{log_file_url}", mode="rb", **s3_storage_kwargs) as fp:
+        encrypted_log = fp.read()  # type: ignore[attr-defined]
+
+    assert encrypted_log.startswith(FORMAT_MAGIC), "log file was not encrypted on S3"
+    assert computation_marker.encode() not in encrypted_log, "log marker leaked as plaintext into the stored log file"
+
+    decrypted_log = _decrypt_to_bytes(
+        encrypted_log,
+        root_key=root_key,
+        file_id=log_transfer_settings.file_id,
+    )
+    assert computation_marker.encode() in decrypted_log
+
+    # wrong key must raise an authentication error
+    with pytest.raises(AesGcmStreamAuthError):
+        _decrypt_to_bytes(
+            encrypted_log,
+            root_key=generate_key(),
+            file_id=log_transfer_settings.file_id,
+        )
 
 
 @pytest.mark.parametrize(

--- a/services/dask-sidecar/tests/unit/computational_sidecar_tasks/test_computational_sidecar_tasks_run.py
+++ b/services/dask-sidecar/tests/unit/computational_sidecar_tasks/test_computational_sidecar_tasks_run.py
@@ -5,6 +5,7 @@
 # pylint: disable=too-many-arguments
 
 import re
+from collections.abc import Callable
 from pprint import pformat
 from unittest import mock
 
@@ -39,7 +40,9 @@ def _assert_log_file_exists_and_contains_expected_logs(
         saved_logs = fp.read()  # type: ignore
     assert saved_logs
     for log in expected_logs:
-        assert log in saved_logs
+        assert log in saved_logs, (
+            f"Could not find '{log}' in log file {log_file_url}:\n {pformat(saved_logs, width=240)}"
+        )
 
 
 @pytest.mark.parametrize("boot_mode, task_owner", [(BootMode.CPU, "no_parent")], indirect=True)
@@ -163,26 +166,35 @@ def test_run_multiple_computational_sidecar_dask(
     dask_client: distributed.Client,
     sleeper_task: ServiceExampleParam,
     mocked_get_image_labels: mock.Mock,
+    s3_remote_file_url: Callable[..., AnyUrl],
+    s3_settings: S3Settings,
 ):
     NUMBER_OF_TASKS = 50
+
+    log_file_urls = [s3_remote_file_url(file_path=f"log_{i}.dat") for i in range(NUMBER_OF_TASKS)]
 
     futures = [
         dask_client.submit(
             run_computational_sidecar,
-            **sleeper_task.sidecar_params(),
+            **{**sleeper_task.sidecar_params(), "log_file_url": log_file_url},
             resources={},
         )
-        for _ in range(NUMBER_OF_TASKS)
+        for log_file_url in log_file_urls
     ]
 
     results = dask_client.gather(futures)
     assert results
     assert isinstance(results, list)
-    # for result in results:
-    # check that the task produce the expected data, not less not more
     for output_data in results:
         for k, v in sleeper_task.expected_output_data.items():
             assert k in output_data
             assert output_data[k] == v
+
+    for log_file_url in log_file_urls:
+        _assert_log_file_exists_and_contains_expected_logs(
+            log_file_url=log_file_url,
+            expected_logs=sleeper_task.expected_logs,
+            s3_settings=s3_settings,
+        )
 
     mocked_get_image_labels.assert_called()

--- a/services/dask-sidecar/tests/unit/computational_sidecar_tasks/test_computational_sidecar_tasks_run.py
+++ b/services/dask-sidecar/tests/unit/computational_sidecar_tasks/test_computational_sidecar_tasks_run.py
@@ -34,7 +34,7 @@ pytest_simcore_core_services_selection = [
 
 def _assert_log_file_exists_and_contains_expected_logs(
     log_file_url: AnyUrl, expected_logs: list[str], s3_settings: S3Settings
-):
+) -> None:
     s3_storage_kwargs = _s3fs_settings_from_s3_settings(s3_settings)
     with fsspec.open(f"{log_file_url}", mode="rt", **s3_storage_kwargs) as fp:
         saved_logs = fp.read()  # type: ignore

--- a/services/dask-sidecar/tests/unit/computational_sidecar_tasks/test_computational_sidecar_tasks_run.py
+++ b/services/dask-sidecar/tests/unit/computational_sidecar_tasks/test_computational_sidecar_tasks_run.py
@@ -13,6 +13,7 @@ import fsspec
 import pytest
 from dask_task_models_library.container_tasks.io import FileUrl, TaskOutputData
 from models_library.services_resources import BootMode
+from pydantic import AnyUrl
 from pytest_simcore.helpers.dask_sidecar_tasks import (
     ServiceExampleParam,
     assert_expected_logs_published_to_rabbit,
@@ -30,6 +31,18 @@ pytest_simcore_core_services_selection = [
 ]
 
 
+def _assert_log_file_exists_and_contains_expected_logs(
+    log_file_url: AnyUrl, expected_logs: list[str], s3_settings: S3Settings
+):
+    s3_storage_kwargs = _s3fs_settings_from_s3_settings(s3_settings)
+    with fsspec.open(f"{log_file_url}", mode="rt", **s3_storage_kwargs) as fp:
+        saved_logs = fp.read()  # type: ignore
+    assert saved_logs
+    for log in expected_logs:
+        assert log in saved_logs
+
+
+@pytest.mark.parametrize("boot_mode, task_owner", [(BootMode.CPU, "no_parent")], indirect=True)
 def test_run_computational_sidecar_real_fct(
     caplog_info_level: pytest.LogCaptureFixture,
     app_environment: EnvVarsDict,
@@ -78,45 +91,16 @@ def test_run_computational_sidecar_real_fct(
             with fsspec.open(f"{v.url}", **s3_storage_kwargs) as fp:
                 assert fp.details.get("size") > 0  # type: ignore
 
-    # check the task has created a log file
-    with fsspec.open(f"{sleeper_task.log_file_url}", mode="rt", **s3_storage_kwargs) as fp:
-        saved_logs = fp.read()  # type: ignore
-    assert saved_logs
-    for log in sleeper_task.expected_logs:
-        assert log in saved_logs
+    _assert_log_file_exists_and_contains_expected_logs(
+        log_file_url=sleeper_task.log_file_url,
+        expected_logs=sleeper_task.expected_logs,
+        s3_settings=s3_settings,
+    )
 
 
-@pytest.mark.parametrize("integration_version, boot_mode", [("1.0.0", BootMode.CPU)], indirect=True)
-def test_run_multiple_computational_sidecar_dask(
-    dask_client: distributed.Client,
-    sleeper_task: ServiceExampleParam,
-    mocked_get_image_labels: mock.Mock,
-):
-    NUMBER_OF_TASKS = 50
-
-    futures = [
-        dask_client.submit(
-            run_computational_sidecar,
-            **sleeper_task.sidecar_params(),
-            resources={},
-        )
-        for _ in range(NUMBER_OF_TASKS)
-    ]
-
-    results = dask_client.gather(futures)
-    assert results
-    assert isinstance(results, list)
-    # for result in results:
-    # check that the task produce the expected data, not less not more
-    for output_data in results:
-        for k, v in sleeper_task.expected_output_data.items():
-            assert k in output_data
-            assert output_data[k] == v
-
-    mocked_get_image_labels.assert_called()
-
-
-@pytest.mark.parametrize("integration_version, boot_mode", [("1.0.0", BootMode.CPU)], indirect=True)
+@pytest.mark.parametrize(
+    "integration_version, boot_mode, task_owner", [("1.0.0", BootMode.CPU, "no_parent")], indirect=True
+)
 async def test_run_computational_sidecar_dask(
     app_environment: EnvVarsDict,
     sleeper_task: ServiceExampleParam,
@@ -162,4 +146,43 @@ async def test_run_computational_sidecar_dask(
         if isinstance(v, FileUrl):
             with fsspec.open(f"{v.url}", **s3_storage_kwargs) as fp:
                 assert fp.details.get("size") > 0  # type: ignore
+
+    _assert_log_file_exists_and_contains_expected_logs(
+        log_file_url=sleeper_task.log_file_url,
+        expected_logs=sleeper_task.expected_logs,
+        s3_settings=s3_settings,
+    )
+
+    mocked_get_image_labels.assert_called()
+
+
+@pytest.mark.parametrize(
+    "integration_version, boot_mode, task_owner", [("1.0.0", BootMode.CPU, "no_parent")], indirect=True
+)
+def test_run_multiple_computational_sidecar_dask(
+    dask_client: distributed.Client,
+    sleeper_task: ServiceExampleParam,
+    mocked_get_image_labels: mock.Mock,
+):
+    NUMBER_OF_TASKS = 50
+
+    futures = [
+        dask_client.submit(
+            run_computational_sidecar,
+            **sleeper_task.sidecar_params(),
+            resources={},
+        )
+        for _ in range(NUMBER_OF_TASKS)
+    ]
+
+    results = dask_client.gather(futures)
+    assert results
+    assert isinstance(results, list)
+    # for result in results:
+    # check that the task produce the expected data, not less not more
+    for output_data in results:
+        for k, v in sleeper_task.expected_output_data.items():
+            assert k in output_data
+            assert output_data[k] == v
+
     mocked_get_image_labels.assert_called()

--- a/services/dask-sidecar/tests/unit/test_utils_aes_gcm.py
+++ b/services/dask-sidecar/tests/unit/test_utils_aes_gcm.py
@@ -367,7 +367,7 @@ def test_encrypt_reads_are_bounded_by_chunk_size(root_key: bytes, context: dict[
     # every explicit read is bounded by chunk_size: the whole file is never read at once
     assert recorder.read_sizes
     assert all(size == chunk_size for size in recorder.read_sizes)
-    assert max(recorder.read_sizes) < len(plaintext)  # pyright: ignore[reportArgumentType]
+    assert max(size for size in recorder.read_sizes if size is not None) < len(plaintext)
 
 
 def test_decrypt_reads_are_bounded(root_key: bytes, context: dict[str, str]):


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Base encryption/decryption tooling was added by https://github.com/ITISFoundation/osparc-simcore/pull/9260 in the dask-sidecar.
Director-v2 wiring was added in https://github.com/ITISFoundation/osparc-simcore/pull/9329.
API-server wiring was added in https://github.com/ITISFoundation/osparc-simcore/pull/9354.

This PR adds sidecar log file encryption. **NOTE:** The live logs are still plain

The file_id used for this is currently "service-logs".

**Current limitations**
- no vault used yet, root key is transmitted via DB + Dask tooling to the underlying computational cluster
- multi-tasks pipelines are not currently automatically handled

**Next steps**
- C++ client: @matusdrobuliak66
- Key-at-rest storage + modifications to retrieve from vault: persist the job-key securely in a vault
- logs encryption (live logs)
- asymetric encryption of job key
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/private-issues/issues/594

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
