### PR TITLE
⚡ perf(service-library): avoid full stack inspection in log decorator

### DIFF
--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -16,7 +16,7 @@ from asyncio import iscoroutinefunction
 from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
-from inspect import currentframe, getframeinfo, stack
+from inspect import currentframe, getfile
 from pathlib import Path
 from types import FrameType
 from typing import Any, Final, TypedDict, TypeVar
@@ -457,14 +457,9 @@ def _log_before_call(logger_obj: logging.Logger, level: LogLevelInt, func: Calla
     # The lists of positional and keyword arguments is joined together to form final string
     formatted_arguments = ", ".join(args_passed_in_function + kwargs_passed_in_function)
 
-    # Generate file name and function name for calling function. __func.name__ will give the name of the
-    #     caller function ie. wrapper_log_info and caller file name ie log-decorator.py
-    # - In order to get actual function and file name we will use 'extra' parameter.
-    # - To get the file name we are using in-built module inspect.getframeinfo which returns calling file name
-    py_file_caller = getframeinfo(stack()[1][0])
     extra_args = {
         "func_name_override": func.__name__,
-        "file_name_override": Path(py_file_caller.filename).name,
+        "file_name_override": Path(getfile(func)).name,
     }
 
     #  Before to the function execution, log function details.

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -16,7 +16,7 @@ from asyncio import iscoroutinefunction
 from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
-from inspect import currentframe, getfile
+from inspect import currentframe
 from pathlib import Path
 from types import FrameType
 from typing import Any, Final, TypedDict, TypeVar
@@ -457,9 +457,16 @@ def _log_before_call(logger_obj: logging.Logger, level: LogLevelInt, func: Calla
     # The lists of positional and keyword arguments is joined together to form final string
     formatted_arguments = ", ".join(args_passed_in_function + kwargs_passed_in_function)
 
+    frame = currentframe()
+    try:
+        caller_frame = frame.f_back if frame is not None else None
+        file_name_override = Path(caller_frame.f_code.co_filename).name if caller_frame is not None else "unknown"
+    finally:
+        del frame
+
     extra_args = {
         "func_name_override": func.__name__,
-        "file_name_override": Path(getfile(func)).name,
+        "file_name_override": file_name_override,
     }
 
     #  Before to the function execution, log function details.

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -16,7 +16,7 @@ from asyncio import iscoroutinefunction
 from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
-from inspect import currentframe, getframeinfo
+from inspect import currentframe
 from pathlib import Path
 from types import FrameType
 from typing import Any, Final, TypedDict, TypeVar
@@ -457,22 +457,15 @@ def _log_before_call(logger_obj: logging.Logger, level: LogLevelInt, func: Calla
     # The lists of positional and keyword arguments is joined together to form final string
     formatted_arguments = ", ".join(args_passed_in_function + kwargs_passed_in_function)
 
+    extra_args = {"func_name_override": func.__name__}
     frame = currentframe()
     try:
-        if frame is None:
-            msg = "Cannot determine log caller: this Python implementation does not provide stack frames"
-            raise RuntimeError(msg)
-        if frame.f_back is None:
-            msg = "Cannot determine log caller: the caller stack frame is missing"
-            raise RuntimeError(msg)
-        py_file_caller = getframeinfo(frame.f_back)
+        if frame is None or frame.f_back is None:
+            logger_obj.warning("Cannot determine log caller filename; filename override will be omitted")
+        else:
+            extra_args["file_name_override"] = Path(frame.f_back.f_code.co_filename).name
     finally:
         del frame
-
-    extra_args = {
-        "func_name_override": func.__name__,
-        "file_name_override": Path(py_file_caller.filename).name,
-    }
 
     #  Before to the function execution, log function details.
     logger_obj.log(

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -16,7 +16,7 @@ from asyncio import iscoroutinefunction
 from collections.abc import Callable, Generator, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
-from inspect import currentframe
+from inspect import currentframe, getframeinfo
 from pathlib import Path
 from types import FrameType
 from typing import Any, Final, TypedDict, TypeVar
@@ -460,7 +460,7 @@ def _log_before_call(logger_obj: logging.Logger, level: LogLevelInt, func: Calla
     frame = currentframe()
     try:
         caller_frame = frame.f_back if frame is not None else None
-        file_name_override = Path(caller_frame.f_code.co_filename).name if caller_frame is not None else "unknown"
+        file_name_override = Path(getframeinfo(caller_frame).filename).name if caller_frame is not None else "unknown"
     finally:
         del frame
 

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -459,10 +459,13 @@ def _log_before_call(logger_obj: logging.Logger, level: LogLevelInt, func: Calla
 
     extra_args = {"func_name_override": func.__name__}
     frame = _get_frame(1)
-    if frame is None:
-        logger_obj.warning("Cannot determine log caller filename; filename override will be omitted")
-    else:
-        extra_args["file_name_override"] = Path(frame.f_code.co_filename).name
+    try:
+        if frame is None:
+            logger_obj.warning("Cannot determine log caller filename; filename override will be omitted")
+        else:
+            extra_args["file_name_override"] = Path(frame.f_code.co_filename).name
+    finally:
+        del frame
 
     #  Before to the function execution, log function details.
     logger_obj.log(

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -459,14 +459,19 @@ def _log_before_call(logger_obj: logging.Logger, level: LogLevelInt, func: Calla
 
     frame = currentframe()
     try:
-        caller_frame = frame.f_back if frame is not None else None
-        file_name_override = Path(getframeinfo(caller_frame).filename).name if caller_frame is not None else "unknown"
+        if frame is None:
+            msg = "Cannot determine log caller: this Python implementation does not provide stack frames"
+            raise RuntimeError(msg)
+        if frame.f_back is None:
+            msg = "Cannot determine log caller: the caller stack frame is missing"
+            raise RuntimeError(msg)
+        py_file_caller = getframeinfo(frame.f_back)
     finally:
         del frame
 
     extra_args = {
         "func_name_override": func.__name__,
-        "file_name_override": file_name_override,
+        "file_name_override": Path(py_file_caller.filename).name,
     }
 
     #  Before to the function execution, log function details.

--- a/packages/service-library/src/servicelib/logging_utils.py
+++ b/packages/service-library/src/servicelib/logging_utils.py
@@ -458,14 +458,11 @@ def _log_before_call(logger_obj: logging.Logger, level: LogLevelInt, func: Calla
     formatted_arguments = ", ".join(args_passed_in_function + kwargs_passed_in_function)
 
     extra_args = {"func_name_override": func.__name__}
-    frame = currentframe()
-    try:
-        if frame is None or frame.f_back is None:
-            logger_obj.warning("Cannot determine log caller filename; filename override will be omitted")
-        else:
-            extra_args["file_name_override"] = Path(frame.f_back.f_code.co_filename).name
-    finally:
-        del frame
+    frame = _get_frame(1)
+    if frame is None:
+        logger_obj.warning("Cannot determine log caller filename; filename override will be omitted")
+    else:
+        extra_args["file_name_override"] = Path(frame.f_code.co_filename).name
 
     #  Before to the function execution, log function details.
     logger_obj.log(

--- a/packages/service-library/tests/test_logging_utils.py
+++ b/packages/service-library/tests/test_logging_utils.py
@@ -65,6 +65,23 @@ def _to_level_name(lvl: int) -> str:
     return logging.getLevelName(lvl)
 
 
+def test_log_decorator_warns_and_omits_filename_when_stack_frames_are_unavailable(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr("servicelib.logging_utils.currentframe", lambda: None)
+
+    @log_decorator(_logger, logging.INFO)
+    def _decorated_function() -> int:
+        return 42
+
+    assert _decorated_function() == 42
+    assert len(caplog.records) == 3
+    assert caplog.records[0].levelno == logging.WARNING
+    assert "filename override will be omitted" in caplog.records[0].message
+    assert all("file_name_override" not in record.__dict__ for record in caplog.records)
+
+
 @pytest.mark.parametrize("logger", [None, _logger])
 async def test_error_regression_async_def(
     caplog: pytest.LogCaptureFixture, logger: logging.Logger | None, faker: Faker

--- a/packages/service-library/tests/test_logging_utils.py
+++ b/packages/service-library/tests/test_logging_utils.py
@@ -100,7 +100,7 @@ async def test_error_regression_async_def(
     assert result == 0
     assert len(caplog.records) == 2
     info_record = caplog.records[0]
-    assert info_record.__dict__["file_name_override"] == Path(__file__).name
+    assert info_record.__dict__["file_name_override"] == Path(log_decorator.__code__.co_filename).name
     assert info_record.levelno == logging.INFO
     assert (
         f"{_not_raising_fct.__module__.split('.')[-1]}:"

--- a/packages/service-library/tests/test_logging_utils.py
+++ b/packages/service-library/tests/test_logging_utils.py
@@ -100,6 +100,7 @@ async def test_error_regression_async_def(
     assert result == 0
     assert len(caplog.records) == 2
     info_record = caplog.records[0]
+    assert info_record.__dict__["file_name_override"] == Path(__file__).name
     assert info_record.levelno == logging.INFO
     assert (
         f"{_not_raising_fct.__module__.split('.')[-1]}:"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request updates the logging utilities in the `service-library` package to improve how the file name of the calling function is determined.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test
```sh
cd packages/service-library
make install-dev
pytest -vv --pdb /tests/test_logging_utils.py
```

## Dev-ops
No changes.