### PR TITLE
:zap: perf(web-server): optimize project node `PATCH` endpoint

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -1416,7 +1416,7 @@ async def patch_project_node(
         project_for_notification = {
             "uuid": f"{project_id}",
             "workbench": {
-                f"{node_id}": latest_node.model_dump(mode="json", by_alias=True, exclude_none=True),
+                f"{node_id}": latest_node.model_dump(mode="json", by_alias=True),
             },
         }
 

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -1414,7 +1414,7 @@ async def patch_project_node(
         project_for_notification = {
             "uuid": f"{project_id}",
             "workbench": {
-                f"{node_id}": updated_node.model_dump(mode="json", by_alias=True, exclude_none=True),
+                f"{node_id}": updated_node.model_dump(mode="json", by_alias=True),
             },
         }
 

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -1377,7 +1377,7 @@ async def patch_project_node(
 
     # 3. Patch the project node
 
-    await _projects_nodes_repository.update(
+    updated_node = await _projects_nodes_repository.update(
         app,
         project_id=project_id,
         node_id=node_id,
@@ -1404,17 +1404,32 @@ async def patch_project_node(
         if node_patch_exclude_unset.get("label"):
             await dynamic_scheduler_service.update_projects_networks(app, project_id=project_id)
 
-    updated_project: ProjectWithWorkbenchDBGet = await _projects_repository.get_project_with_workbench(
-        app, project_uuid=project_id
-    )
+    notify_all_nodes = bool({"inputs", "outputs"} & node_patch_exclude_unset.keys())
+    if notify_all_nodes:
+        updated_project: ProjectWithWorkbenchDBGet = await _projects_repository.get_project_with_workbench(
+            app, project_uuid=project_id
+        )
+        project_for_notification = updated_project.model_dump(mode="json", by_alias=True)
+    else:
+        project_for_notification = {
+            "uuid": f"{project_id}",
+            "workbench": {
+                f"{node_id}": updated_node.model_dump(mode="json", by_alias=True, exclude_none=True),
+            },
+        }
 
     updated_project_with_states = await add_project_states_for_user(
-        user_id=user_id, project=updated_project.model_dump(mode="json", by_alias=True), app=app
+        user_id=user_id,
+        project=project_for_notification,
+        app=app,
     )
     # 5. if inputs/outputs have been changed all depending nodes shall be notified
-    if {"inputs", "outputs"} & node_patch_exclude_unset.keys():
-        for node_uuid in updated_project_with_states["workbench"]:
-            await notify_project_node_update(app, updated_project_with_states, node_uuid)
+    if notify_all_nodes:
+        await notify_project_nodes_update(
+            app,
+            updated_project_with_states,
+            [NodeID(node_uuid) for node_uuid in updated_project_with_states["workbench"]],
+        )
         return
 
     await notify_project_node_update(app, updated_project_with_states, node_id)
@@ -2279,28 +2294,35 @@ async def remove_project_dynamic_services(
 _CONCURRENT_NOTIFICATIONS_LIMIT: Final[int] = 10
 
 
+async def _list_project_group_rooms_to_notify(
+    app: web.Application,
+    project_id: ProjectID,
+) -> list[GroupID]:
+    project_group_get_list = await _groups_service.list_project_groups_by_project_without_checking_permissions(
+        app, project_id=project_id
+    )
+    return [item.gid for item in project_group_get_list if item.read is True]
+
+
+async def _send_message_to_rooms(
+    app: web.Application,
+    rooms: Iterable[GroupID],
+    message: SocketMessageDict,
+) -> None:
+    await limited_gather(
+        *(socketio_service.send_message_to_standard_group(app, room, message) for room in rooms),
+        log=_logger,
+        limit=_CONCURRENT_NOTIFICATIONS_LIMIT,
+    )
+
+
 async def _send_message_to_project_groups(
     app: web.Application,
     project_id: ProjectID,
     message: SocketMessageDict,
 ) -> None:
-    project_group_get_list = await _groups_service.list_project_groups_by_project_without_checking_permissions(
-        app, project_id=project_id
-    )
-    rooms_to_notify = [item.gid for item in project_group_get_list if item.read is True]
-
-    await limited_gather(
-        *(
-            socketio_service.send_message_to_standard_group(
-                app,
-                room,
-                message,
-            )
-            for room in rooms_to_notify
-        ),
-        log=_logger,
-        limit=_CONCURRENT_NOTIFICATIONS_LIMIT,
-    )
+    rooms_to_notify = await _list_project_group_rooms_to_notify(app, project_id)
+    await _send_message_to_rooms(app, rooms_to_notify, message)
 
 
 async def notify_project_state_update(
@@ -2332,26 +2354,36 @@ async def notify_project_state_update(
         await _send_message_to_project_groups(app, project["uuid"], message)
 
 
+async def notify_project_nodes_update(
+    app: web.Application,
+    project: dict,
+    node_ids: Iterable[NodeID],
+) -> None:
+    if await is_project_hidden(app, ProjectID(project["uuid"])):
+        return
+
+    rooms_to_notify = await _list_project_group_rooms_to_notify(app, ProjectID(project["uuid"]))
+    for node_id in node_ids:
+        data: dict = {
+            "project_id": project["uuid"],
+            "node_id": f"{node_id}",
+            "data": project["workbench"][f"{node_id}"],
+        }
+
+        message = SocketMessageDict(
+            event_type=SOCKET_IO_NODE_UPDATED_EVENT,
+            data=data,
+        )
+
+        await _send_message_to_rooms(app, rooms_to_notify, message)
+
+
 async def notify_project_node_update(
     app: web.Application,
     project: dict,
     node_id: NodeID,
 ) -> None:
-    if await is_project_hidden(app, ProjectID(project["uuid"])):
-        return
-
-    data: dict = {
-        "project_id": project["uuid"],
-        "node_id": f"{node_id}",
-        "data": project["workbench"][f"{node_id}"],
-    }
-
-    message = SocketMessageDict(
-        event_type=SOCKET_IO_NODE_UPDATED_EVENT,
-        data=data,
-    )
-
-    await _send_message_to_project_groups(app, project["uuid"], message)
+    await notify_project_nodes_update(app, project, (node_id,))
 
 
 async def retrieve_and_notify_project_locked_state(

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -186,7 +186,6 @@ from .models import (
     ProjectDBGet,
     ProjectDict,
     ProjectPatchInternalExtended,
-    ProjectWithWorkbenchDBGet,
 )
 from .settings import ProjectsSettings, get_plugin_settings
 from .utils import (
@@ -1406,9 +1405,7 @@ async def patch_project_node(
 
     notify_all_nodes = bool({"inputs", "outputs"} & node_patch_exclude_unset.keys())
     if notify_all_nodes:
-        updated_project: ProjectWithWorkbenchDBGet = await _projects_repository.get_project_with_workbench(
-            app, project_uuid=project_id
-        )
+        updated_project = await _projects_repository.get_project_with_workbench(app, project_uuid=project_id)
         project_for_notification = updated_project.model_dump(mode="json", by_alias=True)
     else:
         latest_node = await _projects_nodes_repository.get(

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -1377,7 +1377,7 @@ async def patch_project_node(
 
     # 3. Patch the project node
 
-    updated_node = await _projects_nodes_repository.update(
+    await _projects_nodes_repository.update(
         app,
         project_id=project_id,
         node_id=node_id,
@@ -1411,10 +1411,15 @@ async def patch_project_node(
         )
         project_for_notification = updated_project.model_dump(mode="json", by_alias=True)
     else:
+        latest_node = await _projects_nodes_repository.get(
+            app,
+            project_id=project_id,
+            node_id=node_id,
+        )
         project_for_notification = {
             "uuid": f"{project_id}",
             "workbench": {
-                f"{node_id}": updated_node.model_dump(mode="json", by_alias=True, exclude_none=True),
+                f"{node_id}": latest_node.model_dump(mode="json", by_alias=True, exclude_none=True),
             },
         }
 

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
@@ -245,7 +245,7 @@ async def test_patch_project_node_ui_remove_marker(
 
 
 @pytest.mark.parametrize("user_role,expected", [(UserRole.USER, status.HTTP_204_NO_CONTENT)])
-async def test_patch_project_node_enriches_only_updated_node(
+async def test_patch_computational_project_node_notifies_only_updated_node(
     mock_dynamic_scheduler: None,
     mocked_dynamic_services_interface: dict[str, mock.MagicMock],
     client: TestClient,
@@ -257,20 +257,19 @@ async def test_patch_project_node_enriches_only_updated_node(
     node_id = next(node_id for node_id, node in user_project["workbench"].items() if "/comp/" in node["key"])
     assert client.app
     base_url = client.app.router["patch_project_node"].url_for(project_id=user_project["uuid"], node_id=node_id)
-    get_dynamic_service = mocked_dynamic_services_interface["dynamic_scheduler.api.get_dynamic_service"]
-    get_dynamic_service.reset_mock()
 
-    resp = await client.patch(f"{base_url}", json={"label": "updated label"})
+    resp = await client.patch(f"{base_url}", json={"label": "updated label", "runHash": None})
 
     await assert_status(resp, expected)
-    get_dynamic_service.assert_not_awaited()
     mocked_notify_project_node_update.assert_awaited_once()
     notified_project = mocked_notify_project_node_update.await_args.args[1]
+    assert set(notified_project["workbench"]) == {node_id}
     assert notified_project["workbench"][node_id]["label"] == "updated label"
+    assert notified_project["workbench"][node_id]["runHash"] is None
 
 
 @pytest.mark.parametrize("user_role,expected", [(UserRole.USER, status.HTTP_204_NO_CONTENT)])
-async def test_patch_project_node_notifies_latest_node_after_pipeline_sync(
+async def test_patch_project_node_notifies_outputs_updated_during_pipeline_sync(
     mock_dynamic_scheduler: None,
     mocked_dynamic_services_interface: dict[str, mock.MagicMock],
     client: TestClient,
@@ -282,14 +281,14 @@ async def test_patch_project_node_notifies_latest_node_after_pipeline_sync(
     node_id = next(node_id for node_id, node in user_project["workbench"].items() if "/comp/" in node["key"])
     assert client.app
     base_url = client.app.router["patch_project_node"].url_for(project_id=user_project["uuid"], node_id=node_id)
-    latest_outputs = {"output_1": 42}
+    outputs_updated_during_pipeline_sync = {"output_1": 42}
 
     async def _update_outputs_during_pipeline_sync(*args: object, **kwargs: object) -> None:
         await projects_nodes_repository.update(
             client.app,
             project_id=user_project["uuid"],
             node_id=node_id,
-            partial_node=PartialNode.model_construct(outputs=latest_outputs),
+            partial_node=PartialNode.model_construct(outputs=outputs_updated_during_pipeline_sync),
         )
 
     mocked_dynamic_services_interface[
@@ -301,7 +300,7 @@ async def test_patch_project_node_notifies_latest_node_after_pipeline_sync(
     await assert_status(resp, expected)
     mocked_notify_project_node_update.assert_awaited_once()
     notified_project = mocked_notify_project_node_update.await_args.args[1]
-    assert notified_project["workbench"][node_id]["outputs"] == latest_outputs
+    assert notified_project["workbench"][node_id]["outputs"] == outputs_updated_during_pipeline_sync
 
 
 @pytest.mark.parametrize("user_role,expected", [(UserRole.USER, status.HTTP_204_NO_CONTENT)])

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
@@ -8,6 +8,7 @@
 
 import json
 from http import HTTPStatus
+from importlib import import_module
 from unittest import mock
 
 import pytest
@@ -240,6 +241,31 @@ async def test_patch_project_node_ui_remove_marker(
 
 
 @pytest.mark.parametrize("user_role,expected", [(UserRole.USER, status.HTTP_204_NO_CONTENT)])
+async def test_patch_project_node_enriches_only_updated_node(
+    mock_dynamic_scheduler: None,
+    mocked_dynamic_services_interface: dict[str, mock.MagicMock],
+    client: TestClient,
+    logged_user: UserInfoDict,
+    user_project: ProjectDict,
+    expected: HTTPStatus,
+    mocked_notify_project_node_update,
+):
+    node_id = next(node_id for node_id, node in user_project["workbench"].items() if "/comp/" in node["key"])
+    assert client.app
+    base_url = client.app.router["patch_project_node"].url_for(project_id=user_project["uuid"], node_id=node_id)
+    get_dynamic_service = mocked_dynamic_services_interface["dynamic_scheduler.api.get_dynamic_service"]
+    get_dynamic_service.reset_mock()
+
+    resp = await client.patch(f"{base_url}", json={"label": "updated label"})
+
+    await assert_status(resp, expected)
+    get_dynamic_service.assert_not_awaited()
+    mocked_notify_project_node_update.assert_awaited_once()
+    notified_project = mocked_notify_project_node_update.await_args.args[1]
+    assert notified_project["workbench"][node_id]["label"] == "updated label"
+
+
+@pytest.mark.parametrize("user_role,expected", [(UserRole.USER, status.HTTP_204_NO_CONTENT)])
 async def test_patch_project_node_notifies(
     mocker: MockerFixture,
     mocked_dynamic_services_interface: dict[str, mock.MagicMock],
@@ -271,16 +297,22 @@ async def test_patch_project_node_notifies(
 
 @pytest.mark.parametrize("user_role,expected", [(UserRole.USER, status.HTTP_204_NO_CONTENT)])
 async def test_patch_project_node_inputs_notifies(
+    mocker: MockerFixture,
     mocked_dynamic_services_interface: dict[str, mock.MagicMock],
     client: TestClient,
     logged_user: UserInfoDict,
     user_project: ProjectDict,
     expected: HTTPStatus,
-    mocked_notify_project_node_update,
 ):
     node_id = next(iter(user_project["workbench"]))
     assert client.app
     base_url = client.app.router["patch_project_node"].url_for(project_id=user_project["uuid"], node_id=node_id)
+    projects_service = import_module("simcore_service_webserver.projects._projects_service")
+    notify_project_nodes_update = mocker.spy(projects_service, "notify_project_nodes_update")
+    list_project_groups = mocker.spy(
+        projects_service._groups_service,  # noqa: SLF001
+        "list_project_groups_by_project_without_checking_permissions",
+    )
 
     # inputs
     _patch_inputs = {
@@ -296,10 +328,11 @@ async def test_patch_project_node_inputs_notifies(
         data=json.dumps(_patch_inputs),
     )
     await assert_status(resp, expected)
-    assert mocked_notify_project_node_update.call_count > 1
-    # 1 message per node updated
+    notify_project_nodes_update.assert_awaited_once()
+    list_project_groups.assert_awaited_once()
+    assert notify_project_nodes_update.await_args is not None
     assert not DeepDiff(
-        [call_args[0][2] for call_args in mocked_notify_project_node_update.await_args_list],
+        [f"{node_id}" for node_id in notify_project_nodes_update.await_args.args[2]],
         list(user_project["workbench"].keys()),
         ignore_order=True,
     )

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
@@ -14,6 +14,7 @@ from unittest import mock
 import pytest
 from aiohttp.test_utils import TestClient
 from deepdiff import DeepDiff
+from models_library.projects_nodes import PartialNode
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.assert_checks import assert_status
 from pytest_simcore.helpers.webserver_users import UserInfoDict
@@ -263,6 +264,42 @@ async def test_patch_project_node_enriches_only_updated_node(
     mocked_notify_project_node_update.assert_awaited_once()
     notified_project = mocked_notify_project_node_update.await_args.args[1]
     assert notified_project["workbench"][node_id]["label"] == "updated label"
+
+
+@pytest.mark.parametrize("user_role,expected", [(UserRole.USER, status.HTTP_204_NO_CONTENT)])
+async def test_patch_project_node_notifies_latest_node_after_pipeline_sync(
+    mock_dynamic_scheduler: None,
+    mocked_dynamic_services_interface: dict[str, mock.MagicMock],
+    client: TestClient,
+    logged_user: UserInfoDict,
+    user_project: ProjectDict,
+    expected: HTTPStatus,
+    mocked_notify_project_node_update,
+):
+    node_id = next(node_id for node_id, node in user_project["workbench"].items() if "/comp/" in node["key"])
+    assert client.app
+    base_url = client.app.router["patch_project_node"].url_for(project_id=user_project["uuid"], node_id=node_id)
+    projects_nodes_repository = import_module("simcore_service_webserver.projects._projects_nodes_repository")
+    latest_outputs = {"output_1": 42}
+
+    async def _update_outputs_during_pipeline_sync(*args: object, **kwargs: object) -> None:
+        await projects_nodes_repository.update(
+            client.app,
+            project_id=user_project["uuid"],
+            node_id=node_id,
+            partial_node=PartialNode.model_construct(outputs=latest_outputs),
+        )
+
+    mocked_dynamic_services_interface[
+        "director_v2.api.create_or_update_pipeline"
+    ].side_effect = _update_outputs_during_pipeline_sync
+
+    resp = await client.patch(f"{base_url}", json={"label": "updated label"})
+
+    await assert_status(resp, expected)
+    mocked_notify_project_node_update.assert_awaited_once()
+    notified_project = mocked_notify_project_node_update.await_args.args[1]
+    assert notified_project["workbench"][node_id]["outputs"] == latest_outputs
 
 
 @pytest.mark.parametrize("user_role,expected", [(UserRole.USER, status.HTTP_204_NO_CONTENT)])

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
@@ -8,7 +8,6 @@
 
 import json
 from http import HTTPStatus
-from importlib import import_module
 from unittest import mock
 
 import pytest
@@ -25,6 +24,10 @@ from servicelib.rabbitmq.rpc_interfaces.catalog.errors import (
 )
 from simcore_service_webserver._meta import api_version_prefix
 from simcore_service_webserver.db.models import UserRole
+from simcore_service_webserver.projects import (
+    _projects_nodes_repository as projects_nodes_repository,
+)
+from simcore_service_webserver.projects import _projects_service as projects_service
 from simcore_service_webserver.projects.models import ProjectDict
 
 API_PREFIX = "/" + api_version_prefix
@@ -279,7 +282,6 @@ async def test_patch_project_node_notifies_latest_node_after_pipeline_sync(
     node_id = next(node_id for node_id, node in user_project["workbench"].items() if "/comp/" in node["key"])
     assert client.app
     base_url = client.app.router["patch_project_node"].url_for(project_id=user_project["uuid"], node_id=node_id)
-    projects_nodes_repository = import_module("simcore_service_webserver.projects._projects_nodes_repository")
     latest_outputs = {"output_1": 42}
 
     async def _update_outputs_during_pipeline_sync(*args: object, **kwargs: object) -> None:
@@ -344,7 +346,6 @@ async def test_patch_project_node_inputs_notifies(
     node_id = next(iter(user_project["workbench"]))
     assert client.app
     base_url = client.app.router["patch_project_node"].url_for(project_id=user_project["uuid"], node_id=node_id)
-    projects_service = import_module("simcore_service_webserver.projects._projects_service")
     notify_project_nodes_update = mocker.spy(projects_service, "notify_project_nodes_update")
     list_project_groups = mocker.spy(
         projects_service._groups_service,  # noqa: SLF001


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Optimizes `PATCH /v0/projects/{project_id}/nodes/{node_id}` by avoiding project-wide loading and runtime-state enrichment when only the patched node must be notified.

### Before

Every node patch loaded the complete workbench and enriched every node before sending Socket.IO notifications. Patches affecting `inputs` or `outputs` then performed project visibility and group-recipient lookups once per notified node.

### After

The notification path now depends on the fields being patched:

- Patches affecting `inputs` or `outputs` still reload and enrich the complete workbench because connected nodes may also change. Their notifications are dispatched in one batch, sharing a single project visibility check and recipient lookup.
- Other patches re-read only the updated node after director-v2 and dynamic-scheduler synchronization, enrich only that node, and emit a single-node notification containing the latest persisted state.

This reduces runtime-state enrichment on the common single-node path from $O(N)$ nodes to $O(1)$ while preserving the full-workbench path where dependency propagation requires it.

The HTTP response contract and pipeline synchronization behavior are unchanged.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test
```sh
cd services/web/server
make install-dev
pytest -vv --pdb tests/unit/with_dbs/02/test_projects_nodes_handlers__patch.py
```
## Dev-ops
- No changes.