### PR TITLE
🐛 fix(celery-library): propagate task exceptions when waiting for a job result

### DIFF
--- a/services/api-server/src/simcore_service_api_server/services_rpc/storage.py
+++ b/services/api-server/src/simcore_service_api_server/services_rpc/storage.py
@@ -70,5 +70,4 @@ class StorageService:
             stop_after=_PROJECT_DELETION_MAX_TIMEOUT,
         ):
             if job_result_update.done:
-                # NOTE: raises if the task failed
                 await job_result_update.result()

--- a/services/api-server/src/simcore_service_api_server/services_rpc/storage.py
+++ b/services/api-server/src/simcore_service_api_server/services_rpc/storage.py
@@ -4,17 +4,18 @@ from functools import partial
 from pathlib import Path
 from typing import Final
 
-from celery_library.async_jobs import submit_job, wait_and_get_job_result
+from celery_library.async_jobs import wait_and_get_job_result
 from models_library.api_schemas_async_jobs.async_jobs import (
     AsyncJobGet,
 )
 from models_library.api_schemas_webserver.storage import PathToExport
-from models_library.celery import OwnerMetadata, TaskExecutionMetadata
+from models_library.celery import OwnerMetadata
 from models_library.products import ProductName
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import LocationID
 from models_library.users import UserID
 from servicelib.celery.async_jobs.storage.paths import submit_delete_paths_task
+from servicelib.celery.async_jobs.storage.simcore_s3 import submit_export_data
 from servicelib.celery.task_manager import TaskManager
 
 from ..exceptions.service_errors_utils import service_exception_mapper
@@ -38,15 +39,15 @@ class StorageService:
         self,
         paths_to_export: list[PathToExport],
     ) -> AsyncJobGet:
-        return await submit_job(
+        return await submit_export_data(
             self._task_manager,
-            execution_metadata=TaskExecutionMetadata(name="export_data_as_download_link"),
-            owner_metadata=OwnerMetadata.model_validate(
+            OwnerMetadata.model_validate(
                 ApiServerOwnerMetadata(user_id=self._user_id, product_name=self._product_name).model_dump()
             ),
             user_id=self._user_id,
             product_name=self._product_name,
             paths_to_export=paths_to_export,
+            export_as="download_link",
         )
 
     @_exception_mapper(rpc_exception_map={})

--- a/services/api-server/src/simcore_service_api_server/services_rpc/storage.py
+++ b/services/api-server/src/simcore_service_api_server/services_rpc/storage.py
@@ -62,10 +62,12 @@ class StorageService:
             location_id=_SIMCORE_LOCATION,
             paths={Path(f"{project_id}")},
         )
-        async for _ in wait_and_get_job_result(
+        async for job_result_update in wait_and_get_job_result(
             self._task_manager,
             owner_metadata=owner_metadata,
             job_id=job_id,
             stop_after=_PROJECT_DELETION_MAX_TIMEOUT,
         ):
-            pass
+            if job_result_update.done:
+                # NOTE: raises if the task failed
+                await job_result_update.result()

--- a/services/api-server/tests/unit/service/test_services_rpc_storage.py
+++ b/services/api-server/tests/unit/service/test_services_rpc_storage.py
@@ -1,0 +1,90 @@
+# pylint: disable=protected-access
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from typing import Any
+
+import pytest
+from celery_library.errors import encode_celery_transferable_error
+from faker import Faker
+from models_library.api_schemas_async_jobs.exceptions import JobError
+from models_library.celery import TaskState, TaskStatus, TaskUUID
+from models_library.products import ProductName
+from models_library.progress_bar import ProgressReport
+from models_library.projects import ProjectID
+from models_library.users import UserID
+from pytest_mock import MockerFixture, MockType
+from servicelib.celery.task_manager import TaskManager
+from simcore_service_api_server.services_rpc.storage import StorageService
+
+
+@pytest.fixture
+def task_uuid(faker: Faker) -> TaskUUID:
+    return faker.uuid4(cast_to=None)
+
+
+@pytest.fixture
+def project_id(faker: Faker) -> ProjectID:
+    return faker.uuid4(cast_to=None)
+
+
+def _mocked_task_manager(
+    mocker: MockerFixture,
+    *,
+    task_uuid: TaskUUID,
+    task_state: TaskState,
+    task_result: Any,
+) -> MockType:
+    task_manager = mocker.AsyncMock(spec=TaskManager)
+    task_manager.submit_task.return_value = task_uuid
+    task_manager.get_status.return_value = TaskStatus(
+        task_uuid=task_uuid,
+        task_state=task_state,
+        progress_report=ProgressReport(actual_value=1.0, total=1.0),
+    )
+    task_manager.get_result.return_value = task_result
+    return task_manager
+
+
+async def test_delete_project_s3_assets_succeeds(
+    mocker: MockerFixture,
+    task_uuid: TaskUUID,
+    project_id: ProjectID,
+    user_id: UserID,
+    product_name: ProductName,
+):
+    task_manager = _mocked_task_manager(
+        mocker,
+        task_uuid=task_uuid,
+        task_state=TaskState.SUCCESS,
+        task_result=None,
+    )
+    storage_service = StorageService(_task_manager=task_manager, _user_id=user_id, _product_name=product_name)
+
+    await storage_service.delete_project_s3_assets(project_id=project_id)
+
+    assert task_manager.submit_task.called
+
+
+async def test_delete_project_s3_assets_raises_on_task_failure(
+    mocker: MockerFixture,
+    task_uuid: TaskUUID,
+    project_id: ProjectID,
+    user_id: UserID,
+    product_name: ProductName,
+):
+    # regression: a failed deletion task must not be silently ignored
+    task_manager = _mocked_task_manager(
+        mocker,
+        task_uuid=task_uuid,
+        task_state=TaskState.FAILURE,
+        task_result=encode_celery_transferable_error(ValueError("could not delete project assets")),
+    )
+    storage_service = StorageService(_task_manager=task_manager, _user_id=user_id, _product_name=product_name)
+
+    with pytest.raises(JobError) as err_info:
+        await storage_service.delete_project_s3_assets(project_id=project_id)
+
+    assert err_info.value.exc_type == ValueError.__name__
+    assert "could not delete project assets" in err_info.value.exc_msg

--- a/services/web/server/src/simcore_service_webserver/storage/api.py
+++ b/services/web/server/src/simcore_service_webserver/storage/api.py
@@ -179,7 +179,6 @@ async def delete_project_data_folders(
         ):
             _logger.info("waiting for deletion of project %s data folders to complete", project_id)
             if job_result_update.done:
-                # NOTE: raises if the task failed
                 await job_result_update.result()
 
 
@@ -215,7 +214,6 @@ async def delete_project_node_data_folders(
         ):
             _logger.info("waiting for deletion of project %s node %s data folders to complete", project_id, node_id)
             if job_result_update.done:
-                # NOTE: raises if the task failed
                 await job_result_update.result()
 
 

--- a/services/web/server/src/simcore_service_webserver/storage/api.py
+++ b/services/web/server/src/simcore_service_webserver/storage/api.py
@@ -179,7 +179,7 @@ async def delete_project_data_folders(
         ):
             _logger.info("waiting for deletion of project %s data folders to complete", project_id)
             if job_result_update.done:
-                # NOTE: raises if
+                # NOTE: raises if the task failed
                 await job_result_update.result()
 
 
@@ -215,7 +215,7 @@ async def delete_project_node_data_folders(
         ):
             _logger.info("waiting for deletion of project %s node %s data folders to complete", project_id, node_id)
             if job_result_update.done:
-                # raises if the task failed
+                # NOTE: raises if the task failed
                 await job_result_update.result()
 
 

--- a/services/web/server/src/simcore_service_webserver/storage/api.py
+++ b/services/web/server/src/simcore_service_webserver/storage/api.py
@@ -171,13 +171,16 @@ async def delete_project_data_folders(
             location_id=_SIMCORE_LOCATION,
             paths={Path(f"{project_id}")},
         )
-        async for _ in wait_and_get_job_result(
+        async for job_result_update in wait_and_get_job_result(
             get_task_manager(app),
             owner_metadata=owner_metadata,
             job_id=job_id,
             stop_after=_PROJECT_DELETION_MAX_TIMEOUT,
         ):
             _logger.info("waiting for deletion of project %s data folders to complete", project_id)
+            if job_result_update.done:
+                # NOTE: raises if
+                await job_result_update.result()
 
 
 async def delete_project_node_data_folders(
@@ -204,13 +207,16 @@ async def delete_project_node_data_folders(
             location_id=_SIMCORE_LOCATION,
             paths={Path(f"{project_id}/{node_id}")},
         )
-        async for _ in wait_and_get_job_result(
+        async for job_result_update in wait_and_get_job_result(
             get_task_manager(app),
             owner_metadata=owner_metadata,
             job_id=job_id,
             stop_after=_PROJECT_DELETION_MAX_TIMEOUT,
         ):
             _logger.info("waiting for deletion of project %s node %s data folders to complete", project_id, node_id)
+            if job_result_update.done:
+                # raises if the task failed
+                await job_result_update.result()
 
 
 async def is_healthy(app: web.Application) -> bool:

--- a/services/web/server/tests/unit/isolated/test_storage_api.py
+++ b/services/web/server/tests/unit/isolated/test_storage_api.py
@@ -17,10 +17,10 @@ from models_library.projects_nodes_io import NodeID
 from models_library.users import UserID
 from pytest_mock import MockerFixture, MockType
 from servicelib.celery.task_manager import TaskManager
+from simcore_service_webserver.storage import api as storage_api
 from simcore_service_webserver.storage.api import (
     delete_project_data_folders,
     delete_project_node_data_folders,
-    get_task_manager,
 )
 
 
@@ -65,8 +65,9 @@ def _mock_task_manager(
         progress_report=ProgressReport(actual_value=1.0, total=1.0),
     )
     task_manager.get_result.return_value = task_result
-    mocker.patch(
-        get_task_manager.__name__,
+    mocker.patch.object(
+        storage_api,
+        storage_api.get_task_manager.__name__,
         autospec=True,
         return_value=task_manager,
     )

--- a/services/web/server/tests/unit/isolated/test_storage_api.py
+++ b/services/web/server/tests/unit/isolated/test_storage_api.py
@@ -1,0 +1,154 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+from typing import Any
+
+import pytest
+from aiohttp import web
+from celery_library.errors import encode_celery_transferable_error
+from faker import Faker
+from models_library.api_schemas_async_jobs.exceptions import JobError
+from models_library.celery import TaskState, TaskStatus, TaskUUID
+from models_library.products import ProductName
+from models_library.progress_bar import ProgressReport
+from models_library.projects import ProjectID
+from models_library.projects_nodes_io import NodeID
+from models_library.users import UserID
+from pytest_mock import MockerFixture, MockType
+from servicelib.celery.task_manager import TaskManager
+from simcore_service_webserver.storage.api import (
+    delete_project_data_folders,
+    delete_project_node_data_folders,
+    get_task_manager,
+)
+
+
+@pytest.fixture
+def app() -> web.Application:
+    return web.Application()
+
+
+@pytest.fixture
+def user_id(faker: Faker) -> UserID:
+    return faker.pyint(min_value=1)
+
+
+@pytest.fixture
+def product_name(faker: Faker) -> ProductName:
+    return faker.word()
+
+
+@pytest.fixture
+def project_id(faker: Faker) -> ProjectID:
+    return faker.uuid4(cast_to=None)
+
+
+@pytest.fixture
+def node_id(faker: Faker) -> NodeID:
+    return faker.uuid4(cast_to=None)
+
+
+def _mock_task_manager(
+    mocker: MockerFixture,
+    *,
+    faker: Faker,
+    task_state: TaskState,
+    task_result: Any,
+) -> MockType:
+    task_uuid: TaskUUID = faker.uuid4(cast_to=None)
+    task_manager = mocker.AsyncMock(spec=TaskManager)
+    task_manager.submit_task.return_value = task_uuid
+    task_manager.get_status.return_value = TaskStatus(
+        task_uuid=task_uuid,
+        task_state=task_state,
+        progress_report=ProgressReport(actual_value=1.0, total=1.0),
+    )
+    task_manager.get_result.return_value = task_result
+    mocker.patch(
+        get_task_manager.__name__,
+        autospec=True,
+        return_value=task_manager,
+    )
+    return task_manager
+
+
+async def test_delete_project_data_folders_succeeds(
+    mocker: MockerFixture,
+    faker: Faker,
+    app: web.Application,
+    user_id: UserID,
+    product_name: ProductName,
+    project_id: ProjectID,
+):
+    task_manager = _mock_task_manager(mocker, faker=faker, task_state=TaskState.SUCCESS, task_result=None)
+
+    await delete_project_data_folders(app, product_name=product_name, user_id=user_id, project_id=project_id)
+
+    assert task_manager.submit_task.called
+
+
+async def test_delete_project_data_folders_raises_on_task_failure(
+    mocker: MockerFixture,
+    faker: Faker,
+    app: web.Application,
+    user_id: UserID,
+    product_name: ProductName,
+    project_id: ProjectID,
+):
+    # regression: a failed deletion task must not be silently ignored
+    _mock_task_manager(
+        mocker,
+        faker=faker,
+        task_state=TaskState.FAILURE,
+        task_result=encode_celery_transferable_error(ValueError("could not delete project folders")),
+    )
+
+    with pytest.raises(JobError) as err_info:
+        await delete_project_data_folders(app, product_name=product_name, user_id=user_id, project_id=project_id)
+
+    assert ValueError.__name__ in f"{err_info.value}"
+    assert "could not delete project folders" in f"{err_info.value}"
+
+
+async def test_delete_project_node_data_folders_succeeds(
+    mocker: MockerFixture,
+    faker: Faker,
+    app: web.Application,
+    user_id: UserID,
+    product_name: ProductName,
+    project_id: ProjectID,
+    node_id: NodeID,
+):
+    task_manager = _mock_task_manager(mocker, faker=faker, task_state=TaskState.SUCCESS, task_result=None)
+
+    await delete_project_node_data_folders(
+        app, product_name=product_name, user_id=user_id, project_id=project_id, node_id=node_id
+    )
+
+    assert task_manager.submit_task.called
+
+
+async def test_delete_project_node_data_folders_raises_on_task_failure(
+    mocker: MockerFixture,
+    faker: Faker,
+    app: web.Application,
+    user_id: UserID,
+    product_name: ProductName,
+    project_id: ProjectID,
+    node_id: NodeID,
+):
+    _mock_task_manager(
+        mocker,
+        faker=faker,
+        task_state=TaskState.FAILURE,
+        task_result=encode_celery_transferable_error(ValueError("could not delete node folders")),
+    )
+
+    with pytest.raises(JobError) as err_info:
+        await delete_project_node_data_folders(
+            app, product_name=product_name, user_id=user_id, project_id=project_id, node_id=node_id
+        )
+
+    assert ValueError.__name__ in f"{err_info.value}"
+    assert "could not delete node folders" in f"{err_info.value}"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request improves error handling for project and node data deletion tasks in both the API server and web server, ensuring that failed deletion tasks are no longer silently ignored. It also adds comprehensive unit tests to verify the correct behavior in both success and failure scenarios.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test
```sh
cd services/api-server
pytest -vv --pdb tests/unit/service/test_services_rpc_storage.py
```

```sh
cd services/web/server
pytest -vv --pdb tests/unit/isolated/test_storage_api.py
```

## Dev-ops
- No changes.