### PR TITLE
♻️Performance: Director-v2 computational scheduler does not need to access comp_pipelines table anymore

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/models/comp_runs.py
@@ -3,8 +3,10 @@ from contextlib import suppress
 from typing import (  # https://docs.pydantic.dev/latest/api/standard_library_types/#typeddict
     NewType,
     TypedDict,
+    cast,
 )
 
+import networkx as nx
 from models_library.api_schemas_directorv2.encryption import FileIDStr
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
@@ -97,6 +99,15 @@ class CompRunsAtDB(BaseModel):
         if v is None:
             v = RunMetadataDict()
         return v
+
+    def get_graph(self) -> nx.DiGraph:
+        return cast(
+            nx.DiGraph,
+            nx.convert.from_dict_of_lists(
+                self.dag_adjacency_list,  # type: ignore[arg-type] # list is an Iterable but dict is Invariant
+                create_using=nx.DiGraph,
+            ),
+        )
 
     model_config = ConfigDict(
         from_attributes=True,

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -47,10 +47,8 @@ from ...core.errors import (
     ComputationalSchedulerChangedError,
     DaskClientAcquisisitonError,
     InvalidPipelineError,
-    PipelineNotFoundError,
 )
 from ...core.settings import ComputationalBackendSettings
-from ...models.comp_pipelines import CompPipelineAtDB
 from ...models.comp_runs import CompRunsAtDB, Iteration, RunID, RunMetadataDict
 from ...models.comp_tasks import CompTaskAtDB
 from ...utils.computations import get_pipeline_state_from_task_states
@@ -61,7 +59,6 @@ from ...utils.rabbitmq import (
     publish_service_resource_tracking_started,
     publish_service_started_metrics,
 )
-from ..db.repositories.comp_pipelines import CompPipelinesRepository
 from ..db.repositories.comp_runs import CompRunsRepository
 from ..db.repositories.comp_tasks import CompTasksRepository
 from ..osparc_variables._errors import OsparcVariableResolveTimeoutError
@@ -167,13 +164,6 @@ class BaseCompScheduler(ABC):
     settings: ComputationalBackendSettings
     service_runtime_heartbeat_interval: datetime.timedelta
     redis_client: RedisClientSDK
-
-    async def _get_pipeline_dag(self, project_id: ProjectID) -> nx.DiGraph:
-        comp_pipeline_repo = CompPipelinesRepository.instance(self.db_engine)
-        pipeline_at_db: CompPipelineAtDB = await comp_pipeline_repo.get_pipeline(project_id)
-        dag = pipeline_at_db.get_graph()
-        _logger.debug("%s: current %s", f"{project_id=}", f"{dag=}")
-        return dag
 
     async def _get_pipeline_tasks(
         self, project_id: ProjectID, pipeline_dag: nx.DiGraph
@@ -571,7 +561,7 @@ class BaseCompScheduler(ABC):
 
             try:
                 comp_run = await CompRunsRepository.instance(self.db_engine).get(user_id, project_id, iteration)
-                dag = await self._get_pipeline_dag(project_id)
+                dag = comp_run.get_graph()
 
                 # 1. Update our list of tasks with data from backend (state, results)
                 await self._update_states_from_comp_backend(user_id, project_id, iteration, dag, comp_run)
@@ -638,24 +628,6 @@ class BaseCompScheduler(ABC):
                     )
                 )
                 # NOTE: comp_run was never fetched, so there is no run_id to release resources for
-            except PipelineNotFoundError as exc:
-                _logger.exception(
-                    **create_troubleshooting_log_kwargs(
-                        f"pipeline {project_id} is missing from `comp_pipelines` DB table, "
-                        "something is corrupted. Aborting scheduling",
-                        error=exc,
-                        error_context={
-                            "user_id": f"{user_id}",
-                            "project_id": f"{project_id}",
-                            "iteration": f"{iteration}",
-                        },
-                        tip="Check that the project still exists",
-                    )
-                )
-
-                # NOTE: no need to update task states here as pipeline is already broken
-                await self._safe_release_resources(user_id, project_id, comp_run.run_id)
-                await self._set_run_result(user_id, project_id, iteration, RunningState.FAILED)
             except InvalidPipelineError as exc:
                 _logger.exception(
                     **create_troubleshooting_log_kwargs(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -442,8 +442,7 @@ class DaskScheduler(BaseCompScheduler):
         except PortsValidationError as err:
             _logger.exception(
                 **create_troubleshooting_log_kwargs(
-                    "Unexpected error while parsing output data, "
-                    "comp_tasks/comp_pipeline is not in sync with what was started",
+                    "Unexpected error while parsing output data, comp_tasks is not in sync with what was started",
                     error=err,
                     error_context=log_error_context,
                 )

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -55,9 +55,8 @@ from pydantic import TypeAdapter
 from pytest_mock.plugin import MockerFixture
 from servicelib.rabbitmq import RabbitMQClient
 from servicelib.rabbitmq._constants import BIND_TO_ALL_TOPICS
-from simcore_postgres_database.models.comp_pipeline import comp_pipeline
 from simcore_postgres_database.models.comp_runs import comp_runs
-from simcore_postgres_database.models.comp_tasks import NodeClass, comp_tasks
+from simcore_postgres_database.models.comp_tasks import NodeClass
 from simcore_sdk.node_ports_common.exceptions import S3InvalidPathError
 from simcore_service_director_v2.core.errors import (
     ClustersKeeperNotAvailableError,
@@ -2962,61 +2961,6 @@ def mocked_safe_release_resources(scheduler_api: BaseCompScheduler, mocker: Mock
         scheduler_api,
         "_safe_release_resources",
         wraps=scheduler_api._safe_release_resources,  # noqa: SLF001
-    )
-
-
-async def test_pipeline_not_found_error_aborts_scheduling(
-    with_disabled_auto_scheduling: mock.Mock,
-    with_disabled_scheduler_publisher: mock.Mock,
-    initialized_app: FastAPI,
-    mocked_dask_client: mock.MagicMock,
-    scheduler_api: BaseCompScheduler,
-    mocked_safe_release_resources: mock.AsyncMock,
-    sqlalchemy_async_engine: AsyncEngine,
-    published_project: PublishedProject,
-    run_metadata: RunMetadataDict,
-    computational_pipeline_rabbit_client_parser: mock.AsyncMock,
-    fake_collection_run_id: CollectionRunID,
-):
-    """When the comp_pipeline row is deleted between pipeline start and scheduling,
-    PipelineNotFoundError is raised, resources are released and the run is set to FAILED."""
-    _with_mock_send_computation_tasks(published_project.tasks, mocked_dask_client)
-    run_in_db, _ = await _assert_start_pipeline(
-        initialized_app,
-        sqlalchemy_async_engine=sqlalchemy_async_engine,
-        published_project=published_project,
-        run_metadata=run_metadata,
-        computational_pipeline_rabbit_client_parser=computational_pipeline_rabbit_client_parser,
-        collection_run_id=fake_collection_run_id,
-    )
-
-    # Simulate a corrupted state: remove the pipeline from comp_pipelines
-    async with sqlalchemy_async_engine.begin() as conn:
-        await conn.execute(comp_tasks.delete().where(comp_tasks.c.project_id == f"{published_project.project.uuid}"))
-        await conn.execute(
-            comp_pipeline.delete().where(comp_pipeline.c.project_id == f"{published_project.project.uuid}")
-        )
-
-    # Scheduling must handle PipelineNotFoundError gracefully and mark the run FAILED
-    await scheduler_api.apply(
-        user_id=run_in_db.user_id,
-        project_id=run_in_db.project_uuid,
-        iteration=run_in_db.iteration,
-    )
-    await assert_comp_runs(
-        sqlalchemy_async_engine,
-        expected_total=1,
-        expected_state=RunningState.FAILED,
-        where_statement=and_(
-            comp_runs.c.user_id == run_in_db.user_id,
-            comp_runs.c.project_uuid == f"{run_in_db.project_uuid}",
-        ),
-    )
-    mocked_safe_release_resources.assert_called_once_with(run_in_db.user_id, run_in_db.project_uuid, mock.ANY)
-    await _assert_message_received(
-        computational_pipeline_rabbit_client_parser,
-        1,
-        ComputationalPipelineStatusMessage.model_validate_json,
     )
 
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
For each computational pipeline the dv-2 scheduler needs to access the comp_tasks/comp_pipeline/comp_runs tables. actually accessing the comp_pipeline is not necessary and is removed, therefore reducing the needs for database connections.

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
