### PR TITLE
🐛 Add jitter before run function start

### DIFF
--- a/services/api-server/src/simcore_service_api_server/_service_function_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/_service_function_jobs.py
@@ -58,7 +58,14 @@ def join_inputs(
 
 # a randomized delay (jitter) to avoid hit director-v2/dask at
 # the same instant when calling map()
-_START_JOB_JITTER_MAX_SECONDS: Final[float] = 5.0
+_JITTER_SECONDS_PER_JOB: Final[float] = 0.25
+_MAX_JITTER_CAP_SECONDS: Final[float] = 30.0
+
+
+def _compute_start_jitter_seconds(*, batch_size: int) -> float:
+    if batch_size <= 1:
+        return 0
+    return min(_MAX_JITTER_CAP_SECONDS, batch_size * _JITTER_SECONDS_PER_JOB)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -255,8 +262,10 @@ class FunctionJobService:
         job_links: JobLinks,
         x_simcore_parent_project_uuid: NodeID | None,
         x_simcore_parent_node_id: NodeID | None,
+        batch_size: int = 1,
     ) -> RegisteredFunctionJob:
         """N.B. this function does not check access rights. Use get_cached_function_job for that"""
+        start_jitter_seconds = _compute_start_jitter_seconds(batch_size=batch_size)
 
         if function.function_class == FunctionClass.PROJECT:
             study_job = await self._job_service.create_studies_job(
@@ -267,7 +276,7 @@ class FunctionJobService:
                 x_simcore_parent_project_uuid=x_simcore_parent_project_uuid,
                 x_simcore_parent_node_id=x_simcore_parent_node_id,
             )
-            await asyncio.sleep(random.uniform(0, _START_JOB_JITTER_MAX_SECONDS))  # noqa: S311
+            await asyncio.sleep(random.uniform(0, start_jitter_seconds))  # noqa: S311
             await self._job_service.start_study_job(
                 study_id=function.project_id,
                 job_id=study_job.id,
@@ -299,7 +308,7 @@ class FunctionJobService:
                 x_simcore_parent_project_uuid=x_simcore_parent_project_uuid,
                 x_simcore_parent_node_id=x_simcore_parent_node_id,
             )
-            await asyncio.sleep(random.uniform(0, _START_JOB_JITTER_MAX_SECONDS))  # noqa: S311
+            await asyncio.sleep(random.uniform(0, start_jitter_seconds))  # noqa: S311
             await self._job_service.start_solver_job(
                 solver_key=function.solver_key,
                 version=function.solver_version,

--- a/services/api-server/src/simcore_service_api_server/_service_function_jobs.py
+++ b/services/api-server/src/simcore_service_api_server/_service_function_jobs.py
@@ -1,4 +1,7 @@
+import asyncio
+import random
 from dataclasses import dataclass
+from typing import Final
 
 import jsonschema
 from common_library.exclude import as_dict_exclude_none
@@ -51,6 +54,11 @@ def join_inputs(
 
     # last dict will override defaults
     return {**default_inputs, **function_inputs}
+
+
+# a randomized delay (jitter) to avoid hit director-v2/dask at
+# the same instant when calling map()
+_START_JOB_JITTER_MAX_SECONDS: Final[float] = 5.0
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -259,6 +267,7 @@ class FunctionJobService:
                 x_simcore_parent_project_uuid=x_simcore_parent_project_uuid,
                 x_simcore_parent_node_id=x_simcore_parent_node_id,
             )
+            await asyncio.sleep(random.uniform(0, _START_JOB_JITTER_MAX_SECONDS))  # noqa: S311
             await self._job_service.start_study_job(
                 study_id=function.project_id,
                 job_id=study_job.id,
@@ -290,6 +299,7 @@ class FunctionJobService:
                 x_simcore_parent_project_uuid=x_simcore_parent_project_uuid,
                 x_simcore_parent_node_id=x_simcore_parent_node_id,
             )
+            await asyncio.sleep(random.uniform(0, _START_JOB_JITTER_MAX_SECONDS))  # noqa: S311
             await self._job_service.start_solver_job(
                 solver_key=function.solver_key,
                 version=function.solver_version,

--- a/services/api-server/src/simcore_service_api_server/_service_function_jobs_task_client.py
+++ b/services/api-server/src/simcore_service_api_server/_service_function_jobs_task_client.py
@@ -332,6 +332,7 @@ class FunctionJobTaskClientService:
                 product_name=user_identity.product_name,
                 owner=APP_NAME,
             )
+            batch_size = len(pre_registered_function_job_data_list)
             task_uuids = await logged_gather(
                 *(
                     self._celery_task_manager.submit_task(
@@ -348,6 +349,7 @@ class FunctionJobTaskClientService:
                         job_links=job_links,
                         x_simcore_parent_project_uuid=parent_project_uuid,
                         x_simcore_parent_node_id=parent_node_id,
+                        batch_size=batch_size,
                     )
                     for pre_registered_function_job_data in pre_registered_function_job_data_list
                 ),

--- a/services/api-server/src/simcore_service_api_server/modules/celery/worker/_functions_tasks.py
+++ b/services/api-server/src/simcore_service_api_server/modules/celery/worker/_functions_tasks.py
@@ -1,6 +1,4 @@
-from celery import (  # type: ignore[import-untyped] # pylint: disable=no-name-in-module
-    Task,
-)
+from celery import Task  # type: ignore[import-untyped] # pylint: disable=no-name-in-module
 from celery_library.worker.app_server import get_app_server
 from fastapi import FastAPI
 from models_library.celery import TaskKey
@@ -22,10 +20,7 @@ from ....api.dependencies.services import (
     get_solver_service,
     get_storage_service,
 )
-from ....api.dependencies.webserver_http import (
-    get_session_cookie,
-    get_webserver_session,
-)
+from ....api.dependencies.webserver_http import get_session_cookie, get_webserver_session
 from ....api.dependencies.webserver_rpc import get_wb_api_rpc_client
 from ....models.api_resources import JobLinks
 from ....models.domain.functions import PreRegisteredFunctionJobData
@@ -114,6 +109,7 @@ async def run_function(
     job_links: JobLinks,
     x_simcore_parent_project_uuid: ProjectID | None,
     x_simcore_parent_node_id: NodeID | None,
+    batch_size: int = 1,
 ) -> RegisteredFunctionJob:
     assert task_key  # nosec
     app = get_app_server(task.app).app
@@ -126,4 +122,5 @@ async def run_function(
         job_links=job_links,
         x_simcore_parent_project_uuid=x_simcore_parent_project_uuid,
         x_simcore_parent_node_id=x_simcore_parent_node_id,
+        batch_size=batch_size,
     )

--- a/services/api-server/tests/unit/api_functions/celery/test_functions_celery.py
+++ b/services/api-server/tests/unit/api_functions/celery/test_functions_celery.py
@@ -53,36 +53,17 @@ from models_library.users import UserID
 from pytest_mock import MockType
 from pytest_simcore.helpers.httpx_calls_capture_models import HttpApiCallCaptureModel
 from pytest_simcore.helpers.typing_mock import HandlerMockFactory
-from servicelib.common_headers import (
-    X_SIMCORE_PARENT_NODE_ID,
-    X_SIMCORE_PARENT_PROJECT_UUID,
-)
+from servicelib.common_headers import X_SIMCORE_PARENT_NODE_ID, X_SIMCORE_PARENT_PROJECT_UUID
 from simcore_service_api_server._meta import API_VTAG
 from simcore_service_api_server.api.dependencies.authentication import Identity
-from simcore_service_api_server.api.dependencies.celery import (
-    get_task_manager,
-)
+from simcore_service_api_server.api.dependencies.celery import get_task_manager
 from simcore_service_api_server.exceptions.backend_errors import BaseBackEndError
 from simcore_service_api_server.models.api_resources import JobLinks
-from simcore_service_api_server.models.domain.celery_models import (
-    ApiServerOwnerMetadata,
-)
-from simcore_service_api_server.models.domain.functions import (
-    PreRegisteredFunctionJobData,
-)
-from simcore_service_api_server.models.schemas.jobs import (
-    JobPricingSpecification,
-    NodeID,
-)
-from simcore_service_api_server.modules.celery.worker._functions_tasks import (
-    run_function as run_function_task,
-)
-from tenacity import (
-    AsyncRetrying,
-    retry_if_exception_type,
-    stop_after_delay,
-    wait_fixed,
-)
+from simcore_service_api_server.models.domain.celery_models import ApiServerOwnerMetadata
+from simcore_service_api_server.models.domain.functions import PreRegisteredFunctionJobData
+from simcore_service_api_server.models.schemas.jobs import JobPricingSpecification, NodeID
+from simcore_service_api_server.modules.celery.worker._functions_tasks import run_function as run_function_task
+from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
 pytest_simcore_core_services_selection = [
     "postgres",
@@ -130,6 +111,7 @@ def _register_fake_run_function_task() -> Callable[[Celery], None]:
         job_links: JobLinks,
         x_simcore_parent_project_uuid: NodeID | None,
         x_simcore_parent_node_id: NodeID | None,
+        batch_size: int = 1,
     ) -> RegisteredFunctionJob:
         return RegisteredProjectFunctionJob(
             title=_faker.sentence(),

--- a/services/api-server/tests/unit/api_functions/test_api_routers_functions.py
+++ b/services/api-server/tests/unit/api_functions/test_api_routers_functions.py
@@ -6,7 +6,7 @@
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import httpx
@@ -32,10 +32,7 @@ from models_library.functions import (
     RegisteredProjectFunctionJobPatch,
     RegisteredSolverFunctionJobPatch,
 )
-from models_library.functions_errors import (
-    FunctionIDNotFoundError,
-    FunctionReadAccessDeniedError,
-)
+from models_library.functions_errors import FunctionIDNotFoundError, FunctionReadAccessDeniedError
 from models_library.products import ProductName
 from models_library.rest_pagination import PageMetaInfoLimitOffset
 from models_library.users import UserID
@@ -44,17 +41,12 @@ from pytest_mock import MockerFixture, MockType
 from pytest_simcore.helpers.httpx_calls_capture_models import HttpApiCallCaptureModel
 from servicelib.aiohttp import status
 from servicelib.celery.app_server import BaseAppServer
-from servicelib.common_headers import (
-    X_SIMCORE_PARENT_NODE_ID,
-    X_SIMCORE_PARENT_PROJECT_UUID,
-)
+from servicelib.common_headers import X_SIMCORE_PARENT_NODE_ID, X_SIMCORE_PARENT_PROJECT_UUID
 from servicelib.rabbitmq import RabbitMQRPCClient
 from simcore_service_api_server._meta import API_VTAG
 from simcore_service_api_server.api.dependencies.authentication import Identity
 from simcore_service_api_server.models.api_resources import JobLinks
-from simcore_service_api_server.models.domain.functions import (
-    PreRegisteredFunctionJobData,
-)
+from simcore_service_api_server.models.domain.functions import PreRegisteredFunctionJobData
 from simcore_service_api_server.models.schemas.jobs import JobInputs
 from simcore_service_api_server.modules.celery.worker import _functions_tasks
 from simcore_service_api_server.services_rpc.wb_api_server import WbApiRpcClient
@@ -394,6 +386,9 @@ async def test_run_project_function(
         return app_server
 
     mocker.patch.object(_functions_tasks, "get_app_server", _get_app_server)
+
+    # avoid actually waiting for the pre-start jitter delay in this test
+    mocker.patch("simcore_service_api_server._service_function_jobs.asyncio.sleep", new_callable=AsyncMock)
 
     def _get_task_manager(app: FastAPI) -> CeleryTaskManager:
         return mock_dependency_get_celery_task_manager

--- a/services/api-server/tests/unit/service/test_service_function_jobs.py
+++ b/services/api-server/tests/unit/service/test_service_function_jobs.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name
 
+import asyncio
 import datetime
 from uuid import uuid4
 
@@ -15,9 +16,12 @@ from models_library.functions import RegisteredFunction
 from models_library.products import ProductName
 from models_library.users import UserID
 from pytest_mock import MockerFixture
-from simcore_service_api_server._service_function_jobs import FunctionJobService
+from simcore_service_api_server._service_function_jobs import _START_JOB_JITTER_MAX_SECONDS, FunctionJobService
 from simcore_service_api_server._service_functions import FunctionService
 from simcore_service_api_server._service_jobs import JobService
+from simcore_service_api_server.models.api_resources import JobLinks
+from simcore_service_api_server.models.domain.functions import PreRegisteredFunctionJobData
+from simcore_service_api_server.models.schemas.jobs import JobInputs
 from simcore_service_api_server.services_http.webserver import AuthSession
 from simcore_service_api_server.services_rpc.storage import StorageService
 from simcore_service_api_server.services_rpc.wb_api_server import WbApiRpcClient
@@ -78,3 +82,56 @@ async def test_batch_pre_register_function_jobs_with_empty_list(
     )
 
     assert result == []
+
+
+async def test_run_function_start_is_jittered(
+    function_job_service: FunctionJobService,
+    registered_project_function: RegisteredFunction,
+    fake_job_links: JobLinks,
+    mocker: MockerFixture,
+):
+    """Concurrently calling run_function for a burst of jobs (e.g. a map/sweep)
+    must not trigger the actual computation start (start_study_job) for all of
+    them at the exact same instant: the pre-start jitter should spread out when
+    each one actually starts, to avoid overloading director-v2/dask with a burst
+    of simultaneous submissions.
+    """
+    num_jobs = 40
+
+    fake_job = mocker.Mock(id=uuid4())
+    function_job_service._job_service.create_studies_job = mocker.AsyncMock(return_value=fake_job)  # noqa: SLF001
+    function_job_service._web_rpc_client.patch_registered_function_job = mocker.AsyncMock(  # noqa: SLF001
+        return_value=mocker.Mock()
+    )
+
+    start_times: list[float] = []
+
+    async def _record_start_time(*args, **kwargs) -> None:
+        start_times.append(asyncio.get_running_loop().time())
+
+    function_job_service._job_service.start_study_job = mocker.AsyncMock(  # noqa: SLF001
+        side_effect=_record_start_time
+    )
+
+    pre_registered_jobs = [
+        PreRegisteredFunctionJobData(function_job_id=uuid4(), job_inputs=JobInputs(values={})) for _ in range(num_jobs)
+    ]
+
+    def _run_function(data: PreRegisteredFunctionJobData):
+        return function_job_service.run_function(
+            function=registered_project_function,
+            pre_registered_function_job_data=data,
+            pricing_spec=None,
+            job_links=fake_job_links,
+            x_simcore_parent_project_uuid=None,
+            x_simcore_parent_node_id=None,
+        )
+
+    await asyncio.gather(*map(_run_function, pre_registered_jobs))
+
+    assert len(start_times) == num_jobs
+    spread = max(start_times) - min(start_times)
+    assert spread > _START_JOB_JITTER_MAX_SECONDS * 0.3, (
+        f"Expected start_study_job calls to be spread out by jitter, but spread was only {spread}s "
+        f"(jitter max is {_START_JOB_JITTER_MAX_SECONDS}s)"
+    )

--- a/services/api-server/tests/unit/service/test_service_function_jobs.py
+++ b/services/api-server/tests/unit/service/test_service_function_jobs.py
@@ -16,7 +16,7 @@ from models_library.functions import RegisteredFunction
 from models_library.products import ProductName
 from models_library.users import UserID
 from pytest_mock import MockerFixture
-from simcore_service_api_server._service_function_jobs import _START_JOB_JITTER_MAX_SECONDS, FunctionJobService
+from simcore_service_api_server._service_function_jobs import FunctionJobService, _compute_start_jitter_seconds
 from simcore_service_api_server._service_functions import FunctionService
 from simcore_service_api_server._service_jobs import JobService
 from simcore_service_api_server.models.api_resources import JobLinks
@@ -125,13 +125,47 @@ async def test_run_function_start_is_jittered(
             job_links=fake_job_links,
             x_simcore_parent_project_uuid=None,
             x_simcore_parent_node_id=None,
+            batch_size=num_jobs,
         )
 
     await asyncio.gather(*map(_run_function, pre_registered_jobs))
 
     assert len(start_times) == num_jobs
     spread = max(start_times) - min(start_times)
-    assert spread > _START_JOB_JITTER_MAX_SECONDS * 0.3, (
+    expected_jitter_max = _compute_start_jitter_seconds(batch_size=num_jobs)
+    assert spread > expected_jitter_max * 0.3, (
         f"Expected start_study_job calls to be spread out by jitter, but spread was only {spread}s "
-        f"(jitter max is {_START_JOB_JITTER_MAX_SECONDS}s)"
+        f"(jitter max is {expected_jitter_max}s)"
     )
+
+
+async def test_run_function_isolated_call_has_no_jitter(
+    function_job_service: FunctionJobService,
+    registered_project_function: RegisteredFunction,
+    fake_job_links: JobLinks,
+    mocker: MockerFixture,
+):
+    """An isolated run_function call (batch_size=1, the default) must not incur
+    any jitter delay, since there is no burst of sibling jobs to desynchronize.
+    """
+    fake_job = mocker.Mock(id=uuid4())
+    function_job_service._job_service.create_studies_job = mocker.AsyncMock(return_value=fake_job)  # noqa: SLF001
+    function_job_service._web_rpc_client.patch_registered_function_job = mocker.AsyncMock(  # noqa: SLF001
+        return_value=mocker.Mock()
+    )
+    function_job_service._job_service.start_study_job = mocker.AsyncMock()  # noqa: SLF001
+
+    data = PreRegisteredFunctionJobData(function_job_id=uuid4(), job_inputs=JobInputs(values={}))
+
+    start = asyncio.get_running_loop().time()
+    await function_job_service.run_function(
+        function=registered_project_function,
+        pre_registered_function_job_data=data,
+        pricing_spec=None,
+        job_links=fake_job_links,
+        x_simcore_parent_project_uuid=None,
+        x_simcore_parent_node_id=None,
+    )
+    elapsed = asyncio.get_running_loop().time() - start
+
+    assert elapsed < 0.1


### PR DESCRIPTION
## What do these changes do?

When a map() is called in the function API, make sure not all functions start at exactly the same time to avoid overloading the system.


## How to test

The PR contains new tests


## Dev-ops

N/A
