### PR TITLE
🐛🚑️ fix(storage): add `product_name` parameter to `delete_paths` worker task

### DIFF
--- a/services/storage/src/simcore_service_storage/api/_worker_tasks/_paths.py
+++ b/services/storage/src/simcore_service_storage/api/_worker_tasks/_paths.py
@@ -5,9 +5,9 @@ from celery import Task  # type: ignore[import-untyped]
 from celery_library.worker.app_server import get_app_server
 from models_library.celery import TaskKey
 from models_library.products import ProductName
-from models_library.projects_nodes_io import LocationID, StorageFileID
+from models_library.projects_nodes_io import LocationID
 from models_library.users import UserID
-from pydantic import ByteSize, TypeAdapter
+from pydantic import ByteSize
 from servicelib.logging_utils import log_context
 from servicelib.utils import limited_gather
 
@@ -42,7 +42,4 @@ async def delete_paths(
     assert task_key  # nosec
     with log_context(_logger, logging.INFO, msg=f"delete {paths=} in {location_id=} for {user_id=}, {product_name=}"):
         dsm = get_dsm_provider(get_app_server(task.app).app).get(location_id)
-        files_ids: set[StorageFileID] = {TypeAdapter(StorageFileID).validate_python(f"{path}") for path in paths}
-        await limited_gather(
-            *[dsm.delete_file(user_id, file_id) for file_id in files_ids], limit=MAX_CONCURRENT_S3_TASKS
-        )
+        await limited_gather(*[dsm.delete_path(user_id, path) for path in paths], limit=MAX_CONCURRENT_S3_TASKS)

--- a/services/storage/src/simcore_service_storage/api/_worker_tasks/_paths.py
+++ b/services/storage/src/simcore_service_storage/api/_worker_tasks/_paths.py
@@ -1,26 +1,20 @@
 import logging
 from pathlib import Path
-from typing import Final
 
 from celery import Task  # type: ignore[import-untyped]
 from celery_library.worker.app_server import get_app_server
 from models_library.celery import TaskKey
 from models_library.products import ProductName
-from models_library.projects import ProjectID
-from models_library.projects_nodes_io import LocationID, NodeID, StorageFileID
+from models_library.projects_nodes_io import LocationID
 from models_library.users import UserID
-from pydantic import ByteSize, TypeAdapter
+from pydantic import ByteSize
 from servicelib.logging_utils import log_context
 from servicelib.utils import limited_gather
 
 from ...constants import MAX_CONCURRENT_S3_TASKS
 from ...dsm import get_dsm_provider
-from ...dsm_factory import BaseDataManager
-from ...simcore_s3_dsm import SimcoreS3DataManager
 
 _logger = logging.getLogger(__name__)
-
-_PROJECT_FOLDER_MAX_PARTS: Final[int] = 2
 
 
 async def compute_path_size(
@@ -37,16 +31,6 @@ async def compute_path_size(
         return await dsm.compute_path_size(user_id, product_name, path=Path(path))
 
 
-async def _delete_path(dsm: BaseDataManager, user_id: UserID, path: Path) -> None:
-    # NOTE: a project or project/node folder is not a file identifier, it is authorized at project level
-    if isinstance(dsm, SimcoreS3DataManager) and 0 < len(path.parts) <= _PROJECT_FOLDER_MAX_PARTS:
-        node_id = NodeID(path.parts[1]) if len(path.parts) == _PROJECT_FOLDER_MAX_PARTS else None
-        await dsm.delete_project_simcore_s3(user_id, ProjectID(path.parts[0]), node_id)
-        return
-
-    await dsm.delete_file(user_id, TypeAdapter(StorageFileID).validate_python(f"{path}"))
-
-
 async def delete_paths(
     task: Task,
     task_key: TaskKey,
@@ -58,4 +42,4 @@ async def delete_paths(
     assert task_key  # nosec
     with log_context(_logger, logging.INFO, msg=f"delete {paths=} in {location_id=} for {user_id=}, {product_name=}"):
         dsm = get_dsm_provider(get_app_server(task.app).app).get(location_id)
-        await limited_gather(*[_delete_path(dsm, user_id, path) for path in paths], limit=MAX_CONCURRENT_S3_TASKS)
+        await limited_gather(*[dsm.delete_path(user_id, path) for path in paths], limit=MAX_CONCURRENT_S3_TASKS)

--- a/services/storage/src/simcore_service_storage/api/_worker_tasks/_paths.py
+++ b/services/storage/src/simcore_service_storage/api/_worker_tasks/_paths.py
@@ -5,9 +5,9 @@ from celery import Task  # type: ignore[import-untyped]
 from celery_library.worker.app_server import get_app_server
 from models_library.celery import TaskKey
 from models_library.products import ProductName
-from models_library.projects_nodes_io import LocationID
+from models_library.projects_nodes_io import LocationID, StorageFileID
 from models_library.users import UserID
-from pydantic import ByteSize
+from pydantic import ByteSize, TypeAdapter
 from servicelib.logging_utils import log_context
 from servicelib.utils import limited_gather
 
@@ -42,4 +42,7 @@ async def delete_paths(
     assert task_key  # nosec
     with log_context(_logger, logging.INFO, msg=f"delete {paths=} in {location_id=} for {user_id=}, {product_name=}"):
         dsm = get_dsm_provider(get_app_server(task.app).app).get(location_id)
-        await limited_gather(*[dsm.delete_path(user_id, path) for path in paths], limit=MAX_CONCURRENT_S3_TASKS)
+        files_ids: set[StorageFileID] = {TypeAdapter(StorageFileID).validate_python(f"{path}") for path in paths}
+        await limited_gather(
+            *[dsm.delete_file(user_id, file_id) for file_id in files_ids], limit=MAX_CONCURRENT_S3_TASKS
+        )

--- a/services/storage/src/simcore_service_storage/api/_worker_tasks/_paths.py
+++ b/services/storage/src/simcore_service_storage/api/_worker_tasks/_paths.py
@@ -1,11 +1,13 @@
 import logging
 from pathlib import Path
+from typing import Final
 
 from celery import Task  # type: ignore[import-untyped]
 from celery_library.worker.app_server import get_app_server
 from models_library.celery import TaskKey
 from models_library.products import ProductName
-from models_library.projects_nodes_io import LocationID, StorageFileID
+from models_library.projects import ProjectID
+from models_library.projects_nodes_io import LocationID, NodeID, StorageFileID
 from models_library.users import UserID
 from pydantic import ByteSize, TypeAdapter
 from servicelib.logging_utils import log_context
@@ -13,8 +15,12 @@ from servicelib.utils import limited_gather
 
 from ...constants import MAX_CONCURRENT_S3_TASKS
 from ...dsm import get_dsm_provider
+from ...dsm_factory import BaseDataManager
+from ...simcore_s3_dsm import SimcoreS3DataManager
 
 _logger = logging.getLogger(__name__)
+
+_PROJECT_FOLDER_MAX_PARTS: Final[int] = 2
 
 
 async def compute_path_size(
@@ -31,6 +37,16 @@ async def compute_path_size(
         return await dsm.compute_path_size(user_id, product_name, path=Path(path))
 
 
+async def _delete_path(dsm: BaseDataManager, user_id: UserID, path: Path) -> None:
+    # NOTE: a project or project/node folder is not a file identifier, it is authorized at project level
+    if isinstance(dsm, SimcoreS3DataManager) and 0 < len(path.parts) <= _PROJECT_FOLDER_MAX_PARTS:
+        node_id = NodeID(path.parts[1]) if len(path.parts) == _PROJECT_FOLDER_MAX_PARTS else None
+        await dsm.delete_project_simcore_s3(user_id, ProjectID(path.parts[0]), node_id)
+        return
+
+    await dsm.delete_file(user_id, TypeAdapter(StorageFileID).validate_python(f"{path}"))
+
+
 async def delete_paths(
     task: Task,
     task_key: TaskKey,
@@ -42,7 +58,4 @@ async def delete_paths(
     assert task_key  # nosec
     with log_context(_logger, logging.INFO, msg=f"delete {paths=} in {location_id=} for {user_id=}, {product_name=}"):
         dsm = get_dsm_provider(get_app_server(task.app).app).get(location_id)
-        files_ids: set[StorageFileID] = {TypeAdapter(StorageFileID).validate_python(f"{path}") for path in paths}
-        await limited_gather(
-            *[dsm.delete_file(user_id, file_id) for file_id in files_ids], limit=MAX_CONCURRENT_S3_TASKS
-        )
+        await limited_gather(*[_delete_path(dsm, user_id, path) for path in paths], limit=MAX_CONCURRENT_S3_TASKS)

--- a/services/storage/src/simcore_service_storage/api/_worker_tasks/_paths.py
+++ b/services/storage/src/simcore_service_storage/api/_worker_tasks/_paths.py
@@ -35,13 +35,13 @@ async def delete_paths(
     task: Task,
     task_key: TaskKey,
     user_id: UserID,
+    product_name: ProductName,
     location_id: LocationID,
     paths: set[Path],
 ) -> None:
     assert task_key  # nosec
-    with log_context(_logger, logging.INFO, msg=f"delete {paths=} in {location_id=} for {user_id=}"):
-        app = get_app_server(task.app).app
-        dsm = get_dsm_provider(app).get(location_id)
+    with log_context(_logger, logging.INFO, msg=f"delete {paths=} in {location_id=} for {user_id=}, {product_name=}"):
+        dsm = get_dsm_provider(get_app_server(task.app).app).get(location_id)
         files_ids: set[StorageFileID] = {TypeAdapter(StorageFileID).validate_python(f"{path}") for path in paths}
         await limited_gather(
             *[dsm.delete_file(user_id, file_id) for file_id in files_ids], limit=MAX_CONCURRENT_S3_TASKS

--- a/services/storage/src/simcore_service_storage/datcore_dsm.py
+++ b/services/storage/src/simcore_service_storage/datcore_dsm.py
@@ -329,6 +329,9 @@ class DatCoreDataManager(BaseDataManager):
             fmd_is_directory=False,
         )
 
+    async def delete_path(self, user_id: UserID, path: Path) -> None:
+        await self.delete_file(user_id, TypeAdapter(StorageFileID).validate_python(f"{path}"))
+
 
 def create_datcore_data_manager(app: FastAPI) -> DatCoreDataManager:
     return DatCoreDataManager(app)

--- a/services/storage/src/simcore_service_storage/dsm_factory.py
+++ b/services/storage/src/simcore_service_storage/dsm_factory.py
@@ -10,7 +10,7 @@ from models_library.products import ProductName
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import LocationID, LocationName, StorageFileID
 from models_library.users import UserID
-from pydantic import AnyUrl, ByteSize, NonNegativeInt, TypeAdapter
+from pydantic import AnyUrl, ByteSize, NonNegativeInt
 
 from .models import (
     DatasetMetaData,
@@ -131,10 +131,6 @@ class BaseDataManager(ABC):
     @abstractmethod
     async def delete_file(self, user_id: UserID, file_id: StorageFileID) -> None:
         """deletes file if user has the rights to"""
-
-    async def delete_path(self, user_id: UserID, path: Path) -> None:
-        """deletes an arbitrary path if user has the rights to"""
-        await self.delete_file(user_id, TypeAdapter(StorageFileID).validate_python(f"{path}"))
 
 
 @dataclass

--- a/services/storage/src/simcore_service_storage/dsm_factory.py
+++ b/services/storage/src/simcore_service_storage/dsm_factory.py
@@ -10,7 +10,7 @@ from models_library.products import ProductName
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import LocationID, LocationName, StorageFileID
 from models_library.users import UserID
-from pydantic import AnyUrl, ByteSize, NonNegativeInt
+from pydantic import AnyUrl, ByteSize, NonNegativeInt, TypeAdapter
 
 from .models import (
     DatasetMetaData,
@@ -107,7 +107,8 @@ class BaseDataManager(ABC):
         sha256_checksum: SHA256Str | None,
         is_directory: bool,
     ) -> UploadLinks:
-        """creates one or more upload file links if user has the rights to, expects the client to complete/abort upload"""
+        """creates one or more upload file links if user has the rights to,
+        expects the client to complete/abort upload"""
 
     @abstractmethod
     async def complete_file_upload(
@@ -130,6 +131,10 @@ class BaseDataManager(ABC):
     @abstractmethod
     async def delete_file(self, user_id: UserID, file_id: StorageFileID) -> None:
         """deletes file if user has the rights to"""
+
+    async def delete_path(self, user_id: UserID, path: Path) -> None:
+        """deletes an arbitrary path if user has the rights to"""
+        await self.delete_file(user_id, TypeAdapter(StorageFileID).validate_python(f"{path}"))
 
 
 @dataclass

--- a/services/storage/src/simcore_service_storage/dsm_factory.py
+++ b/services/storage/src/simcore_service_storage/dsm_factory.py
@@ -107,7 +107,8 @@ class BaseDataManager(ABC):
         sha256_checksum: SHA256Str | None,
         is_directory: bool,
     ) -> UploadLinks:
-        """creates one or more upload file links if user has the rights to, expects the client to complete/abort upload"""
+        """creates one or more upload file links if user has the rights to,
+        expects the client to complete/abort upload"""
 
     @abstractmethod
     async def complete_file_upload(
@@ -130,6 +131,10 @@ class BaseDataManager(ABC):
     @abstractmethod
     async def delete_file(self, user_id: UserID, file_id: StorageFileID) -> None:
         """deletes file if user has the rights to"""
+
+    @abstractmethod
+    async def delete_path(self, user_id: UserID, path: Path) -> None:
+        """deletes an arbitrary path if user has the rights to"""
 
 
 @dataclass

--- a/services/storage/src/simcore_service_storage/dsm_factory.py
+++ b/services/storage/src/simcore_service_storage/dsm_factory.py
@@ -107,8 +107,7 @@ class BaseDataManager(ABC):
         sha256_checksum: SHA256Str | None,
         is_directory: bool,
     ) -> UploadLinks:
-        """creates one or more upload file links if user has the rights to,
-        expects the client to complete/abort upload"""
+        """creates one or more upload file links if user has the rights to, expects the client to complete/abort upload"""
 
     @abstractmethod
     async def complete_file_upload(

--- a/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
+++ b/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
@@ -384,13 +384,6 @@ class FileMetaDataRepository(BaseRepository):
         async with transaction_context(self.db_engine, connection) as conn:
             await conn.execute(file_meta_data.delete().where(file_meta_data.c.project_id == f"{project_id}"))
 
-    async def delete_all_from_node(
-        self, *, connection: AsyncConnection | None = None, project_id: ProjectID, node_id: NodeID
-    ) -> None:
-        # NOTE: filtering by project_id too, since the caller only authorizes project_id
+    async def delete_all_from_node(self, *, connection: AsyncConnection | None = None, node_id: NodeID) -> None:
         async with transaction_context(self.db_engine, connection) as conn:
-            await conn.execute(
-                file_meta_data.delete().where(
-                    (file_meta_data.c.project_id == f"{project_id}") & (file_meta_data.c.node_id == f"{node_id}")
-                )
-            )
+            await conn.execute(file_meta_data.delete().where(file_meta_data.c.node_id == f"{node_id}"))

--- a/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
+++ b/services/storage/src/simcore_service_storage/modules/db/file_meta_data.py
@@ -384,6 +384,13 @@ class FileMetaDataRepository(BaseRepository):
         async with transaction_context(self.db_engine, connection) as conn:
             await conn.execute(file_meta_data.delete().where(file_meta_data.c.project_id == f"{project_id}"))
 
-    async def delete_all_from_node(self, *, connection: AsyncConnection | None = None, node_id: NodeID) -> None:
+    async def delete_all_from_node(
+        self, *, connection: AsyncConnection | None = None, project_id: ProjectID, node_id: NodeID
+    ) -> None:
+        # NOTE: filtering by project_id too, since the caller only authorizes project_id
         async with transaction_context(self.db_engine, connection) as conn:
-            await conn.execute(file_meta_data.delete().where(file_meta_data.c.node_id == f"{node_id}"))
+            await conn.execute(
+                file_meta_data.delete().where(
+                    (file_meta_data.c.project_id == f"{project_id}") & (file_meta_data.c.node_id == f"{node_id}")
+                )
+            )

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -108,6 +108,7 @@ from .utils.utils import (
 
 _NO_CONCURRENCY: Final[int] = 1
 _MAX_PARALLEL_S3_CALLS: Final[NonNegativeInt] = 10
+_PROJECT_FOLDER_MAX_PARTS: Final[int] = 2
 
 
 _logger = logging.getLogger(__name__)
@@ -740,6 +741,15 @@ class SimcoreS3DataManager(BaseDataManager):  # pylint:disable=too-many-public-m
                 limit=MAX_CONCURRENT_S3_TASKS,
             )
 
+    async def delete_path(self, user_id: UserID, path: Path) -> None:
+        # NOTE: a project or project/node folder is not a file identifier, it is authorized at project level
+        if 0 < len(path.parts) <= _PROJECT_FOLDER_MAX_PARTS:
+            node_id = NodeID(path.parts[1]) if len(path.parts) == _PROJECT_FOLDER_MAX_PARTS else None
+            await self.delete_project_simcore_s3(user_id, ProjectID(path.parts[0]), node_id)
+            return
+
+        await self.delete_file(user_id, TypeAdapter(StorageFileID).validate_python(f"{path}"))
+
     async def delete_project_simcore_s3(
         self, user_id: UserID, project_id: ProjectID, node_id: NodeID | None = None
     ) -> None:
@@ -754,7 +764,9 @@ class SimcoreS3DataManager(BaseDataManager):  # pylint:disable=too-many-public-m
                 project_id=project_id
             )
         else:
-            await FileMetaDataRepository.instance(get_db_engine(self.app)).delete_all_from_node(node_id=node_id)
+            await FileMetaDataRepository.instance(get_db_engine(self.app)).delete_all_from_node(
+                project_id=project_id, node_id=node_id
+            )
 
         await get_s3_client(self.app).delete_objects_recursively(
             bucket=self.simcore_bucket_name,

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -108,7 +108,6 @@ from .utils.utils import (
 
 _NO_CONCURRENCY: Final[int] = 1
 _MAX_PARALLEL_S3_CALLS: Final[NonNegativeInt] = 10
-_PROJECT_FOLDER_MAX_PARTS: Final[int] = 2
 
 
 _logger = logging.getLogger(__name__)
@@ -741,15 +740,6 @@ class SimcoreS3DataManager(BaseDataManager):  # pylint:disable=too-many-public-m
                 limit=MAX_CONCURRENT_S3_TASKS,
             )
 
-    async def delete_path(self, user_id: UserID, path: Path) -> None:
-        # NOTE: a project or project/node folder is not a file identifier, it is authorized at project level
-        if 0 < len(path.parts) <= _PROJECT_FOLDER_MAX_PARTS:
-            node_id = NodeID(path.parts[1]) if len(path.parts) == _PROJECT_FOLDER_MAX_PARTS else None
-            await self.delete_project_simcore_s3(user_id, ProjectID(path.parts[0]), node_id)
-            return
-
-        await super().delete_path(user_id, path)
-
     async def delete_project_simcore_s3(
         self, user_id: UserID, project_id: ProjectID, node_id: NodeID | None = None
     ) -> None:
@@ -764,9 +754,7 @@ class SimcoreS3DataManager(BaseDataManager):  # pylint:disable=too-many-public-m
                 project_id=project_id
             )
         else:
-            await FileMetaDataRepository.instance(get_db_engine(self.app)).delete_all_from_node(
-                project_id=project_id, node_id=node_id
-            )
+            await FileMetaDataRepository.instance(get_db_engine(self.app)).delete_all_from_node(node_id=node_id)
 
         await get_s3_client(self.app).delete_objects_recursively(
             bucket=self.simcore_bucket_name,

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -108,6 +108,7 @@ from .utils.utils import (
 
 _NO_CONCURRENCY: Final[int] = 1
 _MAX_PARALLEL_S3_CALLS: Final[NonNegativeInt] = 10
+_PROJECT_FOLDER_MAX_PARTS: Final[int] = 2
 
 
 _logger = logging.getLogger(__name__)
@@ -739,6 +740,15 @@ class SimcoreS3DataManager(BaseDataManager):  # pylint:disable=too-many-public-m
                 ],
                 limit=MAX_CONCURRENT_S3_TASKS,
             )
+
+    async def delete_path(self, user_id: UserID, path: Path) -> None:
+        # NOTE: a project or project/node folder is not a file identifier, it is authorized at project level
+        if 0 < len(path.parts) <= _PROJECT_FOLDER_MAX_PARTS:
+            node_id = NodeID(path.parts[1]) if len(path.parts) == _PROJECT_FOLDER_MAX_PARTS else None
+            await self.delete_project_simcore_s3(user_id, ProjectID(path.parts[0]), node_id)
+            return
+
+        await super().delete_path(user_id, path)
 
     async def delete_project_simcore_s3(
         self, user_id: UserID, project_id: ProjectID, node_id: NodeID | None = None

--- a/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
+++ b/services/storage/src/simcore_service_storage/simcore_s3_dsm.py
@@ -764,7 +764,9 @@ class SimcoreS3DataManager(BaseDataManager):  # pylint:disable=too-many-public-m
                 project_id=project_id
             )
         else:
-            await FileMetaDataRepository.instance(get_db_engine(self.app)).delete_all_from_node(node_id=node_id)
+            await FileMetaDataRepository.instance(get_db_engine(self.app)).delete_all_from_node(
+                project_id=project_id, node_id=node_id
+            )
 
         await get_s3_client(self.app).delete_objects_recursively(
             bucket=self.simcore_bucket_name,

--- a/services/storage/tests/unit/test_async_jobs_handlers_paths.py
+++ b/services/storage/tests/unit/test_async_jobs_handlers_paths.py
@@ -9,9 +9,8 @@
 
 import datetime
 import random
-from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any, Final
+from typing import Any
 
 import pytest
 from celery.worker.worker import WorkController
@@ -24,7 +23,6 @@ from fastapi import FastAPI
 from models_library.api_schemas_async_jobs.async_jobs import (
     AsyncJobResult,
 )
-from models_library.api_schemas_async_jobs.exceptions import JobError
 from models_library.celery import OwnerMetadata, TaskExecutionMetadata, Wildcard
 from models_library.products import ProductName
 from models_library.projects_nodes_io import LocationID, NodeID, SimcoreS3FileID
@@ -37,8 +35,6 @@ from simcore_service_storage.simcore_s3_dsm import SimcoreS3DataManager
 
 pytest_simcore_core_services_selection = ["postgres", "rabbit", "redis"]
 pytest_simcore_ops_services_selection = ["adminer"]
-
-_NUM_NODES: Final[int] = 2
 
 type _IsFile = bool
 
@@ -362,148 +358,5 @@ async def test_delete_paths(
         user_id,
         path=path,
         expected_total_size=expected_total_size - len(selected_paths) * project_params.allowed_file_sizes[0],
-        product_name=product_name,
-    )
-
-
-@pytest.mark.parametrize(
-    "location_id",
-    [SimcoreS3DataManager.get_location_id()],
-    ids=[SimcoreS3DataManager.get_location_name()],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "project_params",
-    [
-        ProjectWithFilesParams(
-            num_nodes=_NUM_NODES,
-            allowed_file_sizes=(TypeAdapter(ByteSize).validate_python("1b"),),
-            workspace_files_count=3,
-        )
-    ],
-    ids=str,
-)
-@pytest.mark.parametrize("delete_node_folder", [False, True], ids=["project-folder", "node-folder"])
-async def test_delete_paths_of_folder(
-    initialized_app: FastAPI,
-    task_manager: TaskManager,
-    with_storage_celery_worker: WorkController,
-    user_id: UserID,
-    location_id: LocationID,
-    project_with_seeded_files: tuple[
-        dict[str, Any],
-        dict[NodeID, dict[SimcoreS3FileID, FileIDDict]],
-    ],
-    product_name: ProductName,
-    delete_node_folder: bool,
-):
-    """folders are not valid file identifiers and are authorized at project level"""
-    project, list_of_files = project_with_seeded_files
-    assert len(list_of_files) == _NUM_NODES, "test preconditions are not filled! two nodes are needed for this test"
-    deleted_node_id, kept_node_id = list(list_of_files)
-
-    path = Path(project["uuid"])
-    if delete_node_folder:
-        path /= f"{deleted_node_id}"
-
-    await _assert_delete_paths(
-        task_manager,
-        location_id,
-        user_id,
-        product_name,
-        paths={path},
-    )
-
-    await _assert_compute_path_size(
-        task_manager,
-        location_id,
-        user_id,
-        path=path,
-        expected_total_size=0,
-        product_name=product_name,
-    )
-
-    # deleting a node folder must not touch the sibling node
-    await _assert_compute_path_size(
-        task_manager,
-        location_id,
-        user_id,
-        path=Path(project["uuid"]) / f"{kept_node_id}",
-        expected_total_size=(len(list_of_files[kept_node_id]) if delete_node_folder else 0),
-        product_name=product_name,
-    )
-
-
-@pytest.mark.parametrize(
-    "location_id",
-    [SimcoreS3DataManager.get_location_id()],
-    ids=[SimcoreS3DataManager.get_location_name()],
-    indirect=True,
-)
-@pytest.mark.parametrize("path", [Path("not-a-uuid"), Path("not-a-uuid/neither-is-this")], ids=str)
-async def test_delete_paths_of_invalid_short_path_fails(
-    initialized_app: FastAPI,
-    task_manager: TaskManager,
-    with_storage_celery_worker: WorkController,
-    user_id: UserID,
-    location_id: LocationID,
-    product_name: ProductName,
-    path: Path,
-):
-    """short paths that are neither project[/node] folders nor file identifiers are rejected, not silently ignored"""
-    with pytest.raises(JobError) as exc:
-        await _assert_delete_paths(
-            task_manager,
-            location_id,
-            user_id,
-            product_name,
-            paths={path},
-        )
-
-    assert exc.value.exc_type == "ValueError"
-
-
-@pytest.mark.parametrize(
-    "location_id",
-    [SimcoreS3DataManager.get_location_id()],
-    ids=[SimcoreS3DataManager.get_location_name()],
-    indirect=True,
-)
-async def test_delete_paths_of_node_folder_of_another_project(
-    initialized_app: FastAPI,
-    task_manager: TaskManager,
-    with_storage_celery_worker: WorkController,
-    user_id: UserID,
-    location_id: LocationID,
-    project_with_seeded_files_factory: Callable[
-        [ProjectWithFilesParams],
-        Awaitable[tuple[dict[str, Any], dict[NodeID, dict[SimcoreS3FileID, FileIDDict]]]],
-    ],
-    product_name: ProductName,
-):
-    """a node folder is only deleted when it belongs to the authorized project"""
-    project_params = ProjectWithFilesParams(
-        num_nodes=1,
-        allowed_file_sizes=(TypeAdapter(ByteSize).validate_python("1b"),),
-        workspace_files_count=3,
-    )
-    other_project, other_files = await project_with_seeded_files_factory(project_params)
-    project, _ = await project_with_seeded_files_factory(project_params)
-    other_node_id, other_node_files = next(iter(other_files.items()))
-
-    await _assert_delete_paths(
-        task_manager,
-        location_id,
-        user_id,
-        product_name,
-        paths={Path(project["uuid"]) / f"{other_node_id}"},
-    )
-
-    await _assert_compute_path_size(
-        task_manager,
-        location_id,
-        user_id,
-        path=Path(other_project["uuid"]) / f"{other_node_id}",
-        expected_total_size=len(other_node_files),
         product_name=product_name,
     )

--- a/services/storage/tests/unit/test_async_jobs_handlers_paths.py
+++ b/services/storage/tests/unit/test_async_jobs_handlers_paths.py
@@ -107,6 +107,7 @@ async def _assert_delete_paths(
         owner_metadata=TestOwnerMetadata(user_id=user_id, product_name=product_name, owner="pytest_client_name"),
         location_id=location_id,
         user_id=user_id,
+        product_name=product_name,
         paths=paths,
     )
     async for job_composed_result in wait_and_get_job_result(

--- a/services/storage/tests/unit/test_async_jobs_handlers_paths.py
+++ b/services/storage/tests/unit/test_async_jobs_handlers_paths.py
@@ -23,6 +23,7 @@ from fastapi import FastAPI
 from models_library.api_schemas_async_jobs.async_jobs import (
     AsyncJobResult,
 )
+from models_library.api_schemas_async_jobs.exceptions import JobError
 from models_library.celery import OwnerMetadata, TaskExecutionMetadata, Wildcard
 from models_library.products import ProductName
 from models_library.projects_nodes_io import LocationID, NodeID, SimcoreS3FileID
@@ -430,3 +431,32 @@ async def test_delete_paths_of_folder(
         expected_total_size=(len(list_of_files[kept_node_id]) if delete_node_folder else 0),
         product_name=product_name,
     )
+
+
+@pytest.mark.parametrize(
+    "location_id",
+    [SimcoreS3DataManager.get_location_id()],
+    ids=[SimcoreS3DataManager.get_location_name()],
+    indirect=True,
+)
+@pytest.mark.parametrize("path", [Path("not-a-uuid"), Path("not-a-uuid/neither-is-this")], ids=str)
+async def test_delete_paths_of_invalid_short_path_fails(
+    initialized_app: FastAPI,
+    task_manager: TaskManager,
+    with_storage_celery_worker: WorkController,
+    user_id: UserID,
+    location_id: LocationID,
+    product_name: ProductName,
+    path: Path,
+):
+    """short paths that are neither project[/node] folders nor file identifiers are rejected, not silently ignored"""
+    with pytest.raises(JobError) as exc:
+        await _assert_delete_paths(
+            task_manager,
+            location_id,
+            user_id,
+            product_name,
+            paths={path},
+        )
+
+    assert exc.value.exc_type == "ValueError"

--- a/services/storage/tests/unit/test_async_jobs_handlers_paths.py
+++ b/services/storage/tests/unit/test_async_jobs_handlers_paths.py
@@ -9,6 +9,7 @@
 
 import datetime
 import random
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, Final
 
@@ -460,3 +461,49 @@ async def test_delete_paths_of_invalid_short_path_fails(
         )
 
     assert exc.value.exc_type == "ValueError"
+
+
+@pytest.mark.parametrize(
+    "location_id",
+    [SimcoreS3DataManager.get_location_id()],
+    ids=[SimcoreS3DataManager.get_location_name()],
+    indirect=True,
+)
+async def test_delete_paths_of_node_folder_of_another_project(
+    initialized_app: FastAPI,
+    task_manager: TaskManager,
+    with_storage_celery_worker: WorkController,
+    user_id: UserID,
+    location_id: LocationID,
+    project_with_seeded_files_factory: Callable[
+        [ProjectWithFilesParams],
+        Awaitable[tuple[dict[str, Any], dict[NodeID, dict[SimcoreS3FileID, FileIDDict]]]],
+    ],
+    product_name: ProductName,
+):
+    """a node folder is only deleted when it belongs to the authorized project"""
+    project_params = ProjectWithFilesParams(
+        num_nodes=1,
+        allowed_file_sizes=(TypeAdapter(ByteSize).validate_python("1b"),),
+        workspace_files_count=3,
+    )
+    other_project, other_files = await project_with_seeded_files_factory(project_params)
+    project, _ = await project_with_seeded_files_factory(project_params)
+    other_node_id, other_node_files = next(iter(other_files.items()))
+
+    await _assert_delete_paths(
+        task_manager,
+        location_id,
+        user_id,
+        product_name,
+        paths={Path(project["uuid"]) / f"{other_node_id}"},
+    )
+
+    await _assert_compute_path_size(
+        task_manager,
+        location_id,
+        user_id,
+        path=Path(other_project["uuid"]) / f"{other_node_id}",
+        expected_total_size=len(other_node_files),
+        product_name=product_name,
+    )

--- a/services/storage/tests/unit/test_async_jobs_handlers_paths.py
+++ b/services/storage/tests/unit/test_async_jobs_handlers_paths.py
@@ -32,6 +32,8 @@ from pytest_simcore.helpers.storage_utils import FileIDDict, ProjectWithFilesPar
 from servicelib.celery.task_manager import TaskManager
 from simcore_service_storage.simcore_s3_dsm import SimcoreS3DataManager
 
+from services.storage.tests.unit.test_async_jobs_handlers_simcore_s3 import submit_delete_paths_task
+
 pytest_simcore_core_services_selection = ["postgres", "rabbit", "redis"]
 pytest_simcore_ops_services_selection = ["adminer"]
 
@@ -101,9 +103,8 @@ async def _assert_delete_paths(
     *,
     paths: set[Path],
 ) -> None:
-    async_job = await submit_job(
+    task_id, _ = await submit_delete_paths_task(
         task_manager,
-        execution_metadata=TaskExecutionMetadata(name="delete_paths"),
         owner_metadata=TestOwnerMetadata(user_id=user_id, product_name=product_name, owner="pytest_client_name"),
         location_id=location_id,
         user_id=user_id,
@@ -113,7 +114,7 @@ async def _assert_delete_paths(
     async for job_composed_result in wait_and_get_job_result(
         task_manager,
         owner_metadata=TestOwnerMetadata(user_id=user_id, product_name=product_name, owner="pytest_client_name"),
-        job_id=async_job.job_id,
+        job_id=task_id,
         stop_after=datetime.timedelta(seconds=120),
     ):
         if job_composed_result.done:

--- a/services/storage/tests/unit/test_async_jobs_handlers_paths.py
+++ b/services/storage/tests/unit/test_async_jobs_handlers_paths.py
@@ -10,7 +10,7 @@
 import datetime
 import random
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 import pytest
 from celery.worker.worker import WorkController
@@ -35,6 +35,8 @@ from simcore_service_storage.simcore_s3_dsm import SimcoreS3DataManager
 
 pytest_simcore_core_services_selection = ["postgres", "rabbit", "redis"]
 pytest_simcore_ops_services_selection = ["adminer"]
+
+_NUM_NODES: Final[int] = 2
 
 type _IsFile = bool
 
@@ -372,7 +374,7 @@ async def test_delete_paths(
     "project_params",
     [
         ProjectWithFilesParams(
-            num_nodes=2,
+            num_nodes=_NUM_NODES,
             allowed_file_sizes=(TypeAdapter(ByteSize).validate_python("1b"),),
             workspace_files_count=3,
         )
@@ -395,10 +397,12 @@ async def test_delete_paths_of_folder(
 ):
     """folders are not valid file identifiers and are authorized at project level"""
     project, list_of_files = project_with_seeded_files
+    assert len(list_of_files) == _NUM_NODES, "test preconditions are not filled! two nodes are needed for this test"
+    deleted_node_id, kept_node_id = list(list_of_files)
 
     path = Path(project["uuid"])
     if delete_node_folder:
-        path /= f"{next(iter(list_of_files))}"
+        path /= f"{deleted_node_id}"
 
     await _assert_delete_paths(
         task_manager,
@@ -414,5 +418,15 @@ async def test_delete_paths_of_folder(
         user_id,
         path=path,
         expected_total_size=0,
+        product_name=product_name,
+    )
+
+    # deleting a node folder must not touch the sibling node
+    await _assert_compute_path_size(
+        task_manager,
+        location_id,
+        user_id,
+        path=Path(project["uuid"]) / f"{kept_node_id}",
+        expected_total_size=(len(list_of_files[kept_node_id]) if delete_node_folder else 0),
         product_name=product_name,
     )

--- a/services/storage/tests/unit/test_async_jobs_handlers_paths.py
+++ b/services/storage/tests/unit/test_async_jobs_handlers_paths.py
@@ -29,10 +29,9 @@ from models_library.projects_nodes_io import LocationID, NodeID, SimcoreS3FileID
 from models_library.users import UserID
 from pydantic import ByteSize, TypeAdapter
 from pytest_simcore.helpers.storage_utils import FileIDDict, ProjectWithFilesParams
+from servicelib.celery.async_jobs.storage.paths import submit_delete_paths_task
 from servicelib.celery.task_manager import TaskManager
 from simcore_service_storage.simcore_s3_dsm import SimcoreS3DataManager
-
-from services.storage.tests.unit.test_async_jobs_handlers_simcore_s3 import submit_delete_paths_task
 
 pytest_simcore_core_services_selection = ["postgres", "rabbit", "redis"]
 pytest_simcore_ops_services_selection = ["adminer"]

--- a/services/storage/tests/unit/test_async_jobs_handlers_paths.py
+++ b/services/storage/tests/unit/test_async_jobs_handlers_paths.py
@@ -9,8 +9,9 @@
 
 import datetime
 import random
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 import pytest
 from celery.worker.worker import WorkController
@@ -23,6 +24,7 @@ from fastapi import FastAPI
 from models_library.api_schemas_async_jobs.async_jobs import (
     AsyncJobResult,
 )
+from models_library.api_schemas_async_jobs.exceptions import JobError
 from models_library.celery import OwnerMetadata, TaskExecutionMetadata, Wildcard
 from models_library.products import ProductName
 from models_library.projects_nodes_io import LocationID, NodeID, SimcoreS3FileID
@@ -35,6 +37,8 @@ from simcore_service_storage.simcore_s3_dsm import SimcoreS3DataManager
 
 pytest_simcore_core_services_selection = ["postgres", "rabbit", "redis"]
 pytest_simcore_ops_services_selection = ["adminer"]
+
+_NUM_NODES: Final[int] = 2
 
 type _IsFile = bool
 
@@ -358,5 +362,148 @@ async def test_delete_paths(
         user_id,
         path=path,
         expected_total_size=expected_total_size - len(selected_paths) * project_params.allowed_file_sizes[0],
+        product_name=product_name,
+    )
+
+
+@pytest.mark.parametrize(
+    "location_id",
+    [SimcoreS3DataManager.get_location_id()],
+    ids=[SimcoreS3DataManager.get_location_name()],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "project_params",
+    [
+        ProjectWithFilesParams(
+            num_nodes=_NUM_NODES,
+            allowed_file_sizes=(TypeAdapter(ByteSize).validate_python("1b"),),
+            workspace_files_count=3,
+        )
+    ],
+    ids=str,
+)
+@pytest.mark.parametrize("delete_node_folder", [False, True], ids=["project-folder", "node-folder"])
+async def test_delete_paths_of_folder(
+    initialized_app: FastAPI,
+    task_manager: TaskManager,
+    with_storage_celery_worker: WorkController,
+    user_id: UserID,
+    location_id: LocationID,
+    project_with_seeded_files: tuple[
+        dict[str, Any],
+        dict[NodeID, dict[SimcoreS3FileID, FileIDDict]],
+    ],
+    product_name: ProductName,
+    delete_node_folder: bool,
+):
+    """folders are not valid file identifiers and are authorized at project level"""
+    project, list_of_files = project_with_seeded_files
+    assert len(list_of_files) == _NUM_NODES, "test preconditions are not filled! two nodes are needed for this test"
+    deleted_node_id, kept_node_id = list(list_of_files)
+
+    path = Path(project["uuid"])
+    if delete_node_folder:
+        path /= f"{deleted_node_id}"
+
+    await _assert_delete_paths(
+        task_manager,
+        location_id,
+        user_id,
+        product_name,
+        paths={path},
+    )
+
+    await _assert_compute_path_size(
+        task_manager,
+        location_id,
+        user_id,
+        path=path,
+        expected_total_size=0,
+        product_name=product_name,
+    )
+
+    # deleting a node folder must not touch the sibling node
+    await _assert_compute_path_size(
+        task_manager,
+        location_id,
+        user_id,
+        path=Path(project["uuid"]) / f"{kept_node_id}",
+        expected_total_size=(len(list_of_files[kept_node_id]) if delete_node_folder else 0),
+        product_name=product_name,
+    )
+
+
+@pytest.mark.parametrize(
+    "location_id",
+    [SimcoreS3DataManager.get_location_id()],
+    ids=[SimcoreS3DataManager.get_location_name()],
+    indirect=True,
+)
+@pytest.mark.parametrize("path", [Path("not-a-uuid"), Path("not-a-uuid/neither-is-this")], ids=str)
+async def test_delete_paths_of_invalid_short_path_fails(
+    initialized_app: FastAPI,
+    task_manager: TaskManager,
+    with_storage_celery_worker: WorkController,
+    user_id: UserID,
+    location_id: LocationID,
+    product_name: ProductName,
+    path: Path,
+):
+    """short paths that are neither project[/node] folders nor file identifiers are rejected, not silently ignored"""
+    with pytest.raises(JobError) as exc:
+        await _assert_delete_paths(
+            task_manager,
+            location_id,
+            user_id,
+            product_name,
+            paths={path},
+        )
+
+    assert exc.value.exc_type == "ValueError"
+
+
+@pytest.mark.parametrize(
+    "location_id",
+    [SimcoreS3DataManager.get_location_id()],
+    ids=[SimcoreS3DataManager.get_location_name()],
+    indirect=True,
+)
+async def test_delete_paths_of_node_folder_of_another_project(
+    initialized_app: FastAPI,
+    task_manager: TaskManager,
+    with_storage_celery_worker: WorkController,
+    user_id: UserID,
+    location_id: LocationID,
+    project_with_seeded_files_factory: Callable[
+        [ProjectWithFilesParams],
+        Awaitable[tuple[dict[str, Any], dict[NodeID, dict[SimcoreS3FileID, FileIDDict]]]],
+    ],
+    product_name: ProductName,
+):
+    """a node folder is only deleted when it belongs to the authorized project"""
+    project_params = ProjectWithFilesParams(
+        num_nodes=1,
+        allowed_file_sizes=(TypeAdapter(ByteSize).validate_python("1b"),),
+        workspace_files_count=3,
+    )
+    other_project, other_files = await project_with_seeded_files_factory(project_params)
+    project, _ = await project_with_seeded_files_factory(project_params)
+    other_node_id, other_node_files = next(iter(other_files.items()))
+
+    await _assert_delete_paths(
+        task_manager,
+        location_id,
+        user_id,
+        product_name,
+        paths={Path(project["uuid"]) / f"{other_node_id}"},
+    )
+
+    await _assert_compute_path_size(
+        task_manager,
+        location_id,
+        user_id,
+        path=Path(other_project["uuid"]) / f"{other_node_id}",
+        expected_total_size=len(other_node_files),
         product_name=product_name,
     )

--- a/services/storage/tests/unit/test_async_jobs_handlers_paths.py
+++ b/services/storage/tests/unit/test_async_jobs_handlers_paths.py
@@ -360,3 +360,59 @@ async def test_delete_paths(
         expected_total_size=expected_total_size - len(selected_paths) * project_params.allowed_file_sizes[0],
         product_name=product_name,
     )
+
+
+@pytest.mark.parametrize(
+    "location_id",
+    [SimcoreS3DataManager.get_location_id()],
+    ids=[SimcoreS3DataManager.get_location_name()],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "project_params",
+    [
+        ProjectWithFilesParams(
+            num_nodes=2,
+            allowed_file_sizes=(TypeAdapter(ByteSize).validate_python("1b"),),
+            workspace_files_count=3,
+        )
+    ],
+    ids=str,
+)
+@pytest.mark.parametrize("delete_node_folder", [False, True], ids=["project-folder", "node-folder"])
+async def test_delete_paths_of_folder(
+    initialized_app: FastAPI,
+    task_manager: TaskManager,
+    with_storage_celery_worker: WorkController,
+    user_id: UserID,
+    location_id: LocationID,
+    project_with_seeded_files: tuple[
+        dict[str, Any],
+        dict[NodeID, dict[SimcoreS3FileID, FileIDDict]],
+    ],
+    product_name: ProductName,
+    delete_node_folder: bool,
+):
+    """folders are not valid file identifiers and are authorized at project level"""
+    project, list_of_files = project_with_seeded_files
+
+    path = Path(project["uuid"])
+    if delete_node_folder:
+        path /= f"{next(iter(list_of_files))}"
+
+    await _assert_delete_paths(
+        task_manager,
+        location_id,
+        user_id,
+        product_name,
+        paths={path},
+    )
+
+    await _assert_compute_path_size(
+        task_manager,
+        location_id,
+        user_id,
+        path=path,
+        expected_total_size=0,
+        product_name=product_name,
+    )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request makes a minor update to the `delete_paths` to include `product_name` as a new parameter.

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test
```sh
cd services/storage
make install-dev
pytest -vv --pdb tests/unit/test_async_jobs_handlers_paths.py
```

## Dev-ops
- No change.