### PR TITLE
🐛Director-v2: when there is nothing to stop, there should be no error

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -529,6 +529,7 @@ async def stop_computation(
     # create the complete DAG graph
     complete_dag = create_complete_dag_from_tasks(tasks)
     # stop the pipeline if it is running
+    last_run: CompRunsAtDB | None = None
     pipeline_state = RunningState.NOT_STARTED  # default state if no run exists
     with contextlib.suppress(ComputationalRunNotFoundError):
         last_run = await comp_runs_repo.get_latest_run_by_project(project_id=project_id)

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -529,10 +529,12 @@ async def stop_computation(
     # create the complete DAG graph
     complete_dag = create_complete_dag_from_tasks(tasks)
     # stop the pipeline if it is running
-    last_run = await comp_runs_repo.get_latest_run_by_project(project_id=project_id)
-    pipeline_state = last_run.result
-    if utils.is_pipeline_running(last_run.result):
-        await stop_pipeline(request.app, user_id=computation_stop.user_id, project_id=project_id)
+    pipeline_state = RunningState.NOT_STARTED  # default state if no run exists
+    with contextlib.suppress(ComputationalRunNotFoundError):
+        last_run = await comp_runs_repo.get_latest_run_by_project(project_id=project_id)
+        pipeline_state = last_run.result
+        if utils.is_pipeline_running(last_run.result):
+            await stop_pipeline(request.app, user_id=computation_stop.user_id, project_id=project_id)
 
     return ComputationGet(
         id=project_id,

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -529,10 +529,12 @@ async def stop_computation(
     # create the complete DAG graph
     complete_dag = create_complete_dag_from_tasks(tasks)
     # stop the pipeline if it is running
-    last_run = await comp_runs_repo.get_latest_run_by_project(project_id=project_id)
-    pipeline_state = last_run.result
-    if utils.is_pipeline_running(last_run.result):
-        await stop_pipeline(request.app, user_id=computation_stop.user_id, project_id=project_id)
+    pipeline_state = RunningState.UNKNOWN
+    with contextlib.suppress(ComputationalRunNotFoundError):
+        last_run = await comp_runs_repo.get_latest_run_by_project(project_id=project_id)
+        pipeline_state = last_run.result
+        if utils.is_pipeline_running(last_run.result):
+            await stop_pipeline(request.app, user_id=computation_stop.user_id, project_id=project_id)
 
     return ComputationGet(
         id=project_id,

--- a/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/api/routes/computations.py
@@ -529,12 +529,10 @@ async def stop_computation(
     # create the complete DAG graph
     complete_dag = create_complete_dag_from_tasks(tasks)
     # stop the pipeline if it is running
-    pipeline_state = RunningState.UNKNOWN
-    with contextlib.suppress(ComputationalRunNotFoundError):
-        last_run = await comp_runs_repo.get_latest_run_by_project(project_id=project_id)
-        pipeline_state = last_run.result
-        if utils.is_pipeline_running(last_run.result):
-            await stop_pipeline(request.app, user_id=computation_stop.user_id, project_id=project_id)
+    last_run = await comp_runs_repo.get_latest_run_by_project(project_id=project_id)
+    pipeline_state = last_run.result
+    if utils.is_pipeline_running(last_run.result):
+        await stop_pipeline(request.app, user_id=computation_stop.user_id, project_id=project_id)
 
     return ComputationGet(
         id=project_id,

--- a/services/director-v2/src/simcore_service_director_v2/core/application.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/application.py
@@ -47,6 +47,7 @@ from ..modules import (
 from ..modules.osparc_variables import substitutions
 from .errors import (
     ClusterNotFoundError,
+    ComputationalRunNotFoundError,
     PipelineNotFoundError,
     ProjectNetworkNotFoundError,
     ProjectNotFoundError,
@@ -81,6 +82,10 @@ def _set_exception_handlers(app: FastAPI):
     app.add_exception_handler(
         ClusterNotFoundError,
         make_http_error_handler_for_exception(status.HTTP_404_NOT_FOUND, ClusterNotFoundError),
+    )
+    app.add_exception_handler(
+        ComputationalRunNotFoundError,
+        make_http_error_handler_for_exception(status.HTTP_404_NOT_FOUND, ComputationalRunNotFoundError),
     )
 
     # SEE https://docs.python.org/3/library/exceptions.html#exception-hierarchy

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_api_route_computations.py
@@ -1137,3 +1137,35 @@ async def test_stop_computation_can_be_called_again_once_pipeline_stopped(
         json=ComputationStop(user_id=user["id"]).model_dump(mode="json"),
     )
     assert response.status_code == status.HTTP_202_ACCEPTED, response.text
+
+
+async def test_stop_computation_that_was_never_run_does_not_fail(
+    minimal_configuration: None,
+    fake_workbench_without_outputs: dict[str, Any],
+    fake_workbench_adjacency: dict[str, Any],
+    create_registered_user: Callable[..., dict[str, Any]],
+    create_project: Callable[..., Awaitable[ProjectAtDB]],
+    create_pipeline: Callable[..., Awaitable[CompPipelineAtDB]],
+    async_client: httpx.AsyncClient,
+):
+    """Stopping a computation that has a pipeline but was never run (i.e. no
+    comp_run entry exists yet) must not fail (e.g. it must not raise/propagate
+    ComputationalRunNotFoundError)."""
+    user = create_registered_user()
+    proj = await create_project(user, workbench=fake_workbench_without_outputs)
+    await create_pipeline(project_id=f"{proj.uuid}", dag_adjacency_list=fake_workbench_adjacency)
+
+    # NOTE: no comp_run is created here, simulating a pipeline that was never started
+
+    stop_computation_url = httpx.URL(f"/v2/computations/{proj.uuid}:stop")
+    response = await async_client.post(
+        stop_computation_url,
+        json=ComputationStop(user_id=user["id"]).model_dump(mode="json"),
+    )
+    assert response.status_code == status.HTTP_202_ACCEPTED, response.text
+    returned_computation = ComputationGet.model_validate(response.json())
+    assert returned_computation.state == RunningState.NOT_STARTED
+    assert returned_computation.iteration is None
+    assert returned_computation.started is None
+    assert returned_computation.stopped is None
+    assert returned_computation.submitted is None


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
After https://github.com/ITISFoundation/osparc-simcore/pull/9433 an issue was introduced that would make the dv-2 stop call fail with 500 as stopping a non existing run would fail

When a pipeline exists but was never started. stopping it should not fail.

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- relates to https://github.com/ITISFoundation/osparc-simcore/issues/9437

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
