### PR TITLE
:coffin: ♻️ refactor(web-server): cleanup unused workbench utils

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/_projects_repository_legacy_utils.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_repository_legacy_utils.py
@@ -2,17 +2,13 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, ClassVar, Final, Literal
 
 import sqlalchemy as sa
 from models_library.projects import ProjectID
-from models_library.projects_nodes import Node
-from models_library.projects_nodes_io import NodeIDStr
 from models_library.utils.change_case import camel_to_snake, snake_to_camel
-from pydantic import ValidationError
 from simcore_postgres_database.models.project_to_groups import project_to_groups
 from simcore_postgres_database.models.projects_nodes import (
     projects_nodes as projects_nodes_table,
@@ -36,12 +32,8 @@ from ..users.errors import UserNotFoundError
 from ..utils import format_datetime
 from ._projects_repository import PROJECT_DB_COLS
 from .exceptions import (
-    NodeNotFoundError,
-    ProjectInvalidUsageError,
     ProjectNotFoundError,
 )
-from .models import ProjectDict
-from .utils import find_changed_node_keys
 
 logger = logging.getLogger(__name__)
 
@@ -277,95 +269,6 @@ class BaseProjectDB:
             project["tags"] = tags
 
         return project
-
-
-def update_workbench(old_project: ProjectDict, new_project: ProjectDict) -> ProjectDict:
-    """any non set entry in the new workbench is taken from the old one if available
-
-    Raises:
-        ProjectInvalidUsageError: it is not allowed to add/remove nodes
-
-    Returns:
-        updated project
-    """
-
-    old_workbench: dict[NodeIDStr, Any] = old_project["workbench"]
-    updated_project = deepcopy(new_project)
-    new_workbench: dict[NodeIDStr, Any] = updated_project["workbench"]
-
-    if old_workbench.keys() != new_workbench.keys():
-        # it is forbidden to add/remove nodes here
-        raise ProjectInvalidUsageError
-    for node_key, node in new_workbench.items():
-        old_node = old_workbench.get(node_key)
-        if not old_node:
-            continue
-        for prop in old_node:
-            # check if the key is missing in the new node
-            if prop not in node:
-                # use the old value
-                node[prop] = old_node[prop]
-    return updated_project
-
-
-def patch_workbench(
-    project: ProjectDict,
-    *,
-    new_partial_workbench_data: dict[NodeIDStr, Any],
-    allow_workbench_changes: bool,
-) -> tuple[ProjectDict, dict[NodeIDStr, Any]]:
-    """patch the project workbench with the values in new_partial_workbench_data
-
-    - Example: to add a node: ```{new_node_id: {"key": node_key, "version": node_version, "label": node_label, ...}}```
-    - Example: to modify a node ```{new_node_id: {"outputs": {"output_1": 2}}}```
-    - Example: to remove a node ```{node_id: None}```
-
-
-    Raises:
-        ProjectInvalidUsageError: if allow_workbench_changes is False and user tries to add/remove nodes
-        NodeNotFoundError: obviously the node does not exist and cannot be patched
-
-    Returns:
-        patched project and changed entries
-    """
-    patched_project = deepcopy(project)
-    changed_entries = {}
-    for (
-        node_key,
-        new_node_data,
-    ) in new_partial_workbench_data.items():
-        current_node_data: dict[str, Any] | None = patched_project.get("workbench", {}).get(node_key)
-
-        if current_node_data is None:
-            if not allow_workbench_changes:
-                raise ProjectInvalidUsageError
-            # if it's a new node, let's check that it validates
-            try:
-                Node.model_validate(new_node_data)
-                patched_project["workbench"][node_key] = new_node_data
-                changed_entries.update({node_key: new_node_data})
-            except ValidationError as err:
-                raise NodeNotFoundError(project_uuid=patched_project["uuid"], node_uuid=node_key) from err
-        elif new_node_data is None:
-            if not allow_workbench_changes:
-                raise ProjectInvalidUsageError
-            # remove the node
-            patched_project["workbench"].pop(node_key)
-            changed_entries.update({node_key: None})
-        else:
-            # find changed keys
-            changed_entries.update(
-                {
-                    node_key: find_changed_node_keys(
-                        current_node_data,
-                        new_node_data,
-                        look_for_removed_keys=False,
-                    )
-                }
-            )
-            # patch
-            current_node_data.update(new_node_data)
-    return (patched_project, changed_entries)
 
 
 async def get_project_workbench(


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
