### PR TITLE
🎨 Retry submitting dask job if it disappears

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -127,27 +127,6 @@ class ComputationalBackendSettings(BaseCustomSettings):
         ),
     ] = 2
 
-    COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_INITIAL_DELAY: Annotated[
-        datetime.timedelta,
-        Field(
-            description=(
-                "initial delay before resubmitting a task the computational backend does not know about "
-                "anymore, doubled after each further resubmission (default to seconds, or see "
-                "https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formatting)."
-            )
-        ),
-    ] = datetime.timedelta(seconds=10)
-
-    COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_MAX_DELAY: Annotated[
-        datetime.timedelta,
-        Field(
-            description=(
-                "maximum delay between task resubmissions, caps the exponential backoff (default to seconds, "
-                "or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formatting)."
-            )
-        ),
-    ] = datetime.timedelta(minutes=2)
-
     @cached_property
     def default_cluster(self) -> BaseCluster:
         return BaseCluster(

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -115,14 +115,13 @@ class ComputationalBackendSettings(BaseCustomSettings):
         ),
     ] = datetime.timedelta(minutes=10)
 
-    COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS: Annotated[
+    COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES: Annotated[
         NonNegativeInt,
         Field(
             description=(
-                "maximum number of times a task that the computational backend does not know "
-                "about anymore is resubmitted before it is considered failed. This happens when "
-                "the connection to the dask-scheduler is lost while the task was submitted but "
-                "not yet durably published."
+                "maximum number of times a task is retried in case the (dask) underlying "
+                "computational cluster is restarted and a task disappears before it is "
+                "considered as failed."
             )
         ),
     ] = 2

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -115,6 +115,39 @@ class ComputationalBackendSettings(BaseCustomSettings):
         ),
     ] = datetime.timedelta(minutes=10)
 
+    COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS: Annotated[
+        NonNegativeInt,
+        Field(
+            description=(
+                "maximum number of times a task that the computational backend does not know "
+                "about anymore is resubmitted before it is considered failed. This happens when "
+                "the connection to the dask-scheduler is lost while the task was submitted but "
+                "not yet durably published."
+            )
+        ),
+    ] = 2
+
+    COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_INITIAL_DELAY: Annotated[
+        datetime.timedelta,
+        Field(
+            description=(
+                "initial delay before resubmitting a task the computational backend does not know about "
+                "anymore, doubled after each further resubmission (default to seconds, or see "
+                "https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formatting)."
+            )
+        ),
+    ] = datetime.timedelta(seconds=10)
+
+    COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_MAX_DELAY: Annotated[
+        datetime.timedelta,
+        Field(
+            description=(
+                "maximum delay between task resubmissions, caps the exponential backoff (default to seconds, "
+                "or see https://pydantic-docs.helpmanual.io/usage/types/#datetime-types for string formatting)."
+            )
+        ),
+    ] = datetime.timedelta(minutes=2)
+
     @cached_property
     def default_cluster(self) -> BaseCluster:
         return BaseCluster(

--- a/services/director-v2/src/simcore_service_director_v2/core/settings.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/settings.py
@@ -11,30 +11,15 @@ from common_library.logging.logging_utils_filtering import LoggerName, MessageSu
 from common_library.pydantic_validators import validate_numeric_string_as_timedelta
 from fastapi import FastAPI
 from models_library.basic_types import LogLevel, PortInt
-from models_library.clusters import (
-    BaseCluster,
-    ClusterAuthentication,
-    ClusterTypeInModel,
-    NoAuthentication,
-)
-from pydantic import (
-    AliasChoices,
-    AnyUrl,
-    Field,
-    NonNegativeInt,
-    PositiveInt,
-    field_validator,
-)
+from models_library.clusters import BaseCluster, ClusterAuthentication, ClusterTypeInModel, NoAuthentication
+from pydantic import AliasChoices, AnyUrl, Field, NonNegativeInt, PositiveInt, field_validator
 from settings_library.application import BaseApplicationSettings
 from settings_library.base import BaseCustomSettings
 from settings_library.catalog import CatalogSettings
 from settings_library.director_v0 import DirectorV0Settings
 from settings_library.docker_registry import RegistrySettings
 from settings_library.http_client_request import ClientRequestSettings
-from settings_library.node_ports import (
-    NODE_PORTS_400_REQUEST_TIMEOUT_ATTEMPTS_DEFAULT_VALUE,
-    StorageAuthSettings,
-)
+from settings_library.node_ports import NODE_PORTS_400_REQUEST_TIMEOUT_ATTEMPTS_DEFAULT_VALUE, StorageAuthSettings
 from settings_library.postgres import PostgresSettings
 from settings_library.rabbit import RabbitSettings
 from settings_library.redis import RedisSettings
@@ -124,7 +109,7 @@ class ComputationalBackendSettings(BaseCustomSettings):
                 "considered as failed."
             )
         ),
-    ] = 2
+    ] = 1
 
     @cached_property
     def default_cluster(self) -> BaseCluster:

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -1,5 +1,4 @@
 import contextlib
-import datetime
 import logging
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
@@ -75,9 +74,6 @@ _TASK_RETRIEVAL_ERROR_TYPE: Final[str] = "task-result-retrieval-timeout"
 _TASK_RETRIEVAL_ERROR_CONTEXT_TIME_KEY: Final[str] = "check_time"
 _TASK_NOT_FOUND_ERROR_TYPE: Final[str] = "task-not-found-in-computational-backend"
 _TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY: Final[str] = "resubmissions"
-_TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY: Final[str] = "last_attempt"
-_TASK_NOT_FOUND_RESUBMISSION_INITIAL_DELAY: Final[datetime.timedelta] = datetime.timedelta(seconds=10)
-_TASK_NOT_FOUND_RESUBMISSION_MAX_DELAY: Final[datetime.timedelta] = datetime.timedelta(minutes=2)
 _PUBLICATION_CONCURRENCY_LIMIT: Final[int] = 10
 
 
@@ -555,17 +551,13 @@ class DaskScheduler(BaseCompScheduler):
         log_error_context: dict[str, Any],
         comp_run: CompRunsAtDB,
     ) -> tuple[RunningState, SimcorePlatformStatus, list[ErrorDict], bool]:
-        """Returns the outcome tuple: WAITING_FOR_CLUSTER if resubmitted, STARTED if still waiting
-        for the backoff delay to elapse, or the exhausted (failed) outcome."""
+        """Returns the outcome tuple: WAITING_FOR_CLUSTER if resubmitted, or the exhausted (failed) outcome."""
         resubmissions = 0
-        last_attempt = arrow.utcnow()
         for error in task.errors or []:
             if error["type"] == _TASK_NOT_FOUND_ERROR_TYPE:
                 assert "ctx" in error  # nosec
                 assert _TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY in error["ctx"]  # nosec
-                assert _TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY in error["ctx"]  # nosec
                 resubmissions = int(error["ctx"][_TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY])
-                last_attempt = arrow.get(error["ctx"][_TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY])
                 break
 
         if resubmissions >= self.settings.COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES:
@@ -582,30 +574,6 @@ class DaskScheduler(BaseCompScheduler):
             task_state, _, task_errors, task_completed = await self._handle_task_error(task, result, log_error_context)
             # NOTE: this is a platform failure (backend lost the task), not the user's fault, so no billing
             return task_state, SimcorePlatformStatus.BAD, task_errors, task_completed
-
-        # NOTE: exponential backoff, so we do not hammer a computational backend that is still recovering
-        backoff_delay = min(
-            _TASK_NOT_FOUND_RESUBMISSION_INITIAL_DELAY * (2**resubmissions),
-            _TASK_NOT_FOUND_RESUBMISSION_MAX_DELAY,
-        )
-        if (arrow.utcnow() - last_attempt) < backoff_delay:
-            return (
-                RunningState.STARTED,
-                SimcorePlatformStatus.BAD,
-                [
-                    ErrorDict(
-                        loc=(f"{task.project_id}", f"{task.node_id}"),
-                        msg=f"{result}",
-                        type=_TASK_NOT_FOUND_ERROR_TYPE,
-                        ctx={
-                            _TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY: resubmissions,
-                            _TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY: f"{last_attempt}",
-                            **log_error_context,
-                        },
-                    )
-                ],
-                False,
-            )
 
         _logger.warning(
             **create_troubleshooting_log_kwargs(
@@ -628,7 +596,6 @@ class DaskScheduler(BaseCompScheduler):
                     type=_TASK_NOT_FOUND_ERROR_TYPE,
                     ctx={
                         _TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY: resubmissions + 1,
-                        _TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY: f"{arrow.utcnow()}",
                         **log_error_context,
                     },
                 )

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -37,6 +37,7 @@ from ..._meta import APP_NAME
 from ...core.errors import (
     ComputationalBackendNotConnectedError,
     ComputationalBackendOnDemandNotReadyError,
+    ComputationalBackendTaskNotFoundError,
     ComputationalBackendTaskResultsNotReadyError,
     PortsValidationError,
 )
@@ -71,6 +72,9 @@ _logger = logging.getLogger(__name__)
 _DASK_CLIENT_RUN_REF: Final[str] = "{user_id}:{project_id}:{run_id}"
 _TASK_RETRIEVAL_ERROR_TYPE: Final[str] = "task-result-retrieval-timeout"
 _TASK_RETRIEVAL_ERROR_CONTEXT_TIME_KEY: Final[str] = "check_time"
+_TASK_NOT_FOUND_ERROR_TYPE: Final[str] = "task-not-found-in-computational-backend"
+_TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY: Final[str] = "resubmissions"
+_TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY: Final[str] = "last_attempt"
 _PUBLICATION_CONCURRENCY_LIMIT: Final[int] = 10
 
 
@@ -540,6 +544,90 @@ class DaskScheduler(BaseCompScheduler):
         # state is kept as STARTED so it will be retried
         return RunningState.STARTED, SimcorePlatformStatus.BAD, [], False
 
+    async def _handle_task_not_found_error(
+        self,
+        task: CompTaskAtDB,
+        result: ComputationalBackendTaskNotFoundError,
+        log_error_context: dict[str, Any],
+        comp_run: CompRunsAtDB,
+    ) -> tuple[RunningState, SimcorePlatformStatus, list[ErrorDict], bool] | None:
+        """Returns None if resubmitted, otherwise the outcome tuple (waiting or exhausted)."""
+        resubmissions = 0
+        last_attempt = arrow.utcnow()
+        for error in task.errors or []:
+            if error["type"] == _TASK_NOT_FOUND_ERROR_TYPE:
+                assert "ctx" in error  # nosec
+                assert _TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY in error["ctx"]  # nosec
+                assert _TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY in error["ctx"]  # nosec
+                resubmissions = int(error["ctx"][_TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY])
+                last_attempt = arrow.get(error["ctx"][_TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY])
+                break
+
+        if resubmissions >= self.settings.COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS:
+            _logger.error(
+                **create_troubleshooting_log_kwargs(
+                    f"Task {task.job_id} is unknown to the computational backend "
+                    f"and was already resubmitted {resubmissions} time(s)",
+                    error=result,
+                    error_context=log_error_context,
+                    tip="The dask-scheduler lost the task and resubmitting it did not help. "
+                    "Please contact support if the problem persists.",
+                )
+            )
+            return await self._handle_task_error(task, result, log_error_context)
+
+        # NOTE: exponential backoff, so we do not hammer a computational backend that is still recovering
+        backoff_delay = min(
+            self.settings.COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_INITIAL_DELAY * (2**resubmissions),
+            self.settings.COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_MAX_DELAY,
+        )
+        if (arrow.utcnow() - last_attempt) < backoff_delay:
+            return (
+                RunningState.STARTED,
+                SimcorePlatformStatus.BAD,
+                [
+                    ErrorDict(
+                        loc=(f"{task.project_id}", f"{task.node_id}"),
+                        msg=f"{result}",
+                        type=_TASK_NOT_FOUND_ERROR_TYPE,
+                        ctx={
+                            _TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY: resubmissions,
+                            _TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY: f"{last_attempt}",
+                            **log_error_context,
+                        },
+                    )
+                ],
+                False,
+            )
+
+        _logger.warning(
+            **create_troubleshooting_log_kwargs(
+                f"Task {task.job_id} is unknown to the computational backend, resubmitting it",
+                error=result,
+                error_context=log_error_context,
+                tip="This happens when the connection to the dask-scheduler was lost before "
+                "the task was durably published. The task is automatically resubmitted.",
+            )
+        )
+        await CompTasksRepository(self.db_engine).reset_task_for_resubmission(
+            task.project_id,
+            task.node_id,
+            comp_run.run_id,
+            errors=[
+                ErrorDict(
+                    loc=(f"{task.project_id}", f"{task.node_id}"),
+                    msg=f"{result}",
+                    type=_TASK_NOT_FOUND_ERROR_TYPE,
+                    ctx={
+                        _TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY: resubmissions + 1,
+                        _TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY: f"{arrow.utcnow()}",
+                        **log_error_context,
+                    },
+                )
+            ],
+        )
+        return None
+
     @staticmethod
     async def _handle_task_error(
         task: CompTaskAtDB,
@@ -621,6 +709,25 @@ class DaskScheduler(BaseCompScheduler):
                 ) = await self._handle_computational_backend_not_connected_error(
                     task.current, result, log_error_context
                 )
+            elif isinstance(result, ComputationalBackendTaskNotFoundError):
+                outcome = await self._handle_task_not_found_error(task.current, result, log_error_context, comp_run)
+                if outcome is None:
+                    # the task was reset for resubmission, nothing else to update
+                    return False, None
+                (
+                    task_final_state,
+                    simcore_platform_status,
+                    task_errors,
+                    task_completed,
+                ) = outcome
+                if task_completed:
+                    # resubmissions exhausted: clean up any invalid output files, as for other failures
+                    await clean_task_output_and_log_files_if_invalid(
+                        self.db_engine,
+                        comp_run.user_id,
+                        comp_run.project_uuid,
+                        task.current.node_id,
+                    )
             else:
                 (
                     task_final_state,

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -579,7 +579,9 @@ class DaskScheduler(BaseCompScheduler):
                     "Please contact support if the problem persists.",
                 )
             )
-            return await self._handle_task_error(task, result, log_error_context)
+            task_state, _, task_errors, task_completed = await self._handle_task_error(task, result, log_error_context)
+            # NOTE: this is a platform failure (backend lost the task), not the user's fault, so no billing
+            return task_state, SimcorePlatformStatus.BAD, task_errors, task_completed
 
         # NOTE: exponential backoff, so we do not hammer a computational backend that is still recovering
         backoff_delay = min(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -566,7 +566,7 @@ class DaskScheduler(BaseCompScheduler):
                 last_attempt = arrow.get(error["ctx"][_TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY])
                 break
 
-        if resubmissions >= self.settings.COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS:
+        if resubmissions >= self.settings.COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES:
             _logger.error(
                 **create_troubleshooting_log_kwargs(
                     f"Task {task.job_id} is unknown to the computational backend "

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -605,7 +605,8 @@ class DaskScheduler(BaseCompScheduler):
 
         _logger.warning(
             **create_troubleshooting_log_kwargs(
-                f"Task {task.job_id} is unknown to the computational backend, resubmitting it",
+                f"Task {task.job_id} is unknown to the computational backend, "
+                f"resubmitting it for the {resubmissions + 1} time",
                 error=result,
                 error_context=log_error_context,
                 tip="The dask-scheduler forgets all tasks when it crashes or is restarted. "

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -1,4 +1,5 @@
 import contextlib
+import datetime
 import logging
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
@@ -75,6 +76,8 @@ _TASK_RETRIEVAL_ERROR_CONTEXT_TIME_KEY: Final[str] = "check_time"
 _TASK_NOT_FOUND_ERROR_TYPE: Final[str] = "task-not-found-in-computational-backend"
 _TASK_NOT_FOUND_ERROR_CONTEXT_RESUBMISSIONS_KEY: Final[str] = "resubmissions"
 _TASK_NOT_FOUND_ERROR_CONTEXT_TIME_KEY: Final[str] = "last_attempt"
+_TASK_NOT_FOUND_RESUBMISSION_INITIAL_DELAY: Final[datetime.timedelta] = datetime.timedelta(seconds=10)
+_TASK_NOT_FOUND_RESUBMISSION_MAX_DELAY: Final[datetime.timedelta] = datetime.timedelta(minutes=2)
 _PUBLICATION_CONCURRENCY_LIMIT: Final[int] = 10
 
 
@@ -578,8 +581,8 @@ class DaskScheduler(BaseCompScheduler):
 
         # NOTE: exponential backoff, so we do not hammer a computational backend that is still recovering
         backoff_delay = min(
-            self.settings.COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_INITIAL_DELAY * (2**resubmissions),
-            self.settings.COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_MAX_DELAY,
+            _TASK_NOT_FOUND_RESUBMISSION_INITIAL_DELAY * (2**resubmissions),
+            _TASK_NOT_FOUND_RESUBMISSION_MAX_DELAY,
         )
         if (arrow.utcnow() - last_attempt) < backoff_delay:
             return (
@@ -605,8 +608,8 @@ class DaskScheduler(BaseCompScheduler):
                 f"Task {task.job_id} is unknown to the computational backend, resubmitting it",
                 error=result,
                 error_context=log_error_context,
-                tip="This happens when the connection to the dask-scheduler was lost before "
-                "the task was durably published. The task is automatically resubmitted.",
+                tip="The dask-scheduler forgets all tasks when it crashes or is restarted. "
+                "The task is automatically resubmitted.",
             )
         )
         await CompTasksRepository(self.db_engine).reset_task_for_resubmission(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -553,8 +553,9 @@ class DaskScheduler(BaseCompScheduler):
         result: ComputationalBackendTaskNotFoundError,
         log_error_context: dict[str, Any],
         comp_run: CompRunsAtDB,
-    ) -> tuple[RunningState, SimcorePlatformStatus, list[ErrorDict], bool] | None:
-        """Returns None if resubmitted, otherwise the outcome tuple (waiting or exhausted)."""
+    ) -> tuple[RunningState, SimcorePlatformStatus, list[ErrorDict], bool]:
+        """Returns the outcome tuple: WAITING_FOR_CLUSTER if resubmitted, STARTED if still waiting
+        for the backoff delay to elapse, or the exhausted (failed) outcome."""
         resubmissions = 0
         last_attempt = arrow.utcnow()
         for error in task.errors or []:
@@ -630,7 +631,12 @@ class DaskScheduler(BaseCompScheduler):
                 )
             ],
         )
-        return None
+        return (
+            RunningState.WAITING_FOR_CLUSTER,
+            SimcorePlatformStatus.BAD,
+            [],
+            False,
+        )
 
     @staticmethod
     async def _handle_task_error(
@@ -714,16 +720,15 @@ class DaskScheduler(BaseCompScheduler):
                     task.current, result, log_error_context
                 )
             elif isinstance(result, ComputationalBackendTaskNotFoundError):
-                outcome = await self._handle_task_not_found_error(task.current, result, log_error_context, comp_run)
-                if outcome is None:
-                    # the task was reset for resubmission, nothing else to update
-                    return False, None
                 (
                     task_final_state,
                     simcore_platform_status,
                     task_errors,
                     task_completed,
-                ) = outcome
+                ) = await self._handle_task_not_found_error(task.current, result, log_error_context, comp_run)
+                if task_final_state is RunningState.WAITING_FOR_CLUSTER:
+                    # already persisted via reset_task_for_resubmission (job_id cleared), nothing else to update
+                    return False, None
                 if task_completed:
                     # resubmissions exhausted: clean up any invalid output files, as for other failures
                     await clean_task_output_and_log_files_if_invalid(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -174,6 +174,7 @@ class DaskScheduler(BaseCompScheduler):
                 comp_run.run_id,
                 list(scheduled_tasks.keys()),
                 RunningState.PENDING,
+                clear_errors=False,
             )
             # each task is started independently
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -264,6 +264,7 @@ class CompTasksRepository(BaseRepository):
         state: RunningState,
         errors: list[ErrorDict] | None = None,
         *,
+        clear_errors: bool = True,
         optional_progress: float | None = None,
         optional_started: datetime | None = None,
         optional_stopped: datetime | None = None,
@@ -272,16 +273,17 @@ class CompTasksRepository(BaseRepository):
         passing None for the optional arguments will not update the respective values in the database
         Keyword Arguments:
             errors -- _description_ (default: {None})
+            clear_errors -- if False and errors is None, the errors column is left untouched
+                instead of being cleared (default: {True})
             optional_progress -- _description_ (default: {None})
             optional_started -- _description_ (default: {None})
             optional_stopped -- _description_ (default: {None})
         """
         if not tasks:
             return
-        update_values: dict[str, Any] = {
-            "state": RUNNING_STATE_TO_DB[state],
-            "errors": errors,
-        }
+        update_values: dict[str, Any] = {"state": RUNNING_STATE_TO_DB[state]}
+        if clear_errors or errors is not None:
+            update_values["errors"] = errors
         if optional_progress is not None:
             update_values["progress"] = optional_progress
         if optional_started is not None:

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -240,7 +240,7 @@ class CompTasksRepository(BaseRepository):
         self,
         project_id: ProjectID,
         task: NodeID,
-        run_id: PositiveInt,
+        run_id: RunID,
         errors: list[ErrorDict] | None = None,
     ) -> None:
         """clears the backend job reference so the scheduler picks the task up again"""

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -236,6 +236,26 @@ class CompTasksRepository(BaseRepository):
     async def update_project_task_job_id(self, project_id: ProjectID, task: NodeID, run_id: RunID, job_id: str) -> None:
         await self._update_task(project_id, task, run_id, job_id=job_id)
 
+    async def reset_task_for_resubmission(
+        self,
+        project_id: ProjectID,
+        task: NodeID,
+        run_id: PositiveInt,
+        errors: list[ErrorDict] | None = None,
+    ) -> None:
+        """clears the backend job reference so the scheduler picks the task up again"""
+        await self._update_task(
+            project_id,
+            task,
+            run_id,
+            state=RUNNING_STATE_TO_DB[RunningState.WAITING_FOR_CLUSTER],
+            job_id=None,
+            progress=None,
+            start=None,
+            end=None,
+            errors=errors,
+        )
+
     async def update_project_tasks_state(
         self,
         project_id: ProjectID,

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -49,6 +49,7 @@ from models_library.rabbitmq_messages import (
     RabbitResourceTrackingMessages,
     RabbitResourceTrackingStartedMessage,
     RabbitResourceTrackingStoppedMessage,
+    SimcorePlatformStatus,
 )
 from models_library.users import UserID
 from pydantic import TypeAdapter
@@ -1486,6 +1487,14 @@ def with_disabled_unknown_max_time(mocker: MockerFixture) -> None:
     )
 
 
+@pytest.fixture
+def with_disabled_task_resubmission(scheduler_api: BaseCompScheduler) -> None:
+    # disables resubmission backoff so apply() goes straight to the FAILED branch (settings are frozen, so we copy)
+    scheduler_api.settings = scheduler_api.settings.model_copy(
+        update={"COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS": 0}
+    )
+
+
 @dataclass(frozen=True, kw_only=True)
 class RebootState:
     dask_task_status: RunningState
@@ -1572,6 +1581,7 @@ async def test_handling_scheduled_tasks_after_director_reboots(
     with_disabled_auto_scheduling: mock.Mock,
     with_disabled_scheduler_publisher: mock.Mock,
     with_disabled_unknown_max_time: None,
+    with_disabled_task_resubmission: None,
     mocked_dask_client: mock.MagicMock,
     sqlalchemy_async_engine: AsyncEngine,
     running_project: RunningProject,
@@ -1663,6 +1673,79 @@ async def test_handling_scheduled_tasks_after_director_reboots(
         reboot_state.expected_pipeline_state_notification,
         ComputationalPipelineStatusMessage.model_validate_json,
     )
+
+
+async def test_handle_task_not_found_error_resubmission_and_backoff(
+    sqlalchemy_async_engine: AsyncEngine,
+    running_project: RunningProject,
+    scheduler_api: BaseCompScheduler,
+    mocker: MockerFixture,
+):
+    """Verifies the backoff delay before resubmitting a lost task, and eventual failure after max resubmissions."""
+    settings = scheduler_api.settings
+    task = running_project.tasks[1]
+    comp_run = running_project.runs
+    result = ComputationalBackendTaskNotFoundError(job_id=task.job_id)
+
+    # control time deterministically instead of really sleeping through the backoff delays
+    fake_now = {"value": arrow.utcnow()}
+    mocker.patch(
+        "simcore_service_director_v2.modules.comp_scheduler._scheduler_dask.arrow.utcnow",
+        side_effect=lambda: fake_now["value"],
+    )
+
+    async def _handle_task_not_found(
+        task: CompTaskAtDB,
+    ) -> tuple[RunningState, SimcorePlatformStatus, list[ErrorDict], bool] | None:
+        return await cast(DaskScheduler, scheduler_api)._handle_task_not_found_error(  # noqa: SLF001
+            task, result, {}, comp_run
+        )
+
+    # 1st occurrence ever: too early to tell if this is transient, must NOT resubmit yet
+    outcome = await _handle_task_not_found(task)
+    assert outcome is not None
+    task_state, _platform_status, errors, completed = outcome
+    assert task_state is RunningState.STARTED
+    assert completed is False
+    assert errors[0]["ctx"]["resubmissions"] == 0
+    task = task.model_copy(update={"errors": errors})
+
+    for expected_resubmissions in range(1, settings.COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS + 1):
+        # advance time past the (exponentially growing) backoff delay for this attempt
+        backoff_delay = min(
+            settings.COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_INITIAL_DELAY * (2 ** (expected_resubmissions - 1)),
+            settings.COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_MAX_DELAY,
+        )
+        fake_now["value"] = fake_now["value"].shift(seconds=backoff_delay.total_seconds() + 1)
+
+        # backoff elapsed: the task must now actually be resubmitted
+        outcome = await _handle_task_not_found(task)
+        assert outcome is None, "task should have been reset for resubmission"
+        persisted_tasks, _ = await assert_comp_tasks_and_comp_run_snapshot_tasks(
+            sqlalchemy_async_engine,
+            project_uuid=running_project.project.uuid,
+            task_ids=[task.node_id],
+            expected_state=RunningState.WAITING_FOR_CLUSTER,
+            expected_processing_state_has_job_id=False,
+            expected_progress=None,
+            run_id=comp_run.run_id,
+        )
+        task = persisted_tasks[0]
+        assert task.errors is not None
+        assert task.errors[0]["ctx"]["resubmissions"] == expected_resubmissions
+
+        # right after resubmitting: waits again, or fails for good once resubmissions are exhausted
+        outcome = await _handle_task_not_found(task)
+        assert outcome is not None
+        task_state, _platform_status, errors, completed = outcome
+        if expected_resubmissions < settings.COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS:
+            assert task_state is RunningState.STARTED
+            assert completed is False
+            assert errors[0]["ctx"]["resubmissions"] == expected_resubmissions
+            task = task.model_copy(update={"errors": errors})
+        else:
+            assert task_state is RunningState.FAILED
+            assert completed is True
 
 
 async def test_handling_cancellation_of_jobs_after_reboot(

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -27,10 +27,7 @@ from _helpers import (
     assert_comp_runs_empty,
     assert_comp_tasks_and_comp_run_snapshot_tasks,
 )
-from dask_task_models_library.container_tasks.errors import (
-    ServiceRuntimeError,
-    TaskCancelledError,
-)
+from dask_task_models_library.container_tasks.errors import ServiceRuntimeError, TaskCancelledError
 from dask_task_models_library.container_tasks.events import TaskProgressEvent
 from dask_task_models_library.container_tasks.io import TaskOutputData
 from dask_task_models_library.container_tasks.protocol import TaskOwner
@@ -73,31 +70,17 @@ from simcore_service_director_v2.core.errors import (
 from simcore_service_director_v2.models.comp_pipelines import CompPipelineAtDB
 from simcore_service_director_v2.models.comp_runs import CompRunsAtDB, RunMetadataDict
 from simcore_service_director_v2.models.comp_tasks import CompTaskAtDB, Image
-from simcore_service_director_v2.modules.comp_scheduler._manager import (
-    run_new_pipeline,
-    stop_pipeline,
-)
-from simcore_service_director_v2.modules.comp_scheduler._models import (
-    ReleaseTaskResultRabbitMessage,
-)
-from simcore_service_director_v2.modules.comp_scheduler._scheduler_base import (
-    BaseCompScheduler,
-)
+from simcore_service_director_v2.modules.comp_scheduler._manager import run_new_pipeline, stop_pipeline
+from simcore_service_director_v2.modules.comp_scheduler._models import ReleaseTaskResultRabbitMessage
+from simcore_service_director_v2.modules.comp_scheduler._scheduler_base import BaseCompScheduler
 from simcore_service_director_v2.modules.comp_scheduler._scheduler_dask import (
-    _TASK_NOT_FOUND_RESUBMISSION_INITIAL_DELAY,
-    _TASK_NOT_FOUND_RESUBMISSION_MAX_DELAY,
     _TASK_RETRIEVAL_ERROR_CONTEXT_TIME_KEY,
     _TASK_RETRIEVAL_ERROR_TYPE,
     DaskScheduler,
 )
 from simcore_service_director_v2.modules.comp_scheduler._utils import COMPLETED_STATES
-from simcore_service_director_v2.modules.comp_scheduler._worker import (
-    _get_scheduler_worker,
-)
-from simcore_service_director_v2.modules.dask_client import (
-    DaskJobID,
-    PublishedComputationTask,
-)
+from simcore_service_director_v2.modules.comp_scheduler._worker import _get_scheduler_worker
+from simcore_service_director_v2.modules.dask_client import DaskJobID, PublishedComputationTask
 from simcore_service_director_v2.modules.osparc_variables._errors import (
     OsparcVariableResolveError,
     OsparcVariableResolveTimeoutError,
@@ -1491,7 +1474,7 @@ def with_disabled_unknown_max_time(mocker: MockerFixture) -> None:
 
 @pytest.fixture
 def with_disabled_task_resubmission(scheduler_api: BaseCompScheduler) -> None:
-    # disables resubmission backoff so apply() goes straight to the FAILED branch (settings are frozen, so we copy)
+    # disables resubmission so apply() goes straight to the FAILED branch (settings are frozen, so we copy)
     scheduler_api.settings = scheduler_api.settings.model_copy(update={"COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES": 0})
 
 
@@ -1675,24 +1658,16 @@ async def test_handling_scheduled_tasks_after_director_reboots(
     )
 
 
-async def test_handle_task_not_found_error_resubmission_and_backoff(
+async def test_handle_task_not_found_error_resubmission_and_max_retries(
     sqlalchemy_async_engine: AsyncEngine,
     running_project: RunningProject,
     scheduler_api: BaseCompScheduler,
-    mocker: MockerFixture,
 ):
-    """Verifies the backoff delay before resubmitting a lost task, and eventual failure after max resubmissions."""
+    """Verifies immediate resubmission of a lost task, and eventual failure once max retries are exhausted."""
     settings = scheduler_api.settings
     task = running_project.tasks[1]
     comp_run = running_project.runs
     result = ComputationalBackendTaskNotFoundError(job_id=task.job_id)
-
-    # control time deterministically instead of really sleeping through the backoff delays
-    fake_now = {"value": arrow.utcnow()}
-    mocker.patch(
-        "simcore_service_director_v2.modules.comp_scheduler._scheduler_dask.arrow.utcnow",
-        side_effect=lambda: fake_now["value"],
-    )
 
     async def _handle_task_not_found(
         task: CompTaskAtDB,
@@ -1701,22 +1676,7 @@ async def test_handle_task_not_found_error_resubmission_and_backoff(
             task, result, {}, comp_run
         )
 
-    # 1st occurrence ever: too early to tell if this is transient, must NOT resubmit yet
-    task_state, _platform_status, errors, completed = await _handle_task_not_found(task)
-    assert task_state is RunningState.STARTED
-    assert completed is False
-    assert errors[0]["ctx"]["resubmissions"] == 0
-    task = task.model_copy(update={"errors": errors})
-
     for expected_resubmissions in range(1, settings.COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES + 1):
-        # advance time past the (exponentially growing) backoff delay for this attempt
-        backoff_delay = min(
-            _TASK_NOT_FOUND_RESUBMISSION_INITIAL_DELAY * (2 ** (expected_resubmissions - 1)),
-            _TASK_NOT_FOUND_RESUBMISSION_MAX_DELAY,
-        )
-        fake_now["value"] = fake_now["value"].shift(seconds=backoff_delay.total_seconds() + 1)
-
-        # backoff elapsed: the task must now actually be resubmitted
         task_state, _platform_status, _errors, completed = await _handle_task_not_found(task)
         assert task_state is RunningState.WAITING_FOR_CLUSTER, "task should have been reset for resubmission"
         assert completed is False
@@ -1733,16 +1693,10 @@ async def test_handle_task_not_found_error_resubmission_and_backoff(
         assert task.errors is not None
         assert task.errors[0]["ctx"]["resubmissions"] == expected_resubmissions
 
-        # right after resubmitting: waits again, or fails for good once resubmissions are exhausted
-        task_state, _platform_status, errors, completed = await _handle_task_not_found(task)
-        if expected_resubmissions < settings.COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES:
-            assert task_state is RunningState.STARTED
-            assert completed is False
-            assert errors[0]["ctx"]["resubmissions"] == expected_resubmissions
-            task = task.model_copy(update={"errors": errors})
-        else:
-            assert task_state is RunningState.FAILED
-            assert completed is True
+    # retries exhausted: the task must now fail for good
+    task_state, _platform_status, _errors, completed = await _handle_task_not_found(task)
+    assert task_state is RunningState.FAILED
+    assert completed is True
 
 
 async def test_handling_cancellation_of_jobs_after_reboot(

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -84,6 +84,8 @@ from simcore_service_director_v2.modules.comp_scheduler._scheduler_base import (
     BaseCompScheduler,
 )
 from simcore_service_director_v2.modules.comp_scheduler._scheduler_dask import (
+    _TASK_NOT_FOUND_RESUBMISSION_INITIAL_DELAY,
+    _TASK_NOT_FOUND_RESUBMISSION_MAX_DELAY,
     _TASK_RETRIEVAL_ERROR_CONTEXT_TIME_KEY,
     _TASK_RETRIEVAL_ERROR_TYPE,
     DaskScheduler,
@@ -1713,8 +1715,8 @@ async def test_handle_task_not_found_error_resubmission_and_backoff(
     for expected_resubmissions in range(1, settings.COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS + 1):
         # advance time past the (exponentially growing) backoff delay for this attempt
         backoff_delay = min(
-            settings.COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_INITIAL_DELAY * (2 ** (expected_resubmissions - 1)),
-            settings.COMPUTATIONAL_BACKEND_TASK_RESUBMISSION_MAX_DELAY,
+            _TASK_NOT_FOUND_RESUBMISSION_INITIAL_DELAY * (2 ** (expected_resubmissions - 1)),
+            _TASK_NOT_FOUND_RESUBMISSION_MAX_DELAY,
         )
         fake_now["value"] = fake_now["value"].shift(seconds=backoff_delay.total_seconds() + 1)
 

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -1492,9 +1492,7 @@ def with_disabled_unknown_max_time(mocker: MockerFixture) -> None:
 @pytest.fixture
 def with_disabled_task_resubmission(scheduler_api: BaseCompScheduler) -> None:
     # disables resubmission backoff so apply() goes straight to the FAILED branch (settings are frozen, so we copy)
-    scheduler_api.settings = scheduler_api.settings.model_copy(
-        update={"COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS": 0}
-    )
+    scheduler_api.settings = scheduler_api.settings.model_copy(update={"COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES": 0})
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -1712,7 +1710,7 @@ async def test_handle_task_not_found_error_resubmission_and_backoff(
     assert errors[0]["ctx"]["resubmissions"] == 0
     task = task.model_copy(update={"errors": errors})
 
-    for expected_resubmissions in range(1, settings.COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS + 1):
+    for expected_resubmissions in range(1, settings.COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES + 1):
         # advance time past the (exponentially growing) backoff delay for this attempt
         backoff_delay = min(
             _TASK_NOT_FOUND_RESUBMISSION_INITIAL_DELAY * (2 ** (expected_resubmissions - 1)),
@@ -1740,7 +1738,7 @@ async def test_handle_task_not_found_error_resubmission_and_backoff(
         outcome = await _handle_task_not_found(task)
         assert outcome is not None
         task_state, _platform_status, errors, completed = outcome
-        if expected_resubmissions < settings.COMPUTATIONAL_BACKEND_MAX_TASK_RESUBMISSIONS:
+        if expected_resubmissions < settings.COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES:
             assert task_state is RunningState.STARTED
             assert completed is False
             assert errors[0]["ctx"]["resubmissions"] == expected_resubmissions

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -1696,15 +1696,13 @@ async def test_handle_task_not_found_error_resubmission_and_backoff(
 
     async def _handle_task_not_found(
         task: CompTaskAtDB,
-    ) -> tuple[RunningState, SimcorePlatformStatus, list[ErrorDict], bool] | None:
+    ) -> tuple[RunningState, SimcorePlatformStatus, list[ErrorDict], bool]:
         return await cast(DaskScheduler, scheduler_api)._handle_task_not_found_error(  # noqa: SLF001
             task, result, {}, comp_run
         )
 
     # 1st occurrence ever: too early to tell if this is transient, must NOT resubmit yet
-    outcome = await _handle_task_not_found(task)
-    assert outcome is not None
-    task_state, _platform_status, errors, completed = outcome
+    task_state, _platform_status, errors, completed = await _handle_task_not_found(task)
     assert task_state is RunningState.STARTED
     assert completed is False
     assert errors[0]["ctx"]["resubmissions"] == 0
@@ -1719,8 +1717,9 @@ async def test_handle_task_not_found_error_resubmission_and_backoff(
         fake_now["value"] = fake_now["value"].shift(seconds=backoff_delay.total_seconds() + 1)
 
         # backoff elapsed: the task must now actually be resubmitted
-        outcome = await _handle_task_not_found(task)
-        assert outcome is None, "task should have been reset for resubmission"
+        task_state, _platform_status, _errors, completed = await _handle_task_not_found(task)
+        assert task_state is RunningState.WAITING_FOR_CLUSTER, "task should have been reset for resubmission"
+        assert completed is False
         persisted_tasks, _ = await assert_comp_tasks_and_comp_run_snapshot_tasks(
             sqlalchemy_async_engine,
             project_uuid=running_project.project.uuid,
@@ -1735,9 +1734,7 @@ async def test_handle_task_not_found_error_resubmission_and_backoff(
         assert task.errors[0]["ctx"]["resubmissions"] == expected_resubmissions
 
         # right after resubmitting: waits again, or fails for good once resubmissions are exhausted
-        outcome = await _handle_task_not_found(task)
-        assert outcome is not None
-        task_state, _platform_status, errors, completed = outcome
+        task_state, _platform_status, errors, completed = await _handle_task_not_found(task)
         if expected_resubmissions < settings.COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES:
             assert task_state is RunningState.STARTED
             assert completed is False


### PR DESCRIPTION
## What do these changes do?

Dask-scheduler restarts (or lost connections before a task is durably published) can make the
computational backend "forget" an in-flight task. Previously this was treated as a permanent
failure. 

This PR detects `ComputationalBackendTaskNotFoundError` and resubmits the task instead up to `COMPUTATIONAL_BACKEND_MAX_TASK_RETRIES` (default 2) attempts
before giving up and marking it FAILED.

## How to test

Added `test_handle_task_not_found_error_resubmission`
resubmission, and eventual failure after max retries.

## Dev-ops

N/A
