### PR TITLE
🐛 fix filter in listing groups

### DIFF
--- a/services/web/server/src/simcore_service_webserver/groups/_groups_repository.py
+++ b/services/web/server/src/simcore_service_webserver/groups/_groups_repository.py
@@ -178,14 +178,10 @@ def _list_user_groups_with_read_access_query(
     if product_name is None:
         return base_query
 
-    # Exclude standard groups linked by another product row as either the
-    # product group or the product support group. These groups are
+    # Exclude standard groups linked by another product row (product group). These groups are
     # product-internal and must not leak across products.
     other_product_group_or_support_group_exists = sa.exists(
-        sa.select(sa.literal(1)).where(
-            (products.c.name != product_name)
-            & ((products.c.group_id == groups.c.gid) | (products.c.support_standard_group_id == groups.c.gid))
-        )
+        sa.select(sa.literal(1)).where((products.c.name != product_name) & (products.c.group_id == groups.c.gid))
     )
     return base_query.where((groups.c.type != GroupType.STANDARD) | ~other_product_group_or_support_group_exists)
 

--- a/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_crud.py
+++ b/services/web/server/tests/unit/with_dbs/01/groups/test_groups_handlers_crud.py
@@ -206,7 +206,7 @@ async def test_group_creation_workflow(
 
 
 @pytest.mark.parametrize("user_role", [UserRole.USER])
-async def test_list_user_groups_excludes_other_product_support_group(
+async def test_list_user_groups_includes_other_product_support_group(
     client: TestClient,
     user_role: UserRole,
     logged_user: UserInfoDict,
@@ -280,4 +280,4 @@ async def test_list_user_groups_excludes_other_product_support_group(
 
         # ASSERT
         organization_ids = {group.gid for group in my_groups.organizations or []}
-        assert other_product_support_group_gid not in organization_ids
+        assert other_product_support_group_gid in organization_ids


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
- 🐛 fix recently added filter in listing groups (support group is a normal organization style group, therefore it should be listed.)
- Found by @odeimaiz 

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- introduced by https://github.com/itisfoundation/osparc-simcore/issues/9277


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
