### PR TITLE
🎨E2E: allow handling of already started services when going to the next service

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -40,6 +40,7 @@ _logger = logging.getLogger(__name__)
 SECOND: Final[int] = 1000
 MINUTE: Final[int] = 60 * SECOND
 NODE_START_REQUEST_PATTERN: Final[re.Pattern[str]] = re.compile(r"/projects/[^/]+/nodes/[^:]+:start")
+_APP_MODE_NEXT_APP_START_REQUEST_TIMEOUT: Final[int] = 5 * SECOND
 
 
 @unique
@@ -643,12 +644,22 @@ def wait_for_service_running(
 
 
 def app_mode_trigger_next_app(page: Page) -> None:
-    with (
-        log_context(logging.INFO, msg="triggering next app"),
-        page.expect_request(_node_started_predicate),
-    ):
-        # Move to next step (this auto starts the next service)
-        page.get_by_test_id("AppMode_NextBtn").click()
+    """NOTE: the frontend only issues a node `:start` request if the next
+    service is not already running (see `Node.canNodeStart()` in the
+    frontend). If the next service was already started, clicking "Next"
+    will not fire that request, so we tolerate the timeout here and let the
+    caller's websocket-based waiters handle the already-running case.
+    """
+    with log_context(logging.INFO, msg="triggering next app") as ctx:
+        try:
+            with page.expect_request(_node_started_predicate, timeout=_APP_MODE_NEXT_APP_START_REQUEST_TIMEOUT):
+                # Move to next step (this auto starts the next service)
+                page.get_by_test_id("AppMode_NextBtn").click()
+        except (PlaywrightTimeoutError, TimeoutError):
+            ctx.logger.info(
+                "⚠️ no start request detected within %s ms: the next service was likely already started ⚠️",
+                _APP_MODE_NEXT_APP_START_REQUEST_TIMEOUT,
+            )
 
 
 def wait_for_label_text(page: Page, locator: str, substring: str, timeout: int = 10000) -> Locator:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Playwright could not handle pressing the next button when a service was already started (e.g. the project has autostart services checked). This PR now allows it, which can be handy on on-premise deployments.


<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
