### PR TITLE
♻️Performance: Director v2 DB access improvements

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -287,7 +287,7 @@ class BaseCompScheduler(ABC):
         project_id: ProjectID,
         run_id: RunID,
         iteration: Iteration,
-        dag: nx.DiGraph,
+        tasks: dict[NodeIDStr, CompTaskAtDB],
     ) -> None:
         utc_now = arrow.utcnow().datetime
 
@@ -302,7 +302,6 @@ class BaseCompScheduler(ABC):
                 )
             return bool((utc_now - task.last_heartbeat) > self.service_runtime_heartbeat_interval)
 
-        tasks: dict[NodeIDStr, CompTaskAtDB] = await self._get_pipeline_tasks(project_id, dag)
         if running_tasks := [t for t in tasks.values() if _need_heartbeat(t)]:
             await limited_gather(
                 *(
@@ -597,7 +596,7 @@ class BaseCompScheduler(ABC):
                     )
 
                 # 5. send a heartbeat
-                await self._send_running_tasks_heartbeat(user_id, project_id, comp_run.run_id, iteration, dag)
+                await self._send_running_tasks_heartbeat(user_id, project_id, comp_run.run_id, iteration, comp_tasks)
 
                 # 6. Update the run result
                 pipeline_result = await self._update_run_result_from_tasks(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -248,13 +248,6 @@ class DaskScheduler(BaseCompScheduler):
                     )
                     if t is not None
                 ]
-            for progress_event in task_progress_events:
-                await CompTasksRepository(self.db_engine).update_project_task_progress(
-                    progress_event.task_owner.project_id,
-                    progress_event.task_owner.node_id,
-                    comp_run.run_id,
-                    progress_event.progress,
-                )
 
         except ComputationalBackendOnDemandNotReadyError as exc:
             _logger.info(

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -14,7 +14,6 @@ from models_library.wallets import WalletInfo
 from pydantic import TypeAdapter
 from servicelib.logging_utils import log_context
 from servicelib.rabbitmq import RabbitMQRPCClient
-from servicelib.utils import logged_gather
 from sqlalchemy import CursorResult, literal_column
 from sqlalchemy.dialects.postgresql import insert
 
@@ -257,6 +256,8 @@ class CompTasksRepository(BaseRepository):
             optional_started -- _description_ (default: {None})
             optional_stopped -- _description_ (default: {None})
         """
+        if not tasks:
+            return
         update_values: dict[str, Any] = {
             "state": RUNNING_STATE_TO_DB[state],
             "errors": errors,
@@ -267,7 +268,31 @@ class CompTasksRepository(BaseRepository):
             update_values["start"] = optional_started
         if optional_stopped is not None:
             update_values["end"] = optional_stopped
-        await logged_gather(*(self._update_task(project_id, task_id, run_id, **update_values) for task_id in tasks))
+
+        # NOTE: all the tasks share the same update_values, so this is done as a single
+        # bulk update per table instead of one transaction per task (see ADR on comp_tasks batching)
+        node_ids = [f"{task_id}" for task_id in tasks]
+        with log_context(
+            _logger,
+            logging.DEBUG,
+            msg=f"update tasks state {project_id=}:{node_ids=} with '{update_values}'",
+        ):
+            async with self.db_engine.begin() as conn:
+                await conn.execute(
+                    sa.update(comp_tasks)
+                    .where((comp_tasks.c.project_id == f"{project_id}") & (comp_tasks.c.node_id.in_(node_ids)))
+                    .values(**update_values)
+                )
+                # Sync with comp_run_snapshot_tasks table
+                await conn.execute(
+                    sa.update(comp_run_snapshot_tasks)
+                    .where(
+                        (comp_run_snapshot_tasks.c.run_id == run_id)
+                        & (comp_run_snapshot_tasks.c.project_id == f"{project_id}")
+                        & (comp_run_snapshot_tasks.c.node_id.in_(node_ids))
+                    )
+                    .values(**update_values)
+                )
 
     async def update_project_task_progress(
         self,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
- reduces the amount of DB call to reduce DB engine overload in DV-2
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- requires https://github.com/ITISFoundation/osparc-simcore/pull/9545

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
