### PR TITLE
♻️E2E: use project workbench positions, not DOM.

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -1049,19 +1049,39 @@ def get_node_id_from_service_key(workbench: dict[str, Any], service_key_fragment
     raise ValueError(msg)
 
 
-def _select_node(page: Page, position: int) -> str:
-    """Selects the node at `position` in the workbench tree (left panel) and returns its node id."""
-    tree_items = page.locator('[osparc-test-id="nodeTreeItem"]')
-    node_ids_and_locators = []
-    for index in range(tree_items.count()):
-        item = tree_items.nth(index)
-        node_key = item.get_attribute("osparc-test-key")
-        if node_key and node_key != "root":
-            node_ids_and_locators.append((node_key, item))
+def get_node_id_from_label(workbench: dict[str, Any], label_fragment: str) -> str:
+    """Finds the node id in a project's workbench whose label contains the given fragment.
 
-    node_id, locator = node_ids_and_locators[position]
+    Preferred over the workbench tree's displayed text since the workbench dict is the
+    authoritative source for a node's label.
+    """
+    matches = [node_id for node_id, node_data in workbench.items() if label_fragment in node_data["label"]]
+    available_labels = [node_data["label"] for node_data in workbench.values()]
+    if not matches:
+        msg = f"Could not find a node with label containing {label_fragment!r} (available: {available_labels})"
+        raise ValueError(msg)
+    if len(matches) > 1:
+        msg = f"Found {len(matches)} nodes with label containing {label_fragment!r} (available: {available_labels})"
+        raise ValueError(msg)
+    return matches[0]
+
+
+def get_node_id_from_position(workbench: dict[str, Any], position: int) -> str:
+    """Returns the node id at `position` in the workbench (its insertion order).
+
+    Preferred over the workbench tree's DOM order since the workbench dict is the authoritative
+    source for a project's nodes and their order.
+    """
+    node_ids = list(workbench)
+    assert 0 <= position < len(node_ids), f"position {position} out of range for workbench with {len(node_ids)} node(s)"
+    return node_ids[position]
+
+
+def _select_node(page: Page, *, node_id: str) -> None:
+    """Selects the node with `node_id` in the workbench tree (left panel)."""
+    locator = page.locator(f'[osparc-test-id="nodeTreeItem"][osparc-test-key="{node_id}"]')
+    assert locator.count() == 1, f"expected exactly one tree item for node {node_id!r}, found {locator.count()}"
     locator.click()
-    return node_id
 
 
 _OUTPUT_FILE_NAMES_MAX_WAITING_TIME: Final[timedelta] = timedelta(seconds=30)
@@ -1146,7 +1166,9 @@ def check_node_outputs(
     page: Page,
     *,
     study_id: str,
+    workbench: dict[str, Any],
     node_position: int | None = None,
+    node_name: str | None = None,
     node_id: str | None = None,
     expected_file_names: list[str],
     open_outputs_folder: bool = False,
@@ -1154,12 +1176,25 @@ def check_node_outputs(
 ) -> None:
     """Opens a node's output files panel and asserts it contains exactly `expected_file_names`.
 
+    The node is identified by exactly one of `node_id`, `node_position` (its index in
+    `workbench`) or `node_name` (its label in `workbench`). `workbench` is the project's
+    authoritative source of node ids/labels/order, so the lookup never depends on the fragile
+    workbench tree's DOM order/displayed text.
+
     Port of the legacy `TutorialBase.checkNodeOutputs()` /
     `TutorialBase.checkNodeOutputsAppMode()`.
     """
     if node_id is None:
-        assert node_position is not None, "either node_id or node_position must be provided"
-        node_id = _select_node(page, node_position)
+        assert (node_position is None) != (node_name is None), (
+            "either node_id, node_position or node_name must be provided"
+        )
+        if node_position is not None:
+            node_id = get_node_id_from_position(workbench, node_position)
+        else:
+            assert node_name is not None
+            node_id = get_node_id_from_label(workbench, node_name)
+    assert node_id in workbench, f"node {node_id!r} not found in workbench"
+    _select_node(page, node_id=node_id)
 
     with log_context(logging.INFO, f"Checking node {node_id=} outputs"):
         _check_node_outputs_dialog(

--- a/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
+++ b/packages/pytest-simcore/src/pytest_simcore/helpers/playwright.py
@@ -760,6 +760,12 @@ _RUNNING_STATES: Final[tuple[RunningState, ...]] = (
 )
 
 _RUN_PIPELINE_MAX_WAIT_TIME: Final[int] = 60 * SECOND
+_COMPUTATION_START_REQUEST_PATTERN: Final[re.Pattern[str]] = re.compile(r"/computations")
+_COMPUTATION_START_REQUEST_TIMEOUT: Final[int] = 35 * SECOND
+
+
+def _computation_started_predicate(request: Request) -> bool:
+    return bool(re.search(_COMPUTATION_START_REQUEST_PATTERN, request.url) and request.method.upper() == "POST")
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -863,13 +869,27 @@ def run_pipeline_and_wait_done(
 
     Port of the legacy `TutorialBase.runPipeline()` + `TutorialBase.waitForStudyDone()`.
     """
-    waiter = SocketIOProjectStateUpdatedWaiter(expected_states=tuple(RunningState))
+    # NOTE: mirrors `start_and_stop_pipeline` (tests/conftest.py): expected_states is restricted to
+    # the "actively running" states only (no NOT_STARTED/UNKNOWN/SUCCESS/FAILED/ABORTED) so a stray
+    # `projectStateUpdated` frame still reporting the pre-run state can't race with the actual run
+    # trigger and be mistaken for a final state; the `POST /computations` request is also checked
+    # to confirm the click really triggered a computation.
+    waiter = SocketIOProjectStateUpdatedWaiter(expected_states=_RUNNING_STATES)
     with log_context(
         logging.INFO,
         f"Running pipeline and waiting for it to complete (timeout {timedelta(milliseconds=timeout_ms)})",
-    ):
-        with websocket.expect_event("framereceived", waiter, timeout=timeout_ms) as event:
+    ) as ctx:
+        with (
+            websocket.expect_event("framereceived", waiter, timeout=timeout_ms) as event,
+            page.expect_request(
+                _computation_started_predicate, timeout=_COMPUTATION_START_REQUEST_TIMEOUT
+            ) as request_info,
+        ):
             page.get_by_test_id(run_button_test_id).click()
+        response = request_info.value.response()
+        assert response
+        ctx.logger.info("POST /computations request response: %s", f"{response.status=}")
+        assert response.ok, f"{response.json()}"
         current_state = retrieve_project_state_from_decoded_message(decode_socketio_42_message(event.value))
         current_state = wait_for_computation_done(
             current_state,

--- a/tests/e2e-playwright/tests/portal/conftest.py
+++ b/tests/e2e-playwright/tests/portal/conftest.py
@@ -9,6 +9,7 @@ property of the service, not something the user should have to configure per run
 """
 
 import datetime
+import json
 import logging
 import re
 import urllib.parse
@@ -130,7 +131,7 @@ def open_study_link(page: Page, anonymous_open_timeout: int) -> Callable[..., Op
             log_context(
                 logging.INFO,
                 f"Opening anonymous study link {url=} (timeout {datetime.timedelta(milliseconds=timeout)})",
-            ),
+            ) as ctx,
             page.expect_websocket(timeout=timeout) as ws_info,
             page.expect_response(re.compile(r"/projects/[^:]+:open"), timeout=timeout) as response_info,
         ):
@@ -150,6 +151,8 @@ def open_study_link(page: Page, anonymous_open_timeout: int) -> Callable[..., Op
 
         assert response_info.value.ok, f"{response_info.value.json()}"
         project_data = response_info.value.json()["data"]
+        ctx.logger.info("%s", f"{project_data['uuid']=}")
+        ctx.logger.info("project_workbench=%s", f"{json.dumps(project_data['workbench'], indent=2)}")
 
         assert not ws_info.value.is_closed()
         websocket = RobustWebSocket(page, ws_info.value)

--- a/tests/e2e-playwright/tests/portal/test_bornstein.py
+++ b/tests/e2e-playwright/tests/portal/test_bornstein.py
@@ -65,6 +65,7 @@ def test_bornstein(
     check_node_outputs(
         page,
         study_id=project_data["uuid"],
+        workbench=project_data["workbench"],
         node_position=0,
         expected_file_names=_EXPECTED_OUTPUT_FILES,
     )

--- a/tests/e2e-playwright/tests/portal/test_cc_human.py
+++ b/tests/e2e-playwright/tests/portal/test_cc_human.py
@@ -16,25 +16,30 @@ def test_cc_human(
     run_pipeline_timeout: int,
 ) -> None:
     opened_study = open_study_link(anonymous_study_url)
-    study_id = opened_study.project_data["uuid"]
+    project_data = opened_study.project_data
+    study_id = project_data["uuid"]
+    workbench = project_data["workbench"]
 
     run_pipeline_and_wait_done(page, opened_study.websocket, timeout_ms=run_pipeline_timeout)
 
     check_node_outputs(
         page,
         study_id=study_id,
+        workbench=workbench,
         node_position=1,
         expected_file_names=["vm_1Hz.txt", "logs.zip", "allresult_1Hz.txt"],
     )
     check_node_outputs(
         page,
         study_id=study_id,
+        workbench=workbench,
         node_position=2,
         expected_file_names=["model_INPUT.from1D", "y_1D.txt", "logs.zip", "ECGs.txt"],
     )
     check_node_outputs(
         page,
         study_id=study_id,
+        workbench=workbench,
         node_position=3,
         expected_file_names=["aps.zip", "logs.zip"],
     )

--- a/tests/e2e-playwright/tests/portal/test_cc_rabbit.py
+++ b/tests/e2e-playwright/tests/portal/test_cc_rabbit.py
@@ -16,25 +16,30 @@ def test_cc_rabbit(
     run_pipeline_timeout: int,
 ) -> None:
     opened_study = open_study_link(anonymous_study_url)
-    study_id = opened_study.project_data["uuid"]
+    project_data = opened_study.project_data
+    study_id = project_data["uuid"]
+    workbench = project_data["workbench"]
 
     run_pipeline_and_wait_done(page, opened_study.websocket, timeout_ms=run_pipeline_timeout)
 
     check_node_outputs(
         page,
         study_id=study_id,
+        workbench=workbench,
         node_position=1,
         expected_file_names=["logs.zip", "allresult_1Hz.txt", "vm_1Hz.txt"],
     )
     check_node_outputs(
         page,
         study_id=study_id,
+        workbench=workbench,
         node_position=2,
         expected_file_names=["model_INPUT.from1D", "logs.zip", "cai_1D.txt", "ap_1D.txt", "ECGs.txt"],
     )
     check_node_outputs(
         page,
         study_id=study_id,
+        workbench=workbench,
         node_position=3,
         expected_file_names=["aps.zip", "logs.zip"],
     )

--- a/tests/e2e-playwright/tests/portal/test_kember.py
+++ b/tests/e2e-playwright/tests/portal/test_kember.py
@@ -56,6 +56,7 @@ def test_kember(
     check_node_outputs(
         page,
         study_id=project_data["uuid"],
+        workbench=workbench,
         node_id=kember_solver_id,
         expected_file_names=["logs.zip", "outputController.dat"],
         open_outputs_folder=True,

--- a/tests/e2e-playwright/tests/portal/test_mattward.py
+++ b/tests/e2e-playwright/tests/portal/test_mattward.py
@@ -50,6 +50,7 @@ def test_mattward(
     check_node_outputs(
         page,
         study_id=project_data["uuid"],
+        workbench=project_data["workbench"],
         node_position=0,
         expected_file_names=_EXPECTED_OUTPUT_FILES,
     )

--- a/tests/e2e-playwright/tests/portal/test_opencor.py
+++ b/tests/e2e-playwright/tests/portal/test_opencor.py
@@ -17,13 +17,15 @@ def test_opencor(
 ) -> None:
     url = f"{anonymous_study_url}?stimulation_mode=1&stimulation_level=0.5"
     opened_study = open_study_link(url)
-    study_id = opened_study.project_data["uuid"]
+    project_data = opened_study.project_data
+    study_id = project_data["uuid"]
 
     run_pipeline_and_wait_done(page, opened_study.websocket, timeout_ms=run_pipeline_timeout)
 
     check_node_outputs(
         page,
         study_id=study_id,
+        workbench=project_data["workbench"],
         node_position=0,
         expected_file_names=["results.json", "logs.zip", "membrane-potential.csv"],
     )

--- a/tests/e2e-playwright/tests/sleepers/test_sleepers.py
+++ b/tests/e2e-playwright/tests/sleepers/test_sleepers.py
@@ -167,6 +167,7 @@ def test_sleepers(
             check_node_outputs(
                 page,
                 study_id=project_data["uuid"],
+                workbench=project_data["workbench"],
                 node_id=node_id,
                 expected_file_names=sleeper_expected_output_files,
             )

--- a/tests/e2e-playwright/tests/sleepers/test_sleepers.py
+++ b/tests/e2e-playwright/tests/sleepers/test_sleepers.py
@@ -15,7 +15,8 @@ from typing import Any, Final
 
 from packaging.version import Version
 from packaging.version import parse as parse_version
-from playwright.sync_api import Page
+from playwright.sync_api import APIRequestContext, Page
+from pydantic import AnyUrl
 from pytest_simcore.helpers.logging_tools import (
     ContextMessages,
     log_context,
@@ -53,6 +54,8 @@ def _get_expected_file_names_for_version(version: Version) -> list[str]:
 
 def test_sleepers(
     page: Page,
+    api_request_context: APIRequestContext,
+    product_url: AnyUrl,
     log_in_and_out: RobustWebSocket,
     create_project_from_service_dashboard: Callable[[ServiceType, str, str | None, str | None], dict[str, Any]],
     start_and_stop_pipeline: Callable[..., SocketIOEvent],
@@ -151,6 +154,12 @@ def test_sleepers(
             stage_timeouts=stage_timeouts,
         )
 
+    # NOTE: `project_data["workbench"]` predates the sleeper nodes created via the UI above, so
+    # the project is re-fetched here to get an up-to-date workbench
+    get_prj_response = api_request_context.get(f"{product_url}v0/projects/{project_data['uuid']}")
+    assert get_prj_response.ok, f"Failed to GET project: {get_prj_response.status} {get_prj_response.text()}"
+    workbench = get_prj_response.json()["data"]["workbench"]
+
     # check the outputs (the first item is the title, so we skip it)
     with log_context(
         logging.INFO,
@@ -167,7 +176,7 @@ def test_sleepers(
             check_node_outputs(
                 page,
                 study_id=project_data["uuid"],
-                workbench=project_data["workbench"],
+                workbench=workbench,
                 node_id=node_id,
                 expected_file_names=sleeper_expected_output_files,
             )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Some of the failures in cc_human were due to the fact that the node position was taken from the DOM and not from the effective project workbench. therefore the position was sometimes wrong.
This fixes the problem.

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
