### PR TITLE
✨ [Frontend] Sync with iframe's locale

### DIFF
--- a/services/static-webserver/client/source/class/osparc/utils/LanguageManager.js
+++ b/services/static-webserver/client/source/class/osparc/utils/LanguageManager.js
@@ -49,6 +49,7 @@ qx.Class.define("osparc.utils.LanguageManager", {
       }
       osparc.utils.Utils.localCache.setLocalStorageItem(this.LOCALE_KEY, localeCode);
       qx.locale.Manager.getInstance().setLocale(localeCode);
+      qx.event.message.Bus.getInstance().dispatchByName("localeSwitch", localeCode);
     },
 
     /**

--- a/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
+++ b/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
@@ -91,6 +91,7 @@ qx.Class.define("osparc.widget.PersistentIframe", {
     __diskUsageIndicator: null,
     __reloadButton: null,
     __zoomButton: null,
+    __busHandlers: null,
 
     // override
     _createContentElement : function() {
@@ -256,33 +257,23 @@ qx.Class.define("osparc.widget.PersistentIframe", {
     },
 
     __attachInterframeMessageHandlers: function() {
-      this.__attachInterIframeThemeSyncer();
-      this.__attachInterIframeLocaleSyncer();
+      this.__busHandlers = {};
+      // forward app-driven theme/locale changes to the iframe
+      this.postThemeSwitch = this.__attachInterIframeSyncer("themeSwitch", osparc.widget.PersistentIframe.THEME_SWITCH_MSG);
+      this.postLocaleSwitch = this.__attachInterIframeSyncer("localeSwitch", osparc.widget.PersistentIframe.LOCALE_SWITCH_MSG);
       this.__attachInterIframeListeners();
     },
 
-    __attachInterIframeThemeSyncer: function() {
-      this.postThemeSwitch = theme => {
-        const msg = osparc.widget.PersistentIframe.THEME_SWITCH_MSG + theme;
-        this.sendMessageToIframe(msg);
-      };
-
-      this.themeSwitchHandler = msg => {
-        this.postThemeSwitch(msg.getData());
-      };
-      qx.event.message.Bus.getInstance().subscribe("themeSwitch", this.themeSwitchHandler);
-    },
-
-    __attachInterIframeLocaleSyncer: function() {
-      this.postLocaleSwitch = locale => {
-        const msg = osparc.widget.PersistentIframe.LOCALE_SWITCH_MSG + locale;
-        this.sendMessageToIframe(msg);
-      };
-
-      this.localeSwitchHandler = msg => {
-        this.postLocaleSwitch(msg.getData());
-      };
-      qx.event.message.Bus.getInstance().subscribe("localeSwitch", this.localeSwitchHandler);
+    /**
+     * Subscribes to a Bus event and forwards its payload to the iframe as an "osparc;<key>=<value>" message.
+     * @return {Function} post function so callers can also push the current value on demand.
+     */
+    __attachInterIframeSyncer: function(busName, switchMsg) {
+      const post = value => this.sendMessageToIframe(switchMsg + value);
+      const handler = msg => post(msg.getData());
+      this.__busHandlers[busName] = handler;
+      qx.event.message.Bus.getInstance().subscribe(busName, handler);
+      return post;
     },
 
     __postLoadSetup: function() {
@@ -454,6 +445,7 @@ qx.Class.define("osparc.widget.PersistentIframe", {
     this.__iframe.exclude();
     this.__iframe.dispose();
     this.__iframe = undefined;
-    qx.event.message.Bus.getInstance().unsubscribe("themeSwitch", this.themeSwitchHandler);
+    const bus = qx.event.message.Bus.getInstance();
+    Object.entries(this.__busHandlers || {}).forEach(([busName, handler]) => bus.unsubscribe(busName, handler));
   }
 });

--- a/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
+++ b/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
@@ -353,10 +353,7 @@ qx.Class.define("osparc.widget.PersistentIframe", {
             // switch locale driven by the iframe
             if (message && message.includes(osparc.widget.PersistentIframe.LOCALE_SWITCH_MSG)) {
               const locale = message.replace(osparc.widget.PersistentIframe.LOCALE_SWITCH_MSG, "");
-              const validLocales = osparc.utils.LanguageManager.getAvailableLocales();
-              if (validLocales.includes(locale)) {
-                osparc.utils.LanguageManager.setLocale(locale);
-              }
+              osparc.utils.LanguageManager.setLocale(locale);
             }
             break;
           }

--- a/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
+++ b/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
@@ -291,6 +291,11 @@ qx.Class.define("osparc.widget.PersistentIframe", {
       if (currentTheme && this.postThemeSwitch) {
         this.postThemeSwitch(currentTheme.name);
       }
+      // let the iframe know which locale is currently active
+      const currentLocale = qx.locale.Manager.getInstance().getLocale();
+      if (currentLocale && this.postLocaleSwitch) {
+        this.postLocaleSwitch(currentLocale);
+      }
       // let the iframe know what's the user's name
       const username = osparc.auth.Data.getInstance().getFriendlyUserName();
       const msg = "osparc;username=" + username;
@@ -357,9 +362,9 @@ qx.Class.define("osparc.widget.PersistentIframe", {
             // switch locale driven by the iframe
             if (message && message.includes(osparc.widget.PersistentIframe.LOCALE_SWITCH_MSG)) {
               const locale = message.replace(osparc.widget.PersistentIframe.LOCALE_SWITCH_MSG, "");
-              const validLocales = osparc.utils.Utils.getValidLocales();
+              const validLocales = osparc.utils.LanguageManager.getAvailableLocales();
               if (validLocales.includes(locale)) {
-                osparc.store.Store.getInstance().setLocale(locale);
+                osparc.utils.LanguageManager.setLocale(locale);
               }
             }
             break;

--- a/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
+++ b/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
@@ -53,7 +53,9 @@ qx.Class.define("osparc.widget.PersistentIframe", {
       });
     },
 
-    HIDDEN_TOP: -10000
+    HIDDEN_TOP: -10000,
+    THEME_SWITCH_MSG: "osparc;theme=",
+    LOCALE_SWITCH_MSG: "osparc;locale=",
   },
 
   properties: {
@@ -261,7 +263,7 @@ qx.Class.define("osparc.widget.PersistentIframe", {
 
     __attachInterIframeThemeSyncer: function() {
       this.postThemeSwitch = theme => {
-        const msg = "osparc;theme=" + theme;
+        const msg = osparc.widget.PersistentIframe.THEME_SWITCH_MSG + theme;
         this.sendMessageToIframe(msg);
       };
 
@@ -273,7 +275,7 @@ qx.Class.define("osparc.widget.PersistentIframe", {
 
     __attachInterIframeLocaleSyncer: function() {
       this.postLocaleSwitch = locale => {
-        const msg = "osparc;locale=" + locale;
+        const msg = osparc.widget.PersistentIframe.LOCALE_SWITCH_MSG + locale;
         this.sendMessageToIframe(msg);
       };
 
@@ -339,13 +341,25 @@ qx.Class.define("osparc.widget.PersistentIframe", {
           case "changeTheme":
           case "theme": {
             // switch theme driven by the iframe
-            if (message && message.includes("osparc;theme=")) {
-              const themeName = message.replace("osparc;theme=", "");
+            if (message && message.includes(osparc.widget.PersistentIframe.THEME_SWITCH_MSG)) {
+              const themeName = message.replace(osparc.widget.PersistentIframe.THEME_SWITCH_MSG, "");
               const validThemes = osparc.ui.switch.ThemeSwitcher.getValidThemes();
               const themeFound = validThemes.find(theme => theme.basename === themeName);
               const themeManager = qx.theme.manager.Meta.getInstance();
               if (themeFound !== themeManager.getTheme()) {
                 themeManager.setTheme(themeFound);
+              }
+            }
+            break;
+          }
+          case "changeLocale":
+          case "locale": {
+            // switch locale driven by the iframe
+            if (message && message.includes(osparc.widget.PersistentIframe.LOCALE_SWITCH_MSG)) {
+              const locale = message.replace(osparc.widget.PersistentIframe.LOCALE_SWITCH_MSG, "");
+              const validLocales = osparc.utils.Utils.getValidLocales();
+              if (validLocales.includes(locale)) {
+                osparc.store.Store.getInstance().setLocale(locale);
               }
             }
             break;

--- a/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
+++ b/services/static-webserver/client/source/class/osparc/widget/PersistentIframe.js
@@ -255,6 +255,7 @@ qx.Class.define("osparc.widget.PersistentIframe", {
 
     __attachInterframeMessageHandlers: function() {
       this.__attachInterIframeThemeSyncer();
+      this.__attachInterIframeLocaleSyncer();
       this.__attachInterIframeListeners();
     },
 
@@ -268,6 +269,18 @@ qx.Class.define("osparc.widget.PersistentIframe", {
         this.postThemeSwitch(msg.getData());
       };
       qx.event.message.Bus.getInstance().subscribe("themeSwitch", this.themeSwitchHandler);
+    },
+
+    __attachInterIframeLocaleSyncer: function() {
+      this.postLocaleSwitch = locale => {
+        const msg = "osparc;locale=" + locale;
+        this.sendMessageToIframe(msg);
+      };
+
+      this.localeSwitchHandler = msg => {
+        this.postLocaleSwitch(msg.getData());
+      };
+      qx.event.message.Bus.getInstance().subscribe("localeSwitch", this.localeSwitchHandler);
     },
 
     __postLoadSetup: function() {


### PR DESCRIPTION
## What do these changes do?

Adds bidirectional locale synchronization between the platform and embedded service iframes, so embedded apps can follow (and request) locale changes.

## Related issue/s
- related to https://github.com/ITISFoundation/private-issues/issues/590


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
