### PR TITLE
🐛Computational backend: release dask resources when pipeline or runs information are missing

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -655,7 +655,7 @@ class BaseCompScheduler(ABC):
                 )
 
                 # NOTE: no need to update task states here as pipeline is already broken
-                await self._safe_release_resources(comp_run.user_id, comp_run.project_uuid, comp_run.run_id)
+                await self._safe_release_resources(user_id, project_id, iteration)
                 await self._set_run_result(user_id, project_id, iteration, RunningState.FAILED)
             except InvalidPipelineError as exc:
                 _logger.exception(
@@ -671,7 +671,7 @@ class BaseCompScheduler(ABC):
                     ),
                 )
                 # NOTE: no need to update task states here as pipeline is already broken
-                await self._safe_release_resources(comp_run.user_id, comp_run.project_uuid, comp_run.run_id)
+                await self._safe_release_resources(user_id, project_id, iteration)
                 await self._set_run_result(user_id, project_id, iteration, RunningState.FAILED)
             except ComputationalSchedulerChangedError as exc:
                 _logger.exception(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -639,6 +639,7 @@ class BaseCompScheduler(ABC):
                 )
 
                 # NOTE: no need to update task states here as pipeline is already broken
+                await self._release_resources(comp_run)
                 await self._set_run_result(user_id, project_id, iteration, RunningState.FAILED)
             except InvalidPipelineError as exc:
                 _logger.exception(
@@ -654,6 +655,7 @@ class BaseCompScheduler(ABC):
                     ),
                 )
                 # NOTE: no need to update task states here as pipeline is already broken
+                await self._release_resources(comp_run)
                 await self._set_run_result(user_id, project_id, iteration, RunningState.FAILED)
             except ComputationalSchedulerChangedError as exc:
                 _logger.exception(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -638,7 +638,7 @@ class BaseCompScheduler(ABC):
                         tip="Check that the project still exists",
                     )
                 )
-                await self._safe_release_resources(comp_run.user_id, comp_run.project_uuid, comp_run.run_id)
+                await self._safe_release_resources(user_id, project_id, iteration)
             except PipelineNotFoundError as exc:
                 _logger.exception(
                     **create_troubleshooting_log_kwargs(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -44,6 +44,7 @@ from ...core.errors import (
     ClustersKeeperNotAvailableError,
     ComputationalBackendNotConnectedError,
     ComputationalBackendOnDemandNotReadyError,
+    ComputationalRunNotFoundError,
     ComputationalSchedulerChangedError,
     DaskClientAcquisisitonError,
     InvalidPipelineError,
@@ -551,7 +552,7 @@ class BaseCompScheduler(ABC):
         """process executing tasks from the 3rd party backend"""
 
     @abstractmethod
-    async def _release_resources(self, comp_run: CompRunsAtDB) -> None:
+    async def _safe_release_resources(self, user_id: UserID, project_id: ProjectID, run_id: Iteration) -> None:
         """release resources used by the scheduler for a given user and project"""
 
     async def apply(
@@ -616,13 +617,28 @@ class BaseCompScheduler(ABC):
 
                 # 7. Are we done scheduling that pipeline?
                 if not dag.nodes() or pipeline_result in COMPLETED_STATES:
-                    await self._release_resources(comp_run)
+                    await self._safe_release_resources(comp_run.user_id, comp_run.project_uuid, comp_run.run_id)
                     # there is nothing left, the run is completed, we're done here
                     _logger.info(
                         "pipeline %s scheduling completed with result %s",
                         f"{project_id=}",
                         f"{pipeline_result=}",
                     )
+            except ComputationalRunNotFoundError as exc:
+                _logger.exception(
+                    **create_troubleshooting_log_kwargs(
+                        f"pipeline {project_id} is missing from `comp_runs` DB table, "
+                        "something is corrupted. Aborting scheduling",
+                        error=exc,
+                        error_context={
+                            "user_id": f"{user_id}",
+                            "project_id": f"{project_id}",
+                            "iteration": f"{iteration}",
+                        },
+                        tip="Check that the project still exists",
+                    )
+                )
+                await self._safe_release_resources(comp_run.user_id, comp_run.project_uuid, comp_run.run_id)
             except PipelineNotFoundError as exc:
                 _logger.exception(
                     **create_troubleshooting_log_kwargs(
@@ -639,7 +655,7 @@ class BaseCompScheduler(ABC):
                 )
 
                 # NOTE: no need to update task states here as pipeline is already broken
-                await self._release_resources(comp_run)
+                await self._safe_release_resources(comp_run.user_id, comp_run.project_uuid, comp_run.run_id)
                 await self._set_run_result(user_id, project_id, iteration, RunningState.FAILED)
             except InvalidPipelineError as exc:
                 _logger.exception(
@@ -655,7 +671,7 @@ class BaseCompScheduler(ABC):
                     ),
                 )
                 # NOTE: no need to update task states here as pipeline is already broken
-                await self._release_resources(comp_run)
+                await self._safe_release_resources(comp_run.user_id, comp_run.project_uuid, comp_run.run_id)
                 await self._set_run_result(user_id, project_id, iteration, RunningState.FAILED)
             except ComputationalSchedulerChangedError as exc:
                 _logger.exception(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -285,22 +285,18 @@ class DaskScheduler(BaseCompScheduler):
             limit=_PUBLICATION_CONCURRENCY_LIMIT,
         )
 
-    async def _release_resources(self, comp_run: CompRunsAtDB) -> None:
+    async def _safe_release_resources(self, user_id: UserID, project_id: ProjectID, run_id: Iteration) -> None:
         """release resources used by the scheduler for a given user and project"""
         with (
             log_catch(_logger, reraise=False),
             log_context(
                 _logger,
                 logging.INFO,
-                msg=f"releasing resources for {comp_run.user_id=}, {comp_run.project_uuid=}, {comp_run.run_id=}",
+                msg=f"releasing resources for {user_id=}, {project_id=}, {run_id=}",
             ),
         ):
             await self.dask_clients_pool.release_client_ref(
-                ref=_DASK_CLIENT_RUN_REF.format(
-                    user_id=comp_run.user_id,
-                    project_id=comp_run.project_uuid,
-                    run_id=comp_run.run_id,
-                )
+                ref=_DASK_CLIENT_RUN_REF.format(user_id=user_id, project_id=project_id, run_id=run_id)
             )
 
     async def _stop_tasks(self, user_id: UserID, tasks: list[CompTaskAtDB], comp_run: CompRunsAtDB) -> None:

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -55,6 +55,7 @@ from pydantic import TypeAdapter
 from pytest_mock.plugin import MockerFixture
 from servicelib.rabbitmq import RabbitMQClient
 from servicelib.rabbitmq._constants import BIND_TO_ALL_TOPICS
+from simcore_postgres_database.models.comp_pipeline import comp_pipeline
 from simcore_postgres_database.models.comp_runs import comp_runs
 from simcore_postgres_database.models.comp_tasks import NodeClass
 from simcore_sdk.node_ports_common.exceptions import S3InvalidPathError
@@ -67,6 +68,7 @@ from simcore_service_director_v2.core.errors import (
     ComputationalSchedulerChangedError,
     ComputationalSchedulerError,
     DaskClientAcquisisitonError,
+    InvalidPipelineError,
 )
 from simcore_service_director_v2.models.comp_pipelines import CompPipelineAtDB
 from simcore_service_director_v2.models.comp_runs import CompRunsAtDB, RunMetadataDict
@@ -2910,3 +2912,169 @@ async def test_variable_resolution_error_while_starting_tasks_fails_ready_tasks(
             comp_runs.c.project_uuid == f"{published_project.project.uuid}",
         ),
     )
+
+
+@pytest.fixture
+def mocked_safe_release_resources(scheduler_api: BaseCompScheduler, mocker: MockerFixture) -> mock.AsyncMock:
+    return mocker.patch.object(
+        scheduler_api,
+        "_safe_release_resources",
+        wraps=scheduler_api._safe_release_resources,  # noqa: SLF001
+    )
+
+
+async def test_pipeline_not_found_error_aborts_scheduling(
+    with_disabled_auto_scheduling: mock.Mock,
+    with_disabled_scheduler_publisher: mock.Mock,
+    initialized_app: FastAPI,
+    mocked_dask_client: mock.MagicMock,
+    scheduler_api: BaseCompScheduler,
+    mocked_safe_release_resources: mock.AsyncMock,
+    sqlalchemy_async_engine: AsyncEngine,
+    published_project: PublishedProject,
+    run_metadata: RunMetadataDict,
+    computational_pipeline_rabbit_client_parser: mock.AsyncMock,
+    fake_collection_run_id: CollectionRunID,
+):
+    """When the comp_pipeline row is deleted between pipeline start and scheduling,
+    PipelineNotFoundError is raised, resources are released and the run is set to FAILED."""
+    _with_mock_send_computation_tasks(published_project.tasks, mocked_dask_client)
+    run_in_db, _ = await _assert_start_pipeline(
+        initialized_app,
+        sqlalchemy_async_engine=sqlalchemy_async_engine,
+        published_project=published_project,
+        run_metadata=run_metadata,
+        computational_pipeline_rabbit_client_parser=computational_pipeline_rabbit_client_parser,
+        collection_run_id=fake_collection_run_id,
+    )
+
+    # Simulate a corrupted state: remove the pipeline from comp_pipelines
+    async with sqlalchemy_async_engine.begin() as conn:
+        await conn.execute(
+            comp_pipeline.delete().where(comp_pipeline.c.project_id == f"{published_project.project.uuid}")
+        )
+
+    # Scheduling must handle PipelineNotFoundError gracefully and mark the run FAILED
+    await scheduler_api.apply(
+        user_id=run_in_db.user_id,
+        project_id=run_in_db.project_uuid,
+        iteration=run_in_db.iteration,
+    )
+    await assert_comp_runs(
+        sqlalchemy_async_engine,
+        expected_total=1,
+        expected_state=RunningState.FAILED,
+        where_statement=and_(
+            comp_runs.c.user_id == run_in_db.user_id,
+            comp_runs.c.project_uuid == f"{run_in_db.project_uuid}",
+        ),
+    )
+    mocked_safe_release_resources.assert_awaited_once_with(run_in_db.user_id, run_in_db.project_uuid, run_in_db.run_id)
+    await _assert_message_received(
+        computational_pipeline_rabbit_client_parser,
+        1,
+        ComputationalPipelineStatusMessage.model_validate_json,
+    )
+
+
+async def test_invalid_pipeline_error_aborts_scheduling(
+    with_disabled_auto_scheduling: mock.Mock,
+    with_disabled_scheduler_publisher: mock.Mock,
+    initialized_app: FastAPI,
+    mocked_dask_client: mock.MagicMock,
+    scheduler_api: BaseCompScheduler,
+    mocked_safe_release_resources: mock.AsyncMock,
+    sqlalchemy_async_engine: AsyncEngine,
+    published_project: PublishedProject,
+    run_metadata: RunMetadataDict,
+    computational_pipeline_rabbit_client_parser: mock.AsyncMock,
+    fake_collection_run_id: CollectionRunID,
+    mocker: MockerFixture,
+):
+    """When _get_pipeline_tasks detects a mismatch between DAG nodes and comp_tasks,
+    InvalidPipelineError is raised, resources are released and the run is set to FAILED."""
+    _with_mock_send_computation_tasks(published_project.tasks, mocked_dask_client)
+    run_in_db, _ = await _assert_start_pipeline(
+        initialized_app,
+        sqlalchemy_async_engine=sqlalchemy_async_engine,
+        published_project=published_project,
+        run_metadata=run_metadata,
+        computational_pipeline_rabbit_client_parser=computational_pipeline_rabbit_client_parser,
+        collection_run_id=fake_collection_run_id,
+    )
+
+    mocker.patch.object(
+        scheduler_api,
+        "_get_pipeline_tasks",
+        side_effect=InvalidPipelineError(
+            pipeline_id=run_in_db.project_uuid,
+            msg="simulated: tasks in DB do not match pipeline DAG",
+        ),
+    )
+
+    # Scheduling must handle InvalidPipelineError gracefully and mark the run FAILED
+    await scheduler_api.apply(
+        user_id=run_in_db.user_id,
+        project_id=run_in_db.project_uuid,
+        iteration=run_in_db.iteration,
+    )
+    await assert_comp_runs(
+        sqlalchemy_async_engine,
+        expected_total=1,
+        expected_state=RunningState.FAILED,
+        where_statement=and_(
+            comp_runs.c.user_id == run_in_db.user_id,
+            comp_runs.c.project_uuid == f"{run_in_db.project_uuid}",
+        ),
+    )
+    mocked_safe_release_resources.assert_awaited_once_with(run_in_db.user_id, run_in_db.project_uuid, run_in_db.run_id)
+    await _assert_message_received(
+        computational_pipeline_rabbit_client_parser,
+        1,
+        ComputationalPipelineStatusMessage.model_validate_json,
+    )
+
+
+async def test_computational_run_not_found_error_releases_resources(
+    with_disabled_auto_scheduling: mock.Mock,
+    with_disabled_scheduler_publisher: mock.Mock,
+    initialized_app: FastAPI,
+    mocked_dask_client: mock.MagicMock,
+    scheduler_api: BaseCompScheduler,
+    mocked_safe_release_resources: mock.AsyncMock,
+    sqlalchemy_async_engine: AsyncEngine,
+    published_project: PublishedProject,
+    run_metadata: RunMetadataDict,
+    computational_pipeline_rabbit_client_parser: mock.AsyncMock,
+    fake_collection_run_id: CollectionRunID,
+):
+    """When the comp_run row is missing, ComputationalRunNotFoundError is raised.
+    Resources are released but no run-result update is attempted (there is no run to update)."""
+    _with_mock_send_computation_tasks(published_project.tasks, mocked_dask_client)
+    run_in_db, _ = await _assert_start_pipeline(
+        initialized_app,
+        sqlalchemy_async_engine=sqlalchemy_async_engine,
+        published_project=published_project,
+        run_metadata=run_metadata,
+        computational_pipeline_rabbit_client_parser=computational_pipeline_rabbit_client_parser,
+        collection_run_id=fake_collection_run_id,
+    )
+
+    # Simulate a corrupted state: remove the run from comp_runs
+    async with sqlalchemy_async_engine.begin() as conn:
+        await conn.execute(comp_runs.delete().where(comp_runs.c.run_id == run_in_db.run_id))
+
+    # Scheduling must handle ComputationalRunNotFoundError gracefully without raising
+    await scheduler_api.apply(
+        user_id=run_in_db.user_id,
+        project_id=run_in_db.project_uuid,
+        iteration=run_in_db.iteration,
+    )
+
+    # resources must be released even though the run is missing;
+    # note: iteration is used (not run_id) because comp_run was never fetched
+    mocked_safe_release_resources.assert_awaited_once_with(
+        run_in_db.user_id, run_in_db.project_uuid, run_in_db.iteration
+    )
+    # no comp_run row should exist (was deleted before apply)
+    await assert_comp_runs_empty(sqlalchemy_async_engine)

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -2970,7 +2970,7 @@ async def test_pipeline_not_found_error_aborts_scheduling(
             comp_runs.c.project_uuid == f"{run_in_db.project_uuid}",
         ),
     )
-    mocked_safe_release_resources.assert_awaited_once_with(run_in_db.user_id, run_in_db.project_uuid, run_in_db.run_id)
+    mocked_safe_release_resources.assert_called_once_with(run_in_db.user_id, run_in_db.project_uuid, mock.ANY)
     await _assert_message_received(
         computational_pipeline_rabbit_client_parser,
         1,
@@ -3028,7 +3028,7 @@ async def test_invalid_pipeline_error_aborts_scheduling(
             comp_runs.c.project_uuid == f"{run_in_db.project_uuid}",
         ),
     )
-    mocked_safe_release_resources.assert_awaited_once_with(run_in_db.user_id, run_in_db.project_uuid, run_in_db.run_id)
+    mocked_safe_release_resources.assert_called_once_with(run_in_db.user_id, run_in_db.project_uuid, mock.ANY)
     await _assert_message_received(
         computational_pipeline_rabbit_client_parser,
         1,
@@ -3074,7 +3074,7 @@ async def test_computational_run_not_found_error_releases_resources(
 
     # resources must be released even though the run is missing;
     # note: iteration is used (not run_id) because comp_run was never fetched
-    mocked_safe_release_resources.assert_awaited_once_with(
+    mocked_safe_release_resources.assert_called_once_with(
         run_in_db.user_id, run_in_db.project_uuid, run_in_db.iteration
     )
     # no comp_run row should exist (was deleted before apply)

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -57,7 +57,7 @@ from servicelib.rabbitmq import RabbitMQClient
 from servicelib.rabbitmq._constants import BIND_TO_ALL_TOPICS
 from simcore_postgres_database.models.comp_pipeline import comp_pipeline
 from simcore_postgres_database.models.comp_runs import comp_runs
-from simcore_postgres_database.models.comp_tasks import NodeClass
+from simcore_postgres_database.models.comp_tasks import NodeClass, comp_tasks
 from simcore_sdk.node_ports_common.exceptions import S3InvalidPathError
 from simcore_service_director_v2.core.errors import (
     ClustersKeeperNotAvailableError,
@@ -2950,6 +2950,7 @@ async def test_pipeline_not_found_error_aborts_scheduling(
 
     # Simulate a corrupted state: remove the pipeline from comp_pipelines
     async with sqlalchemy_async_engine.begin() as conn:
+        await conn.execute(comp_tasks.delete().where(comp_tasks.c.project_id == f"{published_project.project.uuid}"))
         await conn.execute(
             comp_pipeline.delete().where(comp_pipeline.c.project_id == f"{published_project.project.uuid}")
         )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This is a first of a fix for https://github.com/ITISFoundation/osparc-simcore/issues/9223
This one fixes the consequence but is not the final fix.

### The problem
the `director-v2` has an entry point for deleting a computation. This waits for 30 seconds and then gives up but does not raise an exception and continues the deletion. This in turn triggers an exception in the computational scheduler as DB entries are removed. During this exception the dask backend resources are not properly released, which in turn leave computational clusters alive although the dv-2 is not using it anymore.

This is a minimal viable bugfix, but in essence it could still fail in case of bad timing (e.g. webserver asks to delete the project, then somehow the project does not delete in 30 seconds, `comp_pipeline`/`comp_tasks` rows get removed, comes back to the webserver that deletes the project row --> deletes the `comp_runs` row --> computational scheduler loses knowledge of that pipeline. if the computational cluster still has computations running, they will be kept there forever.

A subsequent PR will come with maybe a more robust involving the GC and raising an error when the pipeline could not be deleted. 


<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/9223

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
