### PR TITLE
⚡ perf(webserver): drop per-node DB fetch in project share-state

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -1562,12 +1562,11 @@ async def _get_node_share_state(
     *,
     project_uuid: ProjectID,
     node_id: NodeID,
+    node_key: str,
     computational_pipeline_running: bool | None,
     user_primrary_groupid: GroupID,
 ) -> NodeShareState:
-    node = await _projects_nodes_repository.get(app, project_id=project_uuid, node_id=node_id)
-
-    if _is_node_dynamic(node.key):
+    if _is_node_dynamic(node_key):
         # if the service is dynamic and running it is locked if it is not collaborative
         service = await dynamic_scheduler_service.get_dynamic_service(app, node_id=node_id)
 
@@ -2068,6 +2067,7 @@ async def add_project_states_for_user(
                 app,
                 project_uuid=project["uuid"],
                 node_id=NodeID(node_uuid),
+                node_key=node["key"],
                 computational_pipeline_running=is_pipeline_running,
                 user_primrary_groupid=user_primary_group_id,
             )

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -344,7 +344,7 @@ async def patch_project_and_notify_users(
 #
 
 
-def _is_node_dynamic(node_key: str) -> bool:
+def _is_node_dynamic(node_key: ServiceKey) -> bool:
     return "/dynamic/" in node_key
 
 
@@ -1562,7 +1562,7 @@ async def _get_node_share_state(
     *,
     project_uuid: ProjectID,
     node_id: NodeID,
-    node_key: str,
+    node_key: ServiceKey,
     computational_pipeline_running: bool | None,
     user_primrary_groupid: GroupID,
 ) -> NodeShareState:


### PR DESCRIPTION
## What do these changes do?

When listing projects (`GET /v0/projects`), the per-project state aggregation iterates over every node in each project's workbench and, for each node, issued a separate database query via `_projects_nodes_repository.get(...)` inside `_get_node_share_state` — just to read the node's `key` and decide whether the node is dynamic.

That `key` is **already present** in the `project["workbench"]` data loaded earlier in the request. This PR passes the node key directly into `_get_node_share_state` (typed as `ServiceKey`) and removes the redundant DB fetch.

### Impact

For a page of **N** projects with **M** nodes each, this spares **M × N** database round-trips per list-projects call — one of the N+1 patterns behind the slow `GET /v0/projects` endpoint. The saving grows linearly with page size and node count.

## Related issue/s

Part of the `GET /v0/projects` optimization effort (N+1 reduction). Isolated, webserver-only, no API/contract change. See https://github.com/ITISFoundation/osparc-simcore/issues/9414

## How to test

- List projects containing multiple nodes and confirm identical `state` / node `lock_state` output.
- Node share-state semantics are unchanged: `key` is read from the same workbench that the loop already iterates, and is guaranteed present.

## Dev-ops checklist

- No changes.
