### PR TITLE
 🔨 Enhanced `scripts/i18` tooling, specially for the front-end workflow

### DIFF
--- a/scripts/i18n/Makefile
+++ b/scripts/i18n/Makefile
@@ -16,7 +16,7 @@
 #
 # Frontend catalog (full pipeline):
 #   make frontend-all       # frontend-extract -> frontend-translate
-#   make frontend-extract   # xgettext this.tr() -> frontend.pot (+enrich)
+#   make frontend-extract   # xgettext this.tr() + json guided-tours -> frontend.pot (+enrich)
 #   make frontend-plan      # dry-run: log the LLM prompts that WOULD be sent (no call, no save)
 #   make frontend-translate # msgmerge + AI translate frontend catalogs from frontend.pot
 #
@@ -74,8 +74,17 @@ CLIENT_DIR          := $(REPO_ROOT)/services/static-webserver/client
 # git-blame), matching the backend convention instead of embedding absolute paths.
 CLIENT_SRC_REL      := services/static-webserver/client/source/class
 CLIENT_TRANS_DIR    := $(CLIENT_DIR)/source/translation
+FRONTEND_PARTIALS_DIR := $(CLIENT_TRANS_DIR)/_partials
 FRONTEND_POT        := $(CLIENT_TRANS_DIR)/frontend.pot
 CLIENT_LANGS        ?= es_ES zh_CN
+
+# --- Guided tours JSON resources (extracted via json_cmd, not xgettext) ---
+# Data loaded at runtime (osparc.tours.Manager/List/Step), so their
+# user-facing strings are invisible to xgettext's this.tr() scan. Only the
+# listed keys hold user-facing text; id/context/anchorEl/selector/placement/
+# action/beforeClick are wiring and must never be extracted.
+TOURS_DIR_REL    := services/static-webserver/client/source/resource/osparc/tours
+JSON_TOURS_KEYS  := name,description,title,text
 
 # --- Flag helpers ---
 ifeq ($(USE_GIT),true)
@@ -205,16 +214,25 @@ $(LOCALE_OUT_DIR)/%/LC_MESSAGES/messages.mo: $(LOCALE_OUT_DIR)/%/LC_MESSAGES/mes
 frontend-all: frontend-extract frontend-translate  ## Frontend catalog: extract -> translate
 
 # ---------------------------------------------------------------------------
-# frontend-extract — extract this.tr() strings from qooxdoo frontend into the
-# frontend-owned frontend.pot, then enrich with source context.
+# frontend-extract — gather this.tr() (qooxdoo JS) + guided-tours JSON values
+# into per-source _partials/*.pot, msgcat them into the frontend-owned
+# frontend.pot, then enrich with source context. Kept strictly separate from
+# the backend `messages` catalog (see header note).
 # ---------------------------------------------------------------------------
-frontend-extract:  ## Extract frontend this.tr() -> frontend.pot (+enrich)
-	@echo "  [extract] frontend JS -> $(FRONTEND_POT)"
-	@mkdir -p $(CLIENT_TRANS_DIR)
+frontend-extract:  ## Extract frontend this.tr() + guided-tours JSON -> frontend.pot (+enrich)
+	@mkdir -p $(FRONTEND_PARTIALS_DIR)
+	@echo "  [extract] frontend JS -> $(FRONTEND_PARTIALS_DIR)/frontend-js.pot"
 	@cd $(REPO_ROOT) && $(EXTRACTOR) xgettext \
 	  --src $(CLIENT_SRC_REL) \
-	  --out $(FRONTEND_POT) \
+	  --out $(FRONTEND_PARTIALS_DIR)/frontend-js.pot \
 	  --langs javascript
+	@echo "  [extract] guided tours JSON -> $(FRONTEND_PARTIALS_DIR)/frontend-tours.pot"
+	@cd $(REPO_ROOT) && $(EXTRACTOR) json \
+	  --src $(TOURS_DIR_REL) \
+	  --keys $(JSON_TOURS_KEYS) \
+	  --out $(FRONTEND_PARTIALS_DIR)/frontend-tours.pot
+	@echo "  [merge] frontend _partials/*.pot -> $(FRONTEND_POT)"
+	msgcat --use-first $(FRONTEND_PARTIALS_DIR)/*.pot -o $(FRONTEND_POT)
 	@echo "  [enrich] frontend source context -> $(FRONTEND_POT)"
 	@cd $(REPO_ROOT) && $(EXTRACTOR) enrich --pot $(FRONTEND_POT) --repo-root $(REPO_ROOT)
 
@@ -291,7 +309,7 @@ check-i18n-style:  ## Validate no f-strings in user_message() calls (all I18N_DI
 # versioned (human/AI-reviewed translations) and are NEVER deleted here.
 # ---------------------------------------------------------------------------
 clean:  ## Remove regenerable artifacts (_partials/, *.pot, *.mo); keeps versioned .po
-	rm -rf $(PARTIALS_DIR)
+	rm -rf $(PARTIALS_DIR) $(FRONTEND_PARTIALS_DIR)
 	rm -f $(POT) $(FRONTEND_POT)
 	rm -f $(MO_FILES)
 

--- a/scripts/i18n/Makefile
+++ b/scripts/i18n/Makefile
@@ -162,7 +162,7 @@ backend-plan:  ## Dry-run backend: log LLM prompts that WOULD be sent (no call, 
 	  in_po_flag=""; \
 	  if [ -f "$$po" ]; then in_po_flag="--in-po $$po"; fi; \
 	  uv run $(I18N_TOOLS)/i18n_translator.py translate \
-	    --plan --pot $(POT) $$in_po_flag --lang $$lang --out $$po; \
+	    --dry-run --pot $(POT) $$in_po_flag --lang $$lang --out $$po; \
 	done
 
 # ---------------------------------------------------------------------------
@@ -233,7 +233,7 @@ frontend-plan:  ## Dry-run frontend: log LLM prompts that WOULD be sent (no call
 	  in_po_flag=""; \
 	  if [ -f "$$po" ]; then in_po_flag="--in-po $$po"; fi; \
 	  uv run $(I18N_TOOLS)/i18n_translator.py translate \
-	    --plan --pot $(FRONTEND_POT) $$in_po_flag --lang $$lang --out $$po; \
+	    --dry-run --pot $(FRONTEND_POT) $$in_po_flag --lang $$lang --out $$po; \
 	done
 
 # ---------------------------------------------------------------------------

--- a/scripts/i18n/Makefile
+++ b/scripts/i18n/Makefile
@@ -29,17 +29,17 @@ PARTIALS_DIR   := $(LOCALE_OUT_DIR)/_partials
 ENV_FILE       := $(REPO_ROOT)/.env
 
 # --- Backend configuration ---
-LANGS            ?= zh_CN es_ES
+LANGS            ?= zh_CN es_ES               ## Backend target locales (space-separated locale codes)
 POT              := $(LOCALE_OUT_DIR)/messages.pot
 PO_FILES         := $(foreach lang,$(LANGS),$(LOCALE_OUT_DIR)/$(lang)/LC_MESSAGES/messages.po)
 MO_FILES         := $(PO_FILES:.po=.mo)
-MODEL            ?= openai/gpt-4o
-BASE_URL         ?=
-PARALLEL         ?= false
-PROGRESS         ?= true
-INCREMENTAL_SAVE ?= true
-USE_GIT          ?= true
-MAX_WORKERS      ?= 4
+MODEL            ?= openai/gpt-4o             ## LLM model id (provider/model) used for translation
+BASE_URL         ?=                           ## Custom OpenAI-compatible API base URL (empty = provider default)
+PARALLEL         ?= false                     ## Translate entries in parallel
+PROGRESS         ?= true                      ## Show progress bar during translation
+INCREMENTAL_SAVE ?= true                      ## Save .po incrementally as entries are translated
+USE_GIT          ?= true                      ## Use git blame for source-context enrichment
+MAX_WORKERS      ?= 4                         ## Max parallel workers when PARALLEL=true
 TRANSLATE_TS     := $(shell date +%Y%m%dT%H%M%S)
 
 # --- Services/packages containing user_message() calls ---
@@ -76,7 +76,7 @@ CLIENT_SRC_REL      := services/static-webserver/client/source/class
 CLIENT_TRANS_DIR    := $(CLIENT_DIR)/source/translation
 FRONTEND_PARTIALS_DIR := $(CLIENT_TRANS_DIR)/_partials
 FRONTEND_POT        := $(CLIENT_TRANS_DIR)/frontend.pot
-CLIENT_LANGS        ?= es_ES zh_CN
+CLIENT_LANGS        ?= es_ES zh_CN            ## Frontend target locales (space-separated locale codes)
 
 # --- Guided tours JSON resources (extracted via json_cmd, not xgettext) ---
 # Data loaded at runtime (osparc.tours.Manager/List/Step), so their
@@ -121,11 +121,24 @@ EXTRACTOR  := uv run $(I18N_TOOLS)/i18n_extractor.py
 TRANSLATOR := uv run --env-file $(ENV_FILE) $(I18N_TOOLS)/i18n_translator.py
 
 # ---------------------------------------------------------------------------
+# Step header — bold-yellow "[TAG] message" banner printed before each
+# pipeline step, so Makefile-level step boundaries stay legible against the
+# rich-based Python CLI's own colors (i18n_extractor.py / i18n_translator.py
+# use cyan for [translate]/NEW, green for translated counts/"->", yellow
+# foreground for UPDATED, and Rich auto-highlights paths/filenames in magenta
+# and numbers in cyan). Bold yellow reads as "step info", not error, and
+# doesn't collide with any of those. Usage: $(call STEP,TAG,message text)
+# with TAG always uppercase (EXTRACT, MERGE, ENRICH, PLAN, TRANSLATE,
+# COMPILE, VALIDATE).
+# ---------------------------------------------------------------------------
+STEP = printf '\033[1;33m[%s]\033[0m %s\n' "$(1)" "$(2)"
+
+# ---------------------------------------------------------------------------
 .DEFAULT_GOAL := help
 
 .PHONY: backend-all backend-extract backend-plan backend-translate backend-compile \
         frontend-all frontend-extract frontend-plan frontend-translate \
-        check-i18n-style clean
+        check-i18n-style clean vars
 
 # ===========================================================================
 # BACKEND catalog  (messages.pot / messages.po / messages.mo)
@@ -144,19 +157,20 @@ backend-extract:  ## Extract backend user_message() + {% trans %} -> messages.po
 	@for dir in $(I18N_DIRS); do \
 	  name=$$(basename $$dir); \
 	  out=$(PARTIALS_DIR)/$$name.pot; \
-	  echo "  [extract] $(REPO_ROOT)/$$dir/src -> $$out"; \
+	  $(call STEP,EXTRACT,$(REPO_ROOT)/$$dir/src -> $$out); \
 	  cd $(REPO_ROOT) && $(EXTRACTOR) xgettext \
 	    --src $$dir/src \
 	    --out $$out \
 	    --langs python; \
 	done
-	@echo "  [extract] notifications Jinja2 templates -> $(PARTIALS_DIR)/notifications-templates.pot"
+	@$(call STEP,EXTRACT,notifications Jinja2 templates -> $(PARTIALS_DIR)/notifications-templates.pot)
 	@cd $(REPO_ROOT) && $(EXTRACTOR) jinja \
 	  --src $(NOTIFICATIONS_TEMPLATES_DIR) \
 	  --out $(PARTIALS_DIR)/notifications-templates.pot
-	@echo "  [merge] backend _partials/*.pot -> $(POT)"
+	@$(call STEP,MERGE,backend _partials/*.pot -> $(POT))
 	@mkdir -p $(LOCALE_OUT_DIR)
 	msgcat --use-first $(PARTIALS_DIR)/*.pot -o $(POT)
+	@$(call STEP,ENRICH,$(POT))
 	$(EXTRACTOR) enrich --pot $(POT) --repo-root $(REPO_ROOT)
 
 # ---------------------------------------------------------------------------
@@ -166,7 +180,7 @@ backend-extract:  ## Extract backend user_message() + {% trans %} -> messages.po
 # ---------------------------------------------------------------------------
 backend-plan:  ## Dry-run backend: log LLM prompts that WOULD be sent (no call, no save)
 	@for lang in $(LANGS); do \
-	  echo "  [plan] backend $$lang"; \
+	  $(call STEP,PLAN,backend $$lang); \
 	  po=$(LOCALE_OUT_DIR)/$$lang/LC_MESSAGES/messages.po; \
 	  in_po_flag=""; \
 	  if [ -f "$$po" ]; then in_po_flag="--in-po $$po"; fi; \
@@ -186,6 +200,7 @@ $(LOCALE_OUT_DIR)/%/LC_MESSAGES/messages.po: $(POT)
 	else \
 	  msginit --no-translator --input="$(POT)" --locale="$*" --output-file="$@"; \
 	fi
+	@$(call STEP,TRANSLATE,backend $* -> $@)
 	$(TRANSLATOR) translate \
 	  --pot $(POT) \
 	  --in-po $@ \
@@ -206,6 +221,7 @@ $(LOCALE_OUT_DIR)/%/LC_MESSAGES/messages.po: $(POT)
 backend-compile: $(MO_FILES)  ## Compile backend .po -> .mo
 
 $(LOCALE_OUT_DIR)/%/LC_MESSAGES/messages.mo: $(LOCALE_OUT_DIR)/%/LC_MESSAGES/messages.po
+	@$(call STEP,COMPILE,$< -> $@)
 	msgfmt $< -o $@
 
 # ===========================================================================
@@ -221,19 +237,19 @@ frontend-all: frontend-extract frontend-translate  ## Frontend catalog: extract 
 # ---------------------------------------------------------------------------
 frontend-extract:  ## Extract frontend this.tr() + guided-tours JSON -> frontend.pot (+enrich)
 	@mkdir -p $(FRONTEND_PARTIALS_DIR)
-	@echo "  [extract] frontend JS -> $(FRONTEND_PARTIALS_DIR)/frontend-js.pot"
+	@$(call STEP,EXTRACT,frontend JS -> $(FRONTEND_PARTIALS_DIR)/frontend-js.pot)
 	@cd $(REPO_ROOT) && $(EXTRACTOR) xgettext \
 	  --src $(CLIENT_SRC_REL) \
 	  --out $(FRONTEND_PARTIALS_DIR)/frontend-js.pot \
 	  --langs javascript
-	@echo "  [extract] guided tours JSON -> $(FRONTEND_PARTIALS_DIR)/frontend-tours.pot"
+	@$(call STEP,EXTRACT,guided tours JSON -> $(FRONTEND_PARTIALS_DIR)/frontend-tours.pot)
 	@cd $(REPO_ROOT) && $(EXTRACTOR) json \
 	  --src $(TOURS_DIR_REL) \
 	  --keys $(JSON_TOURS_KEYS) \
 	  --out $(FRONTEND_PARTIALS_DIR)/frontend-tours.pot
-	@echo "  [merge] frontend _partials/*.pot -> $(FRONTEND_POT)"
+	@$(call STEP,MERGE,frontend _partials/*.pot -> $(FRONTEND_POT))
 	msgcat --use-first $(FRONTEND_PARTIALS_DIR)/*.pot -o $(FRONTEND_POT)
-	@echo "  [enrich] frontend source context -> $(FRONTEND_POT)"
+	@$(call STEP,ENRICH,frontend source context -> $(FRONTEND_POT))
 	@cd $(REPO_ROOT) && $(EXTRACTOR) enrich --pot $(FRONTEND_POT) --repo-root $(REPO_ROOT)
 
 # ---------------------------------------------------------------------------
@@ -246,7 +262,7 @@ frontend-plan:  ## Dry-run frontend: log LLM prompts that WOULD be sent (no call
 	    zh_CN) out_lang=zh ;; \
 	    *) out_lang=$$lang ;; \
 	  esac; \
-	  echo "  [plan] frontend $$lang"; \
+	  $(call STEP,PLAN,frontend $$lang); \
 	  po=$(CLIENT_TRANS_DIR)/$$out_lang.po; \
 	  in_po_flag=""; \
 	  if [ -f "$$po" ]; then in_po_flag="--in-po $$po"; fi; \
@@ -270,7 +286,7 @@ frontend-translate:  ## msgmerge + AI translate frontend .po files (CLIENT_LANGS
 	    *) out_lang=$$lang ;; \
 	  esac; \
 	  out=$(CLIENT_TRANS_DIR)/$$out_lang.po; \
-	  echo "  [translate] frontend $$lang -> $$out"; \
+	  $(call STEP,TRANSLATE,frontend $$lang -> $$out); \
 	  if [ -f "$$out" ]; then \
 	    msgmerge --update --backup=none "$$out" "$(FRONTEND_POT)"; \
 	  else \
@@ -296,11 +312,25 @@ frontend-translate:  ## msgmerge + AI translate frontend .po files (CLIENT_LANGS
 # ===========================================================================
 
 # ---------------------------------------------------------------------------
+# vars — list configurable variables (the ones declared with '?=' above),
+# parsed straight from this file's source so the doc can never drift from the
+# actual defaults. Shows the DECLARED default (not the live resolved value),
+# mirroring how help.mk parses '## description' comments for targets.
+# ---------------------------------------------------------------------------
+vars:  ## List configurable variables (override via 'make VAR=value ...')
+	@echo "Configurable variables for '$(notdir $(CURDIR))' (override via 'make VAR=value ...'):"
+	@echo ""
+	@grep -hE '^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\?=.*##' $(MAKEFILE_LIST) | \
+	  sed -E 's/^([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*\?=[[:space:]]*(.*)##[[:space:]]*(.*)$$/\1|\2|\3/' | \
+	  awk -F'|' '{gsub(/[[:space:]]+$$/, "", $$2); printf "  \033[36m%-18s\033[0m default=%-20s %s\n", $$1, ($$2==""?"(empty)":$$2), $$3}'
+	@echo ""
+
+# ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
 check-i18n-style:  ## Validate no f-strings in user_message() calls (all I18N_DIRS)
 	@for dir in $(I18N_DIRS); do \
-	  echo "  [validate] $$dir"; \
+	  $(call STEP,VALIDATE,$$dir); \
 	  cd $(REPO_ROOT) && $(EXTRACTOR) validate --src $$dir/src --langs python; \
 	done
 

--- a/scripts/i18n/README.md
+++ b/scripts/i18n/README.md
@@ -153,12 +153,12 @@ The versioned `.po` files (reviewed translations) are **never** deleted by `clea
 Any standard `.po` editor works — the `CTX-*` fields appear as normal translator
 comments and are fully editable:
 
-```markdown
+- [**weblate**](https://github.com/WeblateOrg/weblate/)  —  web-based continuous localization system
 - [**Poedit**](https://poedit.net) — GUI, shows `CTX-SNIPPET` and `CTX-INTERPRETATION` in the sidebar
 - [**Gtranslator**](https://wiki.gnome.org/Apps/Gtranslator) — GNOME desktop editor
 - [**Virtaal**](http://virtaal.translatehouse.org) — lightweight cross-platform option
 - [**VS Code**](https://code.visualstudio.com) — plugins as [*i18n Ally*](https://marketplace.visualstudio.com/items?itemName=lokalise.i18n-ally)
-```
+
 
 ## References
 

--- a/scripts/i18n/README.md
+++ b/scripts/i18n/README.md
@@ -153,7 +153,14 @@ The versioned `.po` files (reviewed translations) are **never** deleted by `clea
 Any standard `.po` editor works — the `CTX-*` fields appear as normal translator
 comments and are fully editable:
 
-- **Poedit** — GUI, shows `CTX-SNIPPET` and `CTX-INTERPRETATION` in the sidebar
-- **Gtranslator** — GNOME desktop editor
-- **Virtaal** — lightweight cross-platform option
-- **VS Code** — install the *i18n Ally* or *gettext* extension for inline review
+```markdown
+- [**Poedit**](https://poedit.net) — GUI, shows `CTX-SNIPPET` and `CTX-INTERPRETATION` in the sidebar
+- [**Gtranslator**](https://wiki.gnome.org/Apps/Gtranslator) — GNOME desktop editor
+- [**Virtaal**](http://virtaal.translatehouse.org) — lightweight cross-platform option
+- [**VS Code**](https://code.visualstudio.com) — plugins as [*i18n Ally*](https://marketplace.visualstudio.com/items?itemName=lokalise.i18n-ally)
+```
+
+## References
+
+- [GNU `gettext` utilities](https://www.gnu.org/software/gettext/manual/html_node/index.html)
+- [`polib` library](https://github.com/izimobil/polib)

--- a/scripts/i18n/README.md
+++ b/scripts/i18n/README.md
@@ -81,15 +81,10 @@ make -C scripts/i18n frontend-plan
 
 ## Key Variables
 
-| Variable       | Default         | Description                             |
-| -------------- | --------------- | --------------------------------------- |
-| `LANGS`        | `zh_CN es_ES`   | Backend locale codes to translate       |
-| `CLIENT_LANGS` | `es_ES zh_CN`   | Frontend locale codes to translate      |
-| `MODEL`        | `openai/gpt-4o` | LiteLLM model string                    |
-| `BASE_URL`     | _(empty)_       | Custom LLM endpoint (e.g. local Ollama) |
-| `PARALLEL`     | `false`         | Enable parallel translation workers     |
-| `MAX_WORKERS`  | `4`             | Worker count when `PARALLEL=true`       |
-| `USE_GIT`      | `true`          | Skip already-committed translations     |
+Run `make -C scripts/i18n vars` to list all configurable variables (defaults +
+descriptions) straight from the Makefile — no need to keep a separate table
+here in sync.
+
 
 ## Model
 

--- a/scripts/i18n/tools/i18n_extractor.py
+++ b/scripts/i18n/tools/i18n_extractor.py
@@ -49,6 +49,9 @@ console = Console()
 LANG_MAP = {
     ".py": "Python",
     ".js": "JavaScript",  # qooxdoo frontend
+    ".ts": "JavaScript",  # rocket frontend; xgettext has no TypeScript language
+    ".tsx": "JavaScript",
+    ".jsx": "JavaScript",
     ".cpp": "C++",
     ".cxx": "C++",
     ".cc": "C++",
@@ -61,7 +64,8 @@ TRANSLATION_FUNC_NAMES = {
     "_",
     "user_message",  # osparc
     "gettext",
-    "tr",
+    "tr",  # qooxdoo frontend
+    "t",  # rocket frontend
     "QT_TR_NOOP",
 }
 
@@ -82,11 +86,13 @@ def run_xgettext(src_files: list[Path], out_pot: Path) -> bool:
 
     cmd = [
         # Extract translatable strings from given input files
+        # SEE https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html
         "xgettext",
         "--keyword=_",
         "--keyword=gettext",
         "--keyword=user_message",  # osparc marker
         "--keyword=tr",  # Qt / MFC
+        "--keyword=t",  # rocket
         "--keyword=QT_TR_NOOP",  # Qt no-op marker
         "--add-comments=@TRANSLATOR",
         "--from-code=UTF-8",
@@ -262,7 +268,7 @@ def validate_no_fstring_translations(src_files: list[Path]) -> bool:  # noqa: C9
     return False
 
 
-def _extract_hints_from_file(path: Path) -> dict[str, str]:
+def _extract_hints_from_python_file(path: Path) -> dict[str, str]:
     """Return {msgid: hint} from ``user_message(_hint=...)`` calls in a single Python file."""
     try:
         source = path.read_text(encoding="utf-8", errors="replace")
@@ -305,7 +311,7 @@ def collect_py_hints(src_files: list[Path]) -> dict[str, str]:
         if path.suffix.lower() != ".py":
             continue
 
-        for msgid, hint in _extract_hints_from_file(path).items():
+        for msgid, hint in _extract_hints_from_python_file(path).items():
             if msgid in hints and hints[msgid] != hint:
                 console.print(f"  [warn] {path}: duplicate _hint for msgid {msgid!r} (keeping first occurrence)")
             else:

--- a/scripts/i18n/tools/i18n_extractor.py
+++ b/scripts/i18n/tools/i18n_extractor.py
@@ -542,6 +542,7 @@ class _StatusHighlighter(RegexHighlighter):
 console = Console(
     highlighter=_StatusHighlighter(),
     theme=Theme({"status_done": "bold green", "status_error": "bold red", "status_warn": "yellow"}),
+    markup=False,  # brackets like [done]/[error] are literal status tags, not Rich markup
 )
 
 

--- a/scripts/i18n/tools/i18n_extractor.py
+++ b/scripts/i18n/tools/i18n_extractor.py
@@ -275,7 +275,7 @@ def validate_no_fstring_translations(src_files: list[Path]) -> bool:  # noqa: C9
     return False
 
 
-def _extract_hints_from_python_file(path: Path) -> dict[str, str]:
+def _extract_hints_from_file(path: Path) -> dict[str, str]:
     """Return {msgid: hint} from ``user_message(_hint=...)`` calls in a single Python file."""
     try:
         source = path.read_text(encoding="utf-8", errors="replace")
@@ -304,7 +304,7 @@ def _extract_hints_from_python_file(path: Path) -> dict[str, str]:
     return hints
 
 
-def collect_py_hints(src_files: list[Path]) -> dict[str, str]:
+def collect_python_hints(src_files: list[Path]) -> dict[str, str]:
     """Scan Python source files and return {msgid: hint} from ``user_message(_hint=...)`` calls.
 
     Only plain string literals are accepted for both ``msg`` and ``_hint``
@@ -318,7 +318,7 @@ def collect_py_hints(src_files: list[Path]) -> dict[str, str]:
         if path.suffix.lower() != ".py":
             continue
 
-        for msgid, hint in _extract_hints_from_python_file(path).items():
+        for msgid, hint in _extract_hints_from_file(path).items():
             if msgid in hints and hints[msgid] != hint:
                 console.print(f"  [warn] {path}: duplicate _hint for msgid {msgid!r} (keeping first occurrence)")
             else:
@@ -433,7 +433,7 @@ def enrich(pot_path: Path, repo_root: Path, py_hints: dict[str, str] | None = No
         py_files = sorted(
             {repo_root / filepath for entry in po for filepath, _ in entry.occurrences if filepath.endswith(".py")}
         )
-        py_hints = collect_py_hints([f for f in py_files if f.exists()])
+        py_hints = collect_python_hints([f for f in py_files if f.exists()])
         if py_hints:
             console.print(f"  [hints] {len(py_hints)} _hint value(s) collected from Python sources")
 

--- a/scripts/i18n/tools/i18n_extractor.py
+++ b/scripts/i18n/tools/i18n_extractor.py
@@ -253,7 +253,7 @@ def run_babel_jinja(src_dir: Path, out_pot: Path) -> bool:
 # correctly handle string escaping. Keys not in *keys* (id, context, anchorEl,
 # selector, placement, action, ...) are wiring and are skipped.
 
-_JSON_KV_LINE_RE = re.compile(r'^\s*"(?P<key>[^"]+)"\s*:\s*(?P<val>"(?:[^"\\]|\\.)*")\s*,?\s*$')
+_JSON_KV_LINE_RE: Final[re.Pattern[str]] = re.compile(r'^\s*"(?P<key>[^"]+)"\s*:\s*(?P<val>"(?:[^"\\]|\\.)*")\s*,?\s*$')
 
 
 def run_json_keys(src_dir: Path, out_pot: Path, keys: set[str], pattern: str) -> bool:

--- a/scripts/i18n/tools/i18n_extractor.py
+++ b/scripts/i18n/tools/i18n_extractor.py
@@ -22,6 +22,14 @@ Two-step .pot extractor:
                      so Babel's jinja2.ext.babel_extract is used. Produces a
                      .pot with the same #: filepath:lineno references.
 
+    Step 1c — json: extract translatable string values from JSON resource
+                     files (e.g. frontend guided tours) by key. These strings
+                     are data loaded at runtime, not literal tr()/gettext()
+                     calls, so neither xgettext nor Babel can see them.
+                     Extraction is line-based (one "key": "value" pair per
+                     line), which yields exact #: filepath:lineno references
+                     and lets json.loads() handle string unescaping.
+
     Step 2 — enrich: for each entry, read #: references to load
                      surrounding source lines (CTX-SNIPPET) and write a
              extractor-owned snippet freshness marker (CTX-SNIPPET-VERSION).
@@ -30,11 +38,14 @@ Usage:
     uv run tools/i18n_extractor.py extract --src src/ --out messages.pot
     uv run tools/i18n_extractor.py xgettext --src src/ --langs python,cpp --out messages.pot
     uv run tools/i18n_extractor.py jinja --src src/templates --out templates.pot
+    uv run tools/i18n_extractor.py json --src src/resource/tours --keys name,description,title,text --out tours.pot
     uv run tools/i18n_extractor.py enrich --pot messages.pot
     uv run tools/i18n_extractor.py validate --src src/
 """
 
 import ast
+import json
+import re
 import subprocess
 from pathlib import Path
 from typing import Final
@@ -219,6 +230,84 @@ def run_babel_jinja(src_dir: Path, out_pot: Path) -> bool:
     out_pot.parent.mkdir(parents=True, exist_ok=True)
     pot.save(str(out_pot))
     console.print(f"  [jinja] {len(pot)} entry/ies -> {out_pot}")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Step 1c: JSON-value extraction (e.g. frontend guided tours)
+# ---------------------------------------------------------------------------
+#
+# Guided tours (services/static-webserver/client/source/resource/osparc/tours/
+# *_tours.json) are data loaded at runtime, so their user-facing strings are
+# NOT reachable by xgettext (which only sees literal tr() calls in .js).
+# This step reads JSON files and pulls out the *values* of a given set of
+# keys (e.g. name/description/title/text), emitting a .pot the same shape as
+# the xgettext/jinja outputs so it merges into the frontend catalog. Runtime
+# translation is expected to happen at the consumption points by wrapping the
+# fetched values in qx.locale.Manager.tr(...) (a catalog lookup by msgid) --
+# that wiring is out of scope for this extractor.
+#
+# Extraction is line-based: every translatable "key": "value" pair is expected
+# on its own line (as produced by standard JSON formatting), which yields an
+# accurate source-line reference for `enrich` and lets the JSON decoder
+# correctly handle string escaping. Keys not in *keys* (id, context, anchorEl,
+# selector, placement, action, ...) are wiring and are skipped.
+
+_JSON_KV_LINE_RE = re.compile(r'^\s*"(?P<key>[^"]+)"\s*:\s*(?P<val>"(?:[^"\\]|\\.)*")\s*,?\s*$')
+
+
+def run_json_keys(src_dir: Path, out_pot: Path, keys: set[str], pattern: str) -> bool:
+    """Extract translatable string values for *keys* from JSON files under *src_dir*.
+
+    Only lines matching "key": "value" (one pair per line) are considered, so
+    a #: reference always resolves to the exact line. Returns True on success,
+    False when no files match *pattern* under *src_dir*.
+    """
+    files = sorted(src_dir.rglob(pattern))
+    if not files:
+        console.print(f"[json] No files matching {pattern!r} under {src_dir}.")
+        return False
+
+    # msgid -> POEntry, so the same string reused across tours/steps merges
+    # into one entry carrying multiple #: occurrences.
+    entries: dict[str, polib.POEntry] = {}
+
+    for path in files:
+        rel = path.relative_to(src_dir)
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for lineno, line in enumerate(lines, start=1):
+            match = _JSON_KV_LINE_RE.match(line)
+            if not match or match.group("key") not in keys:
+                continue
+
+            try:
+                msgid = json.loads(match.group("val"))
+            except json.JSONDecodeError:
+                console.print(f"  [warn] {path}:{lineno}: could not decode JSON value, skipping")
+                continue
+
+            if not msgid:
+                continue
+
+            occurrence = (f"{src_dir}/{rel}", str(lineno))
+            if msgid in entries:
+                entries[msgid].occurrences.append(occurrence)
+                continue
+
+            entries[msgid] = polib.POEntry(msgid=msgid, msgstr="", occurrences=[occurrence])
+
+    pot = polib.POFile(wrapwidth=0)
+    pot.metadata = {
+        "Project-Id-Version": "osparc-simcore",
+        "Content-Type": "text/plain; charset=UTF-8",
+        "Content-Transfer-Encoding": "8bit",
+    }
+    for entry in entries.values():
+        pot.append(entry)
+
+    out_pot.parent.mkdir(parents=True, exist_ok=True)
+    pot.save(str(out_pot))
+    console.print(f"  [json] {len(pot)} entry/ies from {len(files)} file(s) -> {out_pot}")
     return True
 
 
@@ -633,6 +722,31 @@ def jinja_cmd(
     if not run_babel_jinja(src, out):
         raise typer.Exit(code=1)
     console.print(f"[done] jinja -> {out}")
+
+
+@app.command("json")
+def json_cmd(
+    src: Path = typer.Option(Path("src"), help="Directory to scan for JSON resource files"),
+    out: Path = typer.Option(Path("json.pot"), help="Output .pot file"),
+    keys: str = typer.Option(
+        ...,
+        help="Comma-separated JSON keys whose string values are translatable (e.g. name,description,title,text)",
+    ),
+    pattern: str = typer.Option("*.json", help="Glob pattern (relative to --src) selecting JSON files"),
+) -> None:
+    """Extract translatable string values from JSON files by key (e.g. guided tours)."""
+    if not src.is_dir():
+        console.print(f"[error] source directory not found: {src}")
+        raise typer.Exit(code=1)
+
+    key_set = {k.strip() for k in keys.split(",") if k.strip()}
+    if not key_set:
+        console.print("[error] --keys must contain at least one non-empty key")
+        raise typer.Exit(code=1)
+
+    if not run_json_keys(src, out, key_set, pattern):
+        raise typer.Exit(code=1)
+    console.print(f"[done] json -> {out}")
 
 
 @app.command("enrich")

--- a/scripts/i18n/tools/i18n_extractor.py
+++ b/scripts/i18n/tools/i18n_extractor.py
@@ -43,7 +43,7 @@ import polib
 import typer
 from rich.console import Console
 
-CONTEXT_LINES = 6  # source lines captured around each string
+CONTEXT_MAX_LINES = 10  # max lines to expand in each direction around a string
 console = Console()
 
 # @TRANSLATOR marker: human note in source -> xgettext --add-comments -> #. line.
@@ -408,6 +408,37 @@ def key_not_seen(key: str, seen: set[str]) -> bool:
     return key.startswith("CTX-") and key not in seen and key != "CTX-SNIPPET"
 
 
+def _snippet_bounds(lines: list[str], lineno: int, max_context: int = CONTEXT_MAX_LINES) -> tuple[int, int]:
+    """Return a 0-based inclusive (start, end) line range around lineno (1-based).
+
+    Expands to the enclosing block instead of a fixed window: walks upward/downward
+    while sibling lines share the same or deeper indentation, stopping at the first
+    blank line or shallower-indented line (the block's natural boundary, e.g. the
+    enclosing `def`/JSX tag). Bounded by max_context lines in each direction so
+    prompts stay small even inside large blocks.
+    """
+    idx = lineno - 1
+    target_indent = len(lines[idx]) - len(lines[idx].lstrip())
+    min_start = max(0, idx - max_context)
+    max_end = min(len(lines) - 1, idx + max_context)
+
+    start = idx
+    while start > min_start:
+        prev_line = lines[start - 1]
+        start -= 1
+        if not prev_line.strip() or (len(prev_line) - len(prev_line.lstrip())) < target_indent:
+            break
+
+    end = idx
+    while end < max_end:
+        next_line = lines[end + 1]
+        if not next_line.strip() or (len(next_line) - len(next_line.lstrip())) < target_indent:
+            break
+        end += 1
+
+    return start, end
+
+
 def enrich(pot_path: Path, repo_root: Path, py_hints: dict[str, str] | None = None) -> None:
     """
     Step 2: read the .pot produced by xgettext, add extractor-owned CTX metadata
@@ -455,10 +486,9 @@ def enrich(pot_path: Path, repo_root: Path, py_hints: dict[str, str] | None = No
             continue
 
         lines = abs_path.read_text(encoding="utf-8", errors="replace").splitlines()
-        start = max(0, lineno - CONTEXT_LINES // 2 - 1)
-        end = min(len(lines), lineno + CONTEXT_LINES // 2)
+        start, end = _snippet_bounds(lines, lineno)
 
-        snippet_lines = [f"  {'>>>' if i + 1 == lineno else '   '} {lines[i]}" for i in range(start, end)]
+        snippet_lines = [f"  {'>>>' if i + 1 == lineno else '   '} {lines[i]}" for i in range(start, end + 1)]
 
         snippet_version = get_blame_commit(filepath, lineno, cwd=repo_root)
 

--- a/scripts/i18n/tools/i18n_extractor.py
+++ b/scripts/i18n/tools/i18n_extractor.py
@@ -37,6 +37,7 @@ Usage:
 import ast
 import subprocess
 from pathlib import Path
+from typing import Final
 
 import polib
 import typer
@@ -44,6 +45,10 @@ from rich.console import Console
 
 CONTEXT_LINES = 6  # source lines captured around each string
 console = Console()
+
+# @TRANSLATOR marker: human note in source -> xgettext --add-comments -> #. line.
+# Literal is duplicated in i18n_translator.py (_extract_translator_notes); keep in sync.
+TRANSLATOR_TAG: Final = "@TRANSLATOR"
 
 # xgettext language flag per file extension
 LANG_MAP = {
@@ -60,14 +65,21 @@ LANG_MAP = {
     ".rc": "C++",  # STRINGTABLE entries; xgettext treats .rc as C-like
 }
 
-TRANSLATION_FUNC_NAMES = {
-    "_",
-    "user_message",  # osparc
-    "gettext",
-    "tr",  # qooxdoo frontend
-    "t",  # rocket frontend
-    "QT_TR_NOOP",
+# xgettext --keyword flags: single source of truth for run_xgettext()'s cmd, mapped
+# to the language(s)/tool that call each translation function.
+XGETTEXT_KEYWORDS: Final[dict[str, str]] = {
+    "_": "Python",
+    "gettext": "Python",
+    "user_message": "Python (osparc)",
+    "tr": "Qt/MFC C++, qooxdoo JS",
+    "t": "rocket JS/TS",
+    "QT_TR_NOOP": "Qt no-op marker (C++)",
 }
+
+# Subset of XGETTEXT_KEYWORDS that Python code can actually call; used only by the
+# Python AST-based validate_no_fstring_translations() (never scans .js/.cpp files).
+PYTHON_TRANSLATION_FUNC_NAMES: Final[set[str]] = {"_", "gettext", "user_message"}
+assert set(XGETTEXT_KEYWORDS) >= PYTHON_TRANSLATION_FUNC_NAMES  # nosec
 
 
 # ---------------------------------------------------------------------------
@@ -88,13 +100,8 @@ def run_xgettext(src_files: list[Path], out_pot: Path) -> bool:
         # Extract translatable strings from given input files
         # SEE https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html
         "xgettext",
-        "--keyword=_",
-        "--keyword=gettext",
-        "--keyword=user_message",  # osparc marker
-        "--keyword=tr",  # Qt / MFC
-        "--keyword=t",  # rocket
-        "--keyword=QT_TR_NOOP",  # Qt no-op marker
-        "--add-comments=@TRANSLATOR",
+        *(f"--keyword={keyword}" for keyword in XGETTEXT_KEYWORDS),
+        f"--add-comments={TRANSLATOR_TAG}",
         "--from-code=UTF-8",
         "--output",
         str(out_pot),
@@ -244,7 +251,7 @@ def validate_no_fstring_translations(src_files: list[Path]) -> bool:  # noqa: C9
                 continue
 
             call_name = _call_name(node.func)
-            if call_name not in TRANSLATION_FUNC_NAMES:
+            if call_name not in PYTHON_TRANSLATION_FUNC_NAMES:
                 continue
 
             if not node.args:
@@ -458,7 +465,7 @@ def enrich(pot_path: Path, repo_root: Path, py_hints: dict[str, str] | None = No
         # Inject @TRANSLATOR hint from _hint kwarg if not already present.
         hint = hints.get(entry.msgid)
         if hint:
-            at_translator_line = f"@TRANSLATOR {hint}"
+            at_translator_line = f"{TRANSLATOR_TAG} {hint}"
             existing = entry.comment or ""
             if at_translator_line not in existing:
                 entry.comment = (at_translator_line + "\n" + existing).strip()

--- a/scripts/i18n/tools/i18n_extractor.py
+++ b/scripts/i18n/tools/i18n_extractor.py
@@ -53,9 +53,11 @@ from typing import Final
 import polib
 import typer
 from rich.console import Console
+from rich.highlighter import RegexHighlighter
+from rich.theme import Theme
 
 CONTEXT_MAX_LINES = 10  # max lines to expand in each direction around a string
-console = Console()
+
 
 # @TRANSLATOR marker: human note in source -> xgettext --add-comments -> #. line.
 # Literal is duplicated in i18n_translator.py (_extract_translator_notes); keep in sync.
@@ -322,7 +324,7 @@ class JsonKeysExtractor:
 #   CTX-VERSION:         → translation/version stamp by i18n_translator.py
 
 
-def _call_name(node: ast.AST) -> str | None:
+def _get_name(node: ast.AST) -> str | None:
     if isinstance(node, ast.Name):
         return node.id
     if isinstance(node, ast.Attribute):
@@ -350,7 +352,7 @@ def validate_no_fstring_translations(src_files: list[Path]) -> bool:  # noqa: C9
             if not isinstance(node, ast.Call):
                 continue
 
-            call_name = _call_name(node.func)
+            call_name = _get_name(node.func)
             if call_name not in PYTHON_TRANSLATION_FUNC_NAMES:
                 continue
 
@@ -388,7 +390,7 @@ def _extract_hints_from_file(path: Path) -> dict[str, str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
-        if _call_name(node.func) != "user_message":
+        if _get_name(node.func) != "user_message":
             continue
         if not node.args or not isinstance(node.args[0], ast.Constant):
             continue
@@ -468,7 +470,11 @@ def parse_ctx_comment(comment: str) -> tuple[list[str], dict[str, str], list[str
     return passthrough_lines, ctx_fields, snippet_lines
 
 
-def render_ctx_comment(passthrough_lines: list[str], ctx_fields: dict[str, str], snippet_lines: list[str]) -> str:
+def _key_not_seen(key: str, seen: set[str]) -> bool:
+    return key.startswith("CTX-") and key not in seen and key != "CTX-SNIPPET"
+
+
+def _render_ctx_comment(passthrough_lines: list[str], ctx_fields: dict[str, str], snippet_lines: list[str]) -> str:
     """Render comment preserving non-CTX lines while canonicalizing CTX layout."""
     ordered_lines = [line for line in passthrough_lines if line.strip() != ""]
 
@@ -484,13 +490,9 @@ def render_ctx_comment(passthrough_lines: list[str], ctx_fields: dict[str, str],
             seen.add(key)
 
     # Preserve any additional CTX-* fields that might have been added later.
-    ordered_lines.extend(f"{key}: {ctx_fields[key]}" for key in sorted(k for k in ctx_fields if key_not_seen(k, seen)))
+    ordered_lines.extend(f"{key}: {ctx_fields[key]}" for key in sorted(k for k in ctx_fields if _key_not_seen(k, seen)))
 
     return "\n".join(ordered_lines).strip()
-
-
-def key_not_seen(key: str, seen: set[str]) -> bool:
-    return key.startswith("CTX-") and key not in seen and key != "CTX-SNIPPET"
 
 
 def _snippet_bounds(lines: list[str], lineno: int, max_context: int = CONTEXT_MAX_LINES) -> tuple[int, int]:
@@ -522,6 +524,25 @@ def _snippet_bounds(lines: list[str], lineno: int, max_context: int = CONTEXT_MA
         end += 1
 
     return start, end
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class _StatusHighlighter(RegexHighlighter):
+    highlights: Final = [
+        r"(?P<status_done>\[done\])",
+        r"(?P<status_error>\[(?:error|[^\]]*ERROR)\])",
+        r"(?P<status_warn>\[warn\])",
+    ]
+
+
+console = Console(
+    highlighter=_StatusHighlighter(),
+    theme=Theme({"status_done": "bold green", "status_error": "bold red", "status_warn": "yellow"}),
+)
 
 
 def enrich(pot_path: Path, repo_root: Path, py_hints: dict[str, str] | None = None) -> None:
@@ -588,7 +609,7 @@ def enrich(pot_path: Path, repo_root: Path, py_hints: dict[str, str] | None = No
         # entry.comment (#. lines) is left untouched -- it holds @TRANSLATOR notes.
         passthrough, ctx_fields, _ = parse_ctx_comment(entry.tcomment or "")
         ctx_fields["CTX-SNIPPET-VERSION"] = snippet_version
-        entry.tcomment = render_ctx_comment(passthrough, ctx_fields, snippet_lines)
+        entry.tcomment = _render_ctx_comment(passthrough, ctx_fields, snippet_lines)
 
     # Ensure enriched POT keeps UTF-8 metadata for non-ASCII msgids/comments.
     po.encoding = "utf-8"
@@ -596,11 +617,6 @@ def enrich(pot_path: Path, repo_root: Path, py_hints: dict[str, str] | None = No
     po.metadata["Content-Transfer-Encoding"] = "8bit"
     po.save(str(pot_path))
     console.print(f"[enrich] {len(po)} entries enriched -> {pot_path}")
-
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
 
 
 def collect_sources(src_dir: Path, langs: list[str] | None) -> list[Path]:

--- a/scripts/i18n/tools/i18n_extractor.py
+++ b/scripts/i18n/tools/i18n_extractor.py
@@ -61,254 +61,265 @@ console = Console()
 # Literal is duplicated in i18n_translator.py (_extract_translator_notes); keep in sync.
 TRANSLATOR_TAG: Final = "@TRANSLATOR"
 
-# xgettext language flag per file extension
-LANG_MAP = {
-    ".py": "Python",
-    ".js": "JavaScript",  # qooxdoo frontend
-    ".ts": "JavaScript",  # rocket frontend; xgettext has no TypeScript language
-    ".tsx": "JavaScript",
-    ".jsx": "JavaScript",
-    ".cpp": "C++",
-    ".cxx": "C++",
-    ".cc": "C++",
-    ".c": "C",
-    ".h": "C++",
-    ".rc": "C++",  # STRINGTABLE entries; xgettext treats .rc as C-like
-}
+# ---------------------------------------------------------------------------
+# Step 1a: xgettext extraction for source files (Python, C++, MFC .rc)
+# ---------------------------------------------------------------------------
 
-# xgettext --keyword flags: single source of truth for run_xgettext()'s cmd, mapped
-# to the language(s)/tool that call each translation function.
-XGETTEXT_KEYWORDS: Final[dict[str, str]] = {
-    "_": "Python",
-    "gettext": "Python",
-    "user_message": "Python (osparc)",
-    "tr": "Qt/MFC C++, qooxdoo JS",
-    "t": "rocket JS/TS",
-    "QT_TR_NOOP": "Qt no-op marker (C++)",
-}
 
-# Subset of XGETTEXT_KEYWORDS that Python code can actually call; used only by the
+class XgetextExtractor:
+    """Extract translatable strings from source files using GNU xgettext.
+
+    Files are grouped by language to minimize subprocess invocations.
+    SEE https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html
+    """
+
+    # xgettext --language flag per file extension (case-insensitive match).
+    LANG_MAP: Final[dict[str, str]] = {
+        ".py": "Python",
+        ".js": "JavaScript",  # qooxdoo frontend
+        ".ts": "JavaScript",  # rocket frontend; xgettext has no TypeScript language
+        ".tsx": "JavaScript",
+        ".jsx": "JavaScript",
+        ".cpp": "C++",
+        ".cxx": "C++",
+        ".cc": "C++",
+        ".c": "C",
+        ".h": "C++",
+        ".rc": "C++",  # STRINGTABLE entries; xgettext treats .rc as C-like
+    }
+
+    # --keyword flags: single source of truth for all translation functions.
+    KEYWORDS: Final[dict[str, str]] = {
+        "_": "Python",
+        "gettext": "Python",
+        "user_message": "Python (osparc)",
+        "tr": "Qt/MFC C++, qooxdoo JS",
+        "t": "rocket JS/TS",
+        "QT_TR_NOOP": "Qt no-op marker (C++)",
+    }
+
+    def run(self, src_files: list[Path], out_pot: Path) -> bool:
+        """Returns True on success."""
+        if not src_files:
+            console.print("[extract] No source files found.")
+            return False
+
+        base_cmd = [
+            "xgettext",
+            *(f"--keyword={kw}" for kw in self.KEYWORDS),
+            f"--add-comments={TRANSLATOR_TAG}",
+            "--from-code=UTF-8",
+            "--output",
+            str(out_pot),
+            "--package-name=osparc-simcore",
+            "--msgid-bugs-address=",
+        ]
+
+        # Group files by language to batch invocations.
+        by_lang: dict[str, list[Path]] = {}
+        for f in src_files:
+            lang = self.LANG_MAP.get(f.suffix.lower())
+            if lang:
+                by_lang.setdefault(lang, []).append(f)
+            else:
+                console.print(f"  [skip] unsupported extension: {f}")
+
+        if not by_lang:
+            console.print("[extract] No files with supported extensions.")
+            return False
+
+        first = True
+        for lang, files in by_lang.items():
+            batch_cmd = [*base_cmd, f"--language={lang}", *(str(f) for f in files)]
+            if not first:
+                batch_cmd.append("--join-existing")  # append to the .pot from first batch
+            first = False
+
+            result = subprocess.run(batch_cmd, capture_output=True, text=True, check=False)  # noqa: S603
+            if result.returncode != 0:
+                console.print(f"[xgettext ERROR] {result.stderr.strip()}")
+                return False
+            console.print(f"  [xgettext] {lang}: {len(files)} file(s)")
+
+        return True
+
+
+# Subset of XgetextExtractor.KEYWORDS that Python code can actually call; used only by the
 # Python AST-based validate_no_fstring_translations() (never scans .js/.cpp files).
 PYTHON_TRANSLATION_FUNC_NAMES: Final[set[str]] = {"_", "gettext", "user_message"}
-assert set(XGETTEXT_KEYWORDS) >= PYTHON_TRANSLATION_FUNC_NAMES  # nosec
-
-
-# ---------------------------------------------------------------------------
-# Step 1: xgettext
-# ---------------------------------------------------------------------------
-
-
-def run_xgettext(src_files: list[Path], out_pot: Path) -> bool:
-    """
-    Run xgettext over all source files in one invocation.
-    Returns True on success.
-    """
-    if not src_files:
-        console.print("[extract] No source files found.")
-        return False
-
-    cmd = [
-        # Extract translatable strings from given input files
-        # SEE https://www.gnu.org/software/gettext/manual/html_node/xgettext-Invocation.html
-        "xgettext",
-        *(f"--keyword={keyword}" for keyword in XGETTEXT_KEYWORDS),
-        f"--add-comments={TRANSLATOR_TAG}",
-        "--from-code=UTF-8",
-        "--output",
-        str(out_pot),
-        "--package-name=osparc-simcore",
-        "--msgid-bugs-address=",
-        # SUGGESTION: remove --no-location if you want
-    ]
-
-    # xgettext needs --language per file; pass each file with its language.
-    # Group files by language to avoid per-file subprocess overhead.
-    by_lang: dict[str, list[Path]] = {}
-    for f in src_files:
-        lang = LANG_MAP.get(f.suffix.lower())
-        if lang:
-            by_lang.setdefault(lang, []).append(f)
-        else:
-            console.print(f"  [skip] unsupported extension: {f}")
-
-    if not by_lang:
-        console.print("[extract] No files with supported extensions.")
-        return False
-
-    first = True
-    for lang, files in by_lang.items():
-        batch_cmd = [*cmd, f"--language={lang}", *(str(f) for f in files)]
-        if not first:
-            # append to the .pot produced by the first batch
-            batch_cmd.append("--join-existing")
-        first = False
-
-        result = subprocess.run(batch_cmd, capture_output=True, text=True, check=False)  # noqa: S603
-        if result.returncode != 0:
-            console.print(f"[xgettext ERROR] {result.stderr.strip()}")
-            return False
-        console.print(f"  [xgettext] {lang}: {len(files)} file(s)")
-
-    return True
+assert XgetextExtractor.KEYWORDS.keys() >= PYTHON_TRANSLATION_FUNC_NAMES  # nosec
 
 
 # ---------------------------------------------------------------------------
 # Step 1b: Babel extraction for Jinja2 templates
 # ---------------------------------------------------------------------------
-#
-# xgettext cannot parse Jinja2 ({% trans %} blocks, {{ gettext(...) }} calls),
-# so Babel's jinja2.ext.babel_extract is used for *.j2 templates. The output is
-# a polib .pot with the same #: filepath:lineno references that `enrich` and
-# `msgcat` (in the Makefile `merge` step) consume, so it slots into the existing
-# pipeline unchanged.
-
-_JINJA_METHOD_MAP = [("**.j2", "jinja2.ext.babel_extract")]
-# i18n extension is auto-loaded by babel_extract; encoding pinned to UTF-8.
-_JINJA_OPTIONS_MAP = {"**.j2": {"encoding": "utf-8", "silent": "false"}}
 
 
-def run_babel_jinja(src_dir: Path, out_pot: Path) -> bool:
-    """Extract translatable strings from Jinja2 templates under *src_dir*.
+class BabelJinjaExtractor:
+    """Extract translatable strings from Jinja2 templates via Babel.
 
-    Returns True on success. Occurrence paths are recorded relative to the
-    given *src_dir* prefix so they resolve from the repo root (matching the
-    xgettext step), which lets `enrich` locate the source snippets.
+    xgettext cannot parse Jinja2 ({% trans %} blocks, {{ gettext(...) }} calls),
+    so Babel's jinja2.ext.babel_extract is used for *.j2 templates. Output is a
+    .pot with the same #: filepath:lineno references that slot into the existing
+    pipeline unchanged.
     """
-    from babel.messages.extract import extract_from_dir  # noqa: PLC0415
 
-    # (msgid, msgid_plural, context) -> POEntry, so repeated strings merge
-    # into one entry carrying multiple #: occurrences.
-    entries: dict[tuple[str, str | None, str | None], polib.POEntry] = {}
+    # i18n extension is auto-loaded by babel_extract; encoding pinned to UTF-8.
+    _METHOD_MAP: Final = [("**.j2", "jinja2.ext.babel_extract")]
+    _OPTIONS_MAP: Final = {"**.j2": {"encoding": "utf-8", "silent": "false"}}
 
-    for filename, lineno, message, _comments, context in extract_from_dir(
-        dirname=src_dir,
-        method_map=_JINJA_METHOD_MAP,
-        options_map=_JINJA_OPTIONS_MAP,
-    ):
-        if isinstance(message, tuple | list):
-            msgid, msgid_plural = message[0], message[1]
-        else:
-            msgid, msgid_plural = message, None
+    def run(self, src_dir: Path, out_pot: Path) -> bool:
+        """Returns True on success."""
+        from babel.messages.extract import extract_from_dir  # noqa: PLC0415
 
-        if not msgid:
-            continue
+        # (msgid, msgid_plural, context) -> POEntry, so repeated strings merge
+        # into one entry carrying multiple #: occurrences.
+        entries: dict[tuple[str, str | None, str | None], polib.POEntry] = {}
 
-        msgctxt = context or None
-        key = (msgid, msgid_plural, msgctxt)
-        occurrence = (f"{src_dir}/{filename}", str(lineno))
+        for filename, lineno, message, _comments, context in extract_from_dir(
+            dirname=src_dir,
+            method_map=self._METHOD_MAP,
+            options_map=self._OPTIONS_MAP,
+        ):
+            if isinstance(message, tuple | list):
+                msgid, msgid_plural = message[0], message[1]
+            else:
+                msgid, msgid_plural = message, None
 
-        if key in entries:
-            entries[key].occurrences.append(occurrence)
-            continue
+            if not msgid:
+                continue
 
-        if msgid_plural:
-            entry = polib.POEntry(
-                msgid=msgid,
-                msgid_plural=msgid_plural,
-                msgstr_plural={0: "", 1: ""},
-                msgctxt=msgctxt,
-                occurrences=[occurrence],
-            )
-        else:
-            entry = polib.POEntry(
-                msgid=msgid,
-                msgstr="",
-                msgctxt=msgctxt,
-                occurrences=[occurrence],
-            )
-        entries[key] = entry
+            msgctxt = context or None
+            key = (msgid, msgid_plural, msgctxt)
+            occurrence = (f"{src_dir}/{filename}", str(lineno))
 
-    pot = polib.POFile(wrapwidth=0)
-    pot.metadata = {
-        "Project-Id-Version": "osparc-simcore",
-        "Content-Type": "text/plain; charset=UTF-8",
-        "Content-Transfer-Encoding": "8bit",
-    }
-    for entry in entries.values():
-        pot.append(entry)
+            if key in entries:
+                entries[key].occurrences.append(occurrence)
+                continue
 
-    out_pot.parent.mkdir(parents=True, exist_ok=True)
-    pot.save(str(out_pot))
-    console.print(f"  [jinja] {len(pot)} entry/ies -> {out_pot}")
-    return True
+            if msgid_plural:
+                entry = polib.POEntry(
+                    msgid=msgid,
+                    msgid_plural=msgid_plural,
+                    msgstr_plural={0: "", 1: ""},
+                    msgctxt=msgctxt,
+                    occurrences=[occurrence],
+                )
+            else:
+                entry = polib.POEntry(
+                    msgid=msgid,
+                    msgstr="",
+                    msgctxt=msgctxt,
+                    occurrences=[occurrence],
+                )
+            entries[key] = entry
+
+        pot = polib.POFile(wrapwidth=0)
+        pot.metadata = {
+            "Project-Id-Version": "osparc-simcore",
+            "Content-Type": "text/plain; charset=UTF-8",
+            "Content-Transfer-Encoding": "8bit",
+        }
+        for entry in entries.values():
+            pot.append(entry)
+
+        out_pot.parent.mkdir(parents=True, exist_ok=True)
+        pot.save(str(out_pot))
+        console.print(f"  [jinja] {len(pot)} entry/ies -> {out_pot}")
+        return True
 
 
 # ---------------------------------------------------------------------------
 # Step 1c: JSON-value extraction (e.g. frontend guided tours)
 # ---------------------------------------------------------------------------
-#
-# Guided tours (services/static-webserver/client/source/resource/osparc/tours/
-# *_tours.json) are data loaded at runtime, so their user-facing strings are
-# NOT reachable by xgettext (which only sees literal tr() calls in .js).
-# This step reads JSON files and pulls out the *values* of a given set of
-# keys (e.g. name/description/title/text), emitting a .pot the same shape as
-# the xgettext/jinja outputs so it merges into the frontend catalog. Runtime
-# translation is expected to happen at the consumption points by wrapping the
-# fetched values in qx.locale.Manager.tr(...) (a catalog lookup by msgid) --
-# that wiring is out of scope for this extractor.
-#
-# Extraction is line-based: every translatable "key": "value" pair is expected
-# on its own line (as produced by standard JSON formatting), which yields an
-# accurate source-line reference for `enrich` and lets the JSON decoder
-# correctly handle string escaping. Keys not in *keys* (id, context, anchorEl,
-# selector, placement, action, ...) are wiring and are skipped.
-
-_JSON_KV_LINE_RE: Final[re.Pattern[str]] = re.compile(r'^\s*"(?P<key>[^"]+)"\s*:\s*(?P<val>"(?:[^"\\]|\\.)*")\s*,?\s*$')
 
 
-def run_json_keys(src_dir: Path, out_pot: Path, keys: set[str], pattern: str) -> bool:
-    """Extract translatable string values for *keys* from JSON files under *src_dir*.
+class JsonKeysExtractor:
+    """Extract translatable string values from JSON files by key name.
 
-    Only lines matching "key": "value" (one pair per line) are considered, so
-    a #: reference always resolves to the exact line. Returns True on success,
-    False when no files match *pattern* under *src_dir*.
+    Targets JSON resource files (e.g. guided tour definitions) whose user-facing
+    strings are loaded at runtime and therefore NOT reachable by xgettext (which
+    only sees literal tr() calls in .js). Extraction is line-based: every
+    translatable "key": "value" pair must be on its own line, yielding exact
+    #: filepath:lineno references. Keys not in *keys* (id, anchorEl, ...) are
+    wiring and are skipped.
     """
-    files = sorted(src_dir.rglob(pattern))
-    if not files:
-        console.print(f"[json] No files matching {pattern!r} under {src_dir}.")
-        return False
 
-    # msgid -> POEntry, so the same string reused across tours/steps merges
-    # into one entry carrying multiple #: occurrences.
-    entries: dict[str, polib.POEntry] = {}
+    # Matches one "key": "value" JSON line; `val` is raw-encoded so json.loads() handles escapes.
+    KV_LINE_RE: Final[re.Pattern[str]] = re.compile(r'^\s*"(?P<key>[^"]+)"\s*:\s*(?P<val>"(?:[^"\\]|\\.)*")\s*,?\s*$')
 
-    for path in files:
-        rel = path.relative_to(src_dir)
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        for lineno, line in enumerate(lines, start=1):
-            match = _JSON_KV_LINE_RE.match(line)
-            if not match or match.group("key") not in keys:
-                continue
+    def _collect_entries(
+        self,
+        src_dir: Path,
+        files: list[Path],
+        keys: set[str],
+    ) -> dict[str, polib.POEntry]:
+        # msgid -> POEntry: duplicate strings merge into one entry with multiple #: occurrences.
+        entries: dict[str, polib.POEntry] = {}
 
-            try:
-                msgid = json.loads(match.group("val"))
-            except json.JSONDecodeError:
-                console.print(f"  [warn] {path}:{lineno}: could not decode JSON value, skipping")
-                continue
+        for path in files:
+            rel = path.relative_to(src_dir)
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+            for lineno, line in enumerate(lines, start=1):
+                match = self.KV_LINE_RE.match(line)
+                if not match or match.group("key") not in keys:
+                    continue
 
-            if not msgid:
-                continue
+                try:
+                    msgid = json.loads(match.group("val"))
+                except json.JSONDecodeError:
+                    console.print(f"  [warn] {path}:{lineno}: could not decode JSON value, skipping")
+                    continue
 
-            occurrence = (f"{src_dir}/{rel}", str(lineno))
-            if msgid in entries:
-                entries[msgid].occurrences.append(occurrence)
-                continue
+                if not msgid:
+                    continue
 
-            entries[msgid] = polib.POEntry(msgid=msgid, msgstr="", occurrences=[occurrence])
+                occurrence = (f"{src_dir}/{rel}", str(lineno))
+                if msgid in entries:
+                    entries[msgid].occurrences.append(occurrence)
+                    continue
 
-    pot = polib.POFile(wrapwidth=0)
-    pot.metadata = {
-        "Project-Id-Version": "osparc-simcore",
-        "Content-Type": "text/plain; charset=UTF-8",
-        "Content-Transfer-Encoding": "8bit",
-    }
-    for entry in entries.values():
-        pot.append(entry)
+                entries[msgid] = polib.POEntry(msgid=msgid, msgstr="", occurrences=[occurrence])
 
-    out_pot.parent.mkdir(parents=True, exist_ok=True)
-    pot.save(str(out_pot))
-    console.print(f"  [json] {len(pot)} entry/ies from {len(files)} file(s) -> {out_pot}")
-    return True
+        return entries
+
+    def run(self, src_dir: Path, out_pot: Path, keys: set[str], pattern: str) -> bool:
+        """Returns True on success, False when no files match *pattern*."""
+        files = sorted(src_dir.rglob(pattern))
+        if not files:
+            console.print(f"[json] No files matching {pattern!r} under {src_dir}.")
+            return False
+
+        entries = self._collect_entries(src_dir, files, keys)
+
+        pot = polib.POFile(wrapwidth=0)
+        pot.metadata = {
+            "Project-Id-Version": "osparc-simcore",
+            "Content-Type": "text/plain; charset=UTF-8",
+            "Content-Transfer-Encoding": "8bit",
+        }
+        for entry in entries.values():
+            pot.append(entry)
+
+        out_pot.parent.mkdir(parents=True, exist_ok=True)
+        pot.save(str(out_pot))
+        console.print(f"  [json] {len(pot)} entry/ies from {len(files)} file(s) -> {out_pot}")
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Step 2: enrich with extractor-owned context metadata
+# ---------------------------------------------------------------------------
+#
+# These markers are written by the extractor step (this script), not by xgettext.
+# They use the CTX- prefix to stay distinct from the @TRANSLATOR prefix that
+# xgettext captures via --add-comments=@TRANSLATOR (xgettext command).
+#
+#   @TRANSLATOR ...      →  human note in source code → extracted by xgettext → #. line
+#   CTX-SNIPPET:         → machine-generated by enrich
+#   CTX-SNIPPET-VERSION: → git-blame hash for the referenced line
+#   CTX-INTERPRETATION:  → written by i18n_translator.py
+#   CTX-VERSION:         → translation/version stamp by i18n_translator.py
 
 
 def _call_name(node: ast.AST) -> str | None:
@@ -414,21 +425,6 @@ def collect_python_hints(src_files: list[Path]) -> dict[str, str]:
                 hints[msgid] = hint
 
     return hints
-
-
-# ---------------------------------------------------------------------------
-# Step 2: enrich with extractor-owned context metadata
-# ---------------------------------------------------------------------------
-#
-# These markers are written by the extractor step (this script), not by xgettext.
-# They use the CTX- prefix to stay distinct from the @TRANSLATOR prefix that
-# xgettext captures via --add-comments=@TRANSLATOR (xgettext command).
-#
-#   @TRANSLATOR ...      →  human note in source code → extracted by xgettext → #. line
-#   CTX-SNIPPET:         → machine-generated by enrich
-#   CTX-SNIPPET-VERSION: → git-blame hash for the referenced line
-#   CTX-INTERPRETATION:  → written by i18n_translator.py
-#   CTX-VERSION:         → translation/version stamp by i18n_translator.py
 
 
 def get_blame_commit(filepath: str, lineno: int, cwd: Path | None = None) -> str:
@@ -621,7 +617,7 @@ def collect_sources(src_dir: Path, langs: list[str] | None) -> list[Path]:
         for lang in langs:
             allowed_exts |= lang_to_exts.get(lang.lower(), set())
     else:
-        allowed_exts = set(LANG_MAP.keys())
+        allowed_exts = set(XgetextExtractor.LANG_MAP.keys())
 
     files = [f for f in sorted(src_dir.rglob("*")) if f.suffix.lower() in allowed_exts]
     console.print(f"[collect] {len(files)} file(s) under {src_dir}")
@@ -655,7 +651,7 @@ def run_xgettext_step(src: Path, out: Path, langs: str | None) -> None:
     if not src_files:
         raise typer.Exit(code=1)
 
-    if not run_xgettext(src_files, out):
+    if not XgetextExtractor().run(src_files, out):
         raise typer.Exit(code=1)
 
     if not validate_no_fstring_translations(src_files):
@@ -719,7 +715,7 @@ def jinja_cmd(
     if not src.is_dir():
         console.print(f"[error] source directory not found: {src}")
         raise typer.Exit(code=1)
-    if not run_babel_jinja(src, out):
+    if not BabelJinjaExtractor().run(src, out):
         raise typer.Exit(code=1)
     console.print(f"[done] jinja -> {out}")
 
@@ -744,7 +740,7 @@ def json_cmd(
         console.print("[error] --keys must contain at least one non-empty key")
         raise typer.Exit(code=1)
 
-    if not run_json_keys(src, out, key_set, pattern):
+    if not JsonKeysExtractor().run(src, out, key_set, pattern):
         raise typer.Exit(code=1)
     console.print(f"[done] json -> {out}")
 

--- a/scripts/i18n/tools/i18n_translator.py
+++ b/scripts/i18n/tools/i18n_translator.py
@@ -483,7 +483,7 @@ def _translate_entry(  # noqa: C901
         glossary_block = "\n".join(f"  {source_term} → {target_term}" for source_term, target_term in glossary.items())
         sections.append(f"Glossary (use these translations for these terms):\n{glossary_block}")
 
-    if translator_notes.strip():
+    if translator_notes.strip(": "):
         sections.append(f"Translator notes from maintainers (follow these instructions):\n{translator_notes}")
 
     if snippet.strip():

--- a/scripts/i18n/tools/i18n_translator.py
+++ b/scripts/i18n/tools/i18n_translator.py
@@ -48,6 +48,7 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Final, NamedTuple
 
@@ -236,7 +237,7 @@ class LiteLLMProvider:
 
 
 class DryRunProvider:
-    """Provider stand-in for `--plan`: composes/logs the prompt but never calls the LLM.
+    """Provider stand-in for `--dry-run`: composes/logs the prompt but never calls the LLM.
 
     Same `_generate_json` interface as `LiteLLMProvider` (duck-typed), so the whole
     translation pipeline runs unchanged. It needs no API key and no model validation;
@@ -435,18 +436,28 @@ def _get_blame_commit(filepath: str, lineno: int) -> BlameCommitResult:
 # ---------------------------------------------------------------------------
 
 
-def _translate_entry(
+def _filter_glossary(glossary: TermGlossaryDict, msgid: str, snippet: str) -> TermGlossaryDict:
+    """Keep only glossary terms that appear (case-insensitively) in the msgid or snippet.
+
+    Passing the full glossary on every entry adds terms irrelevant to that particular
+    string; filtering keeps the prompt minimal and reduces noise.
+    """
+    haystack = f"{msgid} {snippet}".lower()
+    return {term: translation for term, translation in glossary.items() if term.lower() in haystack}
+
+
+def _translate_entry(  # noqa: C901
     provider: LiteLLMProvider | DryRunProvider,
     msgid: str,
     snippet: str,
     translator_notes: str,
-    existing_interp: str,
     lang_name: LangNameStr,
     glossary: TermGlossaryDict,
+    occurrences: list[tuple[str, str]] | None = None,
     msgid_plural: str = "",
     logger: logging.Logger | None = None,
 ) -> Translation:
-    """Translate one msgid; reuses existing_interp when already computed (cached).
+    """Translate one msgid; the context interpretation is always regenerated fresh.
 
     When ``msgid_plural`` is set the entry is pluralized: both the singular and the
     plural English source forms are translated and returned (``Translation.text`` and
@@ -456,11 +467,9 @@ def _translate_entry(
     is_plural = bool(msgid_plural)
     protected_plural = _protect(msgid_plural) if is_plural else None
 
-    # If we already have a CTX-INTERPRETATION, skip re-interpreting (saves tokens)
     interp_instruction = (
-        f"Reuse the existing context interpretation below (do not regenerate it):\n{existing_interp}"
-        if existing_interp and existing_interp != "(pending)"
-        else "Write a one-sentence context interpretation explaining where/how this string appears."
+        "Write a one-sentence context interpretation explaining where/how this string "
+        "appears (max ~150 characters, a single sentence, no line breaks)."
     )
 
     # Assemble the prompt from sections; skip blocks that have nothing to say so
@@ -478,7 +487,20 @@ def _translate_entry(
         sections.append(f"Translator notes from maintainers (follow these instructions):\n{translator_notes}")
 
     if snippet.strip():
-        sections.append(f"Source code context (the string appears at the line marked >>>):\n{snippet}")
+        sections.append(
+            "Source code snippet around this translatable string (line marked >>> is the "
+            "string itself). This is a snapshot of the surrounding code, not the full file "
+            "-- use it, and the file path(s) below, to infer the context and meaning of the "
+            f"string:\n{snippet}"
+        )
+
+    if occurrences:
+        max_shown = 5
+        shown = occurrences[:max_shown]
+        loc_lines = "\n".join(f"  - {filepath}:{lineno}" for filepath, lineno in shown)
+        if len(occurrences) > max_shown:
+            loc_lines += f"\n  ... and {len(occurrences) - max_shown} more location(s)"
+        sections.append(f"File path(s) where this string is used (may hint at its domain/purpose):\n{loc_lines}")
 
     if is_plural:
         assert protected_plural is not None  # nosec
@@ -544,15 +566,21 @@ def _build_translation_job(
     use_git: bool,
     pot_creation_at: datetime | None,
     logger: logging.Logger | None = None,
+    *,
+    force: bool = False,
 ) -> TranslationJob:
     """Compute a translation job without mutating shared PO state."""
     ctx = _parse_translator_comments(entry)
-    state = _classify_entry_state(
-        entry=entry,
-        ctx=ctx,
-        use_git=use_git,
-        pot_creation_at=pot_creation_at,
-    )
+    if force:
+        # Bypass staleness check: --force / --filter always (re)translate matched entries.
+        state: EntryState = EntryNew(entry=entry) if _is_untranslated(entry) else EntryUpdated(entry=entry)
+    else:
+        state = _classify_entry_state(
+            entry=entry,
+            ctx=ctx,
+            use_git=use_git,
+            pot_creation_at=pot_creation_at,
+        )
     if isinstance(state, EntrySkipped):
         return TranslationSkipped(entry=entry)
 
@@ -562,9 +590,9 @@ def _build_translation_job(
             msgid=entry.msgid,
             snippet=ctx.snippet,
             translator_notes=_extract_translator_notes(entry.comment or ""),
-            existing_interp=ctx.interp,
             lang_name=lang_name,
-            glossary=glossary,
+            glossary=_filter_glossary(glossary, entry.msgid, ctx.snippet),
+            occurrences=entry.occurrences,
             msgid_plural=entry.msgid_plural or "",
             logger=logger,
         )
@@ -589,10 +617,16 @@ def _build_translation_job(
 
 
 def _parse_translator_comments(entry: polib.POEntry) -> TranslatorContext:
-    """Extract Pass-2 enrichment fields (CTX-SNIPPET, CTX-INTERPRETATION, CTX-VERSION) from # comment lines."""
+    """Extract Pass-2 enrichment fields (CTX-SNIPPET, CTX-INTERPRETATION, CTX-VERSION) from # comment lines.
+
+    CTX-INTERPRETATION may wrap onto continuation lines (e.g. a long LLM response);
+    those lines are joined with spaces so the field is always returned as one string.
+    """
     snippet_lines: list[str] = []
-    interp = version = snippet_version = ""
+    interp_lines: list[str] = []
+    version = snippet_version = ""
     in_snippet = False
+    in_interp = False
     # CTX-* fields are stored in translator comments (# => tcomment).
     # Fallback to extracted comments for backward compatibility.
     comment_block = entry.tcomment or entry.comment or ""
@@ -600,34 +634,54 @@ def _parse_translator_comments(entry: polib.POEntry) -> TranslatorContext:
         line = line.strip()  # noqa: PLW2901
         if line.startswith("CTX-SNIPPET:"):
             in_snippet = True
+            in_interp = False
         elif line.startswith("CTX-INTERPRETATION:"):
             in_snippet = False
-            interp = line[len("CTX-INTERPRETATION:") :].strip()
+            in_interp = True
+            interp_lines = [line[len("CTX-INTERPRETATION:") :].strip()]
         elif line.startswith("CTX-SNIPPET-VERSION:"):
             in_snippet = False
+            in_interp = False
             snippet_version = line[len("CTX-SNIPPET-VERSION:") :].strip()
         elif line.startswith("CTX-VERSION:"):
             in_snippet = False
+            in_interp = False
             version = line[len("CTX-VERSION:") :].strip()
         elif in_snippet:
             snippet_lines.append(line)
+        elif in_interp:
+            interp_lines.append(line)
+    interp = " ".join(part for part in interp_lines if part)
     return TranslatorContext("\n".join(snippet_lines), snippet_version, interp, version)
 
 
 def _update_comment(comment: str, interp: str, version: str) -> str:
-    """Rewrite Pass-2 enrichment fields CTX-INTERPRETATION and CTX-VERSION in the # comment block."""
+    """Rewrite Pass-2 enrichment fields CTX-INTERPRETATION and CTX-VERSION in the # comment block.
+
+    Drops any stale continuation lines left over from a previous multiline
+    CTX-INTERPRETATION so interpretations never accumulate across rounds.
+    """
     new_lines = []
     saw_interp = False
+    skipping_old_interp = False
     for line in comment.splitlines():
         stripped = line.strip()
         # Skip old CTX-VERSION lines - they will be re-added below
         if stripped.startswith("CTX-VERSION:"):
+            skipping_old_interp = False
             continue
         if stripped.startswith("CTX-INTERPRETATION:"):
             new_lines.append(f"CTX-INTERPRETATION: {interp}")
             saw_interp = True
-        else:
+            skipping_old_interp = True  # drop stale continuation lines below, if any
+            continue
+        if stripped.startswith("CTX-"):
+            skipping_old_interp = False
             new_lines.append(line)
+            continue
+        if skipping_old_interp:
+            continue
+        new_lines.append(line)
 
     if not saw_interp:
         new_lines.append(f"CTX-INTERPRETATION: {interp}")
@@ -658,6 +712,8 @@ def _is_stale(  # noqa: PLR0911
     """
     if _is_untranslated(entry):
         return True
+
+    # https://www.gnu.org/software/gettext/manual/html_node/Fuzzy-Entries.html
     if "fuzzy" in entry.flags:
         return True
     if ctx.version in ("(pending)", "unknown", ""):
@@ -773,21 +829,31 @@ def translate(  # noqa: C901, PLR0912, PLR0913, PLR0915
         min=1,
         help="Maximum number of concurrent translation workers when parallel mode is enabled.",
     ),
-    dry_run: bool = typer.Option(False, help="Print without saving"),
-    plan: bool = typer.Option(
-        False,
-        "--plan",
+    msgid_filter: str | None = typer.Option(
+        None,
+        "--filter",
         help=(
-            "Dry-run: compose and log the exact LLM prompts (with a stub '(dry-run)' "
-            "response) for entries that WOULD be translated, without calling the LLM "
-            "or saving. Spends no tokens and needs no API key; prompts are printed and "
-            "appended to the log file."
+            "Only translate entries whose msgid matches this glob pattern (fnmatch). "
+            "Implies --force for matched entries."
+        ),
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Force (re)translation even if entries appear fresh, bypassing the staleness check.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help=(
+            "Compose and log the exact LLM prompts (with a stub '(dry-run)' response) for "
+            "entries that WOULD be translated, without calling the LLM or saving. Spends no "
+            "tokens and needs no API key; prompts are printed and appended to the log file."
         ),
     ),
 ) -> None:
     """Translate a .pot/.po catalog into a language-specific .po."""
-    if plan:
-        dry_run = True
+    if dry_run:
         parallel = False
         progress = False
         incremental_save = False
@@ -801,9 +867,9 @@ def translate(  # noqa: C901, PLR0912, PLR0913, PLR0915
     effective_log_file = log_file or (out.parent / "translate.log")
     logger = _build_logger(effective_log_file)
     provider: LiteLLMProvider | DryRunProvider = (
-        DryRunProvider() if plan else LiteLLMProvider(model=model, base_url=base_url)
+        DryRunProvider() if dry_run else LiteLLMProvider(model=model, base_url=base_url)
     )
-    if plan:
+    if dry_run:
         console.print("[bold]\\[provider][/bold] dry-run (no LLM call, nothing saved)")
     else:
         console.print(f"[bold]\\[provider][/bold] model={model}" + (f" base_url={base_url}" if base_url else ""))
@@ -874,6 +940,11 @@ def translate(  # noqa: C901, PLR0912, PLR0913, PLR0915
             _save_po_atomic(po, out)
 
     entries = list(po)
+    if msgid_filter:
+        entries = [e for e in entries if fnmatch(e.msgid, msgid_filter)]
+        entry_word = "entry" if len(entries) == 1 else "entries"
+        console.print(f"[bold]\\[filter][/bold] {len(entries)} {entry_word} match {msgid_filter!r}")
+    effective_force = force or bool(msgid_filter)
 
     if progress:
         progress_bar = Progress(
@@ -898,6 +969,7 @@ def translate(  # noqa: C901, PLR0912, PLR0913, PLR0915
                             use_git,
                             pot_creation_at,
                             logger,
+                            force=effective_force,
                         )
                         for entry in entries
                     ]
@@ -919,6 +991,7 @@ def translate(  # noqa: C901, PLR0912, PLR0913, PLR0915
                         use_git,
                         pot_creation_at,
                         logger,
+                        force=effective_force,
                     )
                     apply_job(job)
                     total += 1
@@ -939,6 +1012,7 @@ def translate(  # noqa: C901, PLR0912, PLR0913, PLR0915
                     use_git,
                     pot_creation_at,
                     logger,
+                    force=effective_force,
                 )
                 for entry in entries
             ]
@@ -955,12 +1029,13 @@ def translate(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 use_git,
                 pot_creation_at,
                 logger,
+                force=effective_force,
             )
             apply_job(job)
             total += 1
 
-    summary_label = "plan" if plan else "done"
-    translated_label = "would translate" if plan else "translated"
+    summary_label = "dry-run" if dry_run else "done"
+    translated_label = "would translate" if dry_run else "translated"
     console.print(
         f"\n[bold]\\[{summary_label}][/bold] {total} entries: "
         f"[green]{translated} {translated_label}[/green], "

--- a/scripts/i18n/tools/i18n_translator.py
+++ b/scripts/i18n/tools/i18n_translator.py
@@ -60,6 +60,10 @@ from rich.table import Table
 
 DEFAULT_GLOSSARY_FILE = "glossary.json"
 
+# @TRANSLATOR marker: human note in source -> xgettext --add-comments -> #. line.
+# Literal is duplicated in i18n_extractor.py (TRANSLATOR_TAG); keep in sync.
+TRANSLATOR_TAG: Final = "@TRANSLATOR"
+
 # --- Type aliases ----------------------------------------------------------
 # Scalars end in `Str`; mapping aliases end in `Dict`.
 type LangCodeStr = str  # e.g. "zh_CN"
@@ -306,8 +310,8 @@ def _extract_translator_notes(comment: str) -> str:
     notes: list[str] = []
     for raw_line in comment.splitlines():
         line = raw_line.strip()
-        if line.startswith("@TRANSLATOR"):
-            notes.append(line[len("@TRANSLATOR") :].strip())
+        if line.startswith(TRANSLATOR_TAG):
+            notes.append(line[len(TRANSLATOR_TAG) :].strip())
         elif line:
             notes.append(line)
     return "\n".join(notes)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

- Enhances `scripts/i18n` tooling and recipes for the front-end workflow
   - includes tour-jsons (by @odeimaiz )
   - 🎨 enhances context for prompts
      -  adaptive code snippets per language
      - annotation
      - tips with file names
      - filtered glossary 
    - 🎨 Translator CLI 
       - simplifies `--dry-run` 
       - adds `--force` translation (not only those new/updated)
       - target translate `msgidr` with `--filter` glob
   - ♻️ separations of programming language
- Makefile
   - Makefile includes new `make -C scripts/i18n vars` <img width="899" height="232" alt="image" src="https://github.com/user-attachments/assets/b170bb0b-4dde-49d1-b814-1f9e6dddc5cf" />
-  ✅ Adapted and tested against the rocket producing trnslations for the frontend with @alexpargon 


>[!Important]
> Read [`scripts/i18n/README.md`](https://github.com/pcrespov/osparc-simcore/blob/3981de9ea66d390aa71cb2525493c4272075339f/scripts/i18n/README.md) for details

>[!Note]
>  `scripts/i18n/tools` will be moved to its own repo in coming PRs


## Related issue/s
- Part of https://github.com/ITISFoundation/private-issues/issues/590
- Rocket [MR-906](https://git.speag.com/oSparc/osparc-s4l/-/merge_requests/906)

## How to test

<img width="1574" height="467" alt="image" src="https://github.com/user-attachments/assets/9d64c572-2016-437e-b9df-fd91acf71806" />


## Dev-ops
NOne
