### PR TITLE
🎨🐛Garbage collector: If background tasks are dead or hanging, set service health to unhealthy

### DIFF
--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_healthcheck.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_healthcheck.py
@@ -1,0 +1,129 @@
+"""Liveness/heartbeat monitoring for garbage-collector periodic background tasks.
+
+`run_monitored_periodic_task` wraps a periodic GC task so that every completed cycle
+records a heartbeat. `on_healthcheck_async_adapter` is registered with the webserver's
+`HealthCheck` (see `..rest.healthcheck`) and reports the service as unhealthy when a task:
+- has stopped running (its `asyncio.Task` completed unexpectedly), or
+- is stuck / hanging (no heartbeat within its expected time window)
+
+This lets docker/swarm's HEALTHCHECK detect the failure and restart the container.
+"""
+
+import datetime
+import functools
+import logging
+from collections.abc import AsyncGenerator, Callable, Coroutine
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Final
+
+from aiohttp import web
+from servicelib.background_task_utils import exclusive_periodic
+from servicelib.logging_utils import log_context
+
+from ..redis import get_redis_lock_manager_client_sdk
+from ..rest.healthcheck import HealthCheckError
+from ._tasks_utils import create_task_name, get_registered_tasks, periodic_task_lifespan
+from .settings import GarbageCollectorSettings, get_plugin_settings
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _TaskLiveness:
+    max_staleness: datetime.timedelta
+    last_heartbeat_utc: datetime.datetime = field(default_factory=lambda: datetime.datetime.now(datetime.UTC))
+
+
+_GC_TASKS_LIVENESS_APPKEY: Final = web.AppKey("gc-tasks-liveness", dict[str, _TaskLiveness])
+
+
+def register_task_liveness(
+    app: web.Application,
+    task_name: str,
+    *,
+    interval: datetime.timedelta,
+    settings: GarbageCollectorSettings,
+) -> None:
+    """Declares that `task_name` is expected to report a heartbeat (see `mark_task_heartbeat`)
+    at least every `max(interval * settings.GARBAGE_COLLECTOR_TASK_STALE_FACTOR,
+    settings.GARBAGE_COLLECTOR_TASK_MIN_STALENESS)`."""
+    app.setdefault(_GC_TASKS_LIVENESS_APPKEY, {})
+    app[_GC_TASKS_LIVENESS_APPKEY][task_name] = _TaskLiveness(
+        max_staleness=max(
+            interval * settings.GARBAGE_COLLECTOR_TASK_STALE_FACTOR,
+            settings.GARBAGE_COLLECTOR_TASK_MIN_STALENESS,
+        )
+    )
+
+
+def mark_task_heartbeat(app: web.Application, task_name: str) -> None:
+    """Records that `task_name` has just completed a cycle."""
+    liveness = app.get(_GC_TASKS_LIVENESS_APPKEY, {}).get(task_name)
+    if liveness is not None:
+        liveness.last_heartbeat_utc = datetime.datetime.now(datetime.UTC)
+
+
+@asynccontextmanager
+async def run_monitored_periodic_task(
+    app: web.Application,
+    service_fn: Callable[[web.Application], Coroutine[None, None, None]],
+    *,
+    task_interval: datetime.timedelta,
+    retry_after: datetime.timedelta | None = None,
+) -> AsyncGenerator[None]:
+    """Runs `service_fn(app)` as an exclusive periodic background task, wrapped in a
+    `log_context` (message inferred from `service_fn.__name__`), and tracks its liveness
+    so that `on_healthcheck_async_adapter` can detect if it stops running or hangs.
+    The task's name (used both for the liveness registry and the underlying asyncio.Task)
+    is derived from `service_fn`'s module and function name via `create_task_name`."""
+    task_name = create_task_name(service_fn)
+    log_message = service_fn.__name__.lstrip("_").replace("_", " ").capitalize()
+    settings = get_plugin_settings(app)
+    register_task_liveness(app, task_name, interval=task_interval, settings=settings)
+    resolved_retry_after = retry_after or min(datetime.timedelta(seconds=10), task_interval / 10)
+
+    @exclusive_periodic(
+        # Function-exclusiveness is required to avoid multiple tasks like this one running concurrently
+        get_redis_lock_manager_client_sdk(app),
+        task_interval=task_interval,
+        retry_after=resolved_retry_after,
+    )
+    @functools.wraps(service_fn)
+    async def _wrapped() -> None:
+        with log_context(_logger, logging.INFO, log_message):
+            await service_fn(app)
+        mark_task_heartbeat(app, task_name)
+
+    async with periodic_task_lifespan(app, _wrapped, task_name=task_name):
+        yield
+
+
+async def on_healthcheck_async_adapter(app: web.Application) -> None:
+    liveness_map = app.get(_GC_TASKS_LIVENESS_APPKEY, {})
+    tasks = get_registered_tasks(app)
+    now = datetime.datetime.now(datetime.UTC)
+
+    errors: list[str] = []
+    for task_name, liveness in liveness_map.items():
+        task = tasks.get(task_name)
+        if task is None:
+            errors.append(f"GC task '{task_name}' was never started")
+            continue
+
+        if task.done():
+            if task.cancelled():
+                errors.append(f"GC task '{task_name}' was cancelled and is not running")
+            else:
+                errors.append(f"GC task '{task_name}' stopped running: {task.exception()!r}")
+            continue
+
+        staleness = now - liveness.last_heartbeat_utc
+        if staleness > liveness.max_staleness:
+            errors.append(
+                f"GC task '{task_name}' has not reported progress in {staleness} "
+                f"(max allowed {liveness.max_staleness}); it might be hanging"
+            )
+
+    if errors:
+        raise HealthCheckError("; ".join(errors))

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_api_keys.py
@@ -8,12 +8,10 @@ from collections.abc import AsyncIterator
 from datetime import timedelta
 
 from aiohttp import web
-from servicelib.background_task_utils import exclusive_periodic
-from servicelib.logging_utils import log_context
 
 from ..api_keys import api_keys_service
-from ..redis import get_redis_lock_manager_client_sdk
-from ._tasks_utils import CleanupContextFunc, periodic_task_lifespan
+from ._healthcheck import run_monitored_periodic_task
+from ._tasks_utils import CleanupContextFunc
 
 _logger = logging.getLogger(__name__)
 
@@ -31,17 +29,7 @@ def create_background_task_to_prune_api_keys(
     async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
         interval = timedelta(seconds=wait_period_s)
 
-        @exclusive_periodic(
-            # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
-            get_redis_lock_manager_client_sdk(app),
-            task_interval=interval,
-            retry_after=min(timedelta(seconds=10), interval / 10),
-        )
-        async def _prune_expired_api_keys_periodically() -> None:
-            with log_context(_logger, logging.INFO, "Pruning expired API keys"):
-                await _prune_expired_api_keys(app)
-
-        async for _ in periodic_task_lifespan(app, _prune_expired_api_keys_periodically):
+        async with run_monitored_periodic_task(app, _prune_expired_api_keys, task_interval=interval):
             yield
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_core.py
@@ -4,22 +4,15 @@
 Specifics of the gc implementation should go into garbage_collector_core.py
 """
 
-import logging
 from collections.abc import AsyncIterator
 from datetime import timedelta
 
 from aiohttp import web
-from servicelib.background_task_utils import exclusive_periodic
-from servicelib.logging_utils import log_context
 
-from ..redis import get_redis_lock_manager_client_sdk
 from ._core import collect_garbage
-from ._tasks_utils import CleanupContextFunc, periodic_task_lifespan
+from ._healthcheck import run_monitored_periodic_task
+from ._tasks_utils import CleanupContextFunc
 from .settings import GarbageCollectorSettings, get_plugin_settings
-
-_logger = logging.getLogger(__name__)
-
-_GC_TASK_NAME = f"{__name__}._collect_garbage_periodically"
 
 
 def create_background_task_for_garbage_collection() -> CleanupContextFunc:
@@ -27,17 +20,7 @@ def create_background_task_for_garbage_collection() -> CleanupContextFunc:
         settings: GarbageCollectorSettings = get_plugin_settings(app)
         interval = timedelta(seconds=settings.GARBAGE_COLLECTOR_INTERVAL_S)
 
-        @exclusive_periodic(
-            # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
-            get_redis_lock_manager_client_sdk(app),
-            task_interval=interval,
-            retry_after=min(timedelta(seconds=10), interval / 10),
-        )
-        async def _collect_garbage_periodically() -> None:
-            with log_context(_logger, logging.INFO, "Garbage collect cycle"):
-                await collect_garbage(app)
-
-        async for _ in periodic_task_lifespan(app, _collect_garbage_periodically, task_name=_GC_TASK_NAME):
+        async with run_monitored_periodic_task(app, collect_garbage, task_interval=interval):
             yield
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_documents.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_documents.py
@@ -3,40 +3,25 @@ Scheduled tasks addressing users
 
 """
 
-import logging
 from collections.abc import AsyncIterator
 from datetime import timedelta
 
 from aiohttp import web
-from servicelib.background_task_utils import exclusive_periodic
-from servicelib.logging_utils import log_context
 
 from ..projects import projects_documents_service
-from ..redis import get_redis_lock_manager_client_sdk
-from ._tasks_utils import CleanupContextFunc, periodic_task_lifespan
-
-_logger = logging.getLogger(__name__)
+from ._healthcheck import run_monitored_periodic_task
+from ._tasks_utils import CleanupContextFunc
 
 
 def create_background_task_to_prune_documents(wait_s: float) -> CleanupContextFunc:
     async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
         interval = timedelta(seconds=wait_s)
 
-        @exclusive_periodic(
-            # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
-            get_redis_lock_manager_client_sdk(app),
+        async with run_monitored_periodic_task(
+            app,
+            projects_documents_service.remove_project_documents_as_admin,
             task_interval=interval,
-            retry_after=min(timedelta(seconds=10), interval / 10),
-        )
-        async def _prune_documents_periodically() -> None:
-            with log_context(
-                _logger,
-                logging.INFO,
-                "Deleting project documents in Redis `documents` table started",
-            ):
-                await projects_documents_service.remove_project_documents_as_admin(app)
-
-        async for _ in periodic_task_lifespan(app, _prune_documents_periodically):
+        ):
             yield
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_trash.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_trash.py
@@ -3,36 +3,25 @@ Scheduled tasks addressing users
 
 """
 
-import logging
 from collections.abc import AsyncIterator
 from datetime import timedelta
 
 from aiohttp import web
-from servicelib.background_task_utils import exclusive_periodic
-from servicelib.logging_utils import log_context
 
-from ..redis import get_redis_lock_manager_client_sdk
 from ..trash import trash_service
-from ._tasks_utils import CleanupContextFunc, periodic_task_lifespan
-
-_logger = logging.getLogger(__name__)
+from ._healthcheck import run_monitored_periodic_task
+from ._tasks_utils import CleanupContextFunc
 
 
 def create_background_task_to_prune_trash(wait_s: float) -> CleanupContextFunc:
     async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
         interval = timedelta(seconds=wait_s)
 
-        @exclusive_periodic(
-            # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
-            get_redis_lock_manager_client_sdk(app),
+        async with run_monitored_periodic_task(
+            app,
+            trash_service.safe_delete_expired_trash_as_admin,
             task_interval=interval,
-            retry_after=min(timedelta(seconds=10), interval / 10),
-        )
-        async def _prune_trash_periodically() -> None:
-            with log_context(_logger, logging.INFO, "Deleting expired trashed items"):
-                await trash_service.safe_delete_expired_trash_as_admin(app)
-
-        async for _ in periodic_task_lifespan(app, _prune_trash_periodically):
+        ):
             yield
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_users.py
@@ -10,14 +10,13 @@ from datetime import timedelta
 from aiohttp import web
 from common_library.logging.logging_base import get_log_record_extra
 from models_library.users import UserID
-from servicelib.background_task_utils import exclusive_periodic
 from servicelib.logging_utils import log_context
 
 from ..login import login_service
-from ..redis import get_redis_lock_manager_client_sdk
 from ..security import security_service
 from ..users import users_service
-from ._tasks_utils import CleanupContextFunc, periodic_task_lifespan
+from ._healthcheck import run_monitored_periodic_task
+from ._tasks_utils import CleanupContextFunc
 
 _logger = logging.getLogger(__name__)
 
@@ -69,17 +68,7 @@ def create_background_task_for_trial_accounts(wait_s: float) -> CleanupContextFu
     async def _cleanup_ctx_fun(app: web.Application) -> AsyncIterator[None]:
         interval = timedelta(seconds=wait_s)
 
-        @exclusive_periodic(
-            # Function-exclusiveness is required to avoid multiple tasks like thisone running concurrently
-            get_redis_lock_manager_client_sdk(app),
-            task_interval=interval,
-            retry_after=min(timedelta(seconds=10), interval / 10),
-        )
-        async def _update_expired_users_periodically() -> None:
-            with log_context(_logger, logging.INFO, "Updating expired users"):
-                await _update_expired_users(app)
-
-        async for _ in periodic_task_lifespan(app, _update_expired_users_periodically):
+        async with run_monitored_periodic_task(app, _update_expired_users, task_interval=interval):
             yield
 
     return _cleanup_ctx_fun

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
@@ -1,7 +1,3 @@
-"""
-Common utilities for background task management in garbage collector
-"""
-
 import asyncio
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine
 from contextlib import asynccontextmanager
@@ -40,28 +36,29 @@ async def periodic_task_lifespan(
     """
     assert getattr(periodic_async_func, "__exclusive_periodic__", False)  # nosec
 
-    # setup
+    task: asyncio.Task | None = None
     task_name = task_name or create_task_name(periodic_async_func)
+    try:
+        task = asyncio.create_task(
+            periodic_async_func(),
+            name=task_name,
+        )
 
-    task = asyncio.create_task(
-        periodic_async_func(),
-        name=task_name,
-    )
+        # Keeping a reference in app's state to prevent premature garbage collection of the task
+        app.setdefault(_GC_PERIODIC_TASKS_APPKEY, {})
+        if task_name in app[_GC_PERIODIC_TASKS_APPKEY]:
+            msg = f"Task {task_name} is already registered in the app state"
+            raise ValueError(msg)
 
-    # Keeping a reference in app's state to prevent premature garbage collection of the task
-    app.setdefault(_GC_PERIODIC_TASKS_APPKEY, {})
-    if task_name in app[_GC_PERIODIC_TASKS_APPKEY]:
-        msg = f"Task {task_name} is already registered in the app state"
-        raise ValueError(msg)
+        app[_GC_PERIODIC_TASKS_APPKEY][task_name] = task
 
-    app[_GC_PERIODIC_TASKS_APPKEY][task_name] = task
+        yield
 
-    yield
-
-    # tear-down
-    await cancel_wait_task(task)
-    if _GC_PERIODIC_TASKS_APPKEY in app:
-        app[_GC_PERIODIC_TASKS_APPKEY].pop(task_name, None)
+    finally:
+        if task is not None:
+            await cancel_wait_task(task)
+        if _GC_PERIODIC_TASKS_APPKEY in app:
+            app[_GC_PERIODIC_TASKS_APPKEY].pop(task_name, None)
 
 
 def get_registered_tasks(app: web.Application) -> dict[str, asyncio.Task]:

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/_tasks_utils.py
@@ -3,7 +3,8 @@ Common utilities for background task management in garbage collector
 """
 
 import asyncio
-from collections.abc import AsyncIterator, Callable, Coroutine
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine
+from contextlib import asynccontextmanager
 from typing import Final
 
 from aiohttp import web
@@ -23,12 +24,13 @@ def create_task_name(coro: Callable) -> str:
 _GC_PERIODIC_TASKS_APPKEY: Final = web.AppKey("gc-tasks", dict[str, asyncio.Task])
 
 
+@asynccontextmanager
 async def periodic_task_lifespan(
     app: web.Application,
     periodic_async_func: Callable[[], Coroutine[None, None, None]],
     *,
     task_name: str | None = None,
-) -> AsyncIterator[None]:
+) -> AsyncGenerator[None]:
     """
     Generic setup and teardown for periodic background tasks.
 
@@ -60,3 +62,8 @@ async def periodic_task_lifespan(
     await cancel_wait_task(task)
     if _GC_PERIODIC_TASKS_APPKEY in app:
         app[_GC_PERIODIC_TASKS_APPKEY].pop(task_name, None)
+
+
+def get_registered_tasks(app: web.Application) -> dict[str, asyncio.Task]:
+    """Returns the currently running GC periodic background tasks, keyed by task name."""
+    return app.get(_GC_PERIODIC_TASKS_APPKEY, {})

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/plugin.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/plugin.py
@@ -8,8 +8,10 @@ from ..application_setup import ModuleCategory, app_setup_func
 from ..products.plugin import setup_products
 from ..projects._projects_repository_legacy import setup_projects_db
 from ..redis import setup_redis
+from ..rest.healthcheck import HEALTHCHECK_APPKEY
 from ..socketio.socketio_service import setup_socketio
 from . import _tasks_api_keys, _tasks_core, _tasks_documents, _tasks_trash, _tasks_users
+from ._healthcheck import on_healthcheck_async_adapter
 from .settings import get_plugin_settings
 
 _logger = logging.getLogger(__name__)
@@ -35,6 +37,9 @@ def setup_garbage_collector(app: web.Application) -> None:
     setup_socketio(app)
 
     settings = get_plugin_settings(app)
+
+    # reports unhealthy if any of the periodic tasks below stops running or hangs
+    app[HEALTHCHECK_APPKEY].register_on_healthcheck(on_healthcheck_async_adapter)
 
     app.cleanup_ctx.append(_tasks_core.create_background_task_for_garbage_collection())
 

--- a/services/web/server/src/simcore_service_webserver/garbage_collector/settings.py
+++ b/services/web/server/src/simcore_service_webserver/garbage_collector/settings.py
@@ -1,7 +1,8 @@
+from datetime import timedelta
 from typing import Annotated
 
 from aiohttp import web
-from pydantic import Field, PositiveInt
+from pydantic import Field, PositiveFloat, PositiveInt
 from settings_library.base import BaseCustomSettings
 
 from ..application_keys import APP_SETTINGS_APPKEY
@@ -41,6 +42,24 @@ class GarbageCollectorSettings(BaseCustomSettings):
         PositiveInt,
         Field(description="Wait time between periodic pruning of documents"),
     ] = 30 * _MINUTE
+
+    GARBAGE_COLLECTOR_TASK_STALE_FACTOR: Annotated[
+        PositiveFloat,
+        Field(
+            description="Multiplier applied to each periodic task's own interval to determine "
+            "how long it can go without reporting progress before the webserver healthcheck "
+            "considers it stuck/hanging and reports the service as unhealthy"
+        ),
+    ] = 5.0
+
+    GARBAGE_COLLECTOR_TASK_MIN_STALENESS: Annotated[
+        timedelta,
+        Field(
+            description="Minimum amount of time a periodic task is allowed to go without reporting "
+            "progress before the webserver healthcheck considers it stuck/hanging, regardless of "
+            "the task's own interval and GARBAGE_COLLECTOR_TASK_STALE_FACTOR"
+        ),
+    ] = timedelta(hours=1)
 
 
 def get_plugin_settings(app: web.Application) -> GarbageCollectorSettings:

--- a/services/web/server/tests/integration/01/test_garbage_collection.py
+++ b/services/web/server/tests/integration/01/test_garbage_collection.py
@@ -40,7 +40,7 @@ from simcore_service_webserver.db.models import projects, users
 from simcore_service_webserver.db.plugin import setup_db
 from simcore_service_webserver.director_v2.plugin import setup_director_v2
 from simcore_service_webserver.garbage_collector import _core as gc_core
-from simcore_service_webserver.garbage_collector._tasks_core import _GC_TASK_NAME
+from simcore_service_webserver.garbage_collector._tasks_utils import create_task_name
 from simcore_service_webserver.garbage_collector.plugin import setup_garbage_collector
 from simcore_service_webserver.groups._groups_service import create_standard_group
 from simcore_service_webserver.groups.groups_service import add_user_in_group
@@ -1048,7 +1048,8 @@ async def test_t10_owner_and_all_shared_users_marked_as_guests(
     EXPECTED: the project and all the users are removed
     """
 
-    gc_task: asyncio.Task = next(task for task in asyncio.all_tasks() if task.get_name() == _GC_TASK_NAME)
+    gc_task_name = create_task_name(gc_core.collect_garbage)
+    gc_task: asyncio.Task = next(task for task in asyncio.all_tasks() if task.get_name() == gc_task_name)
     assert not gc_task.done()
 
     u1 = await login_user(client, exit_stack=exit_stack)

--- a/services/web/server/tests/unit/isolated/test_garbage_collector_healthcheck.py
+++ b/services/web/server/tests/unit/isolated/test_garbage_collector_healthcheck.py
@@ -1,0 +1,135 @@
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# ruff: noqa: SLF001
+
+import asyncio
+import datetime
+
+import pytest
+from aiohttp import web
+from simcore_service_webserver.garbage_collector import _healthcheck, _tasks_utils
+from simcore_service_webserver.garbage_collector.settings import GarbageCollectorSettings
+from simcore_service_webserver.rest.healthcheck import HealthCheckError
+
+
+@pytest.fixture
+def app() -> web.Application:
+    return web.Application()
+
+
+@pytest.fixture
+def settings() -> GarbageCollectorSettings:
+    return GarbageCollectorSettings(
+        GARBAGE_COLLECTOR_TASK_STALE_FACTOR=2.0,
+        GARBAGE_COLLECTOR_TASK_MIN_STALENESS=datetime.timedelta(seconds=1),
+    )
+
+
+def _set_registered_task(app: web.Application, task_name: str, task: asyncio.Task) -> None:
+    app.setdefault(_tasks_utils._GC_PERIODIC_TASKS_APPKEY, {})
+    app[_tasks_utils._GC_PERIODIC_TASKS_APPKEY][task_name] = task
+
+
+async def test_healthy_when_task_running_and_heartbeat_fresh(app: web.Application, settings: GarbageCollectorSettings):
+    task_name = "task-healthy"
+    _healthcheck.register_task_liveness(app, task_name, interval=datetime.timedelta(seconds=1), settings=settings)
+
+    running_task = asyncio.create_task(asyncio.sleep(10))
+    _set_registered_task(app, task_name, running_task)
+    _healthcheck.mark_task_heartbeat(app, task_name)
+
+    await _healthcheck.on_healthcheck_async_adapter(app)  # does not raise
+
+    running_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await running_task
+
+
+async def test_unhealthy_when_task_was_never_started(app: web.Application, settings: GarbageCollectorSettings):
+    task_name = "task-never-started"
+    _healthcheck.register_task_liveness(app, task_name, interval=datetime.timedelta(seconds=1), settings=settings)
+
+    with pytest.raises(HealthCheckError, match="was never started"):
+        await _healthcheck.on_healthcheck_async_adapter(app)
+
+
+async def test_unhealthy_when_task_stopped_with_exception(app: web.Application, settings: GarbageCollectorSettings):
+    task_name = "task-crashed"
+    _healthcheck.register_task_liveness(app, task_name, interval=datetime.timedelta(seconds=1), settings=settings)
+
+    async def _boom() -> None:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    failed_task = asyncio.create_task(_boom())
+    with pytest.raises(RuntimeError, match="boom"):
+        await failed_task
+
+    _set_registered_task(app, task_name, failed_task)
+
+    with pytest.raises(HealthCheckError, match="stopped running"):
+        await _healthcheck.on_healthcheck_async_adapter(app)
+
+
+async def test_unhealthy_when_task_was_cancelled(app: web.Application, settings: GarbageCollectorSettings):
+    task_name = "task-cancelled"
+    _healthcheck.register_task_liveness(app, task_name, interval=datetime.timedelta(seconds=1), settings=settings)
+
+    cancelled_task = asyncio.create_task(asyncio.sleep(10))
+    cancelled_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled_task
+
+    _set_registered_task(app, task_name, cancelled_task)
+
+    with pytest.raises(HealthCheckError, match="cancelled"):
+        await _healthcheck.on_healthcheck_async_adapter(app)
+
+
+async def test_unhealthy_when_heartbeat_is_stale(app: web.Application, settings: GarbageCollectorSettings):
+    task_name = "task-hanging"
+    interval = datetime.timedelta(seconds=1)
+    _healthcheck.register_task_liveness(app, task_name, interval=interval, settings=settings)
+
+    running_task = asyncio.create_task(asyncio.sleep(10))
+    _set_registered_task(app, task_name, running_task)
+
+    # force the last heartbeat far enough in the past to exceed max_staleness (interval * factor)
+    liveness = app[_healthcheck._GC_TASKS_LIVENESS_APPKEY][task_name]
+    liveness.last_heartbeat_utc -= datetime.timedelta(seconds=1000)
+
+    with pytest.raises(HealthCheckError, match="might be hanging"):
+        await _healthcheck.on_healthcheck_async_adapter(app)
+
+    running_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await running_task
+
+
+async def test_healthy_when_no_tasks_registered(app: web.Application):
+    await _healthcheck.on_healthcheck_async_adapter(app)  # does not raise
+
+
+async def test_min_staleness_protects_fast_tasks_from_false_positives(app: web.Application):
+    # a fast task (1s interval) with a low factor would normally allow only 1s of staleness,
+    # but GARBAGE_COLLECTOR_TASK_MIN_STALENESS enforces a higher floor
+    settings = GarbageCollectorSettings(
+        GARBAGE_COLLECTOR_TASK_STALE_FACTOR=1.0,
+        GARBAGE_COLLECTOR_TASK_MIN_STALENESS=datetime.timedelta(hours=1),
+    )
+    task_name = "task-fast"
+    _healthcheck.register_task_liveness(app, task_name, interval=datetime.timedelta(seconds=1), settings=settings)
+
+    running_task = asyncio.create_task(asyncio.sleep(10))
+    _set_registered_task(app, task_name, running_task)
+
+    # 10s of staleness exceeds interval * factor (1s) but is well within the 1h floor
+    liveness = app[_healthcheck._GC_TASKS_LIVENESS_APPKEY][task_name]
+    liveness.last_heartbeat_utc -= datetime.timedelta(seconds=10)
+
+    await _healthcheck.on_healthcheck_async_adapter(app)  # does not raise
+
+    running_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await running_task


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This PR ties the garbage collector (GC) background tasks to the garbage collector healthcheck entrypoint.
If one of the GC background tasks become stale (not running anymore) or hangs for too long, the health entrypoint will return a 5XX which docker swarm will pick up and restart the docker container automatically.


This should help prevent what happened in https://github.com/ITISFoundation/private-issues/issues/626

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/private-issues/issues/626

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
