### PR TITLE
🐛Garbage collector: deleting projects fails as soon as there are more than 100 projects to delete

### DIFF
--- a/services/web/server/src/simcore_service_webserver/folders/_folders_service.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_folders_service.py
@@ -130,6 +130,9 @@ async def get_folder(
     )
 
 
+type TotalCount = int
+
+
 async def list_folders(
     app: web.Application,
     user_id: UserID,
@@ -140,7 +143,7 @@ async def list_folders(
     offset: NonNegativeInt,
     limit: int,
     order_by: OrderBy,
-) -> tuple[list[FolderTuple], int]:
+) -> tuple[list[FolderTuple], TotalCount]:
     # NOTE: Folder access rights for listing are checked within the listing DB function.
 
     total_count, folders = await _folders_repository.list_(

--- a/services/web/server/src/simcore_service_webserver/folders/_trash_service.py
+++ b/services/web/server/src/simcore_service_webserver/folders/_trash_service.py
@@ -288,20 +288,28 @@ async def batch_delete_trashed_folders_as_admin(
     """
     errors: list[tuple[FolderID, Exception]] = []
 
-    for page_params in iter_pagination_params(offset=0, limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE):
+    # NOTE: this loop deletes matching rows as it goes, so re-query from offset=0 each
+    # round (iter_pagination_params assumes a stable collection, which doesn't hold here).
+    # Failed (non-deleted) folders stay in the DB and remain first in the trashed-ASC
+    # ordering, so only skip past them via offset to avoid refetching them forever.
+    offset = 0
+    while True:
         (
-            page_params.total_number_of_items,
+            _,
             expired_trashed_folders,
         ) = await _folders_repository.list_folders_db_as_admin(
             app,
             trashed_explicitly=True,
             trashed_before=trashed_before,
-            offset=page_params.offset,
-            limit=page_params.limit,
+            offset=offset,
+            limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
             order_by=OrderBy(field=IDStr("trashed"), direction=OrderDirection.ASC),
         )
+        if not expired_trashed_folders:
+            break
 
         # BATCH delete
+        newly_failed = 0
         for folder in expired_trashed_folders:
             try:
                 await _folders_repository.delete_recursively(app, folder_id=folder.folder_id, product_name=product_name)
@@ -311,6 +319,9 @@ async def batch_delete_trashed_folders_as_admin(
                 if fail_fast:
                     raise
                 errors.append((folder.folder_id, err))
+                newly_failed += 1
+
+        offset += newly_failed
 
     if errors:
         raise FolderBatchDeleteError(errors=errors, trashed_before=trashed_before, product_name=product_name)
@@ -332,18 +343,25 @@ async def batch_delete_folders_with_content_in_root_workspace_as_admin(
     deleted_folder_ids: list[FolderID] = []
     errors: list[tuple[FolderID, Exception]] = []
 
-    for page_params in iter_pagination_params(offset=0, limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE):
+    # NOTE: see batch_delete_trashed_folders_as_admin for why we avoid
+    # iter_pagination_params and re-query from offset=0, skipping only past failures.
+    offset = 0
+    while True:
         (
-            page_params.total_number_of_items,
+            _,
             folders_for_deletion,
         ) = await _folders_repository.list_folders_db_as_admin(
             app,
             shared_workspace_id=workspace_id,  # <-- Workspace filter
-            offset=page_params.offset,
-            limit=page_params.limit,
+            offset=offset,
+            limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
             order_by=OrderBy(field=IDStr("folder_id")),
         )
+        if not folders_for_deletion:
+            break
+
         # BATCH delete
+        newly_failed = 0
         for folder in folders_for_deletion:
             try:
                 await _folders_repository.delete_recursively(app, folder_id=folder.folder_id, product_name=product_name)
@@ -352,6 +370,9 @@ async def batch_delete_folders_with_content_in_root_workspace_as_admin(
                 if fail_fast:
                     raise
                 errors.append((folder.folder_id, err))
+                newly_failed += 1
+
+        offset += newly_failed
 
     if errors:
         raise FolderBatchDeleteError(

--- a/services/web/server/src/simcore_service_webserver/projects/_crud_api_read.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_crud_api_read.py
@@ -117,6 +117,9 @@ async def _legacy_convert_db_projects_to_api_projects(
     return api_projects
 
 
+type TotalCount = int
+
+
 async def list_projects(  # pylint: disable=too-many-arguments  # noqa: PLR0913
     app: web.Application,
     user_id: UserID,
@@ -138,7 +141,7 @@ async def list_projects(  # pylint: disable=too-many-arguments  # noqa: PLR0913
     limit: int,
     # ordering
     order_by: OrderBy,
-) -> tuple[list[ProjectDict], int]:
+) -> tuple[list[ProjectDict], TotalCount]:
     db = ProjectDBAPI.get_from_app_context(app)
 
     workspace_is_private = True

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_repository.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_repository.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Callable, Iterable
 from datetime import datetime
-from typing import Any, cast
+from typing import Any
 
 import sqlalchemy as sa
 from aiohttp import web
@@ -53,6 +53,9 @@ def _to_sql_expression(table: sa.Table, order_by: OrderBy):
     return direction_func(table.columns[order_by.field])
 
 
+type TotalCount = int
+
+
 async def list_projects_db_get_as_admin(
     app: web.Application,
     connection: AsyncConnection | None = None,
@@ -66,7 +69,7 @@ async def list_projects_db_get_as_admin(
     limit: PositiveInt = MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
     # order
     order_by: OrderBy,
-) -> tuple[int, list[ProjectDBGet]]:
+) -> tuple[TotalCount, list[ProjectDBGet]]:
     base_query = sql.select(*PROJECT_DB_COLS).where(projects.c.trashed.is_not(None))
 
     if is_set(trashed_explicitly):
@@ -89,10 +92,10 @@ async def list_projects_db_get_as_admin(
 
     async with pass_or_acquire_connection(get_asyncpg_engine(app), connection) as conn:
         total_count = await conn.scalar(count_query)
-
+        assert isinstance(total_count, int)  # nosec
         result = await conn.stream(list_query)
         projects_list: list[ProjectDBGet] = [ProjectDBGet.model_validate(row) async for row in result]
-        return cast(int, total_count), projects_list
+        return total_count, projects_list
 
 
 async def get_project(

--- a/services/web/server/src/simcore_service_webserver/projects/_trash_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_trash_service.py
@@ -284,7 +284,7 @@ async def batch_delete_trashed_projects_as_admin(
             trashed_before=trashed_before,
             offset=offset,
             limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
-            order_by=_projects_repository.OLDEST_TRASHED_FIRST,
+            order_by=OrderBy(field=IDStr("id")),
         )
         if not expired_trashed_projects:
             break

--- a/services/web/server/src/simcore_service_webserver/projects/_trash_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_trash_service.py
@@ -12,6 +12,7 @@ from models_library.rest_ordering import OrderBy, OrderDirection
 from models_library.rest_pagination import MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE
 from models_library.users import UserID
 from models_library.workspaces import WorkspaceID
+from servicelib.logging_utils import log_context
 from servicelib.utils import fire_and_forget_task
 
 from ..constants import APP_FIRE_AND_FORGET_TASKS_KEY
@@ -272,33 +273,51 @@ async def batch_delete_trashed_projects_as_admin(
     deleted_project_ids: list[ProjectID] = []
     errors: list[tuple[ProjectID, Exception]] = []
 
-    for page_params in iter_pagination_params(offset=0, limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE):
+    # NOTE: this loop deletes matching rows as it goes, so the collection being
+    # paginated shrinks while iterating. Plain offset/limit pagination
+    # (e.g. iter_pagination_params) does not apply here as it would raise after 2 pages
+    offset = 0
+    while True:
         (
-            page_params.total_number_of_items,
+            projects_count,
             expired_trashed_projects,
         ) = await _projects_repository.list_projects_db_get_as_admin(
             app,
             # both implicit and explicitly trashed
             trashed_before=trashed_before,
-            offset=page_params.offset,
-            limit=page_params.limit,
+            offset=offset,
+            limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
             order_by=_projects_repository.OLDEST_TRASHED_FIRST,
         )
-        # BATCH delete
-        for project in expired_trashed_projects:
-            assert project.trashed  # nosec
+        if not expired_trashed_projects:
+            break
 
-            try:
-                await _projects_service_delete.delete_project_as_admin(
-                    app,
-                    project_uuid=project.uuid,
-                    product_name=project.product_name,
-                )
-                deleted_project_ids.append(project.uuid)
-            except Exception as err:  # pylint: disable=broad-exception-caught
-                if fail_fast:
-                    raise
-                errors.append((project.uuid, err))
+        with log_context(
+            _logger,
+            logging.INFO,
+            "Deleting %d trashed projects out of %d [trashed_at < %s will be deleted]",
+            len(expired_trashed_projects),
+            projects_count,
+            trashed_before,
+        ):
+            newly_failed = 0
+            for project in expired_trashed_projects:
+                assert project.trashed  # nosec
+
+                try:
+                    await _projects_service_delete.delete_project_as_admin(
+                        app,
+                        project_uuid=project.uuid,
+                        product_name=project.product_name,
+                    )
+                    deleted_project_ids.append(project.uuid)
+                except Exception as err:  # pylint: disable=broad-exception-caught
+                    if fail_fast:
+                        raise
+                    errors.append((project.uuid, err))
+                    newly_failed += 1
+
+            offset += newly_failed
 
     if errors:
         raise ProjectsBatchDeleteError(
@@ -325,30 +344,47 @@ async def batch_delete_projects_in_root_workspace_as_admin(
     deleted_project_ids: list[ProjectID] = []
     errors: list[tuple[ProjectID, Exception]] = []
 
-    for page_params in iter_pagination_params(offset=0, limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE):
+    # NOTE: see batch_delete_trashed_projects_as_admin for why we avoid
+    # iter_pagination_params and re-query from offset=0, skipping only past failures.
+    offset = 0
+    while True:
         (
-            page_params.total_number_of_items,
+            projects_count,
             projects_for_deletion,
         ) = await _projects_repository.list_projects_db_get_as_admin(
             app,
             shared_workspace_id=workspace_id,  # <-- Workspace filter
-            offset=page_params.offset,
-            limit=page_params.limit,
+            offset=offset,
+            limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
             order_by=OrderBy(field=IDStr("id")),
         )
-        # BATCH delete
-        for project in projects_for_deletion:
-            try:
-                await _projects_service_delete.delete_project_as_admin(
-                    app,
-                    project_uuid=project.uuid,
-                    product_name=project.product_name,
-                )
-                deleted_project_ids.append(project.uuid)
-            except Exception as err:  # pylint: disable=broad-exception-caught
-                if fail_fast:
-                    raise
-                errors.append((project.uuid, err))
+        if not projects_for_deletion:
+            break
+
+        with log_context(
+            _logger,
+            logging.INFO,
+            "Deleting %d projects in workspace %s out of %d",
+            len(projects_for_deletion),
+            workspace_id,
+            projects_count,
+        ):
+            newly_failed = 0
+            for project in projects_for_deletion:
+                try:
+                    await _projects_service_delete.delete_project_as_admin(
+                        app,
+                        project_uuid=project.uuid,
+                        product_name=project.product_name,
+                    )
+                    deleted_project_ids.append(project.uuid)
+                except Exception as err:  # pylint: disable=broad-exception-caught
+                    if fail_fast:
+                        raise
+                    errors.append((project.uuid, err))
+                    newly_failed += 1
+
+            offset += newly_failed
 
     if errors:
         raise ProjectsBatchDeleteError(

--- a/services/web/server/src/simcore_service_webserver/projects/_trash_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_trash_service.py
@@ -273,9 +273,6 @@ async def batch_delete_trashed_projects_as_admin(
     deleted_project_ids: list[ProjectID] = []
     errors: list[tuple[ProjectID, Exception]] = []
 
-    # NOTE: this loop deletes matching rows as it goes, so the collection being
-    # paginated shrinks while iterating. Plain offset/limit pagination
-    # (e.g. iter_pagination_params) does not apply here as it would raise after 2 pages
     offset = 0
     while True:
         (
@@ -344,8 +341,6 @@ async def batch_delete_projects_in_root_workspace_as_admin(
     deleted_project_ids: list[ProjectID] = []
     errors: list[tuple[ProjectID, Exception]] = []
 
-    # NOTE: see batch_delete_trashed_projects_as_admin for why we avoid
-    # iter_pagination_params and re-query from offset=0, skipping only past failures.
     offset = 0
     while True:
         (

--- a/services/web/server/src/simcore_service_webserver/workspaces/_trash_service.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_trash_service.py
@@ -16,6 +16,7 @@ from models_library.workspaces import (
     WorkspaceID,
     WorkspaceUpdates,
 )
+from servicelib.logging_utils import log_context
 from simcore_postgres_database.utils_repos import transaction_context
 
 from ..db.plugin import get_asyncpg_engine
@@ -370,7 +371,7 @@ async def batch_delete_trashed_workspaces_as_admin(
     offset = 0
     while True:
         (
-            _,
+            total_count,
             expired_trashed_workspaces,
         ) = await _workspaces_repository.list_workspaces_db_get_as_admin(
             app,
@@ -384,22 +385,30 @@ async def batch_delete_trashed_workspaces_as_admin(
 
         # BATCH delete: best-effort across workspaces (per `fail_fast=False`) - one broken
         # workspace does not block the others in this batch from being deleted.
-        newly_failed = 0
-        for trashed_workspace in expired_trashed_workspaces:
-            assert trashed_workspace.trashed  # nosec
+        with log_context(
+            _logger,
+            logging.INFO,
+            "Deleting %d trashed workspaces out of %d [trashed_at < %s will be deleted]",
+            len(expired_trashed_workspaces),
+            total_count,
+            trashed_before,
+        ):
+            newly_failed = 0
+            for trashed_workspace in expired_trashed_workspaces:
+                assert trashed_workspace.trashed  # nosec
 
-            deleted_workspace_id = await _delete_trashed_workspace_content_and_row(
-                app,
-                trashed_workspace=trashed_workspace,
-                fail_fast=fail_fast,
-                errors=errors,
-            )
-            if deleted_workspace_id is not None:
-                deleted_workspace_ids.append(deleted_workspace_id)
-            else:
-                newly_failed += 1
+                deleted_workspace_id = await _delete_trashed_workspace_content_and_row(
+                    app,
+                    trashed_workspace=trashed_workspace,
+                    fail_fast=fail_fast,
+                    errors=errors,
+                )
+                if deleted_workspace_id is not None:
+                    deleted_workspace_ids.append(deleted_workspace_id)
+                else:
+                    newly_failed += 1
 
-        offset += newly_failed
+            offset += newly_failed
 
     if errors:
         raise WorkspaceBatchDeleteError(

--- a/services/web/server/src/simcore_service_webserver/workspaces/_trash_service.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_trash_service.py
@@ -367,19 +367,24 @@ async def batch_delete_trashed_workspaces_as_admin(
     deleted_workspace_ids: list[WorkspaceID] = []
     errors: list[tuple[WorkspaceID, Exception]] = []
 
-    for page_params in iter_pagination_params(offset=0, limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE):
+    offset = 0
+    while True:
         (
-            page_params.total_number_of_items,
+            _,
             expired_trashed_workspaces,
         ) = await _workspaces_repository.list_workspaces_db_get_as_admin(
             app,
             trashed_before=trashed_before,
-            offset=page_params.offset,
-            limit=page_params.limit,
+            offset=offset,
+            limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
             order_by=OrderBy(field=IDStr("workspace_id"), direction=OrderDirection.DESC),
         )
+        if not expired_trashed_workspaces:
+            break
+
         # BATCH delete: best-effort across workspaces (per `fail_fast=False`) - one broken
         # workspace does not block the others in this batch from being deleted.
+        newly_failed = 0
         for trashed_workspace in expired_trashed_workspaces:
             assert trashed_workspace.trashed  # nosec
 
@@ -391,6 +396,10 @@ async def batch_delete_trashed_workspaces_as_admin(
             )
             if deleted_workspace_id is not None:
                 deleted_workspace_ids.append(deleted_workspace_id)
+            else:
+                newly_failed += 1
+
+        offset += newly_failed
 
     if errors:
         raise WorkspaceBatchDeleteError(

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_repository.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_repository.py
@@ -183,7 +183,8 @@ async def get_workspace_for_user(
         row = result.one_or_none()
         if row is None:
             raise WorkspaceAccessForbiddenError(
-                details=f"User {user_id} does not have access to the workspace {workspace_id}. Or workspace does not exist.",
+                details=f"User {user_id} does not have access to the workspace {workspace_id}. "
+                "Or workspace does not exist.",
             )
         return UserWorkspaceWithAccessRights.model_validate(row)
 
@@ -252,6 +253,8 @@ async def delete_workspace(
 
 assert set(WorkspaceDBGet.model_fields.keys()) == {col.name for col in _WORKSPACE_SELECTION_COLS}
 
+type TotalCount = int
+
 
 async def list_workspaces_db_get_as_admin(
     app: web.Application,
@@ -264,7 +267,7 @@ async def list_workspaces_db_get_as_admin(
     limit: int,
     # ordering
     order_by: OrderBy,
-) -> tuple[int, list[WorkspaceDBGet]]:
+) -> tuple[TotalCount, list[WorkspaceDBGet]]:
     """
     NOTE: This is an internal function used for administrative purposes.
     Ex. It lists trashed workspaces across the application for cleanup tasks.

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_service.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_service.py
@@ -3,7 +3,6 @@
 import logging
 
 from aiohttp import web
-from common_library.pagination_tools import iter_pagination_params
 from models_library.basic_types import IDStr
 from models_library.folders import FolderID
 from models_library.products import ProductName
@@ -99,11 +98,11 @@ async def delete_workspace_with_all_content(
     )
 
     # Get all root projects
-    for page_params in iter_pagination_params(offset=0, limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE):
-        (
-            projects,
-            page_params.total_number_of_items,
-        ) = await list_projects(
+    # NOTE: re-query from offset=0 each round since deleted projects vanish from the
+    # matching set; iter_pagination_params assumes a stable collection, which doesn't
+    # hold here (see projects._trash_service.batch_delete_trashed_projects_as_admin).
+    while True:
+        projects, _ = await list_projects(
             app,
             user_id=user_id,
             product_name=product_name,
@@ -113,10 +112,12 @@ async def delete_workspace_with_all_content(
             template_type=None,
             folder_id=None,
             trashed=None,
-            offset=page_params.offset,
-            limit=page_params.limit,
+            offset=0,
+            limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
             order_by=OrderBy(field=IDStr("last_change_date"), direction=OrderDirection.DESC),
         )
+        if not projects:
+            break
 
         workspace_root_projects: list[ProjectID] = [Project(**project).uuid for project in projects]
 
@@ -127,21 +128,20 @@ async def delete_workspace_with_all_content(
             )
 
     # Get all root folders
-    for page_params in iter_pagination_params(offset=0, limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE):
-        (
-            folders,
-            page_params.total_number_of_items,
-        ) = await list_folders(
+    while True:
+        folders, _ = await list_folders(
             app,
             user_id=user_id,
             product_name=product_name,
             workspace_id=workspace_id,
             folder_id=None,
             trashed=None,
-            offset=page_params.offset,
-            limit=page_params.limit,
+            offset=0,
+            limit=MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE,
             order_by=OrderBy(field=IDStr("folder_id"), direction=OrderDirection.ASC),
         )
+        if not folders:
+            break
 
         workspace_root_folders: list[FolderID] = [folder.folder_db.folder_id for folder in folders]
 

--- a/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_service.py
+++ b/services/web/server/src/simcore_service_webserver/workspaces/_workspaces_service.py
@@ -15,6 +15,7 @@ from models_library.workspaces import (
     WorkspaceID,
     WorkspaceUpdates,
 )
+from servicelib.logging_utils import log_context
 
 from ..folders.folders_service import delete_folder_with_all_content, list_folders
 from ..projects import projects_trash_service
@@ -98,11 +99,8 @@ async def delete_workspace_with_all_content(
     )
 
     # Get all root projects
-    # NOTE: re-query from offset=0 each round since deleted projects vanish from the
-    # matching set; iter_pagination_params assumes a stable collection, which doesn't
-    # hold here (see projects._trash_service.batch_delete_trashed_projects_as_admin).
     while True:
-        projects, _ = await list_projects(
+        projects, total_number_projects = await list_projects(
             app,
             user_id=user_id,
             product_name=product_name,
@@ -122,14 +120,21 @@ async def delete_workspace_with_all_content(
         workspace_root_projects: list[ProjectID] = [Project(**project).uuid for project in projects]
 
         # Delete projects properly
-        for project_uuid in workspace_root_projects:
-            await projects_trash_service.delete_project_as_user(
-                app, project_id=project_uuid, user_id=user_id, product_name=product_name
-            )
+        with log_context(
+            _logger,
+            logging.INFO,
+            "Deleting %d root projects out of %d",
+            len(workspace_root_projects),
+            total_number_projects,
+        ):
+            for project_uuid in workspace_root_projects:
+                await projects_trash_service.delete_project_as_user(
+                    app, project_id=project_uuid, user_id=user_id, product_name=product_name
+                )
 
     # Get all root folders
     while True:
-        folders, _ = await list_folders(
+        folders, folders_total_count = await list_folders(
             app,
             user_id=user_id,
             product_name=product_name,
@@ -146,13 +151,20 @@ async def delete_workspace_with_all_content(
         workspace_root_folders: list[FolderID] = [folder.folder_db.folder_id for folder in folders]
 
         # Delete folders properly
-        for folder_id in workspace_root_folders:
-            await delete_folder_with_all_content(
-                app,
-                user_id=user_id,
-                product_name=product_name,
-                folder_id=folder_id,
-            )
+        with log_context(
+            _logger,
+            logging.INFO,
+            "Deleting %d root folders out of %d",
+            len(workspace_root_folders),
+            folders_total_count,
+        ):
+            for folder_id in workspace_root_folders:
+                await delete_folder_with_all_content(
+                    app,
+                    user_id=user_id,
+                    product_name=product_name,
+                    folder_id=folder_id,
+                )
 
     await db.delete_workspace(
         app,

--- a/services/web/server/tests/unit/with_dbs/03/trash/test_trash_service.py
+++ b/services/web/server/tests/unit/with_dbs/03/trash/test_trash_service.py
@@ -25,12 +25,15 @@ from pytest_simcore.helpers.webserver_login import (
 )
 from pytest_simcore.helpers.webserver_projects import create_project
 from servicelib.aiohttp import status
+from simcore_postgres_database.models.folders_v2 import folders_v2
 from simcore_postgres_database.models.workspaces import workspaces as workspaces_table
 from simcore_service_webserver.db.models import UserRole
 from simcore_service_webserver.db.models import projects as projects_table
+from simcore_service_webserver.folders import _folders_service
 from simcore_service_webserver.projects import _projects_service_delete, _trash_service
 from simcore_service_webserver.projects.models import ProjectDict
 from simcore_service_webserver.trash import trash_service
+from simcore_service_webserver.workspaces import _workspaces_service
 from sqlalchemy.ext.asyncio import AsyncEngine
 from tenacity import stop_after_attempt, wait_none
 
@@ -154,6 +157,98 @@ async def test_trash_service__delete_expired_trash_for_more_than_one_page_of_pro
         )
         remaining_uuids = {row.uuid for row in result}
     assert not remaining_uuids
+
+
+async def test_trash_service__delete_expired_trash_for_more_than_one_page_of_folders(
+    client: TestClient,
+    logged_user: UserInfoDict,
+    asyncpg_engine: AsyncEngine,
+):
+    """Regression test for https://github.com/ITISFoundation/osparc-simcore/pull/9510:
+    `batch_delete_trashed_folders_as_admin` had the same multi-page pagination bug as
+    `batch_delete_trashed_projects_as_admin` (see the sibling projects test above).
+    """
+    assert client.app
+
+    num_folders = MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE + 10  # forces more than one page
+
+    created_folder_ids: list[int] = []
+    for i in range(num_folders):
+        folder = await _folders_service.create_folder(
+            client.app,
+            user_id=logged_user["id"],
+            name=f"folder-{i}",
+            parent_folder_id=None,
+            product_name="osparc",
+            workspace_id=None,
+        )
+        created_folder_ids.append(folder.folder_db.folder_id)
+
+    # TRASH all folders directly in the DB (bulk), already expired to bypass TRASH_RETENTION_DAYS timing
+    already_expired = arrow.utcnow().shift(days=-1).datetime
+    async with asyncpg_engine.begin() as conn:
+        await conn.execute(
+            folders_v2.update()
+            .where(folders_v2.c.folder_id.in_(created_folder_ids))
+            .values(trashed=already_expired, trashed_explicitly=True, trashed_by=logged_user["id"])
+        )
+
+    # UNDER TEST: a single GC cycle must delete ALL of them, without raising
+    await trash_service.safe_delete_expired_trash_as_admin(client.app)
+
+    # ASSERT: none of the folders remain in the DB
+    async with asyncpg_engine.connect() as conn:
+        result = await conn.execute(
+            sa.select(folders_v2.c.folder_id).where(folders_v2.c.folder_id.in_(created_folder_ids))
+        )
+        remaining_ids = {row.folder_id for row in result}
+    assert not remaining_ids
+
+
+async def test_trash_service__delete_expired_trash_for_more_than_one_page_of_workspaces(
+    client: TestClient,
+    logged_user: UserInfoDict,
+    asyncpg_engine: AsyncEngine,
+):
+    """Regression test for https://github.com/ITISFoundation/osparc-simcore/pull/9510:
+    `batch_delete_trashed_workspaces_as_admin` had the same multi-page pagination bug as
+    `batch_delete_trashed_projects_as_admin` (see the sibling projects test above).
+    """
+    assert client.app
+
+    num_workspaces = MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE + 10  # forces more than one page
+
+    created_workspace_ids: list[int] = []
+    for i in range(num_workspaces):
+        workspace = await _workspaces_service.create_workspace(
+            client.app,
+            user_id=logged_user["id"],
+            name=f"workspace-{i}",
+            description=None,
+            thumbnail=None,
+            product_name="osparc",
+        )
+        created_workspace_ids.append(workspace.workspace_id)
+
+    # TRASH all workspaces directly in the DB (bulk), already expired to bypass TRASH_RETENTION_DAYS timing
+    already_expired = arrow.utcnow().shift(days=-1).datetime
+    async with asyncpg_engine.begin() as conn:
+        await conn.execute(
+            workspaces_table.update()
+            .where(workspaces_table.c.workspace_id.in_(created_workspace_ids))
+            .values(trashed=already_expired, trashed_by=logged_user["id"])
+        )
+
+    # UNDER TEST: a single GC cycle must delete ALL of them, without raising
+    await trash_service.safe_delete_expired_trash_as_admin(client.app)
+
+    # ASSERT: none of the workspaces remain in the DB
+    async with asyncpg_engine.connect() as conn:
+        result = await conn.execute(
+            sa.select(workspaces_table.c.workspace_id).where(workspaces_table.c.workspace_id.in_(created_workspace_ids))
+        )
+        remaining_ids = {row.workspace_id for row in result}
+    assert not remaining_ids
 
 
 async def test_trash_service__delete_expired_trash_retries_pipeline_stop_and_succeeds(

--- a/services/web/server/tests/unit/with_dbs/03/trash/test_trash_service.py
+++ b/services/web/server/tests/unit/with_dbs/03/trash/test_trash_service.py
@@ -9,10 +9,12 @@
 from copy import deepcopy
 from unittest.mock import MagicMock
 
+import arrow
 import pytest
 import sqlalchemy as sa
 from aiohttp.test_utils import TestClient
 from models_library.api_schemas_webserver.projects import ProjectGet
+from models_library.rest_pagination import MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
@@ -104,6 +106,54 @@ async def test_trash_service__delete_expired_trash(
     async with switch_client_session_to(client, other_user):
         resp = await client.get(f"/v0/projects/{other_user_project_id}")
         await assert_status(resp, status.HTTP_404_NOT_FOUND)
+
+
+async def test_trash_service__delete_expired_trash_for_more_than_one_page_of_projects(
+    client: TestClient,
+    logged_user: UserInfoDict,
+    fake_project: ProjectDict,
+    mocked_catalog: None,
+    mocked_director_v2: None,
+    mocked_dynamic_services_interface: dict[str, MagicMock],
+    mocked_storage: None,
+    asyncpg_engine: AsyncEngine,
+):
+    """Regression test for https://github.com/ITISFoundation/osparc-simcore/pull/9510:
+    `batch_delete_trashed_projects_as_admin` used to raise a RuntimeError (aborting the whole
+    GC run) as soon as more than one page (`MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE`) of trashed
+    projects had to be deleted, because deleting a page's projects changes the count of the
+    very collection `iter_pagination_params` was iterating over.
+    """
+    assert client.app
+
+    num_projects = MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE + 10  # forces more than one page
+
+    created_project_ids: list[str] = []
+    for _ in range(num_projects):
+        project = await create_project(
+            client.app, deepcopy(fake_project), user_id=logged_user["id"], product_name="osparc"
+        )
+        created_project_ids.append(project["uuid"])
+
+    # TRASH all projects directly in the DB (bulk), already expired to bypass TRASH_RETENTION_DAYS timing
+    already_expired = arrow.utcnow().shift(days=-1).datetime
+    async with asyncpg_engine.begin() as conn:
+        await conn.execute(
+            projects_table.update()
+            .where(projects_table.c.uuid.in_(created_project_ids))
+            .values(trashed=already_expired, trashed_explicitly=True, trashed_by=logged_user["id"])
+        )
+
+    # UNDER TEST: a single GC cycle must delete ALL of them, without raising
+    await trash_service.safe_delete_expired_trash_as_admin(client.app)
+
+    # ASSERT: none of the projects remain in the DB
+    async with asyncpg_engine.connect() as conn:
+        result = await conn.execute(
+            sa.select(projects_table.c.uuid).where(projects_table.c.uuid.in_(created_project_ids))
+        )
+        remaining_uuids = {row.uuid for row in result}
+    assert not remaining_uuids
 
 
 async def test_trash_service__delete_expired_trash_retries_pipeline_stop_and_succeeds(

--- a/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__delete_workspace_with_content.py
+++ b/services/web/server/tests/unit/with_dbs/04/workspaces/test_workspaces__delete_workspace_with_content.py
@@ -11,15 +11,19 @@ from http import HTTPStatus
 from unittest import mock
 
 import pytest
+import sqlalchemy as sa
 from aiohttp.test_utils import TestClient
 from models_library.api_schemas_webserver.workspaces import WorkspaceGet
+from models_library.rest_pagination import MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.webserver_projects import create_project
 from pytest_simcore.helpers.webserver_users import UserInfoDict
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
+from simcore_service_webserver.db.models import projects as projects_table
 from simcore_service_webserver.projects.models import ProjectDict
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 
 @dataclasses.dataclass(frozen=True)
@@ -260,3 +264,61 @@ async def test_workspaces_deletion_cleans_up_project_storage_and_pipeline_data(
     assert mock_project_deletion_side_effects.director_v2_delete_pipeline.call_count == len(created_projects), (
         "project pipeline data was not cleaned up (orphaned pipeline data bug)"
     )
+
+
+@pytest.mark.parametrize("user_role,expected", [(UserRole.USER, status.HTTP_200_OK)])
+async def test_workspaces_deletion_with_more_than_one_page_of_root_projects(
+    mocked_dynamic_services_interface: dict[str, mock.MagicMock],
+    client: TestClient,
+    logged_user: UserInfoDict,
+    user_project: ProjectDict,
+    expected: HTTPStatus,
+    fake_project: ProjectDict,
+    workspaces_clean_db: None,
+    mock_project_deletion_side_effects: _ProjectDeletionMocks,
+    asyncpg_engine: AsyncEngine,
+):
+    """Regression test for https://github.com/ITISFoundation/osparc-simcore/pull/9510:
+    `delete_workspace_with_all_content` had the same multi-page pagination bug as
+    `batch_delete_trashed_projects_as_admin` when a workspace had more than one page
+    (`MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE`) of root projects to delete.
+    """
+    assert client.app
+
+    # create a new workspace
+    url = client.app.router["create_workspace"].url_for()
+    resp = await client.post(
+        f"{url}",
+        json={"name": "Workspace with many root projects", "description": None, "thumbnail": None},
+    )
+    data, _ = await assert_status(resp, status.HTTP_201_CREATED)
+    added_workspace = WorkspaceGet.model_validate(data)
+
+    num_projects = MAXIMUM_NUMBER_OF_ITEMS_PER_PAGE + 10  # forces more than one page
+    project_data = deepcopy(fake_project)
+    project_data["workspace_id"] = f"{added_workspace.workspace_id}"
+    created_project_ids: list[str] = []
+    for _ in range(num_projects):
+        project = await create_project(client.app, project_data, user_id=logged_user["id"], product_name="osparc")
+        created_project_ids.append(project["uuid"])
+
+    # ---------------------
+    # TESTING DELETION
+    # ---------------------
+
+    url = client.app.router["delete_workspace"].url_for(workspace_id=f"{added_workspace.workspace_id}")
+    resp = await client.delete(f"{url}")
+    await assert_status(resp, status.HTTP_204_NO_CONTENT)
+
+    # ---------------------
+    # Assertions
+
+    resp = await client.get(f"/v0/workspaces/{added_workspace.workspace_id}")
+    await assert_status(resp, status.HTTP_403_FORBIDDEN)
+
+    async with asyncpg_engine.connect() as conn:
+        result = await conn.execute(
+            sa.select(projects_table.c.uuid).where(projects_table.c.uuid.in_(created_project_ids))
+        )
+        remaining_uuids = {row.uuid for row in result}
+    assert not remaining_uuids


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
During debugging of related issues I found out that the garbage collector service is affected by a flaw:
- when deleting trashed projects it uses `iter_pagination_params` which expects the total number of paged objects to remain the same, which is a wrong assumption when deleting objects.


The same was used for workspaces, folders, and projects. In this PR all are fixed.


The issue is not so problematic in the sense that it means the garbage collector service needs multiple runs in order to clean up, so it eventually still works even with this flaw due to the retrial mechanisms involved in the garbage collector task. Nevertheless that is a bug.

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
