### PR TITLE
Maintenance/add tracing to log context

### DIFF
--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -14,7 +14,7 @@ import queue
 import sys
 from asyncio import iscoroutinefunction
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from inspect import getframeinfo, stack
 from pathlib import Path
@@ -30,7 +30,7 @@ from common_library.logging.logging_utils_filtering import (
     MessageSubstring,
 )
 
-from .tracing import TracingConfig, setup_log_tracing
+from .tracing import TracingConfig, get_current_tracing_config, setup_log_tracing, traced_operation
 from .utils_secrets import mask_sensitive_data
 
 _logger = logging.getLogger(__name__)
@@ -589,6 +589,16 @@ _STACK_LEVEL_OFFSET: Final[int] = 3  # 1 => log_context, 2 => contextlib, 3 => c
 _CONTEXT_ID_LEN: Final[int] = 8
 
 
+def _default_operation_name() -> str:
+    # NOTE: this is a helper called from within `log_context`'s body, which itself adds one frame
+    # on top of the `stacklevel=_STACK_LEVEL_OFFSET` frame-chain used below for `logger.log()`
+    # (0 => this helper, 1 => log_context, 2 => contextlib, 3 => caller). Uses `sys._getframe()`
+    # (O(1), single frame) rather than `inspect.stack()` (O(stack depth), reads source lines for
+    # every frame) since this runs on every traced `log_context` call.
+    frame = sys._getframe(_STACK_LEVEL_OFFSET)  # noqa: SLF001
+    return f"{Path(frame.f_code.co_filename).stem}:{frame.f_code.co_name}"
+
+
 @contextmanager
 def log_context(
     logger: logging.Logger,
@@ -596,6 +606,7 @@ def log_context(
     msg: LogMessageStr,
     *args,
     extra: LogExtra | None = None,
+    operation_name: str | None = None,
 ) -> Iterator[None]:
     # NOTE: preserves original signature https://docs.python.org/3/library/logging.html#logging.Logger.log
 
@@ -608,6 +619,21 @@ def log_context(
 
     started_time = datetime.datetime.now(tz=datetime.UTC)
     starting_log_msg = f"{_STARTING_PREFIX}{msg}"
+
+    tracing_config = get_current_tracing_config()
+
+    with ExitStack() as stack_mgr:
+        if tracing_config is not None and tracing_config.tracing_enabled:
+            # NOTE: mirrors `logging.LogRecord.getMessage()` (only applies `%` formatting when
+            # `args` is truthy) so this matches exactly what ends up in the actual log line.
+            rendered_msg = msg % args if args else msg
+            stack_mgr.enter_context(
+                traced_operation(
+                    operation_name or _default_operation_name(),
+                    tracing_config=tracing_config,
+                    attributes={"log.message": rendered_msg},
+                )
+            )
 
     try:
         logger.log(

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -590,11 +590,7 @@ _CONTEXT_ID_LEN: Final[int] = 8
 
 
 def _default_operation_name() -> str:
-    # NOTE: this is a helper called from within `log_context`'s body, which itself adds one frame
-    # on top of the `stacklevel=_STACK_LEVEL_OFFSET` frame-chain used below for `logger.log()`
-    # (0 => this helper, 1 => log_context, 2 => contextlib, 3 => caller). Uses `sys._getframe()`
-    # (O(1), single frame) rather than `inspect.stack()` (O(stack depth), reads source lines for
-    # every frame) since this runs on every traced `log_context` call.
+    """returns a default operation name made of the filename and function name of the caller of `log_context()`"""
     frame = sys._getframe(_STACK_LEVEL_OFFSET)  # noqa: SLF001
     return f"{Path(frame.f_code.co_filename).stem}:{frame.f_code.co_name}"
 
@@ -635,31 +631,31 @@ def log_context(
                 )
             )
 
-    try:
-        logger.log(
-            level,
-            starting_log_msg,
-            *args,
-            **kwargs,
-            stacklevel=_STACK_LEVEL_OFFSET,
-        )
-        yield
-    finally:
-        potential_exception = sys.exception()
-        additional_info_message = (
-            f" (raised exception {type(potential_exception).__name__})" if potential_exception else ""
-        )
-        elapsed_time = datetime.datetime.now(tz=datetime.UTC) - started_time
-        finished_log_msg = (
-            f"{_DONE_PREFIX}{msg}{additional_info_message} - ⏳{_timedelta_as_minute_second_ms(elapsed_time)}"
-        )
-        logger.log(
-            level,
-            finished_log_msg,
-            *args,
-            **kwargs,
-            stacklevel=_STACK_LEVEL_OFFSET,
-        )
+        try:
+            logger.log(
+                level,
+                starting_log_msg,
+                *args,
+                **kwargs,
+                stacklevel=_STACK_LEVEL_OFFSET,
+            )
+            yield
+        finally:
+            potential_exception = sys.exception()
+            additional_info_message = (
+                f" (raised exception {type(potential_exception).__name__})" if potential_exception else ""
+            )
+            elapsed_time = datetime.datetime.now(tz=datetime.UTC) - started_time
+            finished_log_msg = (
+                f"{_DONE_PREFIX}{msg}{additional_info_message} - ⏳{_timedelta_as_minute_second_ms(elapsed_time)}"
+            )
+            logger.log(
+                level,
+                finished_log_msg,
+                *args,
+                **kwargs,
+                stacklevel=_STACK_LEVEL_OFFSET,
+            )
 
 
 def guess_message_log_level(message: str) -> LogLevelInt:

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -16,8 +16,9 @@ from asyncio import iscoroutinefunction
 from collections.abc import Callable, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
-from inspect import getframeinfo, stack
+from inspect import currentframe, getframeinfo, stack
 from pathlib import Path
+from types import FrameType
 from typing import Any, Final, TypedDict, TypeVar
 from uuid import uuid4
 
@@ -599,16 +600,30 @@ _STACK_LEVEL_OFFSET: Final[int] = 3  # 1 => log_context, 2 => contextlib, 3 => c
 _CONTEXT_ID_LEN: Final[int] = 8
 
 
+def _get_frame(stacklevel: int) -> FrameType | None:
+    """returns the frame `stacklevel` levels up from the *caller* of this function (i.e. behaves like
+    `sys._getframe(stacklevel)` called directly at the call site), or `None` if the stack isn't that deep
+    (or on Python implementations without frame support, per `inspect.currentframe()`)"""
+    frame = currentframe()
+    for _ in range(stacklevel + 1):  # +1 to skip this function's own frame
+        if frame is None:
+            return None
+        frame = frame.f_back
+    return frame
+
+
 def _default_operation_name() -> str:
     """returns a default operation name made of the filename and function name of the caller of `log_context()`"""
-    frame = sys._getframe(_STACK_LEVEL_OFFSET)  # noqa: SLF001
+    frame = _get_frame(_STACK_LEVEL_OFFSET)
+    if frame is None:
+        return "log_context:unknown:unknown"
     return f"log_context:{Path(frame.f_code.co_filename).stem}:{frame.f_code.co_name}"
 
 
 def _caller_lineno() -> int:
     """returns the line number, within the caller's function, of the `with log_context(...):` call"""
-    frame = sys._getframe(_STACK_LEVEL_OFFSET)  # noqa: SLF001
-    return frame.f_lineno
+    frame = _get_frame(_STACK_LEVEL_OFFSET)
+    return frame.f_lineno if frame is not None else 0
 
 
 @contextmanager

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -688,12 +688,12 @@ def log_context(
             yield
         finally:
             potential_exception = sys.exception()
-            additional_info_message = (
-                f" (raised exception {type(potential_exception).__name__})" if potential_exception else ""
-            )
             elapsed_time = datetime.datetime.now(tz=datetime.UTC) - started_time
+
             finished_log_msg = (
-                f"{_DONE_PREFIX}{msg}{additional_info_message} - ⏳{_timedelta_as_minute_second_ms(elapsed_time)}"
+                f"{_DONE_PREFIX}{msg}"
+                f"{f' (raised exception {type(potential_exception).__name__})' if potential_exception else ''}"
+                f" - ⏳{_timedelta_as_minute_second_ms(elapsed_time)}"
             )
             logger.log(
                 level,

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -13,7 +13,7 @@ import logging.handlers
 import queue
 import sys
 from asyncio import iscoroutinefunction
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from inspect import currentframe, getframeinfo, stack
@@ -634,7 +634,7 @@ def log_context(
     *args,
     extra: LogExtra | None = None,
     operation_name: str | None = None,
-) -> Iterator[None]:
+) -> Generator[None]:
     # NOTE: preserves original signature https://docs.python.org/3/library/logging.html#logging.Logger.log
 
     context_id = uuid4().hex[:_CONTEXT_ID_LEN]

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -626,6 +626,15 @@ def _caller_lineno() -> int:
     return frame.f_lineno if frame is not None else 0
 
 
+def _default_operation_name_and_lineno() -> tuple[str, int]:
+    """returns a default operation name made of the filename, function name,
+    and line number of the caller of `log_context()`"""
+    frame = _get_frame(_STACK_LEVEL_OFFSET)
+    if frame is None:
+        return "unknown:unknown - log_context", 0
+    return f"{Path(frame.f_code.co_filename).stem}:{frame.f_code.co_name} - log_context", frame.f_lineno
+
+
 @contextmanager
 def log_context(
     logger: logging.Logger,
@@ -654,13 +663,16 @@ def log_context(
             # NOTE: mirrors `logging.LogRecord.getMessage()` (only applies `%` formatting when
             # `args` is truthy) so this matches exactly what ends up in the actual log line.
             rendered_msg = msg % args if args else msg
+            operation_name_final, lineno = (
+                _default_operation_name_and_lineno() if operation_name is None else (operation_name, _caller_lineno())
+            )
             stack_mgr.enter_context(
                 traced_operation(
-                    operation_name or _default_operation_name(),
+                    operation_name_final,
                     tracing_config=tracing_config,
                     attributes={
                         "log.message": rendered_msg,
-                        "code.lineno": str(_caller_lineno()),
+                        "code.lineno": str(lineno),
                     },
                 )
             )

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -380,8 +380,18 @@ def async_loggers(
     ):
         _apply_logging_configuration(queue_handler, logger_filter_mapping)
 
-        with log_context(_logger, logging.INFO, "Asynchronous logging"):
+        # NOTE: this context is held for the entire application lifetime (i.e. until the
+        # process shuts down). Do NOT use `log_context` here: since `log_context` now creates
+        # a tracing span whenever tracing is enabled, wrapping the whole app runtime in it
+        # would create a span that never ends. Such a span never gets exported (span
+        # processors export on `on_end`), yet it would remain the ambient "current span" for
+        # everything created during the app's lifetime, so every one of its direct children
+        # would reference an unresolvable parent span ID.
+        _logger.info("Starting asynchronous logging")
+        try:
             yield
+        finally:
+            _logger.info("Finished asynchronous logging")
 
 
 class LogExceptionsKwargsDict(TypedDict, total=True):
@@ -592,7 +602,13 @@ _CONTEXT_ID_LEN: Final[int] = 8
 def _default_operation_name() -> str:
     """returns a default operation name made of the filename and function name of the caller of `log_context()`"""
     frame = sys._getframe(_STACK_LEVEL_OFFSET)  # noqa: SLF001
-    return f"{Path(frame.f_code.co_filename).stem}:{frame.f_code.co_name}"
+    return f"log_context:{Path(frame.f_code.co_filename).stem}:{frame.f_code.co_name}"
+
+
+def _caller_lineno() -> int:
+    """returns the line number, within the caller's function, of the `with log_context(...):` call"""
+    frame = sys._getframe(_STACK_LEVEL_OFFSET)  # noqa: SLF001
+    return frame.f_lineno
 
 
 @contextmanager
@@ -627,7 +643,10 @@ def log_context(
                 traced_operation(
                     operation_name or _default_operation_name(),
                     tracing_config=tracing_config,
-                    attributes={"log.message": rendered_msg},
+                    attributes={
+                        "log.message": rendered_msg,
+                        "code.lineno": str(_caller_lineno()),
+                    },
                 )
             )
 

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -616,8 +616,8 @@ def _default_operation_name() -> str:
     """returns a default operation name made of the filename and function name of the caller of `log_context()`"""
     frame = _get_frame(_STACK_LEVEL_OFFSET)
     if frame is None:
-        return "log_context:unknown:unknown"
-    return f"log_context:{Path(frame.f_code.co_filename).stem}:{frame.f_code.co_name}"
+        return "unknown:unknown - log_context"
+    return f"{Path(frame.f_code.co_filename).stem}:{frame.f_code.co_name} - log_context"
 
 
 def _caller_lineno() -> int:

--- a/packages/service-library/src/servicelib/tracing.py
+++ b/packages/service-library/src/servicelib/tracing.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 from collections.abc import Callable, Coroutine
 from contextlib import contextmanager, suppress
-from contextvars import Token
+from contextvars import ContextVar, Token
 from enum import auto
 from typing import Any, Final, Self, overload
 
@@ -34,6 +34,11 @@ from .utils import get_callable_namespaced_name
 type TracingContext = otcontext.Context | None
 
 _PROFILE_ATTRIBUTE_NAME: Final[str] = "pyinstrument.profile"
+
+# NOTE: holds the TracingConfig set up for this process/context so that utilities such as
+# `log_context` can automatically create spans without threading `TracingConfig` through every
+# call site. Set once by `setup_log_tracing()` (see `logging_utils.setup_loggers`/`async_loggers`).
+_current_tracing_config: ContextVar["TracingConfig | None"] = ContextVar("current_tracing_config", default=None)
 _OSPARC_TRACE_ID_HEADER: Final[str] = "x-osparc-trace-id"
 _OSPARC_TRACE_SAMPLED_HEADER: Final[str] = "x-osparc-trace-sampled"
 _OTEL_NAMESPACE: Final[str] = "simcore"
@@ -104,7 +109,17 @@ def setup_httpx_client_tracing(client: AsyncClient | Client, tracing_config: Tra
     HTTPXClientInstrumentor.instrument_client(client, tracer_provider=tracing_config.tracer_provider)
 
 
+def get_current_tracing_config() -> TracingConfig | None:
+    """Returns the `TracingConfig` set by the last call to `setup_log_tracing()`, if any.
+
+    Used by `log_context()` to automatically create spans without requiring every call site to
+    explicitly pass a `TracingConfig`.
+    """
+    return _current_tracing_config.get()
+
+
 def setup_log_tracing(tracing_config: TracingConfig):
+    _current_tracing_config.set(tracing_config)
     if tracing_config.tracing_enabled:
         LoggingInstrumentor().instrument(
             set_logging_format=True,

--- a/packages/service-library/src/servicelib/tracing.py
+++ b/packages/service-library/src/servicelib/tracing.py
@@ -238,12 +238,30 @@ def traced_operation(
     # Only use provided links at root level; child spans inherit parent context automatically
     current_span = trace.get_current_span()
     is_root_span = not current_span.is_recording()
-    span_links = links if is_root_span else []
+    span_links = list(links) if links else []
+
+    # NOTE: a non-recording "current" span is not necessarily *absent* from the ambient
+    # context (e.g. a long-lived asyncio.Task - such as a periodic background task -
+    # copies the context once at creation time; the span it captured back then keeps
+    # being reported as "current" forever, even long after it ended). If we let
+    # `start_as_current_span` use that ambient context as-is, every single execution
+    # would be chained as a child of that same, already-finished span/trace, which
+    # eventually breaks clock-skew adjustment in the tracing backend once that old
+    # trace is no longer retrievable. So for root spans we explicitly detach from the
+    # ambient context and, if that stale span had a valid context, keep a `Link` to it
+    # instead so it remains navigable without corrupting the parent/child relationship.
+    start_context: otcontext.Context | None = None
+    if is_root_span:
+        stale_span_context = current_span.get_span_context()
+        if stale_span_context.is_valid:
+            span_links.append(Link(stale_span_context))
+        start_context = otcontext.Context()
 
     # Create a span with proper attributes and links
     # If tracing is disabled, this creates a no-op span
     with tracer.start_as_current_span(
         operation_name,
+        context=start_context,
         links=span_links,
         attributes=span_attributes,
     ) as span:

--- a/packages/service-library/src/servicelib/tracing.py
+++ b/packages/service-library/src/servicelib/tracing.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import logging
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterator
 from contextlib import contextmanager, suppress
 from contextvars import ContextVar, Token
 from enum import auto
@@ -209,7 +209,7 @@ def traced_operation(
     tracing_config: TracingConfig,
     attributes: dict[str, str] | None = None,
     links: list[Link] | None = None,
-):
+) -> Iterator[None]:
     """Generic context manager for creating traced spans.
 
     Creates a span with the given operation name and attributes. Automatically detects

--- a/packages/service-library/tests/fastapi/test_tracing.py
+++ b/packages/service-library/tests/fastapi/test_tracing.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI
 from fastapi.exceptions import HTTPException
 from fastapi.responses import PlainTextResponse
 from fastapi.testclient import TestClient
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from pydantic import ValidationError
@@ -867,6 +868,67 @@ def test_traced_decorator_raises_on_missing_app_param():
         @traced
         async def _no_app_param(x: int) -> None:
             pass
+
+
+@pytest.mark.parametrize(
+    "tracing_settings_in",
+    [
+        ("http://opentelemetry-collector", 4318, 1.0),
+    ],
+    indirect=True,
+)
+async def test_traced_operation_links_to_stale_ambient_span_instead_of_chaining_onto_it(
+    mock_otel_collector: InMemorySpanExporter,
+    mocked_app: FastAPI,
+    set_and_clean_settings_env_vars: None,
+    tracing_settings_in: tuple[str, int | str, float],
+    faker: Faker,
+):
+    """Reproduces the scenario of a long-lived `asyncio.Task` (e.g. a periodic background task)
+    that copied the ambient context once, while some span was open, at task-creation time.
+    Long after that captured span has ended, `trace.get_current_span()` inside the task still
+    returns it (non-recording). `traced_operation` must NOT chain new spans onto it as a parent
+    (that ancestor may never be exported again, e.g. it belongs to a completed/evicted trace) -
+    instead it should start a brand new root trace and keep a `Link` back to it.
+    """
+    tracing_settings = TracingSettings.create_from_envs()
+    tracing_config = TracingConfig.create(tracing_settings=tracing_settings, service_name=faker.pystr())
+
+    async for _ in get_tracing_instrumentation_lifespan(
+        tracing_config=tracing_config,
+    )(app=mocked_app):
+        # 1. Create and immediately end a span - simulates the span that was "current" at the
+        #    moment a background asyncio.Task copied the ambient context.
+        with traced_operation("stale_ancestor_operation", tracing_config=tracing_config):
+            stale_span = trace.get_current_span()
+            stale_trace_id = stale_span.get_span_context().trace_id
+            stale_span_id = stale_span.get_span_context().span_id
+        assert not stale_span.is_recording()  # confirms it is indeed stale/ended by now
+
+        # 2. Simulate a frozen Task context: `stale_span` is still "current", even though ended.
+        stale_context = trace.set_span_in_context(stale_span)
+        token = otel_context.attach(stale_context)
+        try:
+            with traced_operation("child_of_stale_operation", tracing_config=tracing_config):
+                new_span = trace.get_current_span()
+                new_trace_id = new_span.get_span_context().trace_id
+        finally:
+            otel_context.detach(token)
+
+        spans = mock_otel_collector.get_finished_spans()
+        child_spans = [s for s in spans if s.name == "child_of_stale_operation"]
+        assert len(child_spans) == 1
+        child_span = child_spans[0]
+
+        # New trace root: NOT chained onto the stale span (different trace_id, no parent)
+        assert new_trace_id != stale_trace_id
+        assert child_span.parent is None
+
+        # ... but still navigable back to where it originated via a Link
+        assert child_span.links is not None
+        assert len(child_span.links) == 1
+        assert child_span.links[0].context.trace_id == stale_trace_id
+        assert child_span.links[0].context.span_id == stale_span_id
 
 
 def test_traced_decorator_raises_on_wrong_app_type():

--- a/packages/service-library/tests/test_logging_utils.py
+++ b/packages/service-library/tests/test_logging_utils.py
@@ -6,6 +6,7 @@ import logging
 import re
 from collections.abc import Iterable
 from contextlib import suppress
+from inspect import currentframe, getframeinfo
 from pathlib import Path
 from typing import Any
 
@@ -331,7 +332,7 @@ def test_log_context_creates_span_automatically(
 
     spans = memory_exporter.get_finished_spans()
     assert len(spans) == 1
-    assert spans[0].name == f"{Path(__file__).stem}:test_log_context_creates_span_automatically"
+    assert spans[0].name == f"log_context:{Path(__file__).stem}:test_log_context_creates_span_automatically"
 
 
 def test_log_context_operation_name_overrides_default_span_name(
@@ -386,7 +387,7 @@ def test_log_context_span_has_log_message_attribute(
     assert isinstance(log_message, str)
     assert "doing something important" in log_message
     # span name stays stable/low-cardinality, unaffected by the free-form message
-    assert spans[0].name == f"{Path(__file__).stem}:test_log_context_span_has_log_message_attribute"
+    assert spans[0].name == f"log_context:{Path(__file__).stem}:test_log_context_span_has_log_message_attribute"
 
 
 def test_log_context_span_log_message_attribute_substitutes_args(
@@ -404,6 +405,20 @@ def test_log_context_span_log_message_attribute_substitutes_args(
     assert isinstance(log_message, str)
     assert "item-123" in log_message
     assert "%s" not in log_message
+
+
+def test_log_context_span_has_code_lineno_attribute(
+    tracing_config_enabled: tuple[TracingConfig, InMemorySpanExporter],
+):
+    _tracing_config, memory_exporter = tracing_config_enabled
+
+    with log_context(_logger, logging.INFO, "doing something"):  # <-- this line's number is expected below
+        expected_lineno = getframeinfo(currentframe()).lineno - 1
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes is not None
+    assert spans[0].attributes["code.lineno"] == str(expected_lineno)
 
 
 @pytest.mark.parametrize("level", _ALL_LOGGING_LEVELS, ids=_to_level_name)

--- a/packages/service-library/tests/test_logging_utils.py
+++ b/packages/service-library/tests/test_logging_utils.py
@@ -332,7 +332,7 @@ def test_log_context_creates_span_automatically(
 
     spans = memory_exporter.get_finished_spans()
     assert len(spans) == 1
-    assert spans[0].name == f"log_context:{Path(__file__).stem}:test_log_context_creates_span_automatically"
+    assert spans[0].name == f"{Path(__file__).stem}:test_log_context_creates_span_automatically - log_context"
 
 
 def test_log_context_operation_name_overrides_default_span_name(
@@ -387,7 +387,7 @@ def test_log_context_span_has_log_message_attribute(
     assert isinstance(log_message, str)
     assert "doing something important" in log_message
     # span name stays stable/low-cardinality, unaffected by the free-form message
-    assert spans[0].name == f"log_context:{Path(__file__).stem}:test_log_context_span_has_log_message_attribute"
+    assert spans[0].name == f"{Path(__file__).stem}:test_log_context_span_has_log_message_attribute - log_context"
 
 
 def test_log_context_span_log_message_attribute_substitutes_args(

--- a/packages/service-library/tests/test_logging_utils.py
+++ b/packages/service-library/tests/test_logging_utils.py
@@ -12,6 +12,9 @@ from typing import Any
 import pytest
 from common_library.logging.logging_base import get_log_record_extra
 from faker import Faker
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from pydantic import AnyUrl
 from servicelib.logging_utils import (
     _DEFAULT_FORMATTING,
     CustomFormatter,
@@ -25,7 +28,8 @@ from servicelib.logging_utils import (
     log_exceptions,
     set_parent_module_log_level,
 )
-from servicelib.tracing import TracingConfig
+from servicelib.tracing import TracingConfig, _current_tracing_config, get_current_tracing_config
+from settings_library.tracing import TracingSettings
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -269,6 +273,137 @@ def test_log_context_caller_is_included_in_log(
 
     # Verify file name is in the log
     assert Path(__file__).name in caplog.text
+
+
+@pytest.fixture
+def no_tracing_config() -> Iterable[None]:
+    # NOTE: `_current_tracing_config` is process-wide (set once by `setup_log_tracing` and never
+    # reset), so we explicitly force/restore it here to make this test independent of test order.
+    token = _current_tracing_config.set(None)
+    try:
+        yield
+    finally:
+        _current_tracing_config.reset(token)
+
+
+@pytest.fixture
+def tracing_config_enabled(faker: Faker) -> Iterable[tuple[TracingConfig, InMemorySpanExporter]]:
+    tracing_settings = TracingSettings(
+        TRACING_OPENTELEMETRY_COLLECTOR_IMAGE_VERSION="0.144.0",
+        TRACING_OPENTELEMETRY_COLLECTOR_ENDPOINT=AnyUrl("http://opentelemetry-collector"),
+        TRACING_OPENTELEMETRY_COLLECTOR_PORT=4318,
+        TRACING_OPENTELEMETRY_SAMPLING_PROBABILITY=1.0,
+    )
+    tracing_config = TracingConfig.create(tracing_settings=tracing_settings, service_name=faker.pystr())
+    assert tracing_config.tracer_provider is not None
+
+    memory_exporter = InMemorySpanExporter()
+    tracing_config.tracer_provider.add_span_processor(SimpleSpanProcessor(memory_exporter))
+
+    token = _current_tracing_config.set(tracing_config)
+    try:
+        yield tracing_config, memory_exporter
+    finally:
+        _current_tracing_config.reset(token)
+
+
+def test_log_context_without_tracing_config_creates_no_span(
+    caplog: pytest.LogCaptureFixture,
+    no_tracing_config: None,
+):
+    assert get_current_tracing_config() is None
+    caplog.clear()
+
+    with log_context(_logger, logging.ERROR, "no tracing configured"):
+        ...
+
+    # unchanged behavior: only the start/finish log messages, no tracing side-effects
+    assert len(caplog.messages) == 2
+
+
+def test_log_context_creates_span_automatically(
+    tracing_config_enabled: tuple[TracingConfig, InMemorySpanExporter],
+):
+    _tracing_config, memory_exporter = tracing_config_enabled
+
+    with log_context(_logger, logging.INFO, "doing something"):
+        ...
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == f"{Path(__file__).stem}:test_log_context_creates_span_automatically"
+
+
+def test_log_context_operation_name_overrides_default_span_name(
+    tracing_config_enabled: tuple[TracingConfig, InMemorySpanExporter],
+):
+    _tracing_config, memory_exporter = tracing_config_enabled
+
+    with log_context(_logger, logging.INFO, "doing something", operation_name="my_custom_operation"):
+        ...
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "my_custom_operation"
+
+
+def test_log_context_nested_calls_create_parent_child_spans(
+    tracing_config_enabled: tuple[TracingConfig, InMemorySpanExporter],
+):
+    _tracing_config, memory_exporter = tracing_config_enabled
+
+    with (
+        log_context(_logger, logging.INFO, "outer", operation_name="outer_op"),
+        log_context(_logger, logging.INFO, "inner", operation_name="inner_op"),
+    ):
+        ...
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 2
+    spans_by_name = {span.name: span for span in spans}
+    outer_span = spans_by_name["outer_op"]
+    inner_span = spans_by_name["inner_op"]
+
+    assert inner_span.parent is not None
+    assert outer_span.context is not None
+    assert inner_span.parent.span_id == outer_span.context.span_id
+    assert inner_span.context is not None
+    assert inner_span.context.trace_id == outer_span.context.trace_id
+
+
+def test_log_context_span_has_log_message_attribute(
+    tracing_config_enabled: tuple[TracingConfig, InMemorySpanExporter],
+):
+    _tracing_config, memory_exporter = tracing_config_enabled
+
+    with log_context(_logger, logging.INFO, "doing something important"):
+        ...
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes is not None
+    log_message = spans[0].attributes["log.message"]
+    assert isinstance(log_message, str)
+    assert "doing something important" in log_message
+    # span name stays stable/low-cardinality, unaffected by the free-form message
+    assert spans[0].name == f"{Path(__file__).stem}:test_log_context_span_has_log_message_attribute"
+
+
+def test_log_context_span_log_message_attribute_substitutes_args(
+    tracing_config_enabled: tuple[TracingConfig, InMemorySpanExporter],
+):
+    _tracing_config, memory_exporter = tracing_config_enabled
+
+    with log_context(_logger, logging.INFO, "processing %s", "item-123"):
+        ...
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes is not None
+    log_message = spans[0].attributes["log.message"]
+    assert isinstance(log_message, str)
+    assert "item-123" in log_message
+    assert "%s" not in log_message
 
 
 @pytest.mark.parametrize("level", _ALL_LOGGING_LEVELS, ids=_to_level_name)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR adds automatic OpenTelemetry span creation inside log_context(), plus a related bug fix for stale span chaining that should add span links mostly automatically.

This should simplify trace debugging by using the already present log_context blocks as tracing blocks as well.


<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->

Example of a trace with log contexts
<img width="1812" height="582" alt="image" src="https://github.com/user-attachments/assets/c814ca57-bb87-450e-b0b1-9862f3bdb965" />


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
