### PR TITLE
:zap: 🗃️ perf(postgres): index computation snapshot task updates

### DIFF
--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/3f8c0e8d11a4_index_computation_snapshot_task_updates.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/3f8c0e8d11a4_index_computation_snapshot_task_updates.py
@@ -15,7 +15,7 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade():
+def upgrade() -> None:
     op.create_index(
         "ix_comp_run_snapshot_tasks_run_id_node_id", "comp_run_snapshot_tasks", ["run_id", "node_id"], unique=False
     )

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/3f8c0e8d11a4_index_computation_snapshot_task_updates.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/3f8c0e8d11a4_index_computation_snapshot_task_updates.py
@@ -15,7 +15,7 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade() -> None:
+def upgrade():
     op.create_index(
         "ix_comp_run_snapshot_tasks_run_id_node_id", "comp_run_snapshot_tasks", ["run_id", "node_id"], unique=False
     )

--- a/packages/postgres-database/src/simcore_postgres_database/migration/versions/3f8c0e8d11a4_index_computation_snapshot_task_updates.py
+++ b/packages/postgres-database/src/simcore_postgres_database/migration/versions/3f8c0e8d11a4_index_computation_snapshot_task_updates.py
@@ -1,0 +1,25 @@
+"""index computation snapshot task updates
+
+Revision ID: 3f8c0e8d11a4
+Revises: 0e7558d0499c
+Create Date: 2026-08-14 09:26:52.256875+00:00
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3f8c0e8d11a4"
+down_revision = "0e7558d0499c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "ix_comp_run_snapshot_tasks_run_id_node_id", "comp_run_snapshot_tasks", ["run_id", "node_id"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index("ix_comp_run_snapshot_tasks_run_id_node_id", table_name="comp_run_snapshot_tasks")

--- a/packages/postgres-database/src/simcore_postgres_database/models/comp_run_snapshot_tasks.py
+++ b/packages/postgres-database/src/simcore_postgres_database/models/comp_run_snapshot_tasks.py
@@ -95,4 +95,5 @@ comp_run_snapshot_tasks = sa.Table(
         nullable=True,
         doc="Hardware information of this task",
     ),
+    sa.Index("ix_comp_run_snapshot_tasks_run_id_node_id", "run_id", "node_id"),
 )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This PRa adds a composite index on `comp_run_snapshot_tasks(run_id, node_id)`.

Task state and progress updates locate snapshot rows using `run_id` and `node_id`. 
Production metrics showed these updates reaching approximately 253 ms per call. The new index enables direct row lookup and also supports queries filtering by `run_id`.

<img width="1667" height="56" alt="image" src="https://github.com/user-attachments/assets/7031964d-0470-4d65-9ab0-b32ae29b92a9" />

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
- No changes.