### PR TITLE
Upgrade opentelemetry repo wide

### DIFF
--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -15,7 +15,7 @@ attrs==26.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
-coverage==7.15.4
+coverage==7.15.3
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -23,7 +23,7 @@ frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.19
+idna==3.18
     # via yarl
 iniconfig==2.3.0
     # via pytest
@@ -60,7 +60,7 @@ openapi-schema-validator==0.8.1
     #   openapi-spec-validator
 openapi-spec-validator==0.8.5
     # via openapi-core
-packaging==26.3
+packaging==26.2
     # via pytest
 pathable==0.5.0
     # via jsonschema-path
@@ -79,11 +79,11 @@ pydantic==2.13.4
     #   pydantic-settings
 pydantic-core==2.46.4
     # via pydantic
-pydantic-settings==2.15.0
+pydantic-settings==2.14.2
     # via
     #   openapi-schema-validator
     #   openapi-spec-validator
-pygments==2.21.0
+pygments==2.20.0
     # via pytest
 pytest==9.1.1
     # via
@@ -100,7 +100,7 @@ pytest-instafail==0.5.0
     # via -r requirements.in
 pytest-sugar==1.1.1
     # via -r requirements.in
-python-dotenv==1.2.3
+python-dotenv==1.2.2
     # via pydantic-settings
 pyyaml==6.0.3
     # via
@@ -128,7 +128,7 @@ typing-extensions==4.16.0
     #   pydantic
     #   pydantic-core
     #   typing-inspection
-typing-inspection==0.4.4
+typing-inspection==0.4.2
     # via
     #   pydantic
     #   pydantic-settings

--- a/api/tests/requirements.txt
+++ b/api/tests/requirements.txt
@@ -15,7 +15,7 @@ attrs==26.1.0
     #   aiohttp
     #   jsonschema
     #   referencing
-coverage==7.15.3
+coverage==7.15.4
     # via
     #   -r requirements.in
     #   pytest-cov
@@ -23,7 +23,7 @@ frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.18
+idna==3.19
     # via yarl
 iniconfig==2.3.0
     # via pytest
@@ -60,7 +60,7 @@ openapi-schema-validator==0.8.1
     #   openapi-spec-validator
 openapi-spec-validator==0.8.5
     # via openapi-core
-packaging==26.2
+packaging==26.3
     # via pytest
 pathable==0.5.0
     # via jsonschema-path
@@ -79,11 +79,11 @@ pydantic==2.13.4
     #   pydantic-settings
 pydantic-core==2.46.4
     # via pydantic
-pydantic-settings==2.14.2
+pydantic-settings==2.15.0
     # via
     #   openapi-schema-validator
     #   openapi-spec-validator
-pygments==2.20.0
+pygments==2.21.0
     # via pytest
 pytest==9.1.1
     # via
@@ -100,7 +100,7 @@ pytest-instafail==0.5.0
     # via -r requirements.in
 pytest-sugar==1.1.1
     # via -r requirements.in
-python-dotenv==1.2.2
+python-dotenv==1.2.3
     # via pydantic-settings
 pyyaml==6.0.3
     # via
@@ -128,7 +128,7 @@ typing-extensions==4.16.0
     #   pydantic
     #   pydantic-core
     #   typing-inspection
-typing-inspection==0.4.2
+typing-inspection==0.4.4
     # via
     #   pydantic
     #   pydantic-settings

--- a/packages/aws-library/requirements/_base.txt
+++ b/packages/aws-library/requirements/_base.txt
@@ -137,7 +137,7 @@ multidict==6.7.1
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -155,17 +155,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -176,37 +176,37 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.63b1
+opentelemetry-instrumentation-botocore==0.65b0
     # via -r requirements/_base.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -218,7 +218,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests

--- a/packages/celery-library/requirements/_base.txt
+++ b/packages/celery-library/requirements/_base.txt
@@ -120,7 +120,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -137,17 +137,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -158,35 +158,35 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-celery==0.63b1
+opentelemetry-instrumentation-celery==0.65b0
     # via -r requirements/_base.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -198,7 +198,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests

--- a/packages/service-library/requirements/_aiohttp.txt
+++ b/packages/service-library/requirements/_aiohttp.txt
@@ -30,26 +30,26 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
-opentelemetry-instrumentation-aiohttp-client==0.63b1
+opentelemetry-instrumentation-aiohttp-client==0.65b0
     # via -r requirements/_aiohttp.in
-opentelemetry-instrumentation-aiohttp-server==0.63b1
+opentelemetry-instrumentation-aiohttp-server==0.65b0
     # via -r requirements/_aiohttp.in
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server

--- a/packages/service-library/requirements/_base.txt
+++ b/packages/service-library/requirements/_base.txt
@@ -101,7 +101,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -117,17 +117,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -137,33 +137,33 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/_base.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -174,7 +174,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests

--- a/packages/service-library/requirements/_fastapi.txt
+++ b/packages/service-library/requirements/_fastapi.txt
@@ -74,26 +74,26 @@ markupsafe==3.0.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/_fastapi.in
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/packages/simcore-sdk/requirements/_base.txt
+++ b/packages/simcore-sdk/requirements/_base.txt
@@ -123,7 +123,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -139,17 +139,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -159,33 +159,33 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -196,7 +196,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests

--- a/services/agent/requirements/_base.txt
+++ b/services/agent/requirements/_base.txt
@@ -141,7 +141,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -159,17 +159,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -181,37 +181,37 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -224,7 +224,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/api-server/requirements/_base.txt
+++ b/services/api-server/requirements/_base.txt
@@ -216,7 +216,7 @@ multidict==6.1.0
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -237,17 +237,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -261,43 +261,43 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.63b1
+opentelemetry-instrumentation-botocore==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-celery==0.63b1
+opentelemetry-instrumentation-celery==0.65b0
     # via -r requirements/../../../packages/celery-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -312,7 +312,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/autoscaling/requirements/_base.txt
+++ b/services/autoscaling/requirements/_base.txt
@@ -204,7 +204,7 @@ multidict==6.7.0
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -224,17 +224,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -247,41 +247,41 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.63b1
+opentelemetry-instrumentation-botocore==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -295,7 +295,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/catalog/requirements/_base.txt
+++ b/services/catalog/requirements/_base.txt
@@ -155,7 +155,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -173,17 +173,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -195,37 +195,37 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -238,7 +238,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/clusters-keeper/requirements/_base.txt
+++ b/services/clusters-keeper/requirements/_base.txt
@@ -201,7 +201,7 @@ multidict==6.7.0
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -221,17 +221,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -244,41 +244,41 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.63b1
+opentelemetry-instrumentation-botocore==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -292,7 +292,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/dask-sidecar/requirements/_base.txt
+++ b/services/dask-sidecar/requirements/_base.txt
@@ -197,7 +197,7 @@ numpy==2.3.5
     #   bokeh
     #   contourpy
     #   pandas
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -215,17 +215,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -236,37 +236,37 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.63b1
+opentelemetry-instrumentation-botocore==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -278,7 +278,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests

--- a/services/datcore-adapter/requirements/_base.txt
+++ b/services/datcore-adapter/requirements/_base.txt
@@ -154,7 +154,7 @@ multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -172,17 +172,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -194,37 +194,37 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -237,7 +237,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/director-v2/requirements/_base.txt
+++ b/services/director-v2/requirements/_base.txt
@@ -209,7 +209,7 @@ networkx==3.5
     # via -r requirements/_base.in
 numpy==2.3.5
     # via -r requirements/../../../services/dask-sidecar/requirements/_dask-distributed.txt
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -228,17 +228,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-aiohttp-client
@@ -251,39 +251,39 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-aiohttp-client==0.63b1
+opentelemetry-instrumentation-aiohttp-client==0.65b0
     # via -r requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -297,7 +297,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-asgi

--- a/services/director/requirements/_base.txt
+++ b/services/director/requirements/_base.txt
@@ -142,7 +142,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -160,17 +160,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -182,37 +182,37 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -225,7 +225,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/docker-api-proxy/requirements/_test.txt
+++ b/services/docker-api-proxy/requirements/_test.txt
@@ -125,7 +125,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -141,17 +141,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asyncpg
@@ -161,33 +161,33 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -198,7 +198,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-httpx
     #   opentelemetry-instrumentation-requests

--- a/services/dynamic-scheduler/requirements/_base.txt
+++ b/services/dynamic-scheduler/requirements/_base.txt
@@ -171,7 +171,7 @@ multidict==6.1.0
     #   yarl
 nicegui==2.23.3
     # via -r requirements/_base.in
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -189,17 +189,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -211,37 +211,37 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -254,7 +254,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -169,7 +169,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -187,17 +187,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -209,37 +209,37 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -252,7 +252,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/efs-guardian/requirements/_base.txt
+++ b/services/efs-guardian/requirements/_base.txt
@@ -179,7 +179,7 @@ multidict==6.6.2
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -199,17 +199,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -222,41 +222,41 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.63b1
+opentelemetry-instrumentation-botocore==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -270,7 +270,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/invitations/requirements/_base.txt
+++ b/services/invitations/requirements/_base.txt
@@ -143,7 +143,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -161,17 +161,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -183,37 +183,37 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -226,7 +226,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/notifications/requirements/_base.txt
+++ b/services/notifications/requirements/_base.txt
@@ -170,7 +170,7 @@ multidict==6.2.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -189,17 +189,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -212,39 +212,39 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-celery==0.63b1
+opentelemetry-instrumentation-celery==0.65b0
     # via -r requirements/../../../packages/celery-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -258,7 +258,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/payments/requirements/_base.txt
+++ b/services/payments/requirements/_base.txt
@@ -160,7 +160,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -178,17 +178,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -200,37 +200,37 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -243,7 +243,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/resource-usage-tracker/requirements/_base.txt
+++ b/services/resource-usage-tracker/requirements/_base.txt
@@ -202,7 +202,7 @@ numpy==2.3.4
     #   matplotlib
     #   pandas
     #   prometheus-api-client
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -222,17 +222,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -245,41 +245,41 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.63b1
+opentelemetry-instrumentation-botocore==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -293,7 +293,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/storage/requirements/_base.txt
+++ b/services/storage/requirements/_base.txt
@@ -210,7 +210,7 @@ multidict==6.1.0
     #   aiobotocore
     #   aiohttp
     #   yarl
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -231,17 +231,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-propagator-aws-xray
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-asgi
@@ -255,47 +255,47 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-asgi==0.63b1
+opentelemetry-instrumentation-asgi==0.65b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-botocore==0.63b1
+opentelemetry-instrumentation-botocore==0.65b0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/_base.in
     #   -r requirements/_base.in
-opentelemetry-instrumentation-celery==0.63b1
+opentelemetry-instrumentation-celery==0.65b0
     # via
     #   -r requirements/../../../packages/celery-library/requirements/_base.in
     #   -r requirements/_base.in
-opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-fastapi==0.65b0
     # via -r requirements/../../../packages/service-library/requirements/_fastapi.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
 opentelemetry-propagator-aws-xray==1.0.2
     # via opentelemetry-instrumentation-botocore
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../packages/aws-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -310,7 +310,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi

--- a/services/web/server/requirements/_base.txt
+++ b/services/web/server/requirements/_base.txt
@@ -202,7 +202,7 @@ multidict==6.1.0
     #   yarl
 openpyxl==3.0.9
     # via -r requirements/_base.in
-opentelemetry-api==1.42.1
+opentelemetry-api==1.44.0
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -221,17 +221,17 @@ opentelemetry-api==1.42.1
     #   opentelemetry-instrumentation-threading
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.42.1
+opentelemetry-exporter-otlp==1.44.0
     # via -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.42.1
+opentelemetry-exporter-otlp-proto-http==1.44.0
     # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.63b1
+opentelemetry-instrumentation==0.65b0
     # via
     #   opentelemetry-instrumentation-aio-pika
     #   opentelemetry-instrumentation-aiohttp-client
@@ -244,39 +244,39 @@ opentelemetry-instrumentation==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-instrumentation-threading
-opentelemetry-instrumentation-aio-pika==0.63b1
+opentelemetry-instrumentation-aio-pika==0.65b0
     # via -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-aiohttp-client==0.63b1
+opentelemetry-instrumentation-aiohttp-client==0.65b0
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-opentelemetry-instrumentation-aiohttp-server==0.63b1
+opentelemetry-instrumentation-aiohttp-server==0.65b0
     # via -r requirements/../../../../packages/service-library/requirements/_aiohttp.in
-opentelemetry-instrumentation-asyncpg==0.63b1
+opentelemetry-instrumentation-asyncpg==0.65b0
     # via -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-celery==0.63b1
+opentelemetry-instrumentation-celery==0.65b0
     # via -r requirements/../../../../packages/celery-library/requirements/_base.in
-opentelemetry-instrumentation-httpx==0.63b1
+opentelemetry-instrumentation-httpx==0.65b0
     # via -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-logging==0.63b1
+opentelemetry-instrumentation-logging==0.65b0
     # via -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-redis==0.65b0
     # via -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-instrumentation-requests==0.65b0
     # via -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.65b0
     # via -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-instrumentation-threading==0.63b1
+opentelemetry-instrumentation-threading==0.65b0
     # via -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
-opentelemetry-proto==1.42.1
+opentelemetry-proto==1.44.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.42.1
+opentelemetry-sdk==1.44.0
     # via
     #   -r requirements/../../../../packages/celery-library/requirements/../../../packages/service-library/requirements/_base.in
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.63b1
+opentelemetry-semantic-conventions==0.65b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-aio-pika
@@ -290,7 +290,7 @@ opentelemetry-semantic-conventions==0.63b1
     #   opentelemetry-instrumentation-requests
     #   opentelemetry-instrumentation-sqlalchemy
     #   opentelemetry-sdk
-opentelemetry-util-http==0.63b1
+opentelemetry-util-http==0.65b0
     # via
     #   opentelemetry-instrumentation-aiohttp-client
     #   opentelemetry-instrumentation-aiohttp-server


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


🤖  **Upgrade OpenTelemetry from 1.42.1 to 1.44.0**

Memory profiling (Austin, memory mode) of `director-v2` revealed a net +876 KB memory growth over a 5-minute sampling window, with an alloc/free ratio of 1.47. The primary sources were the OTLP span exporter encoding path (`encode_spans`, `_encode_value`) and internal SDK metric accumulation (`Resource.__hash__`, `Span.__init__`).

Root cause: OTel 1.41.0 introduced always-on internal SDK metrics for span start/end ([#4880](https://github.com/open-telemetry/opentelemetry-python/pull/4880)), processors ([#5012](https://github.com/open-telemetry/opentelemetry-python/pull/5012)), and metric readers ([#4970](https://github.com/open-telemetry/opentelemetry-python/pull/4970)). OTel 1.42.0 then added per-measurement attribute dict copying ([#5106](https://github.com/open-telemetry/opentelemetry-python/pull/5106)). Together these cause compounding memory growth under load.

Fixes landed in 1.43.0–1.44.0:
- Remove unnecessary copy on span instantiation ([#5272](https://github.com/open-telemetry/opentelemetry-python/pull/5272))
- Remove unnecessary dict in `set_attribute` ([#5274](https://github.com/open-telemetry/opentelemetry-python/pull/5274))
- Remove unnecessary copy in iterator ([#5288](https://github.com/open-telemetry/opentelemetry-python/pull/5288))
- Reduce lock contention in attributes ([#5298](https://github.com/open-telemetry/opentelemetry-python/pull/5298))
- Clear Context before buffering in BatchLogRecordProcessor ([#4977](https://github.com/open-telemetry/opentelemetry-python/pull/4977))

--- 

###  Highlights on updated libraries (only updated libraries are included)

- #packages before ~ 24
- #packages after ~ 24

|#|name|before|after|upgrade|count|packages|
|-|----|------|-----|-------|-----|--------|
|   1 | opentelemetry-api         | 1.42.1          | 1.44.0     | *minor*    | 25 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   2 | opentelemetry-exporter-otlp | 1.42.1          | 1.44.0     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   3 | opentelemetry-exporter-otlp-proto-common | 1.42.1          | 1.44.0     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   4 | opentelemetry-exporter-otlp-proto-grpc | 1.42.1          | 1.44.0     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   5 | opentelemetry-exporter-otlp-proto-http | 1.42.1          | 1.44.0     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   6 | opentelemetry-instrumentation | 0.63            | 0.65       | *minor*    | 25 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   7 | opentelemetry-instrumentation-aio-pika | 0.63            | 0.65       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|   8 | opentelemetry-instrumentation-aiohttp-client | 0.63            | 0.65       | *minor*    | 3 | director-v2⬆️</br>service-library🧪</br>web⬆️ |
|   9 | opentelemetry-instrumentation-aiohttp-server | 0.63            | 0.65       | *minor*    | 2 | service-library🧪</br>web⬆️ |
|  10 | opentelemetry-instrumentation-asgi | 0.63            | 0.65       | *minor*    | 17 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>catalog⬆️</br>clusters-keeper⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>storage⬆️ |
|  11 | opentelemetry-instrumentation-asyncpg | 0.63            | 0.65       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  12 | opentelemetry-instrumentation-botocore | 0.63            | 0.65       | *minor*    | 8 | api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>efs-guardian⬆️</br>resource-usage-tracker⬆️</br>storage⬆️ |
|  13 | opentelemetry-instrumentation-celery | 0.63            | 0.65       | *minor*    | 5 | api-server⬆️</br>celery-library🧪</br>notifications⬆️</br>storage⬆️</br>web⬆️ |
|  14 | opentelemetry-instrumentation-fastapi | 0.63            | 0.65       | *minor*    | 17 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>catalog⬆️</br>clusters-keeper⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>storage⬆️ |
|  15 | opentelemetry-instrumentation-httpx | 0.63            | 0.65       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  16 | opentelemetry-instrumentation-logging | 0.63            | 0.65       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  17 | opentelemetry-instrumentation-redis | 0.63            | 0.65       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  18 | opentelemetry-instrumentation-requests | 0.63            | 0.65       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  19 | opentelemetry-instrumentation-sqlalchemy | 0.63            | 0.65       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  20 | opentelemetry-instrumentation-threading | 0.63            | 0.65       | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  21 | opentelemetry-proto       | 1.42.1          | 1.44.0     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  22 | opentelemetry-sdk         | 1.42.1          | 1.44.0     | *minor*    | 23 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  23 | opentelemetry-semantic-conventions | 0.63            | 0.65       | *minor*    | 25 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |
|  24 | opentelemetry-util-http   | 0.63            | 0.65       | *minor*    | 25 | agent⬆️</br>api-server⬆️</br>autoscaling⬆️</br>aws-library🧪</br>catalog⬆️</br>celery-library🧪</br>clusters-keeper⬆️</br>dask-sidecar⬆️</br>datcore-adapter⬆️</br>director-v2⬆️</br>director⬆️</br>docker-api-proxy🧪</br>dynamic-scheduler⬆️</br>dynamic-sidecar⬆️</br>efs-guardian⬆️</br>invitations⬆️</br>notifications⬆️</br>payments⬆️</br>resource-usage-tracker⬆️</br>service-library🧪🧪🧪</br>simcore-sdk🧪</br>storage⬆️</br>web⬆️ |

*Legend*: 
- ⬆️ base dependency (only services because packages are floating)
- 🧪 test dependency
- 🔧 tool dependency

### Repo-wide overview of libraries
- #reqs files parsed: 104

|#|name|versions-base|versions-test|versions-tool|
|-|----|-------------|-------------|-------------|
|   1 | aio-pika                  | 9.6.2                     | 9.6.2                     |                           |
|   2 | aioboto3                  | 14.3.0, 15.0.0, 15.5.0    | 15.5.0                    |                           |
|   3 | aiobotocore               | 2.22.0, 2.23.0, 2.25.1    | 2.25.1                    |                           |
|   4 | aiocache                  | 0.11.1, 0.12.2, 0.12.3    | 0.12.3                    |                           |
|   5 | aiodebug                  | 2.3.0                     | 2.3.0                     |                           |
|   6 | aiodocker                 | 0.21.0, 0.24.0, 0.26.0    | 0.24.0, 0.26.0            |                           |
|   7 | aiofiles                  | 0.8.0, 23.2.1, 24.1.0, 25.1.0 | 24.1.0, 25.1.0            |                           |
|   8 | aiohappyeyeballs          | 2.5.0, 2.6.1              | 2.5.0, 2.6.1              |                           |
|   9 | aiohttp                   | 3.13.5                    | 3.13.5                    |                           |
|  10 | aiohttp-jinja2            | 1.6                       |                           |                           |
|  11 | aiohttp-security          | 0.5.0                     |                           |                           |
|  12 | aiohttp-session           | 2.11.0                    |                           |                           |
|  13 | aioitertools              | 0.11.0, 0.12.0, 0.13.0    | 0.13.0                    |                           |
|  14 | aioprocessing             | 2.0.1                     |                           |                           |
|  15 | aioresponses              |                           | 0.7.8                     |                           |
|  16 | aiormq                    | 6.8.0, 6.8.1, 6.9.2, 6.9.3, 6.9.4 | 6.9.2, 6.9.3              |                           |
|  17 | aiosignal                 | 1.4.0                     | 1.4.0                     |                           |
|  18 | aiosmtplib                | 5.1.0                     |                           |                           |
|  19 | alembic                   | 1.8.1, 1.13.1, 1.14.0, 1.14.1, 1.15.1, 1.16.2, 1.17.2, 1.18.4 | 1.8.1, 1.13.1, 1.14.0, 1.15.1, 1.17.2, 1.18.4 |                           |
|  20 | amqp                      | 5.3.1                     | 5.3.1                     |                           |
|  21 | annotated-doc             | 0.0.4, 0.0.5              | 0.0.4, 0.0.5              | 0.0.4                     |
|  22 | annotated-types           | 0.7.0                     | 0.7.0                     |                           |
|  23 | antlr4-python3-runtime    |                           | 4.13.2                    |                           |
|  24 | anyio                     | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0, 4.9.0, 4.11.0, 4.12.1 | 4.3.0, 4.6.2.post1, 4.7.0, 4.8.0, 4.9.0, 4.11.0, 4.12.1, 4.13.0 |                           |
|  25 | arrow                     | 1.3.0, 1.4.0              | 1.4.0                     |                           |
|  26 | asgi-lifespan             | 2.1.0                     | 2.1.0                     |                           |
|  27 | asgiref                   | 3.8.1, 3.10.0             |                           |                           |
|  28 | ast-serialize             |                           | 0.5.0                     | 0.5.0                     |
|  29 | astroid                   |                           |                           | 4.0.4                     |
|  30 | async-asgi-testclient     |                           | 1.4.11                    |                           |
|  31 | asyncpg                   | 0.30.0, 0.31.0            | 0.30.0                    |                           |
|  32 | asyncpg-stubs             |                           | 0.30.2                    |                           |
|  33 | attrs                     | 23.2.0, 24.2.0, 25.1.0, 25.2.0, 25.3.0, 25.4.0, 26.1.0 | 23.2.0, 24.2.0, 25.1.0, 25.2.0, 25.3.0, 25.4.0, 26.1.0 |                           |
|  34 | aws-sam-translator        |                           | 1.103.0, 1.106.0          |                           |
|  35 | aws-xray-sdk              |                           | 0.95, 2.15.0              |                           |
|  36 | bidict                    | 0.22.0, 0.23.1            | 0.23.1                    |                           |
|  37 | billiard                  | 4.2.1, 4.2.3, 4.2.4       | 4.2.1, 4.2.3, 4.2.4       |                           |
|  38 | binaryornot               | 0.6.0                     |                           |                           |
|  39 | black                     |                           |                           | 26.3.1, 26.5.1            |
|  40 | blinker                   |                           | 1.9.0                     |                           |
|  41 | blosc                     | 1.11.3                    |                           |                           |
|  42 | bokeh                     | 3.8.1                     | 3.9.0                     |                           |
|  43 | boto3                     | 1.37.3, 1.38.27, 1.40.60, 1.40.61 | 1.37.3, 1.38.27, 1.40.61  |                           |
|  44 | boto3-stubs               |                           | 1.42.70                   |                           |
|  45 | botocore                  | 1.37.3, 1.38.27, 1.40.60, 1.40.61 | 1.37.3, 1.38.27, 1.40.61, 1.42.70 |                           |
|  46 | botocore-stubs            | 1.34.69, 1.36.17, 1.38.46, 1.40.74, 1.42.41, 1.43.14 | 1.40.74, 1.42.41, 1.43.14 |                           |
|  47 | brotli                    |                           | 1.2.0                     |                           |
|  48 | build                     |                           |                           | 1.4.0                     |
|  49 | bump2version              |                           |                           | 1.0.1                     |
|  50 | cachebox                  | 5.2.3                     | 5.2.3                     |                           |
|  51 | captcha                   | 0.5.0                     |                           |                           |
|  52 | celery                    | 5.6.3                     | 5.6.3                     |                           |
|  53 | certifi                   | 2023.7.22, 2024.2.2, 2024.8.30, 2025.1.31, 2025.6.15, 2025.11.12, 2026.2.25 | 2023.7.22, 2024.2.2, 2024.8.30, 2025.1.31, 2025.6.15, 2025.11.12, 2026.2.25, 2026.5.20 |                           |
|  54 | cffi                      | 2.0.0, 2.1.1              | 2.0.0, 2.1.1              |                           |
|  55 | cfgv                      |                           |                           | 3.5.0                     |
|  56 | cfn-lint                  |                           | 1.41.0, 1.47.1            |                           |
|  57 | change-case               |                           |                           | 0.5.2                     |
|  58 | charset-normalizer        | 2.0.12, 3.3.2, 3.4.0, 3.4.1, 3.4.2, 3.4.4, 3.4.6 | 2.0.12, 3.3.2, 3.4.0, 3.4.1, 3.4.2, 3.4.4, 3.4.6, 3.4.7 |                           |
|  59 | click                     | 8.2.1, 8.3.1              | 8.2.1, 8.3.1              | 8.2.1, 8.3.1, 8.4.1       |
|  60 | click-didyoumean          | 0.3.1                     | 0.3.1                     |                           |
|  61 | click-plugins             | 1.1.1, 1.1.1.2            | 1.1.1, 1.1.1.2            |                           |
|  62 | click-repl                | 0.3.0                     | 0.3.0                     |                           |
|  63 | cloudpickle               | 3.1.2                     | 3.1.2                     |                           |
|  64 | configargparse            |                           | 1.7.5                     |                           |
|  65 | contourpy                 | 1.3.3                     | 1.3.3                     |                           |
|  66 | cookiecutter              | 2.7.1                     |                           |                           |
|  67 | coverage                  |                           | 7.13.5                    |                           |
|  68 | cryptography              | 50.0.0                    | 50.0.0                    |                           |
|  69 | cycler                    | 0.12.1                    |                           |                           |
|  70 | dask                      | 2025.11.0, 2026.3.0       | 2025.11.0                 |                           |
|  71 | dateparser                | 1.2.0                     |                           |                           |
|  72 | debugpy                   |                           | 1.8.20                    |                           |
|  73 | deepdiff                  | 9.1.0                     | 9.1.0                     |                           |
|  74 | dill                      |                           |                           | 0.4.1                     |
|  75 | distlib                   |                           |                           | 0.4.0                     |
|  76 | distributed               | 2025.11.0, 2026.3.0       | 2025.11.0                 |                           |
|  77 | dnspython                 | 2.2.1, 2.6.1, 2.7.0, 2.8.0 | 2.2.1, 2.8.0              |                           |
|  78 | docker                    | 7.1.0                     | 7.1.0                     |                           |
|  79 | docutils                  | 0.21.2                    |                           |                           |
|  80 | ecdsa                     | 0.19.0                    |                           |                           |
|  81 | email-validator           | 2.1.1, 2.2.0, 2.3.0       | 2.2.0, 2.3.0              |                           |
|  82 | et-xmlfile                | 1.1.0                     |                           |                           |
|  83 | exceptiongroup            |                           | 1.3.1                     |                           |
|  84 | execnet                   |                           | 2.1.2                     |                           |
|  85 | faker                     | 19.6.1                    | 19.6.1, 40.11.0, 40.19.1  |                           |
|  86 | fakeredis                 |                           | 2.34.1                    |                           |
|  87 | fast-depends              | 3.0.3, 3.0.8              | 3.0.8                     |                           |
|  88 | fastapi                   | 0.141.1                   | 0.141.1                   |                           |
|  89 | fastapi-cli               | 0.0.32                    | 0.0.32                    |                           |
|  90 | fastapi-cloud-cli         | 0.1.5, 0.3.1              | 0.15.0                    |                           |
|  91 | fastapi-lifespan-manager  | 0.1.4                     | 0.1.4                     |                           |
|  92 | fastapi-pagination        | 0.15.16                   | 0.15.16                   |                           |
|  93 | fastar                    | 0.11.0                    | 0.11.0                    |                           |
|  94 | faststream                | 0.6.7                     | 0.6.7                     |                           |
|  95 | filelock                  |                           |                           | 3.25.2, 3.29.0            |
|  96 | flaky                     |                           | 3.8.1                     |                           |
|  97 | flask                     |                           | 2.1.3, 3.1.3              |                           |
|  98 | flask-cors                |                           | 6.0.2, 6.0.5              |                           |
|  99 | flask-login               |                           | 0.6.3                     |                           |
| 100 | flexcache                 | 0.3                       | 0.3                       |                           |
| 101 | flexparser                | 0.4                       | 0.4                       |                           |
| 102 | fonttools                 | 4.50.0                    |                           |                           |
| 103 | frozenlist                | 1.4.1, 1.5.0, 1.7.0, 1.8.0 | 1.4.1, 1.5.0, 1.7.0, 1.8.0 |                           |
| 104 | fsspec                    | 2025.10.0, 2026.2.0       | 2025.10.0                 |                           |
| 105 | gevent                    |                           | 25.9.1                    |                           |
| 106 | geventhttpclient          |                           | 2.3.9                     |                           |
| 107 | googleapis-common-protos  | 1.70.0, 1.72.0, 1.73.0    | 1.73.0                    |                           |
| 108 | graphql-core              |                           | 3.2.8, 3.2.11             |                           |
| 109 | greenlet                  | 3.2.4, 3.3.2              | 3.2.4, 3.3.2, 3.5.1       |                           |
| 110 | grpcio                    | 1.68.0, 1.68.1, 1.70.0, 1.71.0, 1.73.1, 1.76.0, 1.78.0 | 1.78.0                    |                           |
| 111 | gunicorn                  | 23.0.0                    |                           |                           |
| 112 | h11                       | 0.16.0                    | 0.16.0                    |                           |
| 113 | h2                        | 4.3.0                     | 4.3.0                     |                           |
| 114 | hpack                     | 4.1.0                     | 4.1.0                     |                           |
| 115 | httmock                   | 1.4.0                     |                           |                           |
| 116 | httpcore                  | 1.0.9                     | 1.0.9                     |                           |
| 117 | httptools                 | 0.6.4, 0.7.1              | 0.7.1                     |                           |
| 118 | httpx                     | 0.28.1                    | 0.28.1                    |                           |
| 119 | hypercorn                 |                           | 0.17.3                    |                           |
| 120 | hyperframe                | 6.1.0                     | 6.1.0                     |                           |
| 121 | hypothesis                |                           | 6.151.9                   |                           |
| 122 | icdiff                    |                           | 2.0.10                    |                           |
| 123 | identify                  |                           |                           | 2.6.18, 2.6.19            |
| 124 | idna                      | 3.3, 3.6, 3.10, 3.11      | 3.3, 3.6, 3.10, 3.11, 3.16 |                           |
| 125 | ifaddr                    | 0.2.0                     |                           |                           |
| 126 | iniconfig                 | 2.3.0                     | 2.3.0                     |                           |
| 127 | inotify                   |                           |                           | 0.2.12                    |
| 128 | isort                     |                           |                           | 8.0.1                     |
| 129 | itsdangerous              | 2.2.0                     | 2.2.0                     |                           |
| 130 | jinja-app-loader          | 1.0.2                     |                           |                           |
| 131 | jinja2                    | 3.1.6                     | 3.1.6                     | 3.1.6                     |
| 132 | jinja2-time               | 0.2.0                     |                           |                           |
| 133 | jmespath                  | 1.0.1, 1.1.0              | 1.0.1, 1.1.0              |                           |
| 134 | joserfc                   |                           | 1.5.0, 1.6.3              |                           |
| 135 | jsf                       |                           | 0.11.2                    |                           |
| 136 | jsondiff                  | 2.0.0                     |                           |                           |
| 137 | jsonpatch                 |                           | 1.33                      |                           |
| 138 | jsonpath-ng               |                           | 1.8.0                     |                           |
| 139 | jsonpickle                |                           | 4.1.1                     |                           |
| 140 | jsonpointer               |                           | 3.0.0, 3.1.1              |                           |
| 141 | jsonref                   | 1.1.0                     | 1.1.0                     |                           |
| 142 | jsonschema                | 4.26.0                    | 4.26.0                    |                           |
| 143 | jsonschema-path           |                           | 0.3.4                     |                           |
| 144 | jsonschema-specifications | 2023.7.1, 2024.10.1, 2025.4.1, 2025.9.1 | 2023.7.1, 2024.10.1, 2025.4.1, 2025.9.1 |                           |
| 145 | kiwisolver                | 1.4.9                     |                           |                           |
| 146 | kombu                     | 5.6.2                     | 5.6.2                     |                           |
| 147 | lazy-object-proxy         |                           | 1.12.0                    |                           |
| 148 | librt                     |                           | 0.8.1, 0.11.0             | 0.8.1, 0.11.0             |
| 149 | locket                    | 1.0.0                     | 1.0.0                     |                           |
| 150 | locust                    |                           | 2.43.3                    |                           |
| 151 | locust-plugins            |                           | 5.0.0                     |                           |
| 152 | lupa                      |                           | 2.6                       |                           |
| 153 | lz4                       | 4.4.5                     |                           |                           |
| 154 | mako                      | 1.3.12                    | 1.3.12                    |                           |
| 155 | markdown-it-py            | 3.0.0, 4.0.0              | 3.0.0, 4.0.0              | 4.0.0                     |
| 156 | markdown2                 | 2.5.3                     |                           |                           |
| 157 | markupsafe                | 3.0.2, 3.0.3              | 3.0.2, 3.0.3              | 3.0.2                     |
| 158 | matplotlib                | 3.10.7                    |                           |                           |
| 159 | mccabe                    |                           |                           | 0.7.0                     |
| 160 | mdurl                     | 0.1.2                     | 0.1.2                     | 0.1.2                     |
| 161 | moto                      |                           | 5.2.2                     |                           |
| 162 | mpmath                    |                           | 1.3.0                     |                           |
| 163 | msgpack                   | 1.1.0, 1.1.2              | 1.1.2                     |                           |
| 164 | multidict                 | 6.0.5, 6.1.0, 6.2.0, 6.6.2, 6.7.0, 6.7.1 | 6.1.0, 6.6.2, 6.7.0, 6.7.1 |                           |
| 165 | mypy                      |                           | 1.19.1, 2.1.0             | 1.19.1, 2.1.0             |
| 166 | mypy-extensions           |                           | 1.1.0                     | 1.1.0                     |
| 167 | narwhals                  | 2.11.0                    | 2.18.0                    |                           |
| 168 | nest-asyncio              | 1.6.0                     |                           |                           |
| 169 | networkx                  | 3.5                       | 3.6.1                     |                           |
| 170 | nicegui                   | 2.23.3                    |                           |                           |
| 171 | nodeenv                   |                           |                           | 1.10.0                    |
| 172 | numpy                     | 2.3.4, 2.3.5              | 2.3.5, 2.4.3              |                           |
| 173 | openapi-schema-validator  |                           | 0.6.3                     |                           |
| 174 | openapi-spec-validator    |                           | 0.7.2                     |                           |
| 175 | openpyxl                  | 3.0.9                     |                           |                           |
| 176 | opentelemetry-api         | 1.44.0                    | 1.44.0                    |                           |
| 177 | opentelemetry-exporter-otlp | 1.44.0                    | 1.44.0                    |                           |
| 178 | opentelemetry-exporter-otlp-proto-common | 1.44.0                    | 1.44.0                    |                           |
| 179 | opentelemetry-exporter-otlp-proto-grpc | 1.44.0                    | 1.44.0                    |                           |
| 180 | opentelemetry-exporter-otlp-proto-http | 1.44.0                    | 1.44.0                    |                           |
| 181 | opentelemetry-instrumentation | 0.65b0                    | 0.65b0                    |                           |
| 182 | opentelemetry-instrumentation-aio-pika | 0.65b0                    | 0.65b0                    |                           |
| 183 | opentelemetry-instrumentation-aiohttp-client | 0.65b0                    |                           |                           |
| 184 | opentelemetry-instrumentation-aiohttp-server | 0.65b0                    |                           |                           |
| 185 | opentelemetry-instrumentation-asgi | 0.65b0                    |                           |                           |
| 186 | opentelemetry-instrumentation-asyncpg | 0.65b0                    | 0.65b0                    |                           |
| 187 | opentelemetry-instrumentation-botocore | 0.65b0                    |                           |                           |
| 188 | opentelemetry-instrumentation-celery | 0.65b0                    |                           |                           |
| 189 | opentelemetry-instrumentation-fastapi | 0.65b0                    |                           |                           |
| 190 | opentelemetry-instrumentation-httpx | 0.65b0                    | 0.65b0                    |                           |
| 191 | opentelemetry-instrumentation-logging | 0.65b0                    | 0.65b0                    |                           |
| 192 | opentelemetry-instrumentation-redis | 0.65b0                    | 0.65b0                    |                           |
| 193 | opentelemetry-instrumentation-requests | 0.65b0                    | 0.65b0                    |                           |
| 194 | opentelemetry-instrumentation-sqlalchemy | 0.65b0                    | 0.65b0                    |                           |
| 195 | opentelemetry-instrumentation-threading | 0.65b0                    | 0.65b0                    |                           |
| 196 | opentelemetry-propagator-aws-xray | 1.0.2                     |                           |                           |
| 197 | opentelemetry-proto       | 1.44.0                    | 1.44.0                    |                           |
| 198 | opentelemetry-sdk         | 1.44.0                    | 1.44.0                    |                           |
| 199 | opentelemetry-semantic-conventions | 0.65b0                    | 0.65b0                    |                           |
| 200 | opentelemetry-util-http   | 0.65b0                    | 0.65b0                    |                           |
| 201 | ordered-set               | 4.1.0                     |                           |                           |
| 202 | orderly-set               | 5.5.0                     | 5.5.0                     |                           |
| 203 | orjson                    | 3.11.9                    | 3.11.9                    |                           |
| 204 | osparc                    | 0.8.3                     |                           |                           |
| 205 | osparc-client             | 0.8.3                     |                           |                           |
| 206 | packaging                 | 24.0, 24.1, 24.2, 25.0, 26.0 | 24.0, 24.1, 24.2, 25.0, 26.0, 26.2 | 24.0, 24.1, 24.2, 25.0, 26.0, 26.2 |
| 207 | pact-python               |                           | 3.2.1                     |                           |
| 208 | pact-python-ffi           |                           | 0.4.28.2                  |                           |
| 209 | pamqp                     | 3.3.0                     | 3.3.0                     |                           |
| 210 | pandas                    | 2.3.3                     | 3.0.1                     |                           |
| 211 | parse                     | 1.20.2                    | 1.21.1                    |                           |
| 212 | partd                     | 1.4.2                     | 1.4.2                     |                           |
| 213 | passlib                   | 1.7.4                     |                           |                           |
| 214 | pathable                  |                           | 0.4.4                     |                           |
| 215 | pathspec                  |                           | 1.0.4, 1.1.1              | 1.0.4, 1.1.1              |
| 216 | phonenumbers              | 9.0.9                     |                           |                           |
| 217 | pillow                    | 12.2.0                    | 12.2.0                    |                           |
| 218 | pint                      | 0.25, 0.25.2              | 0.25.2                    |                           |
| 219 | platformdirs              | 4.3.6, 4.5.0, 4.9.4       | 4.9.4                     | 4.3.6, 4.5.0, 4.9.4, 4.10.0 |
| 220 | playwright                |                           | 1.58.0, 1.60.0            |                           |
| 221 | pluggy                    | 1.6.0                     | 1.6.0                     |                           |
| 222 | polib                     |                           | 1.2.0                     |                           |
| 223 | pprintpp                  |                           | 0.4.0                     |                           |
| 224 | pre-commit                |                           |                           | 4.5.1, 4.6.0              |
| 225 | priority                  |                           | 2.0.0                     |                           |
| 226 | prometheus-api-client     | 0.6.0                     |                           |                           |
| 227 | prometheus-client         | 0.14.1, 0.20.0, 0.21.0, 0.21.1, 0.22.1, 0.23.1 |                           |                           |
| 228 | prompt-toolkit            | 3.0.50, 3.0.51, 3.0.52    | 3.0.50, 3.0.51, 3.0.52    |                           |
| 229 | propcache                 | 0.2.1, 0.3.0, 0.3.1, 0.3.2, 0.4.1, 0.5.2 | 0.2.1, 0.3.0, 0.3.1, 0.3.2, 0.4.1, 0.5.2 |                           |
| 230 | protobuf                  | 5.29.6, 6.33.5            | 6.33.5                    |                           |
| 231 | pscript                   | 0.7.7                     |                           |                           |
| 232 | psutil                    | 6.0.0, 6.1.0, 7.0.0, 7.1.3, 7.2.2 | 6.1.0, 7.0.0, 7.1.3, 7.2.2 |                           |
| 233 | psycogreen                |                           | 1.0.2                     |                           |
| 234 | psycopg2-binary           | 2.9.11                    | 2.9.11                    |                           |
| 235 | ptvsd                     |                           | 4.3.2                     |                           |
| 236 | py-cpuinfo                |                           | 9.0.0                     |                           |
| 237 | py-partiql-parser         |                           | 0.6.3                     |                           |
| 238 | pyasn1                    | 0.6.1                     |                           |                           |
| 239 | pyasynchat                |                           | 1.0.5                     |                           |
| 240 | pyasyncore                |                           | 1.0.5                     |                           |
| 241 | pycountry                 | 23.12.11                  |                           |                           |
| 242 | pycparser                 | 2.21, 2.22, 3.0           | 2.22, 3.0                 |                           |
| 243 | pycryptodome              | 3.21.0, 3.22.0, 3.23.0    | 3.23.0                    |                           |
| 244 | pydantic                  | 2.13.4                    | 2.13.4                    |                           |
| 245 | pydantic-core             | 2.46.4                    | 2.46.4                    |                           |
| 246 | pydantic-extra-types      | 2.11.1                    | 2.11.1                    |                           |
| 247 | pydantic-settings         | 2.14.2                    | 2.14.2                    |                           |
| 248 | pyee                      |                           | 13.0.1                    |                           |
| 249 | pyftpdlib                 |                           | 2.2.0                     |                           |
| 250 | pygments                  | 2.15.1, 2.17.2, 2.18.0, 2.19.1, 2.19.2 | 2.15.1, 2.17.2, 2.18.0, 2.19.1, 2.19.2, 2.20.0 | 2.19.2                    |
| 251 | pyinstrument              | 5.1.1, 5.1.2              | 5.1.1, 5.1.2              |                           |
| 252 | pyjwt                     | 2.4.0                     |                           |                           |
| 253 | pyleak                    |                           | 0.2.0                     |                           |
| 254 | pylint                    |                           |                           | 4.0.5                     |
| 255 | pyopenssl                 |                           | 26.4.0                    |                           |
| 256 | pyparsing                 | 3.1.2                     | 3.1.2, 3.3.2              |                           |
| 257 | pyproject-hooks           |                           |                           | 1.2.0                     |
| 258 | pytest                    | 9.0.2                     | 9.0.2, 9.0.3              |                           |
| 259 | pytest-aiohttp            |                           | 1.1.0                     |                           |
| 260 | pytest-asyncio            |                           | 1.3.0                     |                           |
| 261 | pytest-base-url           |                           | 2.1.0                     |                           |
| 262 | pytest-benchmark          |                           | 5.2.3                     |                           |
| 263 | pytest-celery             |                           | 1.1.3, 1.3.0              |                           |
| 264 | pytest-cov                |                           | 7.0.0                     |                           |
| 265 | pytest-docker             |                           | 3.2.5                     |                           |
| 266 | pytest-docker-tools       |                           | 3.1.9                     |                           |
| 267 | pytest-html               |                           | 4.2.0                     |                           |
| 268 | pytest-icdiff             |                           | 0.9                       |                           |
| 269 | pytest-instafail          |                           | 0.5.0                     |                           |
| 270 | pytest-localftpserver     |                           | 1.5.0                     |                           |
| 271 | pytest-metadata           |                           | 3.1.1                     |                           |
| 272 | pytest-mock               |                           | 3.15.1                    |                           |
| 273 | pytest-playwright         |                           | 0.8.0                     |                           |
| 274 | pytest-runner             |                           | 6.0.1                     |                           |
| 275 | pytest-sugar              |                           | 1.1.1                     |                           |
| 276 | pytest-timeout            |                           | 2.4.0                     |                           |
| 277 | pytest-xdist              |                           | 3.8.0                     |                           |
| 278 | python-dateutil           | 2.8.2, 2.9.0.post0        | 2.8.2, 2.9.0.post0        |                           |
| 279 | python-discovery          |                           |                           | 1.1.3, 1.2.0, 1.4.0       |
| 280 | python-dotenv             | 1.0.1, 1.1.0, 1.1.1, 1.2.1, 1.2.2 | 1.0.1, 1.1.0, 1.1.1, 1.2.1, 1.2.2 |                           |
| 281 | python-engineio           | 4.11.2, 4.12.2, 4.12.3    | 4.12.2, 4.13.1            |                           |
| 282 | python-jose               | 3.3.0                     |                           |                           |
| 283 | python-magic              | 0.4.25, 0.4.27            |                           |                           |
| 284 | python-multipart          | 0.0.32                    | 0.0.32                    |                           |
| 285 | python-slugify            | 8.0.4                     | 8.0.4                     |                           |
| 286 | python-socketio           | 5.13.0, 5.14.3            | 5.13.0, 5.16.1            |                           |
| 287 | pytokens                  |                           |                           | 0.4.1                     |
| 288 | pytz                      | 2022.1, 2024.1, 2025.2    |                           |                           |
| 289 | pyyaml                    | 6.0.3                     | 6.0.3                     | 6.0.3                     |
| 290 | pyzmq                     |                           | 27.1.0                    |                           |
| 291 | redis                     | 6.4.0, 7.4.0              | 6.4.0, 7.4.0              |                           |
| 292 | referencing               | 0.29.3, 0.35.1            | 0.29.3, 0.35.1, 0.37.0    |                           |
| 293 | regex                     | 2025.11.3                 | 2025.11.3, 2026.2.28, 2026.7.19 |                           |
| 294 | repro-zipfile             | 0.4.1                     |                           |                           |
| 295 | requests                  | 2.34.2                    | 2.34.2                    |                           |
| 296 | requests-mock             |                           | 1.12.1                    |                           |
| 297 | responses                 |                           | 0.26.0                    |                           |
| 298 | respx                     |                           | 0.22.0                    |                           |
| 299 | rfc3339-validator         |                           | 0.1.4                     |                           |
| 300 | rich                      | 14.1.0, 14.2.0, 14.3.3    | 14.1.0, 14.3.3            | 14.3.3                    |
| 301 | rich-toolkit              | 0.15.0, 0.15.1            | 0.19.7                    |                           |
| 302 | rignore                   | 0.6.4, 0.7.6              | 0.7.6                     |                           |
| 303 | rpds-py                   | 0.28.0, 0.29.0, 0.30.0, 2026.6.3 | 0.28.0, 0.29.0, 0.30.0, 2026.6.3 |                           |
| 304 | rsa                       | 4.9                       |                           |                           |
| 305 | rstr                      |                           | 3.2.2                     |                           |
| 306 | ruff                      |                           |                           | 0.15.6, 0.15.7, 0.15.14   |
| 307 | s3fs                      | 2025.10.0                 |                           |                           |
| 308 | s3transfer                | 0.11.3, 0.13.0, 0.14.0    | 0.11.3, 0.13.0, 0.14.0    |                           |
| 309 | sentry-sdk                | 2.35.0, 2.44.0            | 2.55.0                    |                           |
| 310 | setproctitle              | 1.3.7                     |                           |                           |
| 311 | setuptools                |                           | 80.9.0, 82.0.1            |                           |
| 312 | sh                        | 2.0.6, 2.2.1, 2.2.2, 2.3.0 |                           |                           |
| 313 | shellingham               | 1.5.4                     | 1.5.4                     | 1.5.4                     |
| 314 | shortuuid                 | 1.0.13                    |                           |                           |
| 315 | simple-websocket          | 1.1.0                     | 1.1.0                     |                           |
| 316 | six                       | 1.16.0, 1.17.0            | 1.16.0, 1.17.0            |                           |
| 317 | smart-open                |                           | 7.5.1                     |                           |
| 318 | sniffio                   | 1.3.1                     | 1.3.1                     |                           |
| 319 | sortedcontainers          | 2.4.0                     | 2.4.0                     |                           |
| 320 | sqlalchemy                | 2.0.51                    | 2.0.51                    |                           |
| 321 | starlette                 | 0.47.2, 0.49.3, 0.52.1, 1.3.1 | 0.47.3, 0.52.1            |                           |
| 322 | stream-zip                | 0.0.84                    | 0.0.84                    |                           |
| 323 | swagger-ui-py             | 23.9.23                   |                           |                           |
| 324 | sympy                     |                           | 1.14.0                    |                           |
| 325 | tblib                     | 3.2.2                     | 3.2.2                     |                           |
| 326 | tenacity                  | 8.5.0, 9.0.0, 9.1.2, 9.1.4 | 8.5.0, 9.0.0, 9.1.4       |                           |
| 327 | termcolor                 |                           | 3.3.0                     |                           |
| 328 | text-unidecode            | 1.3                       | 1.3                       |                           |
| 329 | tomlkit                   |                           |                           | 0.14.0, 0.15.0            |
| 330 | toolz                     | 0.12.0, 0.12.1, 1.0.0, 1.1.0 | 1.1.0                     |                           |
| 331 | tornado                   | 6.5.2, 6.5.5              | 6.5.2                     |                           |
| 332 | tqdm                      | 4.66.3, 4.67.1, 4.67.3    | 4.67.3                    |                           |
| 333 | twilio                    | 7.12.0                    |                           |                           |
| 334 | typer                     | 0.16.1, 0.20.0, 0.24.1    | 0.16.1, 0.24.1            | 0.24.1                    |
| 335 | types-aioboto3            |                           | 15.5.0                    |                           |
| 336 | types-aiobotocore         | 3.3.0, 3.8.0              | 3.3.0, 3.8.0              |                           |
| 337 | types-aiobotocore-ec2     | 3.3.0, 3.8.0              | 3.3.0                     |                           |
| 338 | types-aiobotocore-iam     |                           | 3.3.0                     |                           |
| 339 | types-aiobotocore-kms     | 3.3.0, 3.8.0              |                           |                           |
| 340 | types-aiobotocore-s3      | 3.3.0, 3.8.0              | 3.2.1, 3.3.0, 3.8.0       |                           |
| 341 | types-aiobotocore-ssm     | 3.3.0, 3.8.0              | 3.3.0                     |                           |
| 342 | types-aiofiles            |                           | 25.1.0.20251011, 25.1.0.20260409 |                           |
| 343 | types-awscrt              | 0.20.5, 0.23.10, 0.27.4, 0.28.4, 0.31.3, 0.34.1 | 0.28.4, 0.31.3, 0.34.1    |                           |
| 344 | types-boto3               |                           | 1.42.70                   |                           |
| 345 | types-cachetools          |                           |                           | 6.2.0.20260317            |
| 346 | types-docker              |                           | 7.1.0.20260109            |                           |
| 347 | types-jsonschema          |                           | 4.26.0.20260202           |                           |
| 348 | types-networkx            |                           | 3.6.1.20260303            |                           |
| 349 | types-openpyxl            |                           | 3.1.5.20260316            |                           |
| 350 | types-paramiko            |                           | 4.0.0.20250822            |                           |
| 351 | types-passlib             |                           | 1.7.7.20260211            |                           |
| 352 | types-polib               |                           | 1.2.0.20260518            |                           |
| 353 | types-psutil              |                           | 7.2.2.20260130            |                           |
| 354 | types-psycopg2            |                           | 2.9.21.20260223           |                           |
| 355 | types-pyasn1              |                           | 0.6.0.20250914            |                           |
| 356 | types-python-dateutil     | 2.9.0.20240316, 2.9.0.20241003, 2.9.0.20241206, 2.9.0.20250516 |                           |                           |
| 357 | types-python-jose         |                           | 3.5.0.20250531            |                           |
| 358 | types-pyyaml              |                           | 6.0.12.20250915           |                           |
| 359 | types-requests            |                           | 2.32.4.20260107           |                           |
| 360 | types-s3transfer          |                           | 0.16.0                    |                           |
| 361 | types-tqdm                |                           | 4.67.3.20260303           |                           |
| 362 | typing-extensions         | 4.14.1, 4.15.0            | 4.14.1, 4.15.0            | 4.14.1, 4.15.0            |
| 363 | typing-inspection         | 0.4.2                     | 0.4.2                     |                           |
| 364 | tzdata                    | 2024.1, 2025.2, 2025.3    | 2025.2, 2025.3, 2026.2    |                           |
| 365 | tzlocal                   | 5.2, 5.3.1                | 5.3.1                     |                           |
| 366 | u-msgpack-python          | 2.8.0                     |                           |                           |
| 367 | urllib3                   | 2.7.0                     | 2.7.0                     |                           |
| 368 | uvicorn                   | 0.34.2, 0.35.0, 0.38.0    | 0.42.0                    |                           |
| 369 | uvloop                    | 0.21.0, 0.22.1            | 0.21.0, 0.22.1            |                           |
| 370 | vbuild                    | 0.8.2                     |                           |                           |
| 371 | vine                      | 5.1.0                     | 5.1.0                     |                           |
| 372 | virtualenv                |                           |                           | 21.2.0, 21.4.1            |
| 373 | watchdog                  | 6.0.0                     |                           | 6.0.0                     |
| 374 | watchfiles                | 1.1.1                     | 1.1.1                     |                           |
| 375 | wcwidth                   | 0.2.13, 0.2.14, 0.6.0     | 0.2.13, 0.2.14, 0.6.0     |                           |
| 376 | websocket-client          |                           | 1.9.0                     |                           |
| 377 | websockets                | 12.0, 14.1, 14.2, 15.0.1  | 16.0                      |                           |
| 378 | werkzeug                  | 2.1.2                     | 2.1.2, 3.1.6              |                           |
| 379 | wrapt                     | 1.16.0, 1.17.0, 1.17.2, 1.17.3 | 1.16.0, 1.17.0, 1.17.2, 1.17.3, 2.1.2 |                           |
| 380 | wsproto                   | 1.2.0, 1.3.1              | 1.2.0, 1.3.2              |                           |
| 381 | xmltodict                 |                           | 1.0.4                     |                           |
| 382 | xyzservices               | 2025.10.0                 | 2025.11.0                 |                           |
| 383 | yarl                      | 1.24.5                    | 1.24.5                    |                           |
| 384 | zict                      | 3.0.0                     | 3.0.0                     |                           |
| 385 | zope-event                |                           | 6.1                       |                           |
| 386 | zope-interface            |                           | 8.2                       |                           |



## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- https://github.com/ITISFoundation/private-issues/issues/646

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
