### PR TITLE
:recycle: Improve Playwright - node selection and cookie banner

### DIFF
--- a/tests/e2e-playwright/tests/conftest.py
+++ b/tests/e2e-playwright/tests/conftest.py
@@ -415,15 +415,16 @@ def log_in_and_out(
         assert response
         assert response.ok, response.body()
 
-    # In case the accept cookies or new release window shows up, we accept
-    page.wait_for_timeout(2000)
-    acceptCookiesBtnLocator = page.get_by_test_id("acceptCookiesBtn")
-    if acceptCookiesBtnLocator.is_visible():
-        acceptCookiesBtnLocator.click()
-        page.wait_for_timeout(1000)
-        newReleaseCloseBtnLocator = page.get_by_test_id("newReleaseCloseBtn")
-        if newReleaseCloseBtnLocator.is_visible():
-            newReleaseCloseBtnLocator.click()
+    # The cookie-consent banner and the "new release" popup can appear at
+    # unpredictable times (often a moment after page load)
+    page.add_locator_handler(
+        page.get_by_test_id("acceptCookiesBtn"),
+        lambda locator: locator.click(),
+    )
+    page.add_locator_handler(
+        page.get_by_test_id("newReleaseCloseBtn"),
+        lambda locator: locator.click(),
+    )
 
     with (
         log_context(

--- a/tests/e2e-playwright/tests/portal/test_cc_human.py
+++ b/tests/e2e-playwright/tests/portal/test_cc_human.py
@@ -26,20 +26,20 @@ def test_cc_human(
         page,
         study_id=study_id,
         workbench=workbench,
-        node_position=1,
+        node_name="Human GB 0D cardiac model",
         expected_file_names=["vm_1Hz.txt", "logs.zip", "allresult_1Hz.txt"],
     )
     check_node_outputs(
         page,
         study_id=study_id,
         workbench=workbench,
-        node_position=2,
+        node_name="Human GB 1D cardiac model",
         expected_file_names=["model_INPUT.from1D", "y_1D.txt", "logs.zip", "ECGs.txt"],
     )
     check_node_outputs(
         page,
         study_id=study_id,
         workbench=workbench,
-        node_position=3,
+        node_name="Human GB 2D cardiac model",
         expected_file_names=["aps.zip", "logs.zip"],
     )

--- a/tests/e2e-playwright/tests/portal/test_cc_rabbit.py
+++ b/tests/e2e-playwright/tests/portal/test_cc_rabbit.py
@@ -26,20 +26,20 @@ def test_cc_rabbit(
         page,
         study_id=study_id,
         workbench=workbench,
-        node_position=1,
+        node_name="Rabbit SS 0D cardiac model",
         expected_file_names=["logs.zip", "allresult_1Hz.txt", "vm_1Hz.txt"],
     )
     check_node_outputs(
         page,
         study_id=study_id,
         workbench=workbench,
-        node_position=2,
+        node_name="Rabbit SS 1D cardiac model",
         expected_file_names=["model_INPUT.from1D", "logs.zip", "cai_1D.txt", "ap_1D.txt", "ECGs.txt"],
     )
     check_node_outputs(
         page,
         study_id=study_id,
         workbench=workbench,
-        node_position=3,
+        node_name="Rabbit SS 2D cardiac model",
         expected_file_names=["aps.zip", "logs.zip"],
     )


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
### 1) Portal cc tests: select nodes by label, not workbench position

test_cc_rabbit and test_cc_human failed in the output-check step:
```
Node ... outputs not ready yet:
  missing=['allresult_1Hz.txt', 'vm_1Hz.txt']
  unexpected=['ECGs.txt', 'ap_1D.txt', 'cai_1D.txt', 'model_INPUT.from1D']
```

The pipeline ran fine and the nodes produced the right files. check_node_outputs(node_position=N) resolves the node with list(workbench)[N], which is the workbench dict's insertion order. That order turned out to be [0D model, 1D model, 2D model, viewers…, Initial WT], with the Initial WT file-picker last. The tests assumed it was first, so node_position=1 pointed at the 1D model instead of the 0D model, and every check was off by one. Fixed by selecting the nodes by their label instead of a positional index, using the node_name.

### 2) Login flow: dismiss the cookie banner when it shows up
The old code tried to handle this with a fixed wait_for_timeout(2000) and a is_visible() check. When the banner rendered later , it was never dismissed and blocked everything behind it. Register a locator handler for the cookie and "new release" buttons so Playwright auto-dismisses them the moment they appear
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
