### PR TITLE
i18n: adds exclude filter in extractor CLI and updates po catalogs

### DIFF
--- a/.github/instructions/python-tests.instructions.md
+++ b/.github/instructions/python-tests.instructions.md
@@ -14,10 +14,15 @@ This is a multi-project monorepo with two main groups of projects in the folders
 - Do not use `class Test...` containers for grouping tests.
 - When flattening or adding tests, use descriptive function name prefixes (e.g. `test_ordering_query_params_defaults_*`) to preserve grouping intent.
 - Do not add return type annotations to `test_*` functions. All non-test helpers must be fully annotated.
+- Prefer a weak DRY approach in tests: reduce repetition when it helps readability, but DO NOT ABSTRACT AWAY INTENT.
+  - When multiple tests differ only by inputs/expected outputs, consider `pytest.mark.parametrize` if the case table makes it clearer what behavior is being verified.
+  - Keep separate explicit tests when parametrization would hide the scenario or make failures harder to understand. Prefer clarity over maximal DRY.
 
 ### Fixtures
 
 - Reuse existing fixtures and helpers before creating new ones. Check `packages/pytest-simcore` first.
+- When the same setup/arrange block is repeated across tests, extract it into a fixture with a descriptive name so intent is clear at the call site.
+- Small inline repetition is acceptable when extracting a fixture would add indirection and make the individual test harder to read. Prefer clarity over maximal DRY.
 - If a fixture is used across multiple files within the same project, move it to the local `conftest.py`.
 - If a fixture is useful across multiple projects, move it to `pytest-simcore` instead.
 
@@ -49,4 +54,4 @@ This is a multi-project monorepo with two main groups of projects in the folders
 See the [`run-python-tests`](../skills/run-python-tests/SKILL.md) skill for the full step-by-step procedure.
 
 ---
-*Last updated: 2026-04-23*
+*Last updated: 2026-08-19*

--- a/packages/common-library/src/common_library/locale/es_ES/LC_MESSAGES/messages.po
+++ b/packages/common-library/src/common_library/locale/es_ES/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osparc-simcore\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-14 18:43+0200\n"
+"POT-Creation-Date: 2026-08-19 15:19+0200\n"
 "PO-Revision-Date: 2026-06-24 16:28+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Translation-Date: 2026-08-14T16:43:12Z\n"
+"X-Translation-Date: 2026-08-19T13:20:00Z\n"
 "X-Translation-Model: ollama/translategemma:4b\n"
 
 # CTX-INTERPRETATION: This message is displayed to users when the backend
@@ -652,7 +652,7 @@ msgstr ""
 # iteration. the completion status of a project pipeline execution for a
 # specific iteration. the completion status of a project pipeline execution
 # for a specific iteration.
-#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:239
+#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:229
 #, python-brace-format
 msgid ""
 "Project pipeline execution for iteration {iteration} has completed with "
@@ -664,7 +664,7 @@ msgstr ""
 # CTX-INTERPRETATION: This message is an error notification related to task
 # scheduling in the application. system to notify users of an unexpected issue
 # during the scheduling of tasks.
-#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:860
+#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:831
 msgid ""
 "An unexpected error occurred during task scheduling. Please contact oSparc "
 "support if this issue persists."
@@ -676,7 +676,7 @@ msgstr ""
 # scheduling a task with variable resolution has exceeded the time limit and
 # will attempt to retry. warning message when a task involving variable
 # resolution fails to complete in time and will be attempted again.
-#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:891
+#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:862
 msgid "Variable resolution timed out during task scheduling, will retry."
 msgstr ""
 "La resolución variable excedió el tiempo límite durante la programación de "
@@ -686,7 +686,7 @@ msgstr ""
 # cannot allocate the necessary computational resources in time. fails to
 # allocate computational resources for their task, prompting them to retry or
 # seek support.
-#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:959
+#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:930
 msgid ""
 "The system has timed out while waiting for computational resources. Please "
 "try running your project again or contact oSparc support if this issue "

--- a/packages/common-library/src/common_library/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/packages/common-library/src/common_library/locale/zh_CN/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osparc-simcore\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-14 18:43+0200\n"
+"POT-Creation-Date: 2026-08-19 15:19+0200\n"
 "PO-Revision-Date: 2026-06-24 16:28+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,7 +15,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Translation-Date: 2026-08-14T16:43:10Z\n"
+"X-Translation-Date: 2026-08-19T13:19:58Z\n"
 "X-Translation-Model: ollama/translategemma:4b\n"
 
 # CTX-INTERPRETATION: This message is displayed to users when the backend
@@ -551,7 +551,7 @@ msgstr ""
 # CTX-INTERPRETATION: This string is a log message indicating the completion
 # status of a project pipeline execution for a specific iteration in a
 # scientific simulation application.
-#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:239
+#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:229
 #, python-brace-format
 msgid ""
 "Project pipeline execution for iteration {iteration} has completed with "
@@ -560,7 +560,7 @@ msgstr "项目管道执行的第{iteration}次迭代已完成，状态为：{run
 
 # CTX-INTERPRETATION: This string is an error message displayed to the user
 # when a task scheduling issue occurs in the application.
-#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:860
+#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:831
 msgid ""
 "An unexpected error occurred during task scheduling. Please contact oSparc "
 "support if this issue persists."
@@ -569,14 +569,14 @@ msgstr "在任务调度过程中发生了意外错误。如果此问题仍然存
 # CTX-INTERPRETATION: This string appears in the application's log system when
 # a task involving variable resolution fails to complete in time and will be
 # attempted again.
-#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:891
+#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:862
 msgid "Variable resolution timed out during task scheduling, will retry."
 msgstr "在任务调度期间，变量分辨率超时，将重试。"
 
 # CTX-INTERPRETATION: This message appears when the system fails to allocate
 # computational resources for a task, prompting the user to retry or seek
 # support.
-#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:959
+#: services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py:930
 msgid ""
 "The system has timed out while waiting for computational resources. Please "
 "try running your project again or contact oSparc support if this issue "

--- a/scripts/i18n/tools/i18n_extractor.py
+++ b/scripts/i18n/tools/i18n_extractor.py
@@ -45,6 +45,7 @@ Two-step .pot extractor:
 
 Usage:
     uv run tools/i18n_extractor.py extract --src src/ --out messages.pot
+    uv run tools/i18n_extractor.py extract --src src/ --exclude 'test_*.cpp' --exclude 'test/*' --out messages.pot
     uv run tools/i18n_extractor.py xgettext --src src/ --langs python,cpp --out messages.pot
     uv run tools/i18n_extractor.py xgettext --src ui/src --out ui.pot --node-cwd ui/
     uv run tools/i18n_extractor.py jinja --src src/templates --out templates.pot
@@ -810,8 +811,12 @@ def enrich(pot_path: Path, repo_root: Path, py_hints: dict[str, str] | None = No
     console.print(f"[enrich] {len(po)} entries enriched -> {pot_path}")
 
 
-def collect_sources(src_dir: Path, langs: list[str] | None) -> list[Path]:
-    """Return all source files under src_dir, optionally filtered by language."""
+def collect_sources(
+    src_dir: Path,
+    langs: list[str] | None,
+    exclude_patterns: list[str] | None = None,
+) -> list[Path]:
+    """Return source files under src_dir, filtered by language and exclusion globs."""
     allowed_exts: set[str] = set()
     if langs:
         lang_to_exts = {
@@ -827,6 +832,10 @@ def collect_sources(src_dir: Path, langs: list[str] | None) -> list[Path]:
         allowed_exts = set(XgetextExtractor.LANG_MAP.keys()) | TS_AST_EXTRACTOR_EXTS
 
     files = [f for f in sorted(src_dir.rglob("*")) if f.suffix.lower() in allowed_exts]
+    if exclude_patterns:
+        files = [
+            path for path in files if not any(path.relative_to(src_dir).match(pattern) for pattern in exclude_patterns)
+        ]
     console.print(f"[collect] {len(files)} file(s) under {src_dir}")
     return files
 
@@ -856,10 +865,16 @@ app = typer.Typer(
 )
 
 
-def run_xgettext_step(src: Path, out: Path, langs: str | None, node_cwd: Path | None = None) -> None:
+def run_xgettext_step(
+    src: Path,
+    out: Path,
+    langs: str | None,
+    node_cwd: Path | None = None,
+    exclude_patterns: list[str] | None = None,
+) -> None:
     """Shared implementation for xgettext."""
     lang_list = [lang.strip() for lang in langs.split(",")] if langs else None
-    src_files = collect_sources(src, lang_list)
+    src_files = collect_sources(src, lang_list, exclude_patterns)
     if not src_files:
         raise typer.Exit(code=1)
 
@@ -892,10 +907,10 @@ def run_xgettext_step(src: Path, out: Path, langs: str | None, node_cwd: Path | 
     console.print(f"[done] xgettext -> {out}")
 
 
-def run_validate_step(src: Path, langs: str | None) -> None:
+def run_validate_step(src: Path, langs: str | None, exclude_patterns: list[str] | None = None) -> None:
     """Shared implementation for validation-only checks."""
     lang_list = [lang.strip() for lang in langs.split(",")] if langs else None
-    src_files = collect_sources(src, lang_list)
+    src_files = collect_sources(src, lang_list, exclude_patterns)
     if not src_files:
         raise typer.Exit(code=1)
 
@@ -915,9 +930,21 @@ def run_enrich_step(pot: Path, repo_root: Path) -> None:
     console.print(f"[done] enrich -> {pot}")
 
 
-def run_xgettext_cmd(src: Path, out: Path, langs: str | None, node_cwd: Path | None = None) -> None:
+def run_xgettext_cmd(
+    src: Path,
+    out: Path,
+    langs: str | None,
+    node_cwd: Path | None = None,
+    exclude_patterns: list[str] | None = None,
+) -> None:
     """Run only xgettext extraction over source files."""
-    run_xgettext_step(src=src, out=out, langs=langs, node_cwd=node_cwd)
+    run_xgettext_step(
+        src=src,
+        out=out,
+        langs=langs,
+        node_cwd=node_cwd,
+        exclude_patterns=exclude_patterns,
+    )
 
 
 def run_enrich_cmd(pot: Path, repo_root: Path) -> None:
@@ -938,9 +965,14 @@ def xgettext_cmd(
         help="Directory whose node_modules contains 'typescript' -- required when --src "
         "contains .js/.jsx/.ts/.tsx files (e.g. the frontend project root)",
     ),
+    exclude: list[str] | None = typer.Option(
+        None,
+        "--exclude",
+        help="Source-relative glob to exclude; may be repeated (e.g. test_*.cpp, test/*)",
+    ),
 ) -> None:
     """Run only xgettext extraction."""
-    run_xgettext_cmd(src=src, out=out, langs=langs, node_cwd=node_cwd)
+    run_xgettext_cmd(src=src, out=out, langs=langs, node_cwd=node_cwd, exclude_patterns=exclude)
 
 
 @app.command("jinja")
@@ -1011,9 +1043,14 @@ def extract(
         help="Directory whose node_modules contains 'typescript' -- required when --src "
         "contains .js/.jsx/.ts/.tsx files (e.g. the frontend project root)",
     ),
+    exclude: list[str] | None = typer.Option(
+        None,
+        "--exclude",
+        help="Source-relative glob to exclude; may be repeated (e.g. test_*.cpp, test/*)",
+    ),
 ) -> None:
     """Run xgettext then enrich."""
-    run_xgettext_cmd(src=src, out=out, langs=langs, node_cwd=node_cwd)
+    run_xgettext_cmd(src=src, out=out, langs=langs, node_cwd=node_cwd, exclude_patterns=exclude)
     run_enrich_cmd(pot=out, repo_root=repo_root)
 
 
@@ -1024,9 +1061,14 @@ def validate_cmd(
         None,
         help="Comma-separated languages to scan: python,cpp,c,mfc (default: all)",
     ),
+    exclude: list[str] | None = typer.Option(
+        None,
+        "--exclude",
+        help="Source-relative glob to exclude; may be repeated (e.g. test_*.cpp, test/*)",
+    ),
 ) -> None:
     """Run validation checks only (no catalog generation)."""
-    run_validate_step(src=src, langs=langs)
+    run_validate_step(src=src, langs=langs, exclude_patterns=exclude)
 
 
 def main() -> None:

--- a/scripts/i18n/tools/tests/test_i18n_extractor.py
+++ b/scripts/i18n/tools/tests/test_i18n_extractor.py
@@ -31,6 +31,7 @@ import json
 import subprocess
 import sys
 import types
+from collections.abc import Callable
 from pathlib import Path
 
 import polib
@@ -56,6 +57,19 @@ def _xgettext_available() -> bool:
 
 
 requires_xgettext = pytest.mark.skipif(not _xgettext_available(), reason="xgettext binary required")
+
+
+@pytest.fixture
+def make_cpp_files(tmp_path: Path) -> Callable[[str], tuple[Path, Path]]:
+    def _make(test_relative_path: str) -> tuple[Path, Path]:
+        production_file = tmp_path / "widget.cpp"
+        test_file = tmp_path / test_relative_path
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        production_file.touch()
+        test_file.touch()
+        return production_file, test_file
+
+    return _make
 
 
 # ---------------------------------------------------------------------------
@@ -86,46 +100,32 @@ def test_collect_python_hints_reads_hint_kwarg(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_collect_sources_excludes_test_filename_pattern(tmp_path: Path) -> None:
-    production_file = tmp_path / "widget.cpp"
-    test_file = tmp_path / "test_widget.cpp"
-    production_file.touch()
-    test_file.touch()
+@pytest.mark.parametrize(
+    "test_relative_path, exclude_pattern",
+    [
+        ("test_widget.cpp", "test_*.cpp"),
+        ("test/widget.cpp", "test/*"),
+        ("testsuite/widget.cpp", "testsuite/*.cpp"),
+    ],
+)
+def test_collect_sources_excludes_test_paths(
+    make_cpp_files: Callable[[str], tuple[Path, Path]],
+    tmp_path: Path,
+    test_relative_path: str,
+    exclude_pattern: str,
+) -> None:
+    production_file, _ = make_cpp_files(test_relative_path)
 
-    files = ix.collect_sources(tmp_path, ["cpp"], ["test_*.cpp"])
-
-    assert files == [production_file]
-
-
-def test_collect_sources_excludes_test_directory(tmp_path: Path) -> None:
-    production_file = tmp_path / "widget.cpp"
-    test_file = tmp_path / "test" / "widget.cpp"
-    test_file.parent.mkdir()
-    production_file.touch()
-    test_file.touch()
-
-    files = ix.collect_sources(tmp_path, ["cpp"], ["test/*"])
+    files = ix.collect_sources(tmp_path, ["cpp"], [exclude_pattern])
 
     assert files == [production_file]
 
 
-def test_collect_sources_excludes_testsuite_cpp_files(tmp_path: Path) -> None:
-    production_file = tmp_path / "widget.cpp"
-    test_file = tmp_path / "testsuite" / "widget.cpp"
-    test_file.parent.mkdir()
-    production_file.touch()
-    test_file.touch()
-
-    files = ix.collect_sources(tmp_path, ["cpp"], ["testsuite/*.cpp"])
-
-    assert files == [production_file]
-
-
-def test_collect_sources_includes_test_files_without_exclusions(tmp_path: Path) -> None:
-    production_file = tmp_path / "widget.cpp"
-    test_file = tmp_path / "test_widget.cpp"
-    production_file.touch()
-    test_file.touch()
+def test_collect_sources_includes_test_files_without_exclusions(
+    make_cpp_files: Callable[[str], tuple[Path, Path]],
+    tmp_path: Path,
+) -> None:
+    production_file, test_file = make_cpp_files("test_widget.cpp")
 
     files = ix.collect_sources(tmp_path, ["cpp"])
 

--- a/scripts/i18n/tools/tests/test_i18n_extractor.py
+++ b/scripts/i18n/tools/tests/test_i18n_extractor.py
@@ -82,6 +82,57 @@ def test_collect_python_hints_reads_hint_kwarg(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Source discovery exclusions
+# ---------------------------------------------------------------------------
+
+
+def test_collect_sources_excludes_test_filename_pattern(tmp_path: Path) -> None:
+    production_file = tmp_path / "widget.cpp"
+    test_file = tmp_path / "test_widget.cpp"
+    production_file.touch()
+    test_file.touch()
+
+    files = ix.collect_sources(tmp_path, ["cpp"], ["test_*.cpp"])
+
+    assert files == [production_file]
+
+
+def test_collect_sources_excludes_test_directory(tmp_path: Path) -> None:
+    production_file = tmp_path / "widget.cpp"
+    test_file = tmp_path / "test" / "widget.cpp"
+    test_file.parent.mkdir()
+    production_file.touch()
+    test_file.touch()
+
+    files = ix.collect_sources(tmp_path, ["cpp"], ["test/*"])
+
+    assert files == [production_file]
+
+
+def test_collect_sources_excludes_testsuite_cpp_files(tmp_path: Path) -> None:
+    production_file = tmp_path / "widget.cpp"
+    test_file = tmp_path / "testsuite" / "widget.cpp"
+    test_file.parent.mkdir()
+    production_file.touch()
+    test_file.touch()
+
+    files = ix.collect_sources(tmp_path, ["cpp"], ["testsuite/*.cpp"])
+
+    assert files == [production_file]
+
+
+def test_collect_sources_includes_test_files_without_exclusions(tmp_path: Path) -> None:
+    production_file = tmp_path / "widget.cpp"
+    test_file = tmp_path / "test_widget.cpp"
+    production_file.touch()
+    test_file.touch()
+
+    files = ix.collect_sources(tmp_path, ["cpp"])
+
+    assert files == [test_file, production_file]
+
+
+# ---------------------------------------------------------------------------
 # JSON key extraction (guided tours)
 # ---------------------------------------------------------------------------
 

--- a/scripts/makefiles/i18n.mk
+++ b/scripts/makefiles/i18n.mk
@@ -26,6 +26,8 @@ i18n-extract: ## Extract user_message() strings -> _partials/$(I18N_COMPONENT_NA
 	uv run $(I18N_TOOLS)/i18n_extractor.py xgettext \
 	  --src $$(realpath --relative-to=$(REPO_BASE_DIR) $(I18N_SRC_DIR)) \
 	  --out $(I18N_PARTIALS)/$(I18N_COMPONENT_NAME).pot \
+		  --exclude 'test/*' \
+		  --exclude 'tests/*' \
 	  --langs python
 
 i18n-translate: ## (Delegate) AI translate full catalog via orchestrator
@@ -38,6 +40,8 @@ i18n-check: ## Validate no f-strings in user_message() calls
 	@cd $(REPO_BASE_DIR) && \
 	uv run $(I18N_TOOLS)/i18n_extractor.py validate \
 	  --src $$(realpath --relative-to=$(REPO_BASE_DIR) $(I18N_SRC_DIR)) \
+		  --exclude 'test/*' \
+		  --exclude 'tests/*' \
 	  --langs python
 
 .PHONY: i18n-info

--- a/scripts/makefiles/ollama.mk
+++ b/scripts/makefiles/ollama.mk
@@ -28,10 +28,10 @@
 ### reflects the shared-daemon reality: two Makefiles both running
 ### `ollama-serve` should coordinate on the SAME daemon, not start two).
 
-OLLAMA_HOST            ?= http://localhost:11434   ## Ollama daemon URL (health-check + API base)
+OLLAMA_HOST            ?= http://localhost:11434    ## Ollama daemon URL (health-check + API base)
 OLLAMA_MODEL           ?= llama3.1                  ## Model tag for `ollama-pull`/`ollama-ensure` (set before include to override)
 OLLAMA_STARTUP_TIMEOUT ?= 30                        ## Seconds to wait for `ollama serve` to become healthy
-OLLAMA_STATE_DIR       ?= /tmp/s4l-ollama-mk         ## PID/log file location (shared across includers -- see note above)
+OLLAMA_STATE_DIR       ?= /tmp/s4l-ollama-mk        ## PID/log file location (shared across includers -- see note above)
 
 # \note re-assign with $(strip ...): the column-aligned `##` comments above leave
 # trailing whitespace IN the value itself (make only strips the comment, not

--- a/services/static-webserver/client/source/translation/es_ES.po
+++ b/services/static-webserver/client/source/translation/es_ES.po
@@ -9,7 +9,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Translation-Date: 2026-07-30T14:21:07Z\n"
+"X-Translation-Date: 2026-08-19T13:20:03Z\n"
 "X-Translation-Model: ollama/translategemma:4b\n"
 
 # CTX-INTERPRETATION: The string "About " appears as part of a label or title,
@@ -1916,7 +1916,7 @@ msgstr " - Carpeta: "
 #: services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js:690
 #: services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js:691
 #: services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js:1333
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:485
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:495
 msgid "Move"
 msgstr "Mover"
 
@@ -8462,7 +8462,7 @@ msgstr "Rechazar y Enviar"
 # CTX-INTERPRETATION: The string appears in a form where the user is prompted
 # to enter a subject for a message or email, likely related to a preview or
 # approval/rejection process.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:211
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:215
 #: services/static-webserver/client/source/class/osparc/po/SendEmail.js:131
 msgid "Please enter a subject"
 msgstr "Por favor, introduzca un asunto"
@@ -8470,7 +8470,7 @@ msgstr "Por favor, introduzca un asunto"
 # CTX-INTERPRETATION: The string appears in the email content editor,
 # prompting the user to preview the email before sending, likely to avoid
 # errors or unintended consequences.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:218
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:222
 #: services/static-webserver/client/source/class/osparc/po/SendEmail.js:138
 msgid "Please preview the email before sending"
 msgstr "Por favor, revise el correo electrónico antes de enviarlo."
@@ -8478,28 +8478,28 @@ msgstr "Por favor, revise el correo electrónico antes de enviarlo."
 # CTX-INTERPRETATION: The string "User approved and email sent" appears in the
 # PreviewApprovalRejection.js file, likely indicating a successful user
 # approval action and subsequent email notification.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:254
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:258
 msgid "User approved and email sent"
 msgstr "Usuario ha aprobado y se ha enviado un correo electrónico"
 
 # CTX-INTERPRETATION: The string appears in a JavaScript file related to user
 # rejection and email notification, likely within a preview approval or
 # rejection workflow.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:282
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:286
 msgid "User rejected and email sent"
 msgstr "Usuario rechazó y se envió un correo electrónico"
 
 # CTX-INTERPRETATION: The string "User approved" appears within a JavaScript
 # file related to user approval/rejection workflows, likely displayed in a
 # user interface.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:300
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:304
 msgid "User approved"
 msgstr "Aprobado por el usuario"
 
 # CTX-INTERPRETATION: The string "User rejected" appears in the
 # PreviewApprovalRejection component, likely indicating that a user has
 # declined a preview or approval action within the application.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:316
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:320
 msgid "User rejected"
 msgstr "Usuario rechazó"
 
@@ -8620,43 +8620,43 @@ msgstr "Rechazar"
 # CTX-INTERPRETATION: The string "Preview Approve" appears as the label for a
 # button within a dialog window, likely used to preview and approve an
 # invitation.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:401
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:409
 msgid "Preview Approve"
 msgstr "Vista y Aprobación"
 
 # CTX-INTERPRETATION: The string "Preview email" is used as a title for a pop-
 # up window that displays a preview of an email invitation, likely within a
 # user interface for managing pending invitations.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:456
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:573
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:466
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:583
 msgid "Preview email"
 msgstr "Vista del correo electrónico"
 
 # CTX-INTERPRETATION: The string "Move to another product" appears as a
 # tooltip for a button, likely used within a user interface for managing
 # products or items, possibly related to inventory or order processing.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:465
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:475
 msgid "Move to another product"
 msgstr "Mover a otro producto"
 
 # CTX-INTERPRETATION: The string "Select the target product:" appears within a
 # user interface, likely in a form or dialog, prompting the user to choose a
 # specific product from a list or selection.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:476
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:486
 msgid "Select the target product:"
 msgstr "Seleccione el producto objetivo:"
 
 # CTX-INTERPRETATION: The string "Move to Product" is used within a user
 # interface element, likely a button or dialog, to indicate the action of
 # assigning a user to a specific product.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:494
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:504
 msgid "Move to Product"
 msgstr "Mover a Producto"
 
 # CTX-INTERPRETATION: This string appears in the 'osparc/po/UsersPending.js'
 # file, likely indicating that a user has been successfully moved within the
 # application, possibly after a user management operation.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:534
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:544
 msgid "User moved successfully"
 msgstr "Usuario movido con éxito"
 

--- a/services/static-webserver/client/source/translation/zh.po
+++ b/services/static-webserver/client/source/translation/zh.po
@@ -8,7 +8,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Translation-Date: 2026-07-30T14:21:13Z\n"
+"X-Translation-Date: 2026-08-19T13:20:05Z\n"
 "X-Translation-Model: ollama/translategemma:4b\n"
 
 # CTX-INTERPRETATION: The string "About " appears as part of a label or title,
@@ -1889,7 +1889,7 @@ msgstr " - 文件夹： "
 #: services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js:690
 #: services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js:691
 #: services/static-webserver/client/source/class/osparc/dashboard/StudyBrowser.js:1333
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:485
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:495
 msgid "Move"
 msgstr "移动"
 
@@ -8380,7 +8380,7 @@ msgstr "拒绝并发送"
 # CTX-INTERPRETATION: The string "Please enter a subject" appears in a form
 # related to sending emails or previewing approval/rejection processes,
 # prompting the user to provide a subject for the email or preview.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:211
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:215
 #: services/static-webserver/client/source/class/osparc/po/SendEmail.js:131
 msgid "Please enter a subject"
 msgstr "请输入主题"
@@ -8388,7 +8388,7 @@ msgstr "请输入主题"
 # CTX-INTERPRETATION: The string appears in the email content editor,
 # prompting the user to preview the email before sending, likely to avoid
 # errors or unintended consequences.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:218
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:222
 #: services/static-webserver/client/source/class/osparc/po/SendEmail.js:138
 msgid "Please preview the email before sending"
 msgstr "在发送之前，请预览电子邮件内容。"
@@ -8396,28 +8396,28 @@ msgstr "在发送之前，请预览电子邮件内容。"
 # CTX-INTERPRETATION: This string appears in the PreviewApprovalRejection.js
 # file, likely indicating that a user has approved a preview and an email
 # notification has been successfully sent.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:254
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:258
 msgid "User approved and email sent"
 msgstr "用户已批准并已发送电子邮件"
 
 # CTX-INTERPRETATION: This string appears in the PreviewApprovalRejection.js
 # file, likely indicating that a user has rejected a preview and an email
 # notification has been sent to the relevant parties.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:282
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:286
 msgid "User rejected and email sent"
 msgstr "用户已拒绝并已发送电子邮件"
 
 # CTX-INTERPRETATION: The string "User approved" appears in the context of a
 # user approving a preview or action within a scientific simulation
 # application, likely displayed in a user interface.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:300
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:304
 msgid "User approved"
 msgstr "用户已批准"
 
 # CTX-INTERPRETATION: The string "User rejected" appears in the context of a
 # user rejecting a preview or approval, likely within a user interface for a
 # scientific simulation application.
-#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:316
+#: services/static-webserver/client/source/class/osparc/po/PreviewApprovalRejection.js:320
 msgid "User rejected"
 msgstr "用户已拒绝"
 
@@ -8537,36 +8537,36 @@ msgstr "拒绝"
 # CTX-INTERPRETATION: The string "Preview Approve" appears as the label for a
 # button within a dialog window, likely used to preview an approval request
 # before formally approving it.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:401
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:409
 msgid "Preview Approve"
 msgstr "预览批准"
 
 # CTX-INTERPRETATION: This string is used as a title for a preview window that
 # displays an email invitation, likely within a user interface for managing
 # pending invitations.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:456
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:573
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:466
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:583
 msgid "Preview email"
 msgstr "预览邮件"
 
 # CTX-INTERPRETATION: The string "Move to another product" appears as a
 # tooltip for a button, likely used within a user interface for managing
 # products or items, possibly related to inventory or order processing.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:465
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:475
 msgid "Move to another product"
 msgstr "移动到另一个产品"
 
 # CTX-INTERPRETATION: The string "Select the target product:" appears within a
 # user interface, likely a form or dialog, where the user is prompted to
 # choose a specific product from a list or selection mechanism.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:476
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:486
 msgid "Select the target product:"
 msgstr "选择目标产品："
 
 # CTX-INTERPRETATION: The string "Move to Product" is used within a user
 # interface element, likely a dialog or window, to indicate the action of
 # assigning a user to a specific product.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:494
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:504
 msgid "Move to Product"
 msgstr "将用户添加到产品"
 
@@ -8574,7 +8574,7 @@ msgstr "将用户添加到产品"
 # specifically within the 'UsersPending' component, indicating that a user has
 # been successfully moved or transitioned to a different state within the
 # application.
-#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:534
+#: services/static-webserver/client/source/class/osparc/po/UsersPending.js:544
 msgid "User moved successfully"
 msgstr "用户已成功移动"
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?


While exploring po catalogs, i noticed that some of the translation messages were coming from test files. This PR adds a filter to exclude path glob patterns

In addition, it updates po catalogs



## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

- Part of https://github.com/ITISFoundation/private-issues/issues/624


## How to test

```
cd scripts/i18n
make test
```

## Dev-ops

None
