### PR TITLE
🎨E2E: check output push happens till the frontend

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -382,18 +382,109 @@ class SocketIOWaitNodeForOutputs:
     node_id: str
 
     def __call__(self, message: str) -> bool:
-        with log_context(logging.DEBUG, msg=f"handling websocket {message=}"):
+        with log_context(logging.DEBUG, msg=f"handling websocket {message=}") as ctx:
             if message.startswith(SOCKETIO_MESSAGE_PREFIX):
                 decoded_message = decode_socketio_42_message(message)
                 if decoded_message.name == _OSparcMessages.NODE_UPDATED:
                     assert "data" in decoded_message.obj
                     assert "node_id" in decoded_message.obj
                     if decoded_message.obj["node_id"] == self.node_id:
-                        assert "outputs" in decoded_message.obj["data"]
-
-                        return len(decoded_message.obj["data"]["outputs"]) == self.expected_number_of_outputs
+                        # NOTE: NodeUpdated is also sent for state-only changes (e.g. PUBLISHED),
+                        # which carry no "outputs" key at all
+                        outputs = decoded_message.obj["data"].get("outputs")
+                        if outputs is not None:
+                            is_complete = len(outputs) == self.expected_number_of_outputs
+                            if is_complete:
+                                ctx.logger.info(
+                                    "📤 outputs push received for node %s (%d/%d)",
+                                    self.node_id,
+                                    len(outputs),
+                                    self.expected_number_of_outputs,
+                                )
+                            return is_complete
 
         return False
+
+
+@dataclass
+class SocketIOWaitNodesForOutputs:
+    """Like `SocketIOWaitNodeForOutputs`, but resolves only once *every* node in
+    `node_id_to_expected_number_of_outputs` has reported its expected number of outputs
+    (e.g. several nodes completing concurrently in the same pipeline run).
+    """
+
+    node_id_to_expected_number_of_outputs: dict[str, int]
+    _pending_node_ids: set[str] = field(init=False)
+    _received_number_of_outputs: dict[str, int] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._pending_node_ids = set(self.node_id_to_expected_number_of_outputs)
+        self._received_number_of_outputs = {}
+
+    def __call__(self, message: str) -> bool:
+        with log_context(logging.DEBUG, msg=f"handling websocket {message=}") as ctx:
+            if message.startswith(SOCKETIO_MESSAGE_PREFIX):
+                decoded_message = decode_socketio_42_message(message)
+                if decoded_message.name == _OSparcMessages.NODE_UPDATED:
+                    assert "data" in decoded_message.obj
+                    assert "node_id" in decoded_message.obj
+                    node_id = decoded_message.obj["node_id"]
+                    if node_id in self._pending_node_ids:
+                        # NOTE: NodeUpdated is also sent for state-only changes (e.g. PUBLISHED),
+                        # which carry no "outputs" key at all
+                        outputs = decoded_message.obj["data"].get("outputs")
+                        if outputs is not None:
+                            self._received_number_of_outputs[node_id] = len(outputs)
+                            expected = self.node_id_to_expected_number_of_outputs[node_id]
+                            if len(outputs) == expected:
+                                self._pending_node_ids.discard(node_id)
+                                ctx.logger.info(
+                                    "📤 outputs push received for node %s (%d/%d), %d node(s) left",
+                                    node_id,
+                                    len(outputs),
+                                    expected,
+                                    len(self._pending_node_ids),
+                                )
+
+        return not self._pending_node_ids
+
+    def missing_outputs_report(self) -> str:
+        """Reports, for each node still pending, how many outputs were received vs expected."""
+        return ", ".join(
+            f"{node_id}: {self._received_number_of_outputs.get(node_id, 0)}/{expected}"
+            for node_id, expected in self.node_id_to_expected_number_of_outputs.items()
+            if node_id in self._pending_node_ids
+        )
+
+
+@contextlib.contextmanager
+def wait_for_nodes_outputs_updated(
+    websocket: RobustWebSocket,
+    *,
+    node_id_to_expected_number_of_outputs: dict[str, int],
+    timeout: int | None = None,
+) -> Generator[None]:
+    """Asserts that a `NodeUpdated` websocket message with the expected number of outputs is
+    received for every node in `node_id_to_expected_number_of_outputs` while the wrapped block
+    runs. Unlike `check_node_outputs` (which only polls the REST API after the fact), this
+    verifies the websocket push actually happened.
+    """
+    waiter = SocketIOWaitNodesForOutputs(node_id_to_expected_number_of_outputs=node_id_to_expected_number_of_outputs)
+    with (
+        log_context(
+            logging.INFO,
+            msg=ContextMessages(
+                starting=f"⏳ waiting for outputs push for nodes {list(node_id_to_expected_number_of_outputs)}",
+                done="✅ received outputs push for all expected nodes",
+                raised=lambda: (
+                    f"❌ missing outputs push for: {waiter.missing_outputs_report()}. "
+                    "TIP: check that the webserver's db-listener service is running properly!"
+                ),
+            ),
+        ),
+        websocket.expect_event("framereceived", waiter, timeout=timeout),
+    ):
+        yield
 
 
 _FAIL_FAST_DYNAMIC_SERVICE_STATES: Final[tuple[str, ...]] = ("failed",)

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -776,6 +776,13 @@ class PipelineStageTimeouts:
     waiting_for_resources_ms: int = 5 * MINUTE
     started_ms: int = 5 * MINUTE
 
+    @property
+    def total_ms(self) -> int:
+        """Upper bound covering every stage sequentially, for wrappers spanning the whole wait."""
+        return (
+            self.published_or_pending_ms + self.waiting_for_cluster_ms + self.waiting_for_resources_ms + self.started_ms
+        )
+
 
 def wait_for_computation_done(
     current_state: RunningState,

--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -811,7 +811,8 @@ def start_and_stop_pipeline(
     def _do() -> SocketIOEvent:
         with log_context(
             logging.INFO,
-            f"Start computation in {product_url=}...",
+            f"Start computation in {product_url=} "
+            f"(timeout: {datetime.timedelta(milliseconds=_OUTER_CONTEXT_TIMEOUT_MS)})...",
         ) as ctx:
             waiter = SocketIOProjectStateUpdatedWaiter(
                 expected_states=(

--- a/tests/e2e-playwright/tests/sleepers/test_sleepers.py
+++ b/tests/e2e-playwright/tests/sleepers/test_sleepers.py
@@ -30,6 +30,7 @@ from pytest_simcore.helpers.playwright import (
     check_node_outputs,
     retrieve_project_state_from_decoded_message,
     wait_for_computation_done,
+    wait_for_nodes_outputs_updated,
 )
 
 _WAITING_FOR_SUCCESS_MAX_WAITING_TIME_PER_SLEEPER: Final[int] = 1 * MINUTE
@@ -95,6 +96,13 @@ def test_sleepers(
             workbench_selector.click()
         break
 
+    # collect all sleeper node ids upfront, so we can watch their websocket updates below
+    sleeper_node_ids: list[str] = []
+    for sleeper in page.get_by_test_id("nodeTreeItem").all()[1:]:
+        node_id = sleeper.get_attribute("osparc-test-key")
+        assert node_id
+        sleeper_node_ids.append(node_id)
+
     # set inputs if needed
     if input_sleep_time:
         for index, sleeper in enumerate(page.get_by_test_id("nodeTreeItem").all()[1:]):
@@ -112,19 +120,26 @@ def test_sleepers(
     # sometimes they may jump
     # PUBLISHED -> [WAITING_FOR_CLUSTER] -> (PENDING) -> [WAITING_FOR_RESOURCES] ->
     # (PENDING) -> STARTED -> SUCCESS/FAILED
-    socket_io_event = start_and_stop_pipeline()
-    current_state = retrieve_project_state_from_decoded_message(socket_io_event)
-    test_logger.info("pipeline is in %s", f"{current_state=}")
+    # NOTE: asserts every sleeper actually pushes a NodeUpdated websocket message with its
+    # outputs, instead of only relying on the after-the-fact REST check below
+    with wait_for_nodes_outputs_updated(
+        log_in_and_out,
+        node_id_to_expected_number_of_outputs=dict.fromkeys(sleeper_node_ids, len(sleeper_expected_output_files)),
+        timeout=num_sleepers * _WAITING_FOR_SUCCESS_MAX_WAITING_TIME_PER_SLEEPER,
+    ):
+        socket_io_event = start_and_stop_pipeline()
+        current_state = retrieve_project_state_from_decoded_message(socket_io_event)
+        test_logger.info("pipeline is in %s", f"{current_state=}")
 
-    # handles the autoscaled-deployment state machine (cold cluster/worker scale-up can take
-    # several minutes without the pipeline actually being stuck)
-    current_state = wait_for_computation_done(
-        current_state,
-        websocket=log_in_and_out,
-        stage_timeouts=PipelineStageTimeouts(
-            started_ms=num_sleepers * _WAITING_FOR_SUCCESS_MAX_WAITING_TIME_PER_SLEEPER,
-        ),
-    )
+        # handles the autoscaled-deployment state machine (cold cluster/worker scale-up can take
+        # several minutes without the pipeline actually being stuck)
+        current_state = wait_for_computation_done(
+            current_state,
+            websocket=log_in_and_out,
+            stage_timeouts=PipelineStageTimeouts(
+                started_ms=num_sleepers * _WAITING_FOR_SUCCESS_MAX_WAITING_TIME_PER_SLEEPER,
+            ),
+        )
 
     # check the outputs (the first item is the title, so we skip it)
     with log_context(

--- a/tests/e2e-playwright/tests/sleepers/test_sleepers.py
+++ b/tests/e2e-playwright/tests/sleepers/test_sleepers.py
@@ -23,6 +23,7 @@ from pytest_simcore.helpers.logging_tools import (
 )
 from pytest_simcore.helpers.playwright import (
     MINUTE,
+    SECOND,
     PipelineStageTimeouts,
     RobustWebSocket,
     ServiceType,
@@ -34,6 +35,8 @@ from pytest_simcore.helpers.playwright import (
 )
 
 _WAITING_FOR_SUCCESS_MAX_WAITING_TIME_PER_SLEEPER: Final[int] = 1 * MINUTE
+# NOTE: small grace budget for stages a non-autoscaled deployment should never actually enter
+_NON_AUTOSCALED_STAGE_GRACE_TIME: Final[int] = 30 * SECOND
 
 _VERSION_TO_EXPECTED_FILE_NAMES: Final[dict[Version, list[str]]] = {
     parse_version("1.0.0"): ["logs.zip", "single_number.txt"],
@@ -55,6 +58,7 @@ def test_sleepers(
     start_and_stop_pipeline: Callable[..., SocketIOEvent],
     num_sleepers: int,
     input_sleep_time: int | None,
+    is_autoscaled: bool,
 ):
     project_data = create_project_from_service_dashboard(ServiceType.COMPUTATIONAL, "sleeper", "itis", None)
 
@@ -122,10 +126,18 @@ def test_sleepers(
     # (PENDING) -> STARTED -> SUCCESS/FAILED
     # NOTE: asserts every sleeper actually pushes a NodeUpdated websocket message with its
     # outputs, instead of only relying on the after-the-fact REST check below
+    # on non-autoscaled deployments the cluster/resources stages are never entered, so keep
+    # their budget minimal instead of the full 5 min each (would otherwise slow down failures)
+    stage_timeouts = PipelineStageTimeouts(
+        waiting_for_cluster_ms=(5 * MINUTE) if is_autoscaled else _NON_AUTOSCALED_STAGE_GRACE_TIME,
+        waiting_for_resources_ms=(5 * MINUTE) if is_autoscaled else _NON_AUTOSCALED_STAGE_GRACE_TIME,
+        started_ms=num_sleepers * _WAITING_FOR_SUCCESS_MAX_WAITING_TIME_PER_SLEEPER,
+    )
     with wait_for_nodes_outputs_updated(
         log_in_and_out,
         node_id_to_expected_number_of_outputs=dict.fromkeys(sleeper_node_ids, len(sleeper_expected_output_files)),
-        timeout=num_sleepers * _WAITING_FOR_SUCCESS_MAX_WAITING_TIME_PER_SLEEPER,
+        # NOTE: covers every autoscaling stage (cold cluster/worker scale-up), not just STARTED
+        timeout=stage_timeouts.total_ms,
     ):
         socket_io_event = start_and_stop_pipeline()
         current_state = retrieve_project_state_from_decoded_message(socket_io_event)
@@ -136,9 +148,7 @@ def test_sleepers(
         current_state = wait_for_computation_done(
             current_state,
             websocket=log_in_and_out,
-            stage_timeouts=PipelineStageTimeouts(
-                started_ms=num_sleepers * _WAITING_FOR_SUCCESS_MAX_WAITING_TIME_PER_SLEEPER,
-            ),
+            stage_timeouts=stage_timeouts,
         )
 
     # check the outputs (the first item is the title, so we skip it)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
adds a check when testing sleepers that the outputs are properly pushed via websockets.

When this goes bad, we might get a chance to know that the db-listener service might be in a bad state.
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/private-issues/issues/643

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
