### PR TITLE
Bugfix/delete parent folder shall delete entries in db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,6 @@ repo*.config*
 
 # uv
 .uv-bin/*
+
+# graphify
+/**/graphify-out/*

--- a/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
+++ b/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
@@ -358,9 +358,22 @@ class FileMetaDataRepository(BaseRepository):
         *,
         connection: AsyncConnection | None = None,
         file_ids: list[SimcoreS3FileID],
+        delete_descendants: bool,
     ) -> None:
         async with transaction_context(self.db_engine, connection) as conn:
-            await conn.execute(file_meta_data.delete().where(file_meta_data.c.file_id.in_(file_ids)))
+            if not delete_descendants:
+                await conn.execute(file_meta_data.delete().where(file_meta_data.c.file_id.in_(file_ids)))
+                return
+
+            conditions = [
+                sa.or_(
+                    file_meta_data.c.file_id == file_id,
+                    file_meta_data.c.file_id.startswith(f"{file_id}/"),
+                )
+                for file_id in file_ids
+            ]
+
+            await conn.execute(file_meta_data.delete().where(sa.or_(*conditions)))
 
     async def delete_all_from_project(
         self, *, connection: AsyncConnection | None = None, project_id: ProjectID

--- a/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
+++ b/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
@@ -358,10 +358,20 @@ class FileMetaDataRepository(BaseRepository):
         *,
         connection: AsyncConnection | None = None,
         file_ids: list[SimcoreS3FileID],
-        delete_descendants: bool,
+        recursive: bool,
     ) -> None:
+        """Delete the files with `file_ids`.
+
+        Arguments:
+            file_ids -- the files to delete
+            recursive -- if True, deletes all files that are children of the given file_ids
+                            (e.g. file_id starts with file_id/)
+
+        Keyword Arguments:
+            connection -- the database connection to use (default: {None})
+        """
         async with transaction_context(self.db_engine, connection) as conn:
-            if not delete_descendants:
+            if not recursive:
                 await conn.execute(file_meta_data.delete().where(file_meta_data.c.file_id.in_(file_ids)))
                 return
 

--- a/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
+++ b/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
@@ -2,8 +2,10 @@ import contextlib
 import datetime
 from collections.abc import AsyncGenerator
 from pathlib import Path
+from typing import Annotated
 
 import sqlalchemy as sa
+from annotated_types import doc
 from models_library.basic_types import SHA256Str
 from models_library.products import ProductName
 from models_library.projects import ProjectID
@@ -357,19 +359,10 @@ class FileMetaDataRepository(BaseRepository):
         self,
         *,
         connection: AsyncConnection | None = None,
-        file_ids: list[SimcoreS3FileID],
-        recursive: bool,
+        file_ids: Annotated[list[SimcoreS3FileID], doc("file IDs to delete")],
+        recursive: Annotated[bool, doc("if True, deletes all files that are children of the given file_ids")],
     ) -> None:
-        """Delete the files with `file_ids`.
-
-        Arguments:
-            file_ids -- the files to delete
-            recursive -- if True, deletes all files that are children of the given file_ids
-                            (e.g. file_id starts with file_id/)
-
-        Keyword Arguments:
-            connection -- the database connection to use (default: {None})
-        """
+        """Delete the files with `file_ids`."""
         async with transaction_context(self.db_engine, connection) as conn:
             if not recursive:
                 await conn.execute(file_meta_data.delete().where(file_meta_data.c.file_id.in_(file_ids)))

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -566,7 +566,9 @@ class SimcoreS3DataManager(BaseDataManager):  # pylint:disable=too-many-public-m
             await self._update_database_from_storage(fmd)
         except S3KeyNotFoundError:
             # the file does not exist, so we delete the entry in the db
-            await FileMetaDataRepository.instance(get_db_engine(self.app)).delete(file_ids=[fmd.file_id])
+            await FileMetaDataRepository.instance(get_db_engine(self.app)).delete(
+                file_ids=[fmd.file_id], delete_descendants=False
+            )
 
     async def complete_file_upload(
         self,
@@ -694,7 +696,11 @@ class SimcoreS3DataManager(BaseDataManager):  # pylint:disable=too-many-public-m
 
             async with transaction_context(get_db_engine(self.app)) as connection:
                 file_meta_data_repo = FileMetaDataRepository.instance(get_db_engine(self.app))
-                await file_meta_data_repo.delete(connection=connection, file_ids=[file_id])
+                await file_meta_data_repo.delete(
+                    connection=connection,
+                    file_ids=[file_id],
+                    delete_descendants=True,
+                )
 
                 # NOTE: if the file was at root level, we do not have to update the parent (not tracked in the DB)
                 if is_nested_level_file_id(file_id) and (

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -567,7 +567,7 @@ class SimcoreS3DataManager(BaseDataManager):  # pylint:disable=too-many-public-m
         except S3KeyNotFoundError:
             # the file does not exist, so we delete the entry in the db
             await FileMetaDataRepository.instance(get_db_engine(self.app)).delete(
-                file_ids=[fmd.file_id], delete_descendants=False
+                file_ids=[fmd.file_id], recursive=False
             )
 
     async def complete_file_upload(
@@ -699,7 +699,7 @@ class SimcoreS3DataManager(BaseDataManager):  # pylint:disable=too-many-public-m
                 await file_meta_data_repo.delete(
                     connection=connection,
                     file_ids=[file_id],
-                    delete_descendants=True,
+                    recursive=True,
                 )
 
                 # NOTE: if the file was at root level, we do not have to update the parent (not tracked in the DB)

--- a/services/storage/tests/unit/test_handlers_files.py
+++ b/services/storage/tests/unit/test_handlers_files.py
@@ -1082,6 +1082,85 @@ async def test_delete_file(
     ids=[SimcoreS3DataManager.get_location_name()],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    "file_size",
+    [
+        pytest.param(TypeAdapter(ByteSize).validate_python("1Mib")),
+    ],
+    ids=byte_size_ids,
+)
+async def test_delete_parent_folder_path_removes_descendants_from_db(
+    sqlalchemy_async_engine: AsyncEngine,
+    storage_s3_client: SimcoreS3API,
+    storage_s3_bucket: S3BucketName,
+    initialized_app: FastAPI,
+    client: httpx.AsyncClient,
+    file_size: ByteSize,
+    upload_file: Callable[..., Awaitable[tuple[Path, SimcoreS3FileID]]],
+    location_id: LocationID,
+    user_id: UserID,
+    project_id: ProjectID,
+    node_id: NodeID,
+):
+    parent_folder = TypeAdapter(SimcoreS3FileID).validate_python(f"{project_id}/{node_id}/sub-folderA")
+    nested_file_1 = TypeAdapter(SimcoreS3FileID).validate_python(f"{parent_folder}/first.txt")
+    nested_file_2 = TypeAdapter(SimcoreS3FileID).validate_python(f"{parent_folder}/level-2/second.txt")
+    sibling_file = TypeAdapter(SimcoreS3FileID).validate_python(f"{project_id}/{node_id}/sub-folderAB/keep.txt")
+
+    await upload_file(file_size, "first.txt", file_id=nested_file_1)
+    await upload_file(file_size, "second.txt", file_id=nested_file_2)
+    await upload_file(file_size, "keep.txt", file_id=sibling_file)
+
+    delete_url = url_from_operation_id(
+        client,
+        initialized_app,
+        "delete_file",
+        location_id=f"{location_id}",
+        file_id=parent_folder,
+    ).with_query(user_id=user_id)
+    response = await client.delete(f"{delete_url}")
+    assert_status(response, status.HTTP_204_NO_CONTENT, None)
+
+    await assert_file_meta_data_in_db(
+        sqlalchemy_async_engine,
+        file_id=nested_file_1,
+        expected_entry_exists=False,
+        expected_file_size=None,
+        expected_upload_id=None,
+        expected_upload_expiration_date=None,
+        expected_sha256_checksum=None,
+    )
+    await assert_file_meta_data_in_db(
+        sqlalchemy_async_engine,
+        file_id=nested_file_2,
+        expected_entry_exists=False,
+        expected_file_size=None,
+        expected_upload_id=None,
+        expected_upload_expiration_date=None,
+        expected_sha256_checksum=None,
+    )
+    await assert_file_meta_data_in_db(
+        sqlalchemy_async_engine,
+        file_id=sibling_file,
+        expected_entry_exists=True,
+        expected_file_size=file_size,
+        expected_upload_id=False,
+        expected_upload_expiration_date=False,
+        expected_sha256_checksum=None,
+    )
+
+    with pytest.raises(S3KeyNotFoundError):
+        await storage_s3_client.get_object_metadata(bucket=storage_s3_bucket, object_key=nested_file_1)
+    with pytest.raises(S3KeyNotFoundError):
+        await storage_s3_client.get_object_metadata(bucket=storage_s3_bucket, object_key=nested_file_2)
+
+
+@pytest.mark.parametrize(
+    "location_id",
+    [SimcoreS3DataManager.get_location_id()],
+    ids=[SimcoreS3DataManager.get_location_name()],
+    indirect=True,
+)
 async def test_copy_as_soft_link(
     initialized_app: FastAPI,
     client: httpx.AsyncClient,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Adds descendant aware deletion to the file_meta_data repository method and regression tests
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/9420

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
