### PR TITLE
🐛 fix(dynamic-scheduler): send director-v2 requests as JSON

### DIFF
--- a/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/director_v2/_thin_client.py
+++ b/services/dynamic-scheduler/src/simcore_service_dynamic_scheduler/services/director_v2/_thin_client.py
@@ -2,8 +2,8 @@ import datetime
 from typing import cast
 
 from common_library.exclude import as_dict_exclude_none
-from common_library.json_serialization import json_dumps
 from fastapi import FastAPI, status
+from fastapi.encoders import jsonable_encoder
 from httpx import Response, Timeout
 from models_library.api_schemas_dynamic_scheduler.dynamic_services import (
     DynamicServiceStart,
@@ -75,7 +75,7 @@ class DirectorV2ThinClient(BaseThinClient):
 
         return await self.client.post(
             "/dynamic_services",
-            content=json_dumps(post_data),
+            json=jsonable_encoder(post_data),
             headers=headers,
             follow_redirects=True,
         )
@@ -119,7 +119,7 @@ class DirectorV2ThinClient(BaseThinClient):
         post_data = {"port_keys": port_keys}
         return await self.client.post(
             f"/dynamic_services/{node_id}:retrieve",
-            content=json_dumps(post_data),
+            json=jsonable_encoder(post_data),
             timeout=timeout.total_seconds(),
         )
 

--- a/services/dynamic-scheduler/tests/unit/api_rpc/test_api_rpc__services.py
+++ b/services/dynamic-scheduler/tests/unit/api_rpc/test_api_rpc__services.py
@@ -26,6 +26,7 @@ from pydantic import TypeAdapter
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
+from respx.models import Route
 from servicelib.rabbitmq import RabbitMQRPCClient, RPCServerError
 from servicelib.rabbitmq.rpc_interfaces.dynamic_scheduler import services
 from servicelib.rabbitmq.rpc_interfaces.dynamic_scheduler.errors import (
@@ -232,7 +233,7 @@ def mock_director_v2_service_run(
     service_status_new_style: DynamicServiceGet,
     service_status_legacy: NodeGet,
     fake_director_v0_base_url: str,
-) -> Iterator[None]:
+) -> Iterator[Route]:
     with respx.mock(
         base_url="http://director-v2:8000/v2",
         assert_all_called=False,
@@ -249,18 +250,26 @@ def mock_director_v2_service_run(
                 status.HTTP_201_CREATED,
                 text=service_status_new_style.model_dump_json(),
             )
-        yield None
+        yield request
 
 
 @pytest.mark.parametrize("is_legacy", [True, False])
 async def test_run_dynamic_service(
     mock_director_v0_service_run: None,
-    mock_director_v2_service_run: None,
+    mock_director_v2_service_run: Route,
     rpc_client: RabbitMQRPCClient,
     dynamic_service_start: DynamicServiceStart,
     is_legacy: bool,
 ):
     result = await services.run_dynamic_service(rpc_client, dynamic_service_start=dynamic_service_start)
+
+    sent_request = mock_director_v2_service_run.calls.last.request
+    assert sent_request.headers["Content-Type"] == "application/json"
+    sent_body = json.loads(sent_request.content)
+    assert isinstance(sent_body, dict)
+    assert sent_body["basepath"] == f"/x/{dynamic_service_start.node_uuid}"
+    assert sent_body["key"] == dynamic_service_start.key
+    assert sent_body["project_id"] == f"{dynamic_service_start.project_id}"
 
     if is_legacy:
         assert isinstance(result, NodeGet)

--- a/services/dynamic-scheduler/tests/unit/api_rpc/test_api_rpc__services.py
+++ b/services/dynamic-scheduler/tests/unit/api_rpc/test_api_rpc__services.py
@@ -523,28 +523,32 @@ async def test_restart_user_services(
 
 
 @pytest.fixture
-def mock_director_v2_service_retrieve_inputs(node_id: NodeID) -> Iterator[None]:
+def mock_director_v2_service_retrieve_inputs(node_id: NodeID) -> Iterator[Route]:
     with respx.mock(
         base_url="http://director-v2:8000/v2",
         assert_all_called=False,
         assert_all_mocked=True,  # IMPORTANT: KEEP always True!
     ) as mock:
-        mock.post(f"/dynamic_services/{node_id}:retrieve").respond(
+        request = mock.post(f"/dynamic_services/{node_id}:retrieve").respond(
             status.HTTP_200_OK,
             text=TypeAdapter(RetrieveDataOutEnveloped)
             .validate_python(RetrieveDataOutEnveloped.model_json_schema()["examples"][0])
             .model_dump_json(),
         )
 
-        yield None
+        yield request
 
 
 async def test_retrieve_inputs(
-    mock_director_v2_service_retrieve_inputs: None,
+    mock_director_v2_service_retrieve_inputs: Route,
     rpc_client: RabbitMQRPCClient,
     node_id: NodeID,
 ):
     results = await services.retrieve_inputs(rpc_client, node_id=node_id, port_keys=[], timeout_s=10)
+
+    sent_request = mock_director_v2_service_retrieve_inputs.calls.last.request
+    assert sent_request.headers["Content-Type"] == "application/json"
+    assert json.loads(sent_request.content) == {"port_keys": []}
     assert results.model_dump(mode="python") == RetrieveDataOutEnveloped.model_json_schema()["examples"][0]
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
FastAPI 0.141.1 enables strict content-type handling by default, so JSON bodies without `Content-Type: application/json` are no longer parsed as JSON.

This PR uses HTTPX’s JSON API for director-v2 requests, fixing the resulting `422 model_attributes_type` error and adding regression coverage.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test
```sh
cd services/dynamic-scheduler
make install-dev
pytest -vv --pdb tests/unit/api_rpc/test_api_rpc__services.py
```

## Dev-ops
- No changes.