### PR TITLE
🐛 fix(storage): align DatCore pagination contract

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/simcore_storage_datcore_adapter.py
+++ b/packages/pytest-simcore/src/pytest_simcore/simcore_storage_datcore_adapter.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 import respx
 from faker import Faker
-from fastapi_pagination import Page, Params
+from fastapi_pagination import LimitOffsetPage, LimitOffsetParams
 from servicelib.aiohttp import status
 from simcore_service_storage.modules.datcore_adapter.datcore_adapter_settings import (
     DatcoreAdapterSettings,
@@ -41,7 +41,9 @@ def datcore_adapter_service_mock(faker: Faker) -> Iterator[respx.MockRouter]:
         list_datasets_re = re.compile(r"/datasets")
         respx_mocker.get(list_datasets_re, name="list_datasets").respond(
             status.HTTP_200_OK,
-            json=Page.create(items=[], params=Params(size=10), total=0).model_dump(mode="json"),
+            json=LimitOffsetPage.create(items=[], params=LimitOffsetParams(limit=10, offset=0), total=0).model_dump(
+                mode="json"
+            ),
         )
 
         def _create_download_link(request, file_id):

--- a/services/storage/src/simcore_service_storage/modules/datcore_adapter/datcore_adapter.py
+++ b/services/storage/src/simcore_service_storage/modules/datcore_adapter/datcore_adapter.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 
 import httpx
 from fastapi import FastAPI, status
-from fastapi_pagination import Page
+from fastapi_pagination import LimitOffsetPage
 from models_library.api_schemas_datcore_adapter.datasets import (
     DatasetMetaData as DatCoreDatasetMetaData,
 )
@@ -158,6 +158,10 @@ def _create_next_cursor(total: TotalNumber, page: _Page, size: _Size) -> Generic
     return None
 
 
+def _to_limit_offset_params(page: _Page, size: _Size) -> dict[str, NonNegativeInt]:
+    return {"limit": size, "offset": (page - 1) * size}
+
+
 async def _list_top_level_objects(
     app: FastAPI,
     *,
@@ -175,13 +179,12 @@ async def _list_top_level_objects(
         api_secret,
         "GET",
         request_path,
-        params={"size": size, "page": page},
+        params=_to_limit_offset_params(page, size),
     )
     assert isinstance(response, dict)  # nosec
-    file_metadata_page = Page[DatCoreFileMetaData](**response)
+    file_metadata_page = LimitOffsetPage[DatCoreFileMetaData].model_validate(response)
     entries = file_metadata_page.items
-    total = file_metadata_page.total
-    assert isinstance(total, int)  # nosec
+    total = TypeAdapter(TotalNumber).validate_python(file_metadata_page.total)
     next_cursor = _create_next_cursor(total, page, size)
 
     return (
@@ -287,14 +290,13 @@ async def list_datasets(
         api_secret,
         "GET",
         "/datasets",
-        params={"size": size, "page": page},
+        params=_to_limit_offset_params(page, size),
     )
     assert isinstance(response, dict)  # nosec
-    datasets_page = Page[DatCoreDatasetMetaData](**response)
+    datasets_page = LimitOffsetPage[DatCoreDatasetMetaData].model_validate(response)
     datasets = datasets_page.items
-    total = datasets_page.total
+    total = TypeAdapter(TotalNumber).validate_python(datasets_page.total)
 
-    assert isinstance(total, int)  # nosec
     next_cursor = _create_next_cursor(total, page, size)
 
     return (

--- a/services/storage/src/simcore_service_storage/modules/datcore_adapter/datcore_adapter.py
+++ b/services/storage/src/simcore_service_storage/modules/datcore_adapter/datcore_adapter.py
@@ -184,7 +184,7 @@ async def _list_top_level_objects(
     assert isinstance(response, dict)  # nosec
     file_metadata_page = LimitOffsetPage[DatCoreFileMetaData].model_validate(response)
     entries = file_metadata_page.items
-    total = TypeAdapter(TotalNumber).validate_python(file_metadata_page.total)
+    total: TotalNumber = TypeAdapter(TotalNumber).validate_python(file_metadata_page.total)
     next_cursor = _create_next_cursor(total, page, size)
 
     return (
@@ -295,7 +295,7 @@ async def list_datasets(
     assert isinstance(response, dict)  # nosec
     datasets_page = LimitOffsetPage[DatCoreDatasetMetaData].model_validate(response)
     datasets = datasets_page.items
-    total = TypeAdapter(TotalNumber).validate_python(datasets_page.total)
+    total: TotalNumber = TypeAdapter(TotalNumber).validate_python(datasets_page.total)
 
     next_cursor = _create_next_cursor(total, page, size)
 

--- a/services/storage/src/simcore_service_storage/modules/datcore_adapter/datcore_adapter_client_utils.py
+++ b/services/storage/src/simcore_service_storage/modules/datcore_adapter/datcore_adapter_client_utils.py
@@ -1,10 +1,14 @@
 import logging
 from collections.abc import Callable
 from math import ceil
-from typing import Any, cast
+from typing import Any
 
 import httpx
 from fastapi import FastAPI
+from fastapi_pagination import LimitOffsetPage
+from models_library.api_schemas_storage.storage_schemas import (
+    DEFAULT_NUMBER_OF_PATHS_PER_PAGE,
+)
 from servicelib.fastapi.httpx_client import get_httpx_client
 
 from ...core.settings import get_application_settings
@@ -71,22 +75,31 @@ async def retrieve_all_pages[T](
     path: str,
     return_type_creator: Callable[..., T],
 ) -> list[T]:
-    page = 1
+    offset = 0
     objs = []
-    while (
-        response := cast(
-            dict[str, Any],
-            await request(app, api_key, api_secret, method, path, params={"page": page}),
+    while True:
+        response_page = LimitOffsetPage[dict[str, Any]].model_validate(
+            await request(
+                app,
+                api_key,
+                api_secret,
+                method,
+                path,
+                params={"limit": DEFAULT_NUMBER_OF_PATHS_PER_PAGE, "offset": offset},
+            )
         )
-    ) and response.get("items"):
+        assert response_page.limit is not None  # nosec
+        assert response_page.offset is not None  # nosec
         _logger.debug(
             "called %s [%d/%d], received %d objects",
             path,
-            page,
-            ceil(response.get("total", -1) / response.get("size", 1)),
-            len(response.get("items", [])),
+            response_page.offset // response_page.limit + 1,
+            ceil(response_page.total / response_page.limit),
+            len(response_page.items),
         )
 
-        objs += [return_type_creator(d) for d in response.get("items", [])]
-        page += 1
+        objs += [return_type_creator(item) for item in response_page.items]
+        offset = response_page.offset + response_page.limit
+        if not response_page.items or offset >= response_page.total:
+            break
     return objs

--- a/services/storage/src/simcore_service_storage/modules/datcore_adapter/datcore_adapter_client_utils.py
+++ b/services/storage/src/simcore_service_storage/modules/datcore_adapter/datcore_adapter_client_utils.py
@@ -76,8 +76,9 @@ async def retrieve_all_pages[T](
     return_type_creator: Callable[..., T],
 ) -> list[T]:
     offset = 0
-    objs = []
-    while True:
+    total: int | None = None
+    objs: list[T] = []
+    while total is None or offset < total:
         response_page = LimitOffsetPage[dict[str, Any]].model_validate(
             await request(
                 app,
@@ -99,7 +100,8 @@ async def retrieve_all_pages[T](
         )
 
         objs += [return_type_creator(item) for item in response_page.items]
+        total = response_page.total
         offset = response_page.offset + response_page.limit
-        if not response_page.items or offset >= response_page.total:
+        if not response_page.items:
             break
     return objs

--- a/services/storage/tests/unit/test_datcore_adapter.py
+++ b/services/storage/tests/unit/test_datcore_adapter.py
@@ -1,7 +1,50 @@
 import pytest
 from fastapi import FastAPI
 from pytest_mock import MockerFixture
-from simcore_service_storage.modules.datcore_adapter import datcore_adapter
+from simcore_service_storage.modules.datcore_adapter import (
+    datcore_adapter,
+    datcore_adapter_client_utils,
+)
+
+
+async def test_list_all_datasets_retrieves_each_limit_offset_page(mocker: MockerFixture):
+    api_secret = f"{mocker.sentinel.api_secret}"
+    dataset = {
+        "display_name": "My dataset",
+        "id": "N:dataset:12345678-1234-1234-1234-123456789abc",
+        "size": None,
+    }
+    request_mock = mocker.patch.object(
+        datcore_adapter_client_utils,
+        "request",
+        autospec=True,
+        side_effect=[
+            {"items": [dataset] * 50, "limit": 50, "offset": 0, "total": 51},
+            {"items": [dataset], "limit": 50, "offset": 50, "total": 51},
+        ],
+    )
+
+    datasets = await datcore_adapter.list_all_datasets(FastAPI(), "api-key", api_secret)
+
+    assert len(datasets) == 51
+    assert request_mock.await_args_list == [
+        mocker.call(
+            mocker.ANY,
+            "api-key",
+            api_secret,
+            "GET",
+            "/datasets",
+            params={"limit": 50, "offset": 0},
+        ),
+        mocker.call(
+            mocker.ANY,
+            "api-key",
+            api_secret,
+            "GET",
+            "/datasets",
+            params={"limit": 50, "offset": 50},
+        ),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/services/storage/tests/unit/test_datcore_adapter.py
+++ b/services/storage/tests/unit/test_datcore_adapter.py
@@ -1,0 +1,62 @@
+import pytest
+from fastapi import FastAPI
+from pytest_mock import MockerFixture
+from simcore_service_storage.modules.datcore_adapter import datcore_adapter
+
+
+@pytest.mark.parametrize(
+    "cursor, expected_offset, expected_next_cursor",
+    [
+        (None, 0, '{"next_page":2,"size":50}'),
+        ('{"next_page":2,"size":50}', 50, None),
+    ],
+)
+async def test_list_datasets_accepts_datcore_pagination_response(
+    mocker: MockerFixture,
+    cursor: str | None,
+    expected_offset: int,
+    expected_next_cursor: str | None,
+):
+    api_secret = f"{mocker.sentinel.api_secret}"
+    request_mock = mocker.patch.object(
+        datcore_adapter,
+        "request",
+        autospec=True,
+        return_value={
+            "items": [
+                {
+                    "display_name": "My dataset",
+                    "id": "N:dataset:12345678-1234-1234-1234-123456789abc",
+                    "size": None,
+                }
+            ],
+            "limit": 50,
+            "offset": expected_offset,
+            "total": 51,
+        },
+    )
+
+    datasets, next_cursor, total = await datcore_adapter.list_datasets(
+        FastAPI(),
+        api_key="api-key",
+        api_secret=api_secret,
+        cursor=cursor,
+        limit=50,
+    )
+
+    assert [dataset.model_dump() for dataset in datasets] == [
+        {
+            "dataset_id": "N:dataset:12345678-1234-1234-1234-123456789abc",
+            "display_name": "My dataset",
+        }
+    ]
+    assert next_cursor == expected_next_cursor
+    assert total == 51
+    request_mock.assert_awaited_once_with(
+        mocker.ANY,
+        "api-key",
+        api_secret,
+        "GET",
+        "/datasets",
+        params={"limit": 50, "offset": expected_offset},
+    )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Following the recent fastapi-pagination upgrade, storage failed while parsing DatCore paginated responses:

```
3 validation errors for Page[DatasetMetaData]
page
  Field required
size
  Field required
pages
  Field required
```

This pull request refactors the pagination logic in the `datcore_adapter` module to use `LimitOffsetPage` instead of `Page`, aligning the code with a limit/offset pagination model. It also introduces a utility function for converting page/size to limit/offset parameters and updates the dataset listing logic and tests to match the new pagination approach.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test
```sh
cd services/storage
make install-dev
pytest -vv --pdb tests/unit/test_datcore_adapter.py
```

## Dev-ops
- No changes.