### PR TITLE
Always drop service observation task references

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
@@ -402,6 +402,7 @@ class Scheduler(  # pylint: disable=too-many-instance-attributes, too-many-publi
 
             del self._inverse_search_mapping[node_uuid]
             self._to_observe.pop(service_name, None)
+            self._service_observation_task.pop(service_name, None)
 
         _logger.debug("Removed service '%s' from scheduler", service_name)
 


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- https://github.com/ITISFoundation/private-issues/issues/646

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
