### PR TITLE
🐛♻️Computational backend: ensure Dask resources are properly released after a pipeline successfuly completes

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/core/errors.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/errors.py
@@ -154,6 +154,10 @@ class ComputationalBackendTaskResultsNotReadyError(ComputationalSchedulerError):
     msg_template = "The task result is not ready yet for job '{job_id}'"
 
 
+class ComputationalBackendTaskResultsReleaseError(ComputationalSchedulerError):
+    msg_template = "Releasing the task result for job '{job_id}' timed-out"
+
+
 class ClustersKeeperNotAvailableError(ComputationalSchedulerError):
     msg_template = "clusters-keeper service is not available!"
 

--- a/services/director-v2/src/simcore_service_director_v2/models/comp_run_snapshot_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/comp_run_snapshot_tasks.py
@@ -16,12 +16,13 @@ from pydantic import (
 from simcore_postgres_database.models.comp_pipeline import StateType
 
 from ..utils.db import DB_TO_RUNNING_STATE
+from .comp_runs import Iteration, RunID
 from .comp_tasks import BaseCompTaskAtDB, Image
 
 
 class CompRunSnapshotTaskAtDBGet(BaseCompTaskAtDB):
     snapshot_task_id: PositiveInt
-    run_id: PositiveInt
+    run_id: RunID
 
     model_config = ConfigDict(
         extra="forbid",
@@ -40,7 +41,8 @@ class CompRunSnapshotTaskAtDBGet(BaseCompTaskAtDB):
                         "inputs": {
                             "input_1": {
                                 "label": "input_files",
-                                "description": "Any input files. One or serveral files compressed in a zip will be downloaded in an inputs folder.",
+                                "description": "Any input files. One or several files compressed "
+                                "in a zip will be downloaded in an inputs folder.",
                                 "type": "data:*/*",
                                 "displayOrder": 1.0,
                             }
@@ -63,7 +65,8 @@ class CompRunSnapshotTaskAtDBGet(BaseCompTaskAtDB):
                     "outputs": {
                         "output_1": {
                             "store": 0,
-                            "path": "341351c4-23d1-4366-95d0-bc01386001a7/7f62be0e-1298-4fe4-be76-66b6e859c260/output_1.zip",
+                            "path": "341351c4-23d1-4366-95d0-bc01386001a7"
+                            "/7f62be0e-1298-4fe4-be76-66b6e859c260/output_1.zip",
                         }
                     },
                     "image": image_example,
@@ -89,7 +92,7 @@ class CompRunSnapshotTaskAtDBGet(BaseCompTaskAtDB):
 
 
 class CompRunSnapshotTaskAtDBCreate(BaseCompTaskAtDB):
-    run_id: PositiveInt
+    run_id: RunID
 
 
 def _none_to_zero_float_pre_validator(value: Any):
@@ -100,7 +103,7 @@ def _none_to_zero_float_pre_validator(value: Any):
 
 class CompRunSnapshotTaskDBGet(BaseModel):
     snapshot_task_id: PositiveInt
-    run_id: PositiveInt
+    run_id: RunID
     project_uuid: ProjectID
     node_id: NodeID
     state: RunningState
@@ -108,14 +111,14 @@ class CompRunSnapshotTaskDBGet(BaseModel):
     image: dict[str, Any]
     started_at: datetime | None
     ended_at: datetime | None
-    iteration: PositiveInt
+    iteration: Iteration
 
     @field_validator("state", mode="before")
     @classmethod
     def convert_result_from_state_type_enum_if_needed(cls, v):
         if isinstance(v, str):
             # try to convert to a StateType, if it fails the validations will continue
-            # and pydantic will try to convert it to a RunninState later on
+            # and pydantic will try to convert it to a RunningState later on
             with suppress(ValueError):
                 v = StateType(v)
         if isinstance(v, StateType):

--- a/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
@@ -48,9 +48,10 @@ class RunMetadataDict(TypedDict, total=False):
     encryption: JobEncryptionRunMetadataDict
 
 
-type Iteration = PositiveInt
+type _IterationInt = PositiveInt
 type _RunIDInt = PositiveInt
-# NewType (not a `type` alias) so the checker flags accidental mix-ups with Iteration
+# NewType (not a `type` alias) so the checker flags accidental mix-ups between Iteration and RunID
+Iteration = NewType("Iteration", _IterationInt)
 RunID = NewType("RunID", _RunIDInt)
 
 

--- a/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
@@ -1,6 +1,7 @@
 import datetime
 from contextlib import suppress
 from typing import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
+    NewType,
     TypedDict,
 )
 
@@ -48,6 +49,9 @@ class RunMetadataDict(TypedDict, total=False):
 
 
 type Iteration = PositiveInt
+type _RunIDInt = PositiveInt
+# NewType (not a `type` alias) so the checker flags accidental mix-ups with Iteration
+RunID = NewType("RunID", _RunIDInt)
 
 
 class CompRunsAtDB(BaseModel):

--- a/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
@@ -55,7 +55,7 @@ RunID = NewType("RunID", _RunIDInt)
 
 
 class CompRunsAtDB(BaseModel):
-    run_id: PositiveInt
+    run_id: RunID
     project_uuid: ProjectID
     user_id: UserID
     iteration: Iteration

--- a/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
@@ -50,7 +50,6 @@ class RunMetadataDict(TypedDict, total=False):
 
 type _IterationInt = PositiveInt
 type _RunIDInt = PositiveInt
-# NewType (not a `type` alias) so the checker flags accidental mix-ups between Iteration and RunID
 Iteration = NewType("Iteration", _IterationInt)
 RunID = NewType("RunID", _RunIDInt)
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/__init__.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/__init__.py
@@ -7,6 +7,7 @@ from servicelib.logging_utils import log_context
 
 from ._constants import MODULE_NAME_SCHEDULER
 from ._manager import run_new_pipeline, setup_manager, shutdown_manager, stop_pipeline
+from ._releaser import setup_releaser, shutdown_releaser
 from ._worker import setup_worker, shutdown_worker
 
 _logger = logging.getLogger(__name__)
@@ -15,6 +16,7 @@ _logger = logging.getLogger(__name__)
 def on_app_startup(app: FastAPI) -> Callable[[], Coroutine[Any, Any, None]]:
     async def start_scheduler() -> None:
         with log_context(_logger, level=logging.INFO, msg=f"starting {MODULE_NAME_SCHEDULER}"):
+            await setup_releaser(app)
             await setup_worker(app)
             await setup_manager(app)
 
@@ -26,6 +28,7 @@ def on_app_shutdown(app: FastAPI) -> Callable[[], Coroutine[Any, Any, None]]:
         with log_context(_logger, level=logging.INFO, msg=f"stopping {MODULE_NAME_SCHEDULER}"):
             await shutdown_manager(app)
             await shutdown_worker(app)
+            await shutdown_releaser(app)
 
     return stop_scheduler
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_constants.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_constants.py
@@ -3,5 +3,13 @@ from typing import Final
 
 MODULE_NAME_SCHEDULER: Final[str] = "computational-distributed-scheduler"
 MODULE_NAME_WORKER: Final[str] = "computational-distributed-worker"
+MODULE_NAME_RELEASER: Final[str] = "computational-distributed-releaser"
 SCHEDULER_INTERVAL: Final[datetime.timedelta] = datetime.timedelta(seconds=5)
 MAX_CONCURRENT_PIPELINE_SCHEDULING: Final[int] = 10
+TASK_RESULT_RELEASE_CONCURRENCY: Final[int] = 5
+# NOTE: on-demand clusters may take up to COMPUTATIONAL_BACKEND_MAX_WAITING_FOR_CLUSTER_TIMEOUT
+# (10 minutes by default) to start, so the retry window must comfortably outlast that instead
+# of using rabbitmq's short (~15s) defaults, otherwise the release would be dropped for good
+# while the cluster is still starting up.
+TASK_RESULT_RELEASE_RETRY_DELAY: Final[datetime.timedelta] = datetime.timedelta(seconds=30)
+TASK_RESULT_RELEASE_MAX_ATTEMPTS: Final[int] = 30

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_manager.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_manager.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ...core.errors import ComputationalRunNotFoundError
 from ...models.comp_pipelines import CompPipelineAtDB
-from ...models.comp_runs import RunMetadataDict
+from ...models.comp_runs import Iteration, RunMetadataDict
 from ...models.comp_tasks import CompTaskAtDB
 from ...utils.rabbitmq import publish_pipeline_scheduling_state, publish_project_log
 from ..db import get_db_engine
@@ -115,7 +115,7 @@ async def stop_pipeline(
     *,
     user_id: UserID,
     project_id: ProjectID,
-    iteration: int | None = None,
+    iteration: Iteration | None = None,
 ) -> None:
     """Stops a pipeline
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_models.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_models.py
@@ -4,8 +4,9 @@ from typing import Literal
 from models_library.projects import ProjectID
 from models_library.rabbitmq_messages import RabbitMessageBase
 from models_library.users import UserID
+from pydantic import PositiveInt
 
-from ...models.comp_runs import Iteration
+from ...models.comp_runs import Iteration, RunMetadataDict
 from ...models.comp_tasks import CompTaskAtDB
 
 
@@ -14,6 +15,21 @@ class SchedulePipelineRabbitMessage(RabbitMessageBase):
     user_id: UserID
     project_id: ProjectID
     iteration: Iteration
+
+    def routing_key(self) -> str | None:  # pylint: disable=no-self-use # abstract
+        return None
+
+
+class ReleaseTaskResultRabbitMessage(RabbitMessageBase):
+    channel_name: Literal["simcore.services.director-v2.release-task-result"] = (
+        "simcore.services.director-v2.release-task-result"
+    )
+    user_id: UserID
+    project_id: ProjectID
+    run_id: PositiveInt
+    use_on_demand_clusters: bool
+    run_metadata: RunMetadataDict
+    job_ids: list[str]
 
     def routing_key(self) -> str | None:  # pylint: disable=no-self-use # abstract
         return None

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_models.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_models.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass
 from typing import Literal
 
+from dask_task_models_library.models import DaskJobID
 from models_library.projects import ProjectID
 from models_library.rabbitmq_messages import RabbitMessageBase
 from models_library.users import UserID
-from pydantic import PositiveInt
 
-from ...models.comp_runs import Iteration, RunMetadataDict
+from ...models.comp_runs import Iteration, RunID, RunMetadataDict
 from ...models.comp_tasks import CompTaskAtDB
 
 
@@ -26,10 +26,10 @@ class ReleaseTaskResultRabbitMessage(RabbitMessageBase):
     )
     user_id: UserID
     project_id: ProjectID
-    run_id: PositiveInt
+    run_id: RunID
     use_on_demand_clusters: bool
     run_metadata: RunMetadataDict
-    job_ids: list[str]
+    job_ids: list[DaskJobID]
 
     def routing_key(self) -> str | None:  # pylint: disable=no-self-use # abstract
         return None

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_publisher.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_publisher.py
@@ -1,10 +1,10 @@
+from dask_task_models_library.models import DaskJobID
 from models_library.projects import ProjectID
 from models_library.users import UserID
-from pydantic import PositiveInt
 from servicelib.rabbitmq import RabbitMQClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from ...models.comp_runs import Iteration, RunMetadataDict
+from ...models.comp_runs import Iteration, RunID, RunMetadataDict
 from ..db.repositories.comp_runs import CompRunsRepository
 from ._models import ReleaseTaskResultRabbitMessage, SchedulePipelineRabbitMessage
 
@@ -36,10 +36,10 @@ async def request_task_result_release(
     *,
     user_id: UserID,
     project_id: ProjectID,
-    run_id: PositiveInt,
+    run_id: RunID,
     use_on_demand_clusters: bool,
     run_metadata: RunMetadataDict,
-    job_ids: list[str],
+    job_ids: list[DaskJobID],
 ) -> None:
     await rabbitmq_client.publish(
         ReleaseTaskResultRabbitMessage.get_channel_name(),

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_publisher.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_publisher.py
@@ -1,11 +1,12 @@
 from models_library.projects import ProjectID
 from models_library.users import UserID
+from pydantic import PositiveInt
 from servicelib.rabbitmq import RabbitMQClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from ...models.comp_runs import Iteration
+from ...models.comp_runs import Iteration, RunMetadataDict
 from ..db.repositories.comp_runs import CompRunsRepository
-from ._models import SchedulePipelineRabbitMessage
+from ._models import ReleaseTaskResultRabbitMessage, SchedulePipelineRabbitMessage
 
 
 async def request_pipeline_scheduling(
@@ -26,5 +27,28 @@ async def request_pipeline_scheduling(
             user_id=user_id,
             project_id=project_id,
             iteration=iteration,
+        ),
+    )
+
+
+async def request_task_result_release(
+    rabbitmq_client: RabbitMQClient,
+    *,
+    user_id: UserID,
+    project_id: ProjectID,
+    run_id: PositiveInt,
+    use_on_demand_clusters: bool,
+    run_metadata: RunMetadataDict,
+    job_ids: list[str],
+) -> None:
+    await rabbitmq_client.publish(
+        ReleaseTaskResultRabbitMessage.get_channel_name(),
+        ReleaseTaskResultRabbitMessage(
+            user_id=user_id,
+            project_id=project_id,
+            run_id=run_id,
+            use_on_demand_clusters=use_on_demand_clusters,
+            run_metadata=run_metadata,
+            job_ids=job_ids,
         ),
     )

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_releaser.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_releaser.py
@@ -1,0 +1,69 @@
+import asyncio
+import functools
+import logging
+from typing import cast
+
+from fastapi import FastAPI
+from servicelib.logging_utils import log_context
+from servicelib.tracing import traced
+
+from ..rabbitmq import get_rabbitmq_client
+from ._constants import (
+    TASK_RESULT_RELEASE_CONCURRENCY,
+    TASK_RESULT_RELEASE_MAX_ATTEMPTS,
+    TASK_RESULT_RELEASE_RETRY_DELAY,
+)
+from ._models import ReleaseTaskResultRabbitMessage
+from ._scheduler_dask import DaskScheduler
+
+_logger = logging.getLogger(__name__)
+
+
+def _get_scheduler_worker(app: FastAPI) -> DaskScheduler:
+    return cast(DaskScheduler, app.state.scheduler_worker)
+
+
+@traced
+async def _handle_release_task_result(app: FastAPI, data: bytes) -> bool:
+    message = ReleaseTaskResultRabbitMessage.model_validate_json(data)
+    with log_context(
+        _logger,
+        logging.DEBUG,
+        msg=f"releasing task results for {message.job_ids}",
+    ):
+        # NOTE: let exceptions propagate: the rabbitmq client will nack and retry the
+        # message (with backoff, up to a max number of attempts) instead of silently
+        # dropping a failed release like the previous inline call used to.
+        await _get_scheduler_worker(app).release_task_result(
+            user_id=message.user_id,
+            project_id=message.project_id,
+            run_id=message.run_id,
+            use_on_demand_clusters=message.use_on_demand_clusters,
+            run_metadata=message.run_metadata,
+            job_ids=message.job_ids,
+        )
+    return True
+
+
+async def setup_releaser(app: FastAPI) -> None:
+    rabbitmq_client = get_rabbitmq_client(app)
+    app.state.task_result_releaser_consumers = await asyncio.gather(
+        *(
+            rabbitmq_client.subscribe(
+                ReleaseTaskResultRabbitMessage.get_channel_name(),
+                functools.partial(_handle_release_task_result, app),
+                exclusive_queue=False,
+                unexpected_error_retry_delay_s=TASK_RESULT_RELEASE_RETRY_DELAY.total_seconds(),
+                unexpected_error_max_attempts=TASK_RESULT_RELEASE_MAX_ATTEMPTS,
+            )
+            for _ in range(TASK_RESULT_RELEASE_CONCURRENCY)
+        )
+    )
+
+
+async def shutdown_releaser(app: FastAPI) -> None:
+    rabbitmq_client = get_rabbitmq_client(app)
+    await asyncio.gather(
+        *(rabbitmq_client.unsubscribe_consumer(*consumer) for consumer in app.state.task_result_releaser_consumers),
+        return_exceptions=False,
+    )

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_releaser.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_releaser.py
@@ -25,15 +25,16 @@ def _get_scheduler_worker(app: FastAPI) -> DaskScheduler:
 
 @traced
 async def _handle_release_task_result(app: FastAPI, data: bytes) -> bool:
+    """Policy: exceptions propagate so the rabbitmq client nacks and retries the
+    message (with backoff, up to a max number of attempts) instead of silently
+    dropping a failed release.
+    """
     message = ReleaseTaskResultRabbitMessage.model_validate_json(data)
     with log_context(
         _logger,
         logging.DEBUG,
         msg=f"releasing task results for {message.job_ids}",
     ):
-        # NOTE: let exceptions propagate: the rabbitmq client will nack and retry the
-        # message (with backoff, up to a max number of attempts) instead of silently
-        # dropping a failed release.
         await _get_scheduler_worker(app).release_task_result(
             user_id=message.user_id,
             project_id=message.project_id,

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_releaser.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_releaser.py
@@ -33,7 +33,7 @@ async def _handle_release_task_result(app: FastAPI, data: bytes) -> bool:
     ):
         # NOTE: let exceptions propagate: the rabbitmq client will nack and retry the
         # message (with backoff, up to a max number of attempts) instead of silently
-        # dropping a failed release like the previous inline call used to.
+        # dropping a failed release.
         await _get_scheduler_worker(app).release_task_result(
             user_id=message.user_id,
             project_id=message.project_id,

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -31,7 +31,6 @@ from models_library.services import ServiceType
 from models_library.services_types import ServiceRunID
 from models_library.users import UserID
 from networkx.classes.reportviews import InDegreeView
-from pydantic import PositiveInt
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
 from servicelib.logging_utils import log_catch, log_context
 from servicelib.rabbitmq import RabbitMQClient, RabbitMQRPCClient
@@ -52,7 +51,7 @@ from ...core.errors import (
 )
 from ...core.settings import ComputationalBackendSettings
 from ...models.comp_pipelines import CompPipelineAtDB
-from ...models.comp_runs import CompRunsAtDB, Iteration, RunMetadataDict
+from ...models.comp_runs import CompRunsAtDB, Iteration, RunID, RunMetadataDict
 from ...models.comp_tasks import CompTaskAtDB
 from ...utils.computations import get_pipeline_state_from_task_states
 from ...utils.rabbitmq import (
@@ -266,7 +265,7 @@ class BaseCompScheduler(ABC):
         project_id: ProjectID,
         dag: nx.DiGraph,
         tasks: dict[NodeIDStr, CompTaskAtDB],
-        run_id: PositiveInt,
+        run_id: RunID,
     ) -> dict[NodeIDStr, CompTaskAtDB]:
         # Perform a reverse topological sort to ensure tasks are ordered from last to first
         sorted_node_ids = list(reversed(list(nx.topological_sort(dag))))
@@ -296,7 +295,7 @@ class BaseCompScheduler(ABC):
         self,
         user_id: UserID,
         project_id: ProjectID,
-        run_id: PositiveInt,
+        run_id: RunID,
         iteration: Iteration,
         dag: nx.DiGraph,
     ) -> None:
@@ -364,7 +363,7 @@ class BaseCompScheduler(ABC):
         project_id: ProjectID,
         iteration: Iteration,
         run_metadata: RunMetadataDict,
-        run_id: PositiveInt,
+        run_id: RunID,
     ) -> None:
         utc_now = arrow.utcnow().datetime
 
@@ -442,7 +441,7 @@ class BaseCompScheduler(ABC):
             started_time=utc_now,
         )
 
-    async def _process_waiting_tasks(self, tasks: list[TaskStateTracker], run_id: PositiveInt) -> None:
+    async def _process_waiting_tasks(self, tasks: list[TaskStateTracker], run_id: RunID) -> None:
         comp_tasks_repo = CompTasksRepository.instance(self.db_engine)
         for task in tasks:
             await comp_tasks_repo.update_project_tasks_state(
@@ -552,7 +551,7 @@ class BaseCompScheduler(ABC):
         """process executing tasks from the 3rd party backend"""
 
     @abstractmethod
-    async def _safe_release_resources(self, user_id: UserID, project_id: ProjectID, run_id: Iteration) -> None:
+    async def _safe_release_resources(self, user_id: UserID, project_id: ProjectID, run_id: RunID) -> None:
         """release resources used by the scheduler for a given user and project"""
 
     async def apply(
@@ -638,7 +637,7 @@ class BaseCompScheduler(ABC):
                         tip="Check that the project still exists",
                     )
                 )
-                await self._safe_release_resources(user_id, project_id, iteration)
+                # NOTE: comp_run was never fetched, so there is no run_id to release resources for
             except PipelineNotFoundError as exc:
                 _logger.exception(
                     **create_troubleshooting_log_kwargs(
@@ -655,7 +654,7 @@ class BaseCompScheduler(ABC):
                 )
 
                 # NOTE: no need to update task states here as pipeline is already broken
-                await self._safe_release_resources(user_id, project_id, iteration)
+                await self._safe_release_resources(user_id, project_id, comp_run.run_id)
                 await self._set_run_result(user_id, project_id, iteration, RunningState.FAILED)
             except InvalidPipelineError as exc:
                 _logger.exception(
@@ -671,7 +670,7 @@ class BaseCompScheduler(ABC):
                     ),
                 )
                 # NOTE: no need to update task states here as pipeline is already broken
-                await self._safe_release_resources(user_id, project_id, iteration)
+                await self._safe_release_resources(user_id, project_id, comp_run.run_id)
                 await self._set_run_result(user_id, project_id, iteration, RunningState.FAILED)
             except ComputationalSchedulerChangedError as exc:
                 _logger.exception(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -25,7 +25,6 @@ from models_library.projects_state import RunningState
 from models_library.rabbitmq_messages import SimcorePlatformStatus
 from models_library.services_types import ServiceRunID
 from models_library.users import UserID
-from pydantic import PositiveInt
 from servicelib.common_headers import UNDEFINED_DEFAULT_SIMCORE_USER_AGENT_VALUE
 from servicelib.logging_utils import log_catch, log_context
 from servicelib.redis._semaphore_decorator import (
@@ -82,7 +81,7 @@ async def _cluster_dask_client(
     *,
     use_on_demand_clusters: bool,
     project_id: ProjectID,
-    run_id: PositiveInt,
+    run_id: RunID,
     run_metadata: RunMetadataDict,
     ref: str | None = None,
 ) -> AsyncGenerator[DaskClient]:
@@ -334,7 +333,7 @@ class DaskScheduler(BaseCompScheduler):
         finally:
             await self.dask_clients_pool.release_client_ref(ref=pool_ref)
 
-    async def _safe_release_resources(self, user_id: UserID, project_id: ProjectID, run_id: Iteration) -> None:
+    async def _safe_release_resources(self, user_id: UserID, project_id: ProjectID, run_id: RunID) -> None:
         """release resources used by the scheduler for a given user and project"""
         with (
             log_catch(_logger, reraise=False),
@@ -420,7 +419,7 @@ class DaskScheduler(BaseCompScheduler):
                     self.rabbitmq_client,
                     user_id=user_id,
                     project_id=comp_run.project_uuid,
-                    run_id=RunID(comp_run.run_id),
+                    run_id=comp_run.run_id,
                     use_on_demand_clusters=comp_run.use_on_demand_clusters,
                     run_metadata=comp_run.metadata,
                     job_ids=releasable_job_ids,

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -1,9 +1,8 @@
-import asyncio
 import contextlib
 import logging
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Final
 from uuid import uuid4
 
@@ -31,7 +30,7 @@ from servicelib.logging_utils import log_catch, log_context
 from servicelib.redis._semaphore_decorator import (
     with_limited_concurrency_cm,
 )
-from servicelib.utils import fire_and_forget_task, limited_as_completed, limited_gather
+from servicelib.utils import limited_as_completed, limited_gather
 from simcore_sdk.node_ports_common.exceptions import S3InvalidPathError
 
 from ..._meta import APP_NAME
@@ -73,10 +72,6 @@ _DASK_CLIENT_RUN_REF: Final[str] = "{user_id}:{project_id}:{run_id}"
 _TASK_RETRIEVAL_ERROR_TYPE: Final[str] = "task-result-retrieval-timeout"
 _TASK_RETRIEVAL_ERROR_CONTEXT_TIME_KEY: Final[str] = "check_time"
 _PUBLICATION_CONCURRENCY_LIMIT: Final[int] = 10
-# NOTE: gives already-published release-task-result messages for this run a chance to reuse
-# the still-warm pooled DaskClient instead of racing _safe_release_resources and having to
-# recreate/tear-down a fresh client per release
-_SAFE_RELEASE_RESOURCES_DELAY_S: Final[float] = 10
 
 
 @asynccontextmanager
@@ -139,7 +134,6 @@ async def _cluster_dask_client(
 @dataclass
 class DaskScheduler(BaseCompScheduler):
     dask_clients_pool: DaskClientsPool
-    _delayed_release_tasks: set[asyncio.Task] = field(default_factory=set, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.dask_clients_pool.register_handlers(
@@ -340,32 +334,18 @@ class DaskScheduler(BaseCompScheduler):
             await self.dask_clients_pool.release_client_ref(ref=pool_ref)
 
     async def _safe_release_resources(self, user_id: UserID, project_id: ProjectID, run_id: Iteration) -> None:
-        """release resources used by the scheduler for a given user and project
-
-        NOTE: delayed (not awaited inline) so any release-task-result message published for this
-        run right before it completed gets a chance to reuse the still-warm pooled DaskClient
-        instead of racing this call and having to recreate one from scratch.
-        """
-
-        async def _delayed_release() -> None:
-            with (
-                log_catch(_logger, reraise=False),
-                log_context(
-                    _logger,
-                    logging.INFO,
-                    msg=f"releasing resources for {user_id=}, {project_id=}, {run_id=}",
-                ),
-            ):
-                await asyncio.sleep(_SAFE_RELEASE_RESOURCES_DELAY_S)
-                await self.dask_clients_pool.release_client_ref(
-                    ref=_DASK_CLIENT_RUN_REF.format(user_id=user_id, project_id=project_id, run_id=run_id)
-                )
-
-        fire_and_forget_task(
-            _delayed_release(),
-            task_suffix_name=f"safe_release_resources_{user_id}_{project_id}_{run_id}",
-            fire_and_forget_tasks_collection=self._delayed_release_tasks,
-        )
+        """release resources used by the scheduler for a given user and project"""
+        with (
+            log_catch(_logger, reraise=False),
+            log_context(
+                _logger,
+                logging.INFO,
+                msg=f"releasing resources for {user_id=}, {project_id=}, {run_id=}",
+            ),
+        ):
+            await self.dask_clients_pool.release_client_ref(
+                ref=_DASK_CLIENT_RUN_REF.format(user_id=user_id, project_id=project_id, run_id=run_id)
+            )
 
     async def _stop_tasks(self, user_id: UserID, tasks: list[CompTaskAtDB], comp_run: CompRunsAtDB) -> None:
         # NOTE: if this exception raises, it means the backend was anyway not up

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -1,9 +1,11 @@
+import asyncio
 import contextlib
 import logging
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Final
+from uuid import uuid4
 
 import arrow
 from common_library.logging.logging_errors import create_troubleshooting_log_kwargs
@@ -29,7 +31,7 @@ from servicelib.logging_utils import log_catch, log_context
 from servicelib.redis._semaphore_decorator import (
     with_limited_concurrency_cm,
 )
-from servicelib.utils import limited_as_completed, limited_gather
+from servicelib.utils import fire_and_forget_task, limited_as_completed, limited_gather
 from simcore_sdk.node_ports_common.exceptions import S3InvalidPathError
 
 from ..._meta import APP_NAME
@@ -59,6 +61,7 @@ from ..db.repositories.comp_runs import (
 )
 from ..db.repositories.comp_tasks import CompTasksRepository
 from ._models import TaskStateTracker
+from ._publisher import request_task_result_release
 from ._scheduler_base import BaseCompScheduler
 from ._utils import (
     WAITING_FOR_START_STATES,
@@ -70,6 +73,10 @@ _DASK_CLIENT_RUN_REF: Final[str] = "{user_id}:{project_id}:{run_id}"
 _TASK_RETRIEVAL_ERROR_TYPE: Final[str] = "task-result-retrieval-timeout"
 _TASK_RETRIEVAL_ERROR_CONTEXT_TIME_KEY: Final[str] = "check_time"
 _PUBLICATION_CONCURRENCY_LIMIT: Final[int] = 10
+# NOTE: gives already-published release-task-result messages for this run a chance to reuse
+# the still-warm pooled DaskClient instead of racing _safe_release_resources and having to
+# recreate/tear-down a fresh client per release
+_SAFE_RELEASE_RESOURCES_DELAY_S: Final[float] = 10
 
 
 @asynccontextmanager
@@ -81,7 +88,8 @@ async def _cluster_dask_client(
     project_id: ProjectID,
     run_id: PositiveInt,
     run_metadata: RunMetadataDict,
-) -> AsyncIterator[DaskClient]:
+    ref: str | None = None,
+) -> AsyncGenerator[DaskClient]:
     """returns the dask client to use for a given user and project, it will automatically create an on-demand
     cluster if needed and wait for it to be ready
 
@@ -106,6 +114,11 @@ async def _cluster_dask_client(
             wallet_id=run_metadata.get("wallet_id"),
         )
 
+    # NOTE: callers that must not share the run-scoped pool reference (e.g. the dataset
+    # releaser, whose lifetime is independent from `_safe_release_resources`) can pass
+    # their own `ref` and are responsible for calling `dask_clients_pool.release_client_ref`
+    client_ref = ref or _DASK_CLIENT_RUN_REF.format(user_id=user_id, project_id=project_id, run_id=run_id)
+
     @with_limited_concurrency_cm(
         scheduler.redis_client,
         key=f"{APP_NAME}-cluster-user_id_{user_id}-wallet_id_{run_metadata.get('wallet_id')}",
@@ -114,11 +127,9 @@ async def _cluster_dask_client(
         blocking_timeout=None,
     )
     @asynccontextmanager
-    async def _acquire_client(user_id: UserID, scheduler: "DaskScheduler") -> AsyncIterator[DaskClient]:
-        async with scheduler.dask_clients_pool.acquire(
-            cluster,
-            ref=_DASK_CLIENT_RUN_REF.format(user_id=user_id, project_id=project_id, run_id=run_id),
-        ) as client:
+    async def _acquire_client(user_id: UserID, scheduler: "DaskScheduler") -> AsyncGenerator[DaskClient]:
+        assert user_id  # nosec
+        async with scheduler.dask_clients_pool.acquire(cluster, ref=client_ref) as client:
             yield client
 
     async with _acquire_client(user_id, scheduler) as client:
@@ -128,6 +139,7 @@ async def _cluster_dask_client(
 @dataclass
 class DaskScheduler(BaseCompScheduler):
     dask_clients_pool: DaskClientsPool
+    _delayed_release_tasks: set[asyncio.Task] = field(default_factory=set, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.dask_clients_pool.register_handlers(
@@ -285,19 +297,75 @@ class DaskScheduler(BaseCompScheduler):
             limit=_PUBLICATION_CONCURRENCY_LIMIT,
         )
 
+    async def release_task_result(
+        self,
+        *,
+        user_id: UserID,
+        project_id: ProjectID,
+        run_id: PositiveInt,
+        use_on_demand_clusters: bool,
+        run_metadata: RunMetadataDict,
+        job_ids: list[str],
+    ) -> None:
+        """unpublish task results/datasets for a given cluster.
+
+        Called by the dedicated release-task-result rabbitmq consumer, decoupled from the
+        main pipeline scheduling flow so a slow/unresponsive scheduler cannot leak consumer
+        slots meant for scheduling.
+
+        NOTE: uses its own pool reference (independent from the run-scoped one managed by
+        `_safe_release_resources`) since this call can happen after the run already finished
+        and released its own reference - reusing that ref here would either be a no-op on an
+        already-torn-down entry or silently leave a fresh client registered forever. All the
+        job_ids of a single scheduling batch share the SAME acquire/release bracket so a run
+        with many completed tasks does not create/delete a client once per task.
+        """
+        pool_ref = f"release-task-result:{uuid4()}"
+        try:
+            async with _cluster_dask_client(
+                user_id,
+                self,
+                use_on_demand_clusters=use_on_demand_clusters,
+                project_id=project_id,
+                run_id=run_id,
+                run_metadata=run_metadata,
+                ref=pool_ref,
+            ) as client:
+                await limited_gather(
+                    *(client.release_task_result(job_id) for job_id in job_ids),
+                    log=_logger,
+                    limit=1,  # to avoid overloading the dask scheduler
+                )
+        finally:
+            await self.dask_clients_pool.release_client_ref(ref=pool_ref)
+
     async def _safe_release_resources(self, user_id: UserID, project_id: ProjectID, run_id: Iteration) -> None:
-        """release resources used by the scheduler for a given user and project"""
-        with (
-            log_catch(_logger, reraise=False),
-            log_context(
-                _logger,
-                logging.INFO,
-                msg=f"releasing resources for {user_id=}, {project_id=}, {run_id=}",
-            ),
-        ):
-            await self.dask_clients_pool.release_client_ref(
-                ref=_DASK_CLIENT_RUN_REF.format(user_id=user_id, project_id=project_id, run_id=run_id)
-            )
+        """release resources used by the scheduler for a given user and project
+
+        NOTE: delayed (not awaited inline) so any release-task-result message published for this
+        run right before it completed gets a chance to reuse the still-warm pooled DaskClient
+        instead of racing this call and having to recreate one from scratch.
+        """
+
+        async def _delayed_release() -> None:
+            with (
+                log_catch(_logger, reraise=False),
+                log_context(
+                    _logger,
+                    logging.INFO,
+                    msg=f"releasing resources for {user_id=}, {project_id=}, {run_id=}",
+                ),
+            ):
+                await asyncio.sleep(_SAFE_RELEASE_RESOURCES_DELAY_S)
+                await self.dask_clients_pool.release_client_ref(
+                    ref=_DASK_CLIENT_RUN_REF.format(user_id=user_id, project_id=project_id, run_id=run_id)
+                )
+
+        fire_and_forget_task(
+            _delayed_release(),
+            task_suffix_name=f"safe_release_resources_{user_id}_{project_id}_{run_id}",
+            fire_and_forget_tasks_collection=self._delayed_release_tasks,
+        )
 
     async def _stop_tasks(self, user_id: UserID, tasks: list[CompTaskAtDB], comp_run: CompRunsAtDB) -> None:
         # NOTE: if this exception raises, it means the backend was anyway not up
@@ -340,6 +408,7 @@ class DaskScheduler(BaseCompScheduler):
                 log=_logger,
                 limit=1,  # to avoid overloading the dask scheduler
             )
+            releasable_job_ids: list[str] = []
             async for future in limited_as_completed(
                 (
                     self._process_task_result(
@@ -355,7 +424,22 @@ class DaskScheduler(BaseCompScheduler):
                 with log_catch(_logger, reraise=False):
                     task_can_be_cleaned, job_id = await future
                     if task_can_be_cleaned and job_id:
-                        await client.release_task_result(job_id)
+                        releasable_job_ids.append(job_id)
+
+        if releasable_job_ids:
+            # NOTE: releasing is delegated to a dedicated consumer so a slow/hanging
+            # dask-scheduler cannot leak this pipeline-scheduling slot (see _releaser.py).
+            # All the job_ids completed in this batch are sent as a single message so the
+            # releaser only needs one client acquire/release for the whole batch.
+            await request_task_result_release(
+                self.rabbitmq_client,
+                user_id=user_id,
+                project_id=comp_run.project_uuid,
+                run_id=comp_run.run_id,
+                use_on_demand_clusters=comp_run.use_on_demand_clusters,
+                run_metadata=comp_run.metadata,
+                job_ids=releasable_job_ids,
+            )
 
     async def _handle_successful_run(
         self,

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -411,15 +411,19 @@ class DaskScheduler(BaseCompScheduler):
             # dask-scheduler cannot leak this pipeline-scheduling slot (see _releaser.py).
             # All the job_ids completed in this batch are sent as a single message so the
             # releaser only needs one client acquire/release for the whole batch.
-            await request_task_result_release(
-                self.rabbitmq_client,
-                user_id=user_id,
-                project_id=comp_run.project_uuid,
-                run_id=comp_run.run_id,
-                use_on_demand_clusters=comp_run.use_on_demand_clusters,
-                run_metadata=comp_run.metadata,
-                job_ids=releasable_job_ids,
-            )
+            # NOTE: best effort: a publish failure here is only logged (not retried) so a
+            # transient RabbitMQ issue does not also break the rest of the pipeline scheduling
+            # (heartbeat, run result, resources release).
+            with log_catch(_logger, reraise=False):
+                await request_task_result_release(
+                    self.rabbitmq_client,
+                    user_id=user_id,
+                    project_id=comp_run.project_uuid,
+                    run_id=comp_run.run_id,
+                    use_on_demand_clusters=comp_run.use_on_demand_clusters,
+                    run_metadata=comp_run.metadata,
+                    job_ids=releasable_job_ids,
+                )
 
     async def _handle_successful_run(
         self,

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -16,6 +16,7 @@ from dask_task_models_library.container_tasks.events import (
     TaskProgressEvent,
 )
 from dask_task_models_library.container_tasks.io import TaskOutputData
+from dask_task_models_library.models import DaskJobID
 from models_library.clusters import BaseCluster
 from models_library.errors import ErrorDict
 from models_library.projects import ProjectID
@@ -40,7 +41,7 @@ from ...core.errors import (
     ComputationalBackendTaskResultsNotReadyError,
     PortsValidationError,
 )
-from ...models.comp_runs import CompRunsAtDB, Iteration, RunMetadataDict
+from ...models.comp_runs import CompRunsAtDB, Iteration, RunID, RunMetadataDict
 from ...models.comp_tasks import CompTaskAtDB
 from ...utils.dask import (
     clean_task_output_and_log_files_if_invalid,
@@ -296,10 +297,10 @@ class DaskScheduler(BaseCompScheduler):
         *,
         user_id: UserID,
         project_id: ProjectID,
-        run_id: PositiveInt,
+        run_id: RunID,
         use_on_demand_clusters: bool,
         run_metadata: RunMetadataDict,
-        job_ids: list[str],
+        job_ids: list[DaskJobID],
     ) -> None:
         """unpublish task results/datasets for a given cluster.
 
@@ -419,7 +420,7 @@ class DaskScheduler(BaseCompScheduler):
                     self.rabbitmq_client,
                     user_id=user_id,
                     project_id=comp_run.project_uuid,
-                    run_id=comp_run.run_id,
+                    run_id=RunID(comp_run.run_id),
                     use_on_demand_clusters=comp_run.use_on_demand_clusters,
                     run_metadata=comp_run.metadata,
                     job_ids=releasable_job_ids,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -8,6 +8,7 @@ loads(dumps(my_object))
 
 """
 
+import asyncio
 import logging
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
@@ -73,6 +74,7 @@ from ..core.errors import (
     ComputationalBackendNotConnectedError,
     ComputationalBackendTaskNotFoundError,
     ComputationalBackendTaskResultsNotReadyError,
+    ComputationalBackendTaskResultsReleaseError,
     TaskSchedulingError,
 )
 from ..core.settings import AppSettings, ComputationalBackendSettings
@@ -544,11 +546,15 @@ class DaskClient:
 
     async def release_task_result(self, job_id: str) -> None:
         _logger.debug("releasing results for %s", f"{job_id=}")
-        try:
+
+        async def _get_and_unpublish_dataset() -> None:
             # first check if the key exists
             await dask_utils.wrap_client_async_routine(self.backend.client.get_dataset(name=job_id))
-
             await dask_utils.wrap_client_async_routine(self.backend.client.unpublish_dataset(name=job_id))
 
+        try:
+            await asyncio.wait_for(_get_and_unpublish_dataset(), timeout=_DASK_DEFAULT_TIMEOUT_S)
         except KeyError:
             _logger.warning("Unknown task cannot be unpublished: %s", f"{job_id=}")
+        except TimeoutError as exc:
+            raise ComputationalBackendTaskResultsReleaseError(job_id=job_id) from exc

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -17,7 +17,6 @@ from models_library.projects_state import RunningState
 from models_library.rest_ordering import OrderBy, OrderDirection
 from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
-from pydantic import PositiveInt
 from simcore_postgres_database.utils_repos import (
     pass_or_acquire_connection,
     transaction_context,
@@ -35,7 +34,7 @@ from ....core.errors import (
     ProjectNotFoundError,
     UserNotFoundError,
 )
-from ....models.comp_runs import CompRunsAtDB, RunMetadataDict
+from ....models.comp_runs import CompRunsAtDB, Iteration, RunMetadataDict
 from ....utils.db import DB_TO_RUNNING_STATE, RUNNING_STATE_TO_DB
 from ..tables import comp_runs
 from ._base import BaseRepository
@@ -51,14 +50,14 @@ _POSTGRES_FK_COLUMN_TO_ERROR_MAP: Final[dict[sa.Column, tuple[type[DirectorError
 }
 
 
-async def _get_next_iteration(conn: AsyncConnection, user_id: UserID, project_id: ProjectID) -> PositiveInt:
+async def _get_next_iteration(conn: AsyncConnection, user_id: UserID, project_id: ProjectID) -> Iteration:
     """Calculate the next iteration number for a project"""
     last_iteration = await conn.scalar(
         sa.select(comp_runs.c.iteration)
         .where((comp_runs.c.user_id == user_id) & (comp_runs.c.project_uuid == f"{project_id}"))
         .order_by(desc(comp_runs.c.iteration))
     )
-    return cast(PositiveInt, (last_iteration or 0) + 1)
+    return cast(Iteration, (last_iteration or 0) + 1)
 
 
 def _handle_foreign_key_violation(exc: sql_exc.IntegrityError, **error_keys: Any) -> None:
@@ -111,7 +110,7 @@ class CompRunsRepository(BaseRepository):
         self,
         user_id: UserID,
         project_id: ProjectID,
-        iteration: PositiveInt | None = None,
+        iteration: Iteration | None = None,
     ) -> CompRunsAtDB:
         """returns the run defined by user_id, project_id and iteration
         In case iteration is None then returns the last iteration
@@ -454,7 +453,7 @@ class CompRunsRepository(BaseRepository):
         *,
         user_id: UserID,
         project_id: ProjectID,
-        iteration: PositiveInt | None = None,
+        iteration: Iteration | None = None,
         metadata: RunMetadataDict,
         use_on_demand_clusters: bool,
         dag_adjacency_list: dict[str, list[str]],
@@ -486,7 +485,7 @@ class CompRunsRepository(BaseRepository):
             raise DirectorError from exc
 
     async def update(
-        self, user_id: UserID, project_id: ProjectID, iteration: PositiveInt, **values
+        self, user_id: UserID, project_id: ProjectID, iteration: Iteration, **values
     ) -> CompRunsAtDB | None:
         async with transaction_context(self.db_engine) as conn:
             result: CursorResult = await conn.execute(
@@ -507,7 +506,7 @@ class CompRunsRepository(BaseRepository):
         *,
         user_id: UserID,
         project_id: ProjectID,
-        iteration: PositiveInt,
+        iteration: Iteration,
         result_state: RunningState,
         final_state: bool | None = False,
     ) -> CompRunsAtDB | None:
@@ -544,7 +543,7 @@ class CompRunsRepository(BaseRepository):
         *,
         user_id: UserID,
         project_id: ProjectID,
-        iteration: PositiveInt,
+        iteration: Iteration,
         started_time: datetime.datetime,
     ) -> CompRunsAtDB | None:
         return await self.update(
@@ -555,7 +554,7 @@ class CompRunsRepository(BaseRepository):
         )
 
     async def mark_for_cancellation(
-        self, *, user_id: UserID, project_id: ProjectID, iteration: PositiveInt
+        self, *, user_id: UserID, project_id: ProjectID, iteration: Iteration
     ) -> CompRunsAtDB | None:
         return await self.update(
             user_id,
@@ -565,7 +564,7 @@ class CompRunsRepository(BaseRepository):
         )
 
     async def mark_for_scheduling(
-        self, *, user_id: UserID, project_id: ProjectID, iteration: PositiveInt
+        self, *, user_id: UserID, project_id: ProjectID, iteration: Iteration
     ) -> CompRunsAtDB | None:
         return await self.update(
             user_id,
@@ -576,7 +575,7 @@ class CompRunsRepository(BaseRepository):
         )
 
     async def mark_as_processed(
-        self, *, user_id: UserID, project_id: ProjectID, iteration: PositiveInt
+        self, *, user_id: UserID, project_id: ProjectID, iteration: Iteration
     ) -> CompRunsAtDB | None:
         return await self.update(
             user_id,

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -11,7 +11,7 @@ from models_library.projects_state import RunningState
 from models_library.rest_ordering import OrderBy, OrderDirection
 from models_library.users import UserID
 from models_library.wallets import WalletInfo
-from pydantic import PositiveInt, TypeAdapter
+from pydantic import TypeAdapter
 from servicelib.logging_utils import log_context
 from servicelib.rabbitmq import RabbitMQRPCClient
 from servicelib.utils import logged_gather
@@ -19,6 +19,7 @@ from sqlalchemy import CursorResult, literal_column
 from sqlalchemy.dialects.postgresql import insert
 
 from .....core.errors import ComputationalTaskNotFoundError
+from .....models.comp_runs import RunID
 from .....models.comp_tasks import CompTaskAtDB, ComputationTaskForRpcDBGet
 from .....modules.resource_usage_tracker_client import ResourceUsageTrackerClient
 from .....utils.computations import to_node_class
@@ -206,9 +207,7 @@ class CompTasksRepository(BaseRepository):
                 )
             return inserted_comp_tasks_db, insufficient_credits
 
-    async def _update_task(
-        self, project_id: ProjectID, task: NodeID, run_id: PositiveInt, **task_kwargs
-    ) -> CompTaskAtDB:
+    async def _update_task(self, project_id: ProjectID, task: NodeID, run_id: RunID, **task_kwargs) -> CompTaskAtDB:
         with log_context(
             _logger,
             logging.DEBUG,
@@ -235,15 +234,13 @@ class CompTasksRepository(BaseRepository):
                 row = result.one()
                 return CompTaskAtDB.model_validate(row)
 
-    async def update_project_task_job_id(
-        self, project_id: ProjectID, task: NodeID, run_id: PositiveInt, job_id: str
-    ) -> None:
+    async def update_project_task_job_id(self, project_id: ProjectID, task: NodeID, run_id: RunID, job_id: str) -> None:
         await self._update_task(project_id, task, run_id, job_id=job_id)
 
     async def update_project_tasks_state(
         self,
         project_id: ProjectID,
-        run_id: PositiveInt,
+        run_id: RunID,
         tasks: list[NodeID],
         state: RunningState,
         errors: list[ErrorDict] | None = None,
@@ -276,7 +273,7 @@ class CompTasksRepository(BaseRepository):
         self,
         project_id: ProjectID,
         node_id: NodeID,
-        run_id: PositiveInt,
+        run_id: RunID,
         progress: float,
     ) -> None:
         await self._update_task(project_id, node_id, run_id, progress=progress)
@@ -285,7 +282,7 @@ class CompTasksRepository(BaseRepository):
         self,
         project_id: ProjectID,
         node_id: NodeID,
-        run_id: PositiveInt,
+        run_id: RunID,
         heartbeat_time: datetime,
     ) -> None:
         await self._update_task(project_id, node_id, run_id, last_heartbeat=heartbeat_time)

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -65,6 +65,7 @@ from simcore_sdk.node_ports_v2 import FileLinkType
 from simcore_service_director_v2.core.errors import (
     ComputationalBackendNotConnectedError,
     ComputationalBackendTaskNotFoundError,
+    ComputationalBackendTaskResultsReleaseError,
     ComputationalSchedulerChangedError,
     InsufficientComputationalResourcesError,
     MissingComputationalResourcesError,
@@ -855,6 +856,24 @@ async def test_failed_task_returns_exceptions(
     assert len(await dask_client.backend.client.list_datasets()) > 0  # type: ignore
     await dask_client.release_task_result(published_computation_task[0].job_id)
     assert len(await dask_client.backend.client.list_datasets()) == 0  # type: ignore
+
+
+async def test_release_task_result_timeouts_raises(
+    dask_client: DaskClient,
+    mocker: MockerFixture,
+):
+    mocker.patch(
+        "simcore_service_director_v2.modules.dask_client._DASK_DEFAULT_TIMEOUT_S",
+        0.1,
+    )
+
+    async def _never_completes(*args, **kwargs) -> None:
+        await asyncio.sleep(10)
+
+    mocker.patch.object(dask_client.backend.client, "get_dataset", side_effect=_never_completes)
+
+    with pytest.raises(ComputationalBackendTaskResultsReleaseError):
+        await dask_client.release_task_result("some-unknown-job-id")
 
 
 # currently in the case of a dask-gateway we do not check for missing resources

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -3078,7 +3078,7 @@ async def test_invalid_pipeline_error_aborts_scheduling(
     )
 
 
-async def test_computational_run_not_found_error_releases_resources(
+async def test_computational_run_not_found_error_does_not_release_resources(
     with_disabled_auto_scheduling: mock.Mock,
     with_disabled_scheduler_publisher: mock.Mock,
     initialized_app: FastAPI,
@@ -3092,7 +3092,8 @@ async def test_computational_run_not_found_error_releases_resources(
     fake_collection_run_id: CollectionRunID,
 ):
     """When the comp_run row is missing, ComputationalRunNotFoundError is raised.
-    Resources are released but no run-result update is attempted (there is no run to update)."""
+    There is no run to release resources for (comp_run was never fetched), so
+    resources must not be released and no run-result update is attempted."""
     _with_mock_send_computation_tasks(published_project.tasks, mocked_dask_client)
     run_in_db, _ = await _assert_start_pipeline(
         initialized_app,
@@ -3114,10 +3115,6 @@ async def test_computational_run_not_found_error_releases_resources(
         iteration=run_in_db.iteration,
     )
 
-    # resources must be released even though the run is missing;
-    # note: iteration is used (not run_id) because comp_run was never fetched
-    mocked_safe_release_resources.assert_called_once_with(
-        run_in_db.user_id, run_in_db.project_uuid, run_in_db.iteration
-    )
+    mocked_safe_release_resources.assert_not_called()
     # no comp_run row should exist (was deleted before apply)
     await assert_comp_runs_empty(sqlalchemy_async_engine)

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -77,6 +77,9 @@ from simcore_service_director_v2.modules.comp_scheduler._manager import (
     run_new_pipeline,
     stop_pipeline,
 )
+from simcore_service_director_v2.modules.comp_scheduler._models import (
+    ReleaseTaskResultRabbitMessage,
+)
 from simcore_service_director_v2.modules.comp_scheduler._scheduler_base import (
     BaseCompScheduler,
 )
@@ -377,6 +380,18 @@ async def computational_pipeline_rabbit_client_parser(
     await client.unsubscribe(queue_name)
 
 
+@pytest.fixture
+async def release_task_result_rabbit_client_parser(
+    create_rabbitmq_client: Callable[[str], RabbitMQClient], mocker: MockerFixture
+) -> AsyncIterator[mock.AsyncMock]:
+    # NOTE: observes the same fanout messages as the app's own _releaser.py consumer
+    client = create_rabbitmq_client("release_task_result_pytest_consumer")
+    mock = mocker.AsyncMock(return_value=True)
+    queue_name, _ = await client.subscribe(ReleaseTaskResultRabbitMessage.get_channel_name(), mock)
+    yield mock
+    await client.unsubscribe(queue_name)
+
+
 async def _assert_message_received(
     mocked_message_parser: mock.AsyncMock,
     expected_call_count: int,
@@ -481,6 +496,7 @@ async def test_proper_pipeline_is_scheduled(  # noqa: PLR0915
     instrumentation_rabbit_client_parser: mock.AsyncMock,
     resource_tracking_rabbit_client_parser: mock.AsyncMock,
     computational_pipeline_rabbit_client_parser: mock.AsyncMock,
+    release_task_result_rabbit_client_parser: mock.AsyncMock,
     run_metadata: RunMetadataDict,
     fake_collection_run_id: CollectionRunID,
 ):
@@ -701,6 +717,7 @@ async def test_proper_pipeline_is_scheduled(  # noqa: PLR0915
     )
 
     completed_tasks = [exp_started_task]
+    released_job_ids = [completed_tasks[0].job_id]
     next_pending_task = published_project.tasks[2]
     expected_pending_tasks.append(next_pending_task)
     updated_pending_tasks, _ = await assert_comp_tasks_and_comp_run_snapshot_tasks(
@@ -858,6 +875,7 @@ async def test_proper_pipeline_is_scheduled(  # noqa: PLR0915
     mocked_dask_client.get_task_result.reset_mock()
     mocked_parse_output_data_fct.assert_not_called()
     expected_pending_tasks.remove(exp_started_task)
+    released_job_ids.append(exp_started_task.job_id)
     messages = await _assert_message_received(
         instrumentation_rabbit_client_parser,
         1,
@@ -937,6 +955,30 @@ async def test_proper_pipeline_is_scheduled(  # noqa: PLR0915
     )
     assert isinstance(messages[0], RabbitResourceTrackingStartedMessage)
     assert isinstance(messages[1], RabbitResourceTrackingStoppedMessage)
+
+    # -------------------------------------------------------------------------------
+    # 9. now that the pipeline completed (FAILED is a completed state), the scheduler must
+    # have requested the release of every completed task's Dask results, and since there
+    # is no more comp_run using it, the underlying Dask client itself must be deleted
+    # (i.e. no leaked resources, which is the whole point of this pipeline scheduling).
+    released_job_ids.append(exp_started_task.job_id)
+    await _assert_message_received(
+        release_task_result_rabbit_client_parser,
+        len(released_job_ids),
+        ReleaseTaskResultRabbitMessage.model_validate_json,
+    )
+    async for attempt in AsyncRetrying(
+        wait=wait_fixed(0.1),
+        stop=stop_after_delay(5),
+        retry=retry_if_exception_type(AssertionError),
+        reraise=True,
+    ):
+        with attempt:
+            mocked_dask_client.release_task_result.assert_has_calls(
+                calls=[mock.call(job_id) for job_id in released_job_ids],
+                any_order=True,
+            )
+            mocked_dask_client.delete.assert_called_once()
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This ensures that computational jobs published in the dask-scheduler have a higher chance of being properly cleanup from the dask-scheduler.

An issue was detected where computational jobs would not be properly "unpublished" from the underlying dask-scheduler. This can be seen for example when running mmux e2e tests against weak internal master, and by checking why aws-master does not close its computational clusters properly.

As a reminder, a computational job is started and its state is saved in the database.
Once the job completes, then the database is updated and the job is unpublished from the underlying dask-scheduler. Sometimes that dask-scheduler might be overwhelmend, or the director-v2 might be restarted (as is often the case in master deployments), and the computational jobs are then never unpublished.
This PR changes this by leveraging RabbitMQ to trigger the dask-scheduler unpublish step. Since RabbitMQ handles retrials upon error, this should cover up for 95% of the cases.

Bonus:
- `run_id` and `iteration` are now a `NewType` and that kind of fixes a few nasty bugs..


<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
