### PR TITLE
♻️ refactor(agent): migrate lifecycle hooks to lifespan manager

### DIFF
--- a/services/agent/src/simcore_service_agent/_meta.py
+++ b/services/agent/src/simcore_service_agent/_meta.py
@@ -31,4 +31,5 @@ APP_STARTED_BANNER_MSG = rf"""
     {API_VTAG}"""
 
 
+APP_STARTING_BANNER_MSG = "{:=^100}".format(f"App {APP_NAME}=={VERSION} starting up")
 APP_FINISHED_BANNER_MSG = "{:=^100}".format(f"🎉 App {APP_NAME}=={VERSION} shutdown completed 🎉")

--- a/services/agent/src/simcore_service_agent/api/rpc/routes.py
+++ b/services/agent/src/simcore_service_agent/api/rpc/routes.py
@@ -1,4 +1,7 @@
+from collections.abc import AsyncIterator
+
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from models_library.rabbitmq_basic_types import RPCNamespace
 from servicelib.rabbitmq import RPCRouter
 
@@ -12,8 +15,8 @@ ROUTERS: list[RPCRouter] = [
 ]
 
 
-def setup_rpc_api_routes(app: FastAPI) -> None:
-    async def startup() -> None:
+def configure_rpc_api_routes(app_lifespan: LifespanManager[FastAPI]) -> None:
+    async def _rpc_api_lifespan(app: FastAPI) -> AsyncIterator[State]:
         rpc_client = get_rabbitmq_rpc_client(app)
         settings: ApplicationSettings = app.state.settings
         rpc_namespace = RPCNamespace.from_entries(
@@ -25,5 +28,6 @@ def setup_rpc_api_routes(app: FastAPI) -> None:
         )
         for router in ROUTERS:
             await rpc_client.register_router(router, rpc_namespace, app)
+        yield {}
 
-    app.add_event_handler("startup", startup)
+    app_lifespan.add(_rpc_api_lifespan)

--- a/services/agent/src/simcore_service_agent/core/application.py
+++ b/services/agent/src/simcore_service_agent/core/application.py
@@ -2,14 +2,15 @@ import logging
 
 from common_library.json_serialization import json_dumps
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager
+from servicelib.fastapi.lifespan_utils import Lifespan, configure_app_lifespan
 from servicelib.fastapi.openapi import (
     get_common_oas_options,
     override_fastapi_openapi_method,
 )
 from servicelib.fastapi.tracing import (
+    configure_fastapi_app_tracing,
     get_tracing_config,
-    initialize_fastapi_app_tracing,
-    setup_tracing,
 )
 from servicelib.tracing import TracingConfig
 
@@ -18,23 +19,47 @@ from .._meta import (
     APP_FINISHED_BANNER_MSG,
     APP_NAME,
     APP_STARTED_BANNER_MSG,
+    APP_STARTING_BANNER_MSG,
     SUMMARY,
     VERSION,
 )
 from ..api.rest.routes import setup_rest_api
-from ..api.rpc.routes import setup_rpc_api_routes
-from ..services.containers_manager import setup_containers_manager
-from ..services.instrumentation import setup_instrumentation
-from ..services.rabbitmq import setup_rabbitmq
-from ..services.volumes_manager import setup_volume_manager
+from ..api.rpc.routes import configure_rpc_api_routes
+from ..services.containers_manager import configure_containers_manager
+from ..services.instrumentation import configure_instrumentation
+from ..services.rabbitmq import configure_rabbitmq
+from ..services.volumes_manager import configure_volume_manager
 from .settings import ApplicationSettings
 
 _logger = logging.getLogger(__name__)
 
 
+def _configure_plugins(
+    app: FastAPI,
+    app_lifespan: LifespanManager[FastAPI],
+    settings: ApplicationSettings,
+    tracing_config: TracingConfig,
+) -> None:
+    if settings.AGENT_PROMETHEUS_INSTRUMENTATION_ENABLED:
+        configure_instrumentation(app, app_lifespan)
+
+    if tracing_config.tracing_enabled:
+        configure_fastapi_app_tracing(
+            app,
+            app_lifespan,
+            tracing_config=tracing_config,
+        )
+
+    configure_rabbitmq(app_lifespan)
+    configure_volume_manager(app_lifespan)
+    configure_containers_manager(app_lifespan)
+    configure_rpc_api_routes(app_lifespan)
+
+
 def create_app(
     settings: ApplicationSettings | None = None,
     tracing_config: TracingConfig | None = None,
+    logging_lifespan: Lifespan | None = None,
 ) -> FastAPI:
     if settings is None:
         settings = ApplicationSettings.create_from_envs()
@@ -46,39 +71,27 @@ def create_app(
         tracing_config = TracingConfig.create(service_name=APP_NAME, tracing_settings=settings.AGENT_TRACING)
 
     assert settings.SC_BOOT_MODE  # nosec
-    app = FastAPI(
-        debug=settings.SC_BOOT_MODE.is_devel_mode(),
-        title=APP_NAME,
-        description=SUMMARY,
-        version=f"{VERSION}",
-        openapi_url=f"/api/{API_VTAG}/openapi.json",
-        **get_common_oas_options(is_devel_mode=settings.SC_BOOT_MODE.is_devel_mode()),
-    )
-    override_fastapi_openapi_method(app)
-    app.state.settings = settings
-    app.state.tracing_config = tracing_config
+    with configure_app_lifespan(
+        logging_lifespan=logging_lifespan,
+        starting_banner=APP_STARTING_BANNER_MSG,
+        started_banner=APP_STARTED_BANNER_MSG,
+        shutdown_complete_banner=APP_FINISHED_BANNER_MSG,
+    ) as app_lifespan:
+        app = FastAPI(
+            debug=settings.SC_BOOT_MODE.is_devel_mode(),
+            title=APP_NAME,
+            description=SUMMARY,
+            version=f"{VERSION}",
+            openapi_url=f"/api/{API_VTAG}/openapi.json",
+            lifespan=app_lifespan,
+            **get_common_oas_options(is_devel_mode=settings.SC_BOOT_MODE.is_devel_mode()),
+        )
+        override_fastapi_openapi_method(app)
+        app.state.settings = settings
+        app.state.tracing_config = tracing_config
 
-    if settings.AGENT_TRACING:
-        setup_tracing(app, get_tracing_config(app))
+        _configure_plugins(app, app_lifespan, settings, get_tracing_config(app))
 
-    setup_instrumentation(app)
-
-    setup_rabbitmq(app)
-    setup_volume_manager(app)
-    setup_containers_manager(app)
     setup_rest_api(app)
-    setup_rpc_api_routes(app)
-
-    if settings.AGENT_TRACING:
-        initialize_fastapi_app_tracing(app, tracing_config=get_tracing_config(app))
-
-    async def _on_startup() -> None:
-        print(APP_STARTED_BANNER_MSG, flush=True)  # noqa: T201
-
-    async def _on_shutdown() -> None:
-        print(APP_FINISHED_BANNER_MSG, flush=True)  # noqa: T201
-
-    app.add_event_handler("startup", _on_startup)
-    app.add_event_handler("shutdown", _on_shutdown)
 
     return app

--- a/services/agent/src/simcore_service_agent/core/application.py
+++ b/services/agent/src/simcore_service_agent/core/application.py
@@ -27,7 +27,7 @@ from ..api.rest.routes import setup_rest_api
 from ..api.rpc.routes import configure_rpc_api_routes
 from ..services.containers_manager import configure_containers_manager
 from ..services.instrumentation import configure_instrumentation
-from ..services.rabbitmq import configure_rabbitmq
+from ..services.rabbitmq import configure_rabbitmq_client
 from ..services.volumes_manager import configure_volume_manager
 from .settings import ApplicationSettings
 
@@ -50,7 +50,7 @@ def _configure_plugins(
             tracing_config=tracing_config,
         )
 
-    configure_rabbitmq(app_lifespan)
+    configure_rabbitmq_client(app_lifespan, settings=settings.AGENT_RABBITMQ)
     configure_volume_manager(app_lifespan)
     configure_containers_manager(app_lifespan)
     configure_rpc_api_routes(app_lifespan)

--- a/services/agent/src/simcore_service_agent/main.py
+++ b/services/agent/src/simcore_service_agent/main.py
@@ -3,7 +3,7 @@ from typing import Final
 
 from common_library.json_serialization import json_dumps
 from fastapi import FastAPI
-from servicelib.fastapi.logging_lifespan import create_logging_shutdown_event
+from servicelib.fastapi.logging_lifespan import create_logging_lifespan
 from servicelib.tracing import TracingConfig
 
 from ._meta import APP_NAME
@@ -21,7 +21,7 @@ _NOISY_LOGGERS: Final[tuple[str, ...]] = (
 def app_factory() -> FastAPI:
     app_settings = ApplicationSettings.create_from_envs()
     tracing_config = TracingConfig.create(service_name=APP_NAME, tracing_settings=app_settings.AGENT_TRACING)
-    logging_shutdown_event = create_logging_shutdown_event(
+    logging_lifespan = create_logging_lifespan(
         log_format_local_dev_enabled=app_settings.AGENT_VOLUMES_LOG_FORMAT_LOCAL_DEV_ENABLED,
         logger_filter_mapping=app_settings.AGENT_VOLUMES_LOG_FILTER_MAPPING,
         tracing_config=tracing_config,
@@ -33,6 +33,8 @@ def app_factory() -> FastAPI:
         "Application settings: %s",
         json_dumps(app_settings, indent=2, sort_keys=True),
     )
-    app = create_app(settings=app_settings, tracing_config=tracing_config)
-    app.add_event_handler("shutdown", logging_shutdown_event)
-    return app
+    return create_app(
+        settings=app_settings,
+        tracing_config=tracing_config,
+        logging_lifespan=logging_lifespan,
+    )

--- a/services/agent/src/simcore_service_agent/services/containers_manager.py
+++ b/services/agent/src/simcore_service_agent/services/containers_manager.py
@@ -1,8 +1,10 @@
 import logging
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 
 from aiodocker import Docker
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from models_library.api_schemas_directorv2.services import (
     DYNAMIC_PROXY_SERVICE_PREFIX,
     DYNAMIC_SIDECAR_RCLONE_CONTAINER_PREFIX,
@@ -60,12 +62,12 @@ def get_containers_manager(app: FastAPI) -> ContainersManager:
     return ContainersManager.get_from_app_state(app)
 
 
-def setup_containers_manager(app: FastAPI) -> None:
-    async def _on_startup() -> None:
+def configure_containers_manager(app_lifespan: LifespanManager[FastAPI]) -> None:
+    async def _containers_manager_lifespan(app: FastAPI) -> AsyncIterator[State]:
         ContainersManager().set_to_app_state(app)
+        try:
+            yield {}
+        finally:
+            await ContainersManager.get_from_app_state(app).shutdown()
 
-    async def _on_shutdown() -> None:
-        await ContainersManager.get_from_app_state(app).shutdown()
-
-    app.add_event_handler("startup", _on_startup)
-    app.add_event_handler("shutdown", _on_shutdown)
+    app_lifespan.add(_containers_manager_lifespan)

--- a/services/agent/src/simcore_service_agent/services/containers_manager.py
+++ b/services/agent/src/simcore_service_agent/services/containers_manager.py
@@ -64,10 +64,11 @@ def get_containers_manager(app: FastAPI) -> ContainersManager:
 
 def configure_containers_manager(app_lifespan: LifespanManager[FastAPI]) -> None:
     async def _containers_manager_lifespan(app: FastAPI) -> AsyncIterator[State]:
-        ContainersManager().set_to_app_state(app)
+        containers_manager = ContainersManager()
         try:
+            containers_manager.set_to_app_state(app)
             yield {}
         finally:
-            await ContainersManager.get_from_app_state(app).shutdown()
+            await containers_manager.shutdown()
 
     app_lifespan.add(_containers_manager_lifespan)

--- a/services/agent/src/simcore_service_agent/services/instrumentation/__init__.py
+++ b/services/agent/src/simcore_service_agent/services/instrumentation/__init__.py
@@ -1,6 +1,6 @@
-from ._setup import get_instrumentation, setup_instrumentation
+from ._setup import configure_instrumentation, get_instrumentation
 
 __all__: tuple[str, ...] = (
+    "configure_instrumentation",
     "get_instrumentation",
-    "setup_instrumentation",
 )

--- a/services/agent/src/simcore_service_agent/services/instrumentation/_setup.py
+++ b/services/agent/src/simcore_service_agent/services/instrumentation/_setup.py
@@ -1,23 +1,32 @@
+from collections.abc import AsyncIterator
+
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from servicelib.fastapi.monitoring import (
-    setup_prometheus_instrumentation,
+    configure_prometheus_instrumentation,
 )
 
 from ...core.settings import ApplicationSettings
 from ._models import AgentInstrumentation
 
 
-def setup_instrumentation(app: FastAPI) -> None:
+def configure_instrumentation(
+    app: FastAPI,
+    app_lifespan: LifespanManager[FastAPI],
+) -> None:
     settings: ApplicationSettings = app.state.settings
     if not settings.AGENT_PROMETHEUS_INSTRUMENTATION_ENABLED:
         return
 
-    registry = setup_prometheus_instrumentation(app)
+    async def _instrumentation_lifespan(lifespan_app: FastAPI) -> AsyncIterator[State]:
+        app.state.instrumentation = AgentInstrumentation(registry=lifespan_app.state.prometheus_metrics.registry)
+        yield {}
 
-    async def on_startup() -> None:
-        app.state.instrumentation = AgentInstrumentation(registry=registry)
-
-    app.add_event_handler("startup", on_startup)
+    configure_prometheus_instrumentation(
+        app,
+        app_lifespan,
+        _instrumentation_lifespan,
+    )
 
 
 def get_instrumentation(app: FastAPI) -> AgentInstrumentation:

--- a/services/agent/src/simcore_service_agent/services/rabbitmq.py
+++ b/services/agent/src/simcore_service_agent/services/rabbitmq.py
@@ -1,28 +1,22 @@
-from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
-from fastapi_lifespan_manager import LifespanManager, State
-from servicelib.rabbitmq import RabbitMQRPCClient, wait_till_rabbitmq_responsive
+from fastapi_lifespan_manager import LifespanManager
+from servicelib.fastapi.rabbitmq_lifespan import configure_rabbitmq_rpc_client
+from servicelib.rabbitmq import RabbitMQRPCClient
 from settings_library.rabbit import RabbitSettings
 
 
-def configure_rabbitmq(app_lifespan: LifespanManager[FastAPI]) -> None:
-    async def _rabbitmq_lifespan(app: FastAPI) -> AsyncIterator[State]:
-        settings: RabbitSettings = app.state.settings.AGENT_RABBITMQ
-        app.state.rabbitmq_rpc_client = None
-        await wait_till_rabbitmq_responsive(settings.dsn)
-
-        app.state.rabbitmq_rpc_client = await RabbitMQRPCClient.create(
-            client_name="dynamic_scheduler_rpc_client", settings=settings
-        )
-        try:
-            yield {}
-        finally:
-            if app.state.rabbitmq_rpc_client:
-                await app.state.rabbitmq_rpc_client.close()
-
-    app_lifespan.add(_rabbitmq_lifespan)
+def configure_rabbitmq_client(
+    app_lifespan: LifespanManager[FastAPI],
+    *,
+    settings: RabbitSettings,
+) -> None:
+    configure_rabbitmq_rpc_client(
+        app_lifespan,
+        settings=settings,
+        client_name="agent_rpc_client",
+    )
 
 
 def get_rabbitmq_rpc_client(app: FastAPI) -> RabbitMQRPCClient:

--- a/services/agent/src/simcore_service_agent/services/rabbitmq.py
+++ b/services/agent/src/simcore_service_agent/services/rabbitmq.py
@@ -1,27 +1,28 @@
+from collections.abc import AsyncIterator
 from typing import cast
 
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from servicelib.rabbitmq import RabbitMQRPCClient, wait_till_rabbitmq_responsive
 from settings_library.rabbit import RabbitSettings
 
 
-def setup_rabbitmq(app: FastAPI) -> None:
-    settings: RabbitSettings = app.state.settings.AGENT_RABBITMQ
-    app.state.rabbitmq_rpc_client = None
-
-    async def _on_startup() -> None:
+def configure_rabbitmq(app_lifespan: LifespanManager[FastAPI]) -> None:
+    async def _rabbitmq_lifespan(app: FastAPI) -> AsyncIterator[State]:
+        settings: RabbitSettings = app.state.settings.AGENT_RABBITMQ
+        app.state.rabbitmq_rpc_client = None
         await wait_till_rabbitmq_responsive(settings.dsn)
 
         app.state.rabbitmq_rpc_client = await RabbitMQRPCClient.create(
             client_name="dynamic_scheduler_rpc_client", settings=settings
         )
+        try:
+            yield {}
+        finally:
+            if app.state.rabbitmq_rpc_client:
+                await app.state.rabbitmq_rpc_client.close()
 
-    async def _on_shutdown() -> None:
-        if app.state.rabbitmq_rpc_client:
-            await app.state.rabbitmq_rpc_client.close()
-
-    app.add_event_handler("startup", _on_startup)
-    app.add_event_handler("shutdown", _on_shutdown)
+    app_lifespan.add(_rabbitmq_lifespan)
 
 
 def get_rabbitmq_rpc_client(app: FastAPI) -> RabbitMQRPCClient:

--- a/services/agent/src/simcore_service_agent/services/volumes_manager.py
+++ b/services/agent/src/simcore_service_agent/services/volumes_manager.py
@@ -1,5 +1,6 @@
 import logging
 from asyncio import Lock, Task
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Final
@@ -8,6 +9,7 @@ import arrow
 from aiodocker.docker import Docker
 from common_library.async_tools import cancel_wait_task
 from fastapi import FastAPI
+from fastapi_lifespan_manager import LifespanManager, State
 from models_library.projects_nodes_io import NodeID
 from pydantic import NonNegativeFloat
 from servicelib.background_task import create_periodic_task
@@ -177,8 +179,8 @@ def get_volumes_manager(app: FastAPI) -> VolumesManager:
     return VolumesManager.get_from_app_state(app)
 
 
-def setup_volume_manager(app: FastAPI) -> None:
-    async def _on_startup() -> None:
+def configure_volume_manager(app_lifespan: LifespanManager[FastAPI]) -> None:
+    async def _volumes_manager_lifespan(app: FastAPI) -> AsyncIterator[State]:
         settings: ApplicationSettings = app.state.settings
 
         volumes_manager = VolumesManager(
@@ -189,9 +191,9 @@ def setup_volume_manager(app: FastAPI) -> None:
         )
         volumes_manager.set_to_app_state(app)
         await volumes_manager.setup()
+        try:
+            yield {}
+        finally:
+            await VolumesManager.get_from_app_state(app).shutdown()
 
-    async def _on_shutdown() -> None:
-        await VolumesManager.get_from_app_state(app).shutdown()
-
-    app.add_event_handler("startup", _on_startup)
-    app.add_event_handler("shutdown", _on_shutdown)
+    app_lifespan.add(_volumes_manager_lifespan)

--- a/services/agent/tests/unit/test_services_containers_manager.py
+++ b/services/agent/tests/unit/test_services_containers_manager.py
@@ -9,6 +9,7 @@ from aiodocker import Docker, DockerError
 from asgi_lifespan import LifespanManager
 from faker import Faker
 from fastapi import FastAPI, status
+from fastapi_lifespan_manager import LifespanManager as AppLifespanManager
 from models_library.api_schemas_directorv2.services import (
     DYNAMIC_PROXY_SERVICE_PREFIX,
     DYNAMIC_SIDECAR_RCLONE_CONTAINER_PREFIX,
@@ -16,15 +17,16 @@ from models_library.api_schemas_directorv2.services import (
 )
 from models_library.projects_nodes_io import NodeID
 from simcore_service_agent.services.containers_manager import (
+    configure_containers_manager,
     get_containers_manager,
-    setup_containers_manager,
 )
 
 
 @pytest.fixture
 async def app() -> AsyncIterable[FastAPI]:
-    app = FastAPI()
-    setup_containers_manager(app)
+    app_lifespan = AppLifespanManager()
+    app = FastAPI(lifespan=app_lifespan)
+    configure_containers_manager(app_lifespan)
 
     async with LifespanManager(app):
         yield app


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request refactors the FastAPI application and its service setup to use a unified, modern lifespan management approach. Instead of registering startup and shutdown event handlers directly on the app, it introduces the use of `fastapi_lifespan_manager.LifespanManager` to coordinate the lifecycle of core services (instrumentation, RabbitMQ, volumes manager, containers manager, and RPC API routes). This change improves maintainability, consistency, and extensibility of the service initialization and teardown process.

## Related issue/s
- part of #4678

## Related PR/s
- unlocks #9561 

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
- No changes.