### PR TITLE
🎨 [Frontend] Do not expose the ``idle=0`` functionality ⚠️

### DIFF
--- a/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/GeneralPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/GeneralPage.js
@@ -141,12 +141,10 @@ qx.Class.define("osparc.desktop.preferences.pages.GeneralPage", {
     __addInactivitySetting: function() {
       const box = new osparc.widget.SectionBox(this.tr("Automatic Shutdown of Idle Instances"));
 
-      box.addHelper(this.tr("Enter 0 to disable this function"));
-
       const form = new qx.ui.form.Form();
       const inactivitySpinner = new qx.ui.form.Spinner().set({
-        minimum: 0,
-        maximum: Number.MAX_SAFE_INTEGER,
+        minimum: 1,
+        maximum: 2*60, // 2 hours
         singleStep: 1,
         allowGrowX: false
       });

--- a/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/GeneralPage.js
+++ b/services/static-webserver/client/source/class/osparc/desktop/preferences/pages/GeneralPage.js
@@ -144,7 +144,7 @@ qx.Class.define("osparc.desktop.preferences.pages.GeneralPage", {
       const form = new qx.ui.form.Form();
       const inactivitySpinner = new qx.ui.form.Spinner().set({
         minimum: 1,
-        maximum: 2*60, // 2 hours
+        maximum: 3*60, // 3 hours
         singleStep: 1,
         allowGrowX: false
       });


### PR DESCRIPTION
## What do these changes do?

this functionality was bringing more bad than good, so we won't expose it any longer to the frontend. It can still be done by tuning the DB if necessary.

Using the User preferences, users will need to go from 1 minute up to 3 hours.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops ⚠️

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->

- [x] run below Q2 after releasing to MASTER
- [x] run below Q2 after releasing to STAGING
- [x] run below Q2 after releasing to PROD


### Q1 - check how many users have the preference set to 0
```sql
SELECT user_id, product_name, preference_name, payload
FROM user_preferences_frontend
WHERE preference_name LIKE '%/UserInactivityThresholdFrontendUserPreference'
  AND (payload ->> 'value')::int = 0;
```

### Q2 - change the preference form 0 to 3 hours
```sql
UPDATE user_preferences_frontend
SET payload = jsonb_set(payload::jsonb, '{value}', '10800'::jsonb)::json
WHERE preference_name LIKE '%/UserInactivityThresholdFrontendUserPreference'
  AND (payload ->> 'value')::int = 0;
```
