### PR TITLE
🐛Director-v0: properly close resources when returning early

### DIFF
--- a/services/director/src/simcore_service_director/modules/docker_registry/_client.py
+++ b/services/director/src/simcore_service_director/modules/docker_registry/_client.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 from collections.abc import AsyncGenerator, Mapping
+from contextlib import aclosing
 from typing import Any, Final, cast
 
 import httpx
@@ -348,8 +349,11 @@ async def list_image_tags_gen(app: FastAPI, image_key: str, *, update_cache=Fals
 
 async def list_image_tags(app: FastAPI, image_key: str) -> list[str]:
     image_tags = []
-    async for tags in list_image_tags_gen(app, image_key):
-        image_tags.extend(tags)
+    # NOTE: aclosing() ensures the generator is closed in this task's context even on early
+    # exit, avoiding cross-context OTel span teardown (GeneratorExit thrown by GC otherwise)
+    async with aclosing(list_image_tags_gen(app, image_key)) as tags_gen:
+        async for tags in tags_gen:
+            image_tags.extend(tags)
     return image_tags
 
 
@@ -475,14 +479,17 @@ async def get_image_details(app: FastAPI, image_key: str, image_tag: str, *, upd
 
 async def get_repo_details(app: FastAPI, image_key: str, *, update_cache=False) -> list[dict[str, Any]]:
     repo_details = []
-    async for image_tags in list_image_tags_gen(app, image_key, update_cache=update_cache):
-        async for image_details_future in limited_as_completed(
-            (get_image_details(app, image_key, tag, update_cache=update_cache) for tag in image_tags),
-            limit=get_application_settings(app).DIRECTOR_REGISTRY_CLIENT_MAX_CONCURRENT_CALLS,
-        ):
-            with log_catch(_logger, reraise=False):
-                if image_details := await image_details_future:
-                    repo_details.append(image_details)
+    # NOTE: aclosing() ensures the generator is closed in this task's context even on early
+    # exit, avoiding cross-context OTel span teardown (GeneratorExit thrown by GC otherwise)
+    async with aclosing(list_image_tags_gen(app, image_key, update_cache=update_cache)) as tags_gen:
+        async for image_tags in tags_gen:
+            async for image_details_future in limited_as_completed(
+                (get_image_details(app, image_key, tag, update_cache=update_cache) for tag in image_tags),
+                limit=get_application_settings(app).DIRECTOR_REGISTRY_CLIENT_MAX_CONCURRENT_CALLS,
+            ):
+                with log_catch(_logger, reraise=False):
+                    if image_details := await image_details_future:
+                        repo_details.append(image_details)
     return repo_details
 
 
@@ -490,15 +497,18 @@ async def list_services(app: FastAPI, service_type: ServiceType, *, update_cache
     with log_context(_logger, logging.DEBUG, msg="listing services"):
         services = []
         concurrency_limit = get_application_settings(app).DIRECTOR_REGISTRY_CLIENT_MAX_CONCURRENT_CALLS
-        async for repos in _list_repositories_gen(app, service_type, update_cache=update_cache):
-            # only list as service if it actually contains the necessary labels
-            async for repo_details_future in limited_as_completed(
-                (get_repo_details(app, repo, update_cache=update_cache) for repo in repos),
-                limit=concurrency_limit,
-            ):
-                with log_catch(_logger, reraise=False):
-                    if repo_details := await repo_details_future:
-                        services.extend(repo_details)
+        # NOTE: aclosing() ensures the generator is closed in this task's context even on early
+        # exit, avoiding cross-context OTel span teardown (GeneratorExit thrown by GC otherwise)
+        async with aclosing(_list_repositories_gen(app, service_type, update_cache=update_cache)) as repos_gen:
+            async for repos in repos_gen:
+                # only list as service if it actually contains the necessary labels
+                async for repo_details_future in limited_as_completed(
+                    (get_repo_details(app, repo, update_cache=update_cache) for repo in repos),
+                    limit=concurrency_limit,
+                ):
+                    with log_catch(_logger, reraise=False):
+                        if repo_details := await repo_details_future:
+                            services.extend(repo_details)
 
         return services
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
in graylog the following errors were found:
<img width="1992" height="504" alt="image" src="https://github.com/user-attachments/assets/32979f16-054f-41dc-8a9a-f78fb52550fe" />

This is happening because of https://github.com/open-telemetry/opentelemetry-python/issues/2606

More precisely since we are using generators in director-v0 that in turn use the traced `log_context` sometimes these generator are finishing earlier and do not cleanup directly .


```
Use aclosing when all of the following are true:
- You have an async generator or async iterator with an aclose() method.
- You care that its termination logic (finally-blocks, async teardown) runs even if you stop consuming early.
- It is not already wrapped in an appropriate async context manager that guarantees closure.
```
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
