### PR TITLE
♻️ refactor(celery-library): replace task polling with event

### DIFF
--- a/packages/celery-library/src/celery_library/task.py
+++ b/packages/celery-library/src/celery_library/task.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import logging
 from collections.abc import Callable, Coroutine
+from contextlib import suppress
 from datetime import timedelta
 from functools import wraps
 from typing import Any, Concatenate, Final, ParamSpec, TypeVar, overload
@@ -53,16 +54,22 @@ def _async_task_wrapper(
                         async_io_task = tg.create_task(
                             coro(task, *args, **kwargs),
                         )
+                        task_completed = asyncio.Event()
+                        async_io_task.add_done_callback(lambda _: task_completed.set())
 
-                        async def _abort_monitor():
-                            while not async_io_task.done():
+                        async def _abort_monitor() -> None:
+                            while not task_completed.is_set():
                                 if not await app_server.task_manager.task_or_group_exists(task_key):
                                     await cancel_wait_task(
                                         async_io_task,
                                         max_delay=_DEFAULT_CANCEL_TASK_TIMEOUT.total_seconds(),
                                     )
                                     raise TaskAbortedError
-                                await asyncio.sleep(_DEFAULT_ABORT_TASK_TIMEOUT.total_seconds())
+                                with suppress(TimeoutError):
+                                    await asyncio.wait_for(
+                                        task_completed.wait(),
+                                        timeout=_DEFAULT_ABORT_TASK_TIMEOUT.total_seconds(),
+                                    )
 
                         tg.create_task(_abort_monitor())
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request makes improvements to the task cancellation and monitoring logic in the Celery library, specifically in the `_run_task` function. The main change is to use an `asyncio.Event` to efficiently track task completion, replacing a polling approach and improving resource usage.

## Related issue/s
- SonarQube https://sonarcloud.io/project/issues?open=AZk9FRUzaIsz3rzM2w56&id=ITISFoundation_osparc-simcore

## How to test
```sh
cd packages/celery-library
make install-dev && make test-dev
```

## Dev-ops
- No change.