### PR TITLE
🐛 fix(catalog): register RPC API after director client is initialized

### DIFF
--- a/services/catalog/src/simcore_service_catalog/core/application.py
+++ b/services/catalog/src/simcore_service_catalog/core/application.py
@@ -45,10 +45,11 @@ def _configure_plugins(
     )
     configure_default_product_name(app_lifespan)
     configure_rabbitmq_client(app_lifespan, settings=settings.CATALOG_RABBITMQ)
-    configure_rpc_api(app_lifespan)
     configure_director(app_lifespan)
     configure_function_services(app_lifespan)
     configure_background_tasks(app_lifespan)
+
+    configure_rpc_api(app_lifespan)
 
     if settings.CATALOG_PROMETHEUS_INSTRUMENTATION_ENABLED:
         configure_prometheus_instrumentation(app, app_lifespan)

--- a/services/catalog/tests/unit/test_core_application.py
+++ b/services/catalog/tests/unit/test_core_application.py
@@ -1,0 +1,35 @@
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+
+
+from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from servicelib.tracing import TracingConfig
+from simcore_service_catalog._meta import APP_NAME
+from simcore_service_catalog.core.application import _configure_plugins
+from simcore_service_catalog.core.settings import ApplicationSettings
+
+
+def test_rpc_api_is_registered_after_director(app_environment: EnvVarsDict):
+    settings = ApplicationSettings.create_from_envs()
+    app = FastAPI()
+    app.state.settings = settings
+    app_lifespan = LifespanManager()
+
+    _configure_plugins(
+        app,
+        app_lifespan,
+        settings,
+        TracingConfig.create(service_name=APP_NAME, tracing_settings=None),
+    )
+
+    names = [getattr(fn, "__name__", "") for fn in app_lifespan.lifespans]
+
+    assert "director_lifespan" in names
+    assert "rpc_api_lifespan" in names
+    assert names.index("director_lifespan") < names.index("rpc_api_lifespan"), (
+        "RPC inbound adapter must be registered AFTER director so it only "
+        "starts consuming once app.state.director_api exists (see issue #9390)"
+    )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

> [!CAUTION]
> This PR **partially** addresses the issue mentioned below.

Reorders the catalog lifespan registration so the RPC inbound adapter (`configure_rpc_api`) is activated **last**, after all of its dependencies (`postgres`, `rabbitmq`, `director`) have been initialized.

Previously `configure_rpc_api` was registered *before* `configure_director`.
Because `fastapi_lifespan_manager` runs lifespans sequentially in add-order, the RPC router — and therefore the RabbitMQ consumer — started consuming `catalog.list_services_paginated` messages *before* `app.state.director_api` was set by `director_lifespan` (which can take up to 2 mins ⚠️ due to its startup retry loop). Any RPC call arriving in that window failed with:

`AttributeError: 'State' object has no attribute 'director_api'`

Moving the RPC registration to the end guarantees `director_api` (and the DB engine / rabbitmq client) exist before the consumer goes live.

## Related issue/s
- relates to #9390 (server-side `director_api` not initialized).

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
No changes.