### PR TITLE
🐛Fix issue with duplication of trashed projects

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/_controller/_rest_exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_controller/_rest_exceptions.py
@@ -34,6 +34,7 @@ from ..exceptions import (
     InsufficientRoleForProjectTemplateTypeUpdateError,
     NodeNotFoundError,
     ParentNodeNotFoundError,
+    ProjectCopyingTrashedProjectError,
     ProjectDeleteError,
     ProjectGroupNotFoundError,
     ProjectInDebtCanNotChangeWalletError,
@@ -83,6 +84,13 @@ _NODE_ERRORS: ExceptionToHttpErrorMap = {
 
 
 _PROJECT_ERRORS: ExceptionToHttpErrorMap = {
+    ProjectCopyingTrashedProjectError: HttpErrorInfo(
+        status.HTTP_409_CONFLICT,
+        user_message(
+            "Cannot duplicate project {project_uuid} because it is in the trash. Restore it first and try again.",
+            _version=1,
+        ),
+    ),
     ProjectDeleteError: HttpErrorInfo(
         status.HTTP_409_CONFLICT,
         user_message(

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
@@ -156,6 +156,13 @@ async def _prepare_project_copy(
     if not as_template:
         new_project["name"] = default_copy_project_name(source_project["name"])
 
+    # A cloned project must never inherit the source's trash state (e.g. the source
+    # might have been stamped with the trash epoch sentinel for immediate deletion,
+    # see `_trash_service.trash_project_for_immediate_deletion`)
+    new_project["trashed"] = None
+    new_project["trashedBy"] = None
+    new_project["trashedExplicitly"] = False
+
     copy_project_nodes_coro = None
     if len(nodes_map) > 0:
         copy_project_nodes_coro = _copy_project_nodes_from_source_project(

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_api_create.py
@@ -127,11 +127,17 @@ async def _prepare_project_copy(
     deep_copy: bool,
     task_progress: TaskProgress,
 ) -> tuple[ProjectDict, CopyProjectNodesCoro | None, CopyFileCoro | None]:
+    """
+    Raises:
+        ProjectCopyingTrashedProjectError: if the source project is trashed
+    """
     source_project = await _projects_service.get_project_for_user(
         app,
         project_uuid=f"{src_project_uuid}",
         user_id=user_id,
     )
+    _projects_service.raise_if_project_is_trashed(source_project)
+
     settings = get_application_settings(app).WEBSERVER_PROJECTS
     assert settings  # nosec
     if max_bytes := settings.PROJECTS_MAX_COPY_SIZE_BYTES:
@@ -155,13 +161,6 @@ async def _prepare_project_copy(
     new_project["accessRights"] = {}
     if not as_template:
         new_project["name"] = default_copy_project_name(source_project["name"])
-
-    # A cloned project must never inherit the source's trash state (e.g. the source
-    # might have been stamped with the trash epoch sentinel for immediate deletion,
-    # see `_trash_service.trash_project_for_immediate_deletion`)
-    new_project["trashed"] = None
-    new_project["trashedBy"] = None
-    new_project["trashedExplicitly"] = False
 
     copy_project_nodes_coro = None
     if len(nodes_map) > 0:

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_repository_legacy.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_repository_legacy.py
@@ -245,6 +245,7 @@ class ProjectDBAPI(BaseProjectDB):
 
         # NOTE: tags are removed in convert_to_db_names so we keep it
         project_tag_ids = TypeAdapter(list[int]).validate_python(project.get("tags", []).copy())
+        trashed_at = project.get("trashed")
         insert_values = convert_to_db_names(project)
         insert_values.update(
             {
@@ -257,7 +258,7 @@ class ProjectDBAPI(BaseProjectDB):
                 "creation_date": now(),
                 "last_change_date": now(),
                 "product_name": product_name,
-                "trashed": arrow.get(trashed_at).datetime if (trashed_at := project.get("trashed")) else None,
+                "trashed": arrow.get(trashed_at).datetime if trashed_at else None,
             }
         )
 

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_repository_legacy.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_repository_legacy.py
@@ -257,7 +257,7 @@ class ProjectDBAPI(BaseProjectDB):
                 "creation_date": now(),
                 "last_change_date": now(),
                 "product_name": product_name,
-                "trashed": arrow.get(project["trashed"]).datetime if "trashed" in project else None,
+                "trashed": arrow.get(trashed_at).datetime if (trashed_at := project.get("trashed")) else None,
             }
         )
 

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_repository_legacy.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_repository_legacy.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any, Final, Self, cast
 from uuid import uuid1
 
+import arrow
 import sqlalchemy as sa
 from aiohttp import web
 from models_library.basic_types import IDStr
@@ -256,6 +257,7 @@ class ProjectDBAPI(BaseProjectDB):
                 "creation_date": now(),
                 "last_change_date": now(),
                 "product_name": product_name,
+                "trashed": arrow.get(project["trashed"]).datetime if "trashed" in project else None,
             }
         )
 

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -172,6 +172,7 @@ from .exceptions import (
     InvalidKeysInResourcesSpecsError,
     NodeNotFoundError,
     NodeShareStateCannotBeComputedError,
+    ProjectCopyingTrashedProjectError,
     ProjectLockError,
     ProjectNodeConnectionsMissingError,
     ProjectNodeOutputPortMissingValueError,
@@ -503,6 +504,16 @@ async def _clone_project_nodes(
     return result
 
 
+def raise_if_project_is_trashed(project: ProjectDict) -> None:
+    """A trashed project cannot be duplicated: the caller must untrash it first.
+
+    Raises:
+        ProjectCopyingTrashedProjectError
+    """
+    if project.get("trashed"):
+        raise ProjectCopyingTrashedProjectError(project_uuid=project["uuid"])
+
+
 async def clone_project_data(
     app: web.Application,
     *,
@@ -522,7 +533,12 @@ async def clone_project_data(
 
     NOTE: this does not handle predefined-project overrides, workspace/folder linking,
     parent-node ancestry or response building — those remain the caller's responsibility.
+
+    Raises:
+        ProjectCopyingTrashedProjectError: if `source_project` is trashed
     """
+    raise_if_project_is_trashed(source_project)
+
     new_project, nodes_map = clone_project_document(
         source_project,
         forced_copy_project_id=forced_copy_project_id,

--- a/services/web/server/src/simcore_service_webserver/projects/exceptions.py
+++ b/services/web/server/src/simcore_service_webserver/projects/exceptions.py
@@ -148,6 +148,16 @@ class ParentProjectNotFoundError(BaseProjectError):
         self.project_uuid = project_uuid
 
 
+class ProjectCopyingTrashedProjectError(BaseProjectError):
+    msg_template = (
+        "Cannot duplicate project '{project_uuid}' because it is in the trash. Restore it first and try again."
+    )
+
+    def __init__(self, *, project_uuid: str, **ctx):
+        super().__init__(**ctx)
+        self.project_uuid = project_uuid
+
+
 class ProjectStartsTooManyDynamicNodesError(BaseProjectError):
     msg_template = (
         "The maximal amount of concurrently running dynamic services was reached. "

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_service__copy.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_service__copy.py
@@ -50,7 +50,9 @@ from simcore_service_webserver.projects._projects_service import (
     _remap_port_links_in_inputs,
     clone_project_data,
     copy_allow_guests_to_push_states_and_output_ports,
+    raise_if_project_is_trashed,
 )
+from simcore_service_webserver.projects.exceptions import ProjectCopyingTrashedProjectError
 from simcore_service_webserver.projects.models import ProjectDict
 from simcore_service_webserver.projects.utils import NodesMap
 
@@ -216,8 +218,50 @@ def test_remap_port_links_in_inputs_with_portlink_form():
 
 
 #
+# raise_if_project_is_trashed
+#
+
+
+def test_raise_if_project_is_trashed_with_non_trashed_project(fake_project: ProjectDict):
+    fake_project["trashed"] = None
+    raise_if_project_is_trashed(fake_project)  # does not raise
+
+
+def test_raise_if_project_is_trashed_with_trashed_project(fake_project: ProjectDict):
+    fake_project["trashed"] = "2026-07-21T00:00:00+00:00"
+    with pytest.raises(ProjectCopyingTrashedProjectError):
+        raise_if_project_is_trashed(fake_project)
+
+
+#
 # clone_project_data
 #
+
+
+async def test_clone_project_data_raises_if_source_is_trashed(
+    client: TestClient,
+    logged_user: UserInfoDict,
+    user_project: ProjectDict,
+    osparc_product_name: ProductName,
+    task_progress: TaskProgress,
+):
+    assert client.app
+
+    # SETUP: a trashed source project must never be duplicated
+    source_project = await _fetch_source_project(client.app, user_project["uuid"], logged_user["id"])
+    source_project["trashed"] = "2026-07-21T00:00:00+00:00"
+
+    # ACT & ASSERT
+    with pytest.raises(ProjectCopyingTrashedProjectError):
+        await clone_project_data(
+            client.app,
+            source_project=source_project,
+            forced_copy_project_id=None,
+            user_id=logged_user["id"],
+            product_name=osparc_product_name,
+            product_api_base_url="http://product.testserver.io",
+            task_progress=task_progress,
+        )
 
 
 async def test_clone_project_data_from_standard_project(

--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -621,7 +621,11 @@ def create_new_project_and_delete(
             _max_delete_attempts = 24
             for attempt in range(_max_delete_attempts):
                 response = api_request_context.delete(f"{product_url}v0/projects/{project_uuid}")
-                if response.status == 204:
+                if response.status in {204, 404}:
+                    # NOTE: 404 means the project was already deleted (e.g. by another
+                    # fixture/test step that also owns/tracks this project, such as
+                    # `create_function_from_project`'s teardown deleting the source
+                    # study of a project-based function). Treat it as already achieved.
                     break
                 if response.status == 409 and attempt < _max_delete_attempts - 1:
                     time.sleep(5)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
While running the MMUX e2e test it seems we end up duplicating an already trashed template project, which via old/new mixtures of project creation converts a proper python datetime to a string, which in turn is not accepted by asyncpg library.

this seems to be related to the changes in https://github.com/ITISFoundation/osparc-simcore/pull/9433


Bonus:
- fix e2e project deletion mechanism to accept 404 as well if the project was already deleted and does not exist anymore (error in mmux teardown)

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/9437

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
