### PR TITLE
Fix: Prevent internal error when reporting a failed file upload

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_manager.py
@@ -118,8 +118,8 @@ class OutputsManager:  # pylint: disable=too-many-instance-attributes
         self._task_scheduler_worker: Task | None = None
         self._schedule_all_ports_for_upload: bool = False
 
-        # keep track if a port was uploaded and there was an error, remove said error if
-        self._last_upload_error_tracker: dict[str, Exception | None] = {}
+        # keep track if a port was uploaded and there was an error, remove said error if last upload was ok
+        self._last_upload_error_tracker: dict[str, str | None] = {}
 
     async def _uploading_task_start(self) -> None:
         port_keys = await self._port_key_tracker.get_uploading()
@@ -163,7 +163,7 @@ class OutputsManager:  # pylint: disable=too-many-instance-attributes
                     future.result()
                     self._last_upload_error_tracker[port_key] = None
                 except Exception as e:  # pylint: disable=broad-except
-                    self._last_upload_error_tracker[port_key] = e
+                    self._last_upload_error_tracker[port_key] = format_exception_as_string(e)
 
             self._task_uploading_followup = create_task(self._port_key_tracker.remove_all_uploading())
 

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
@@ -233,8 +233,9 @@ async def test_recovers_after_raising_error(
 
     assert set(exec_info.value.failures.keys()) == set(port_keys) | set(non_file_type_port_keys)
 
-    def _assert_same_exceptions(first: list[str], second: list[type[BaseException]]) -> None:
+    def _assert_same_exceptions(first: list[str | None], second: list[type[BaseException]]) -> None:
         for formatted_traceback, error_class in zip(first, second, strict=True):
+            assert formatted_traceback is not None
             assert error_class.__name__ in formatted_traceback
             assert mock_error.message in formatted_traceback
 

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_manager.py
@@ -233,12 +233,14 @@ async def test_recovers_after_raising_error(
 
     assert set(exec_info.value.failures.keys()) == set(port_keys) | set(non_file_type_port_keys)
 
-    def _assert_same_exceptions(first: list[Exception], second: list[Exception]) -> None:
-        assert {x.__class__: f"{x}" for x in first} == {x.__class__: f"{x}" for x in second}
+    def _assert_same_exceptions(first: list[str], second: list[type[BaseException]]) -> None:
+        for formatted_traceback, error_class in zip(first, second, strict=True):
+            assert error_class.__name__ in formatted_traceback
+            assert mock_error.message in formatted_traceback
 
     _assert_same_exceptions(
-        exec_info.value.failures.values(),
-        [mock_error.error_class(mock_error.message)] * len(exec_info.value.failures),
+        list(exec_info.value.failures.values()),
+        [mock_error.error_class] * len(exec_info.value.failures),
     )
 
     # the second time uploading there is no error to be raised


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


Avoids serialisation errors by transmitting the stringified traceback for reference, instead of the original python object, sometimes these might contain internals that are no serialisable.


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- https://github.com/ITISFoundation/osparc-simcore/pull/9416
- relative to https://github.com/ITISFoundation/private-issues/issues/646


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
