### PR TITLE
🐛 fix(director-v2): prevent scheduler startup race

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/__init__.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/__init__.py
@@ -16,8 +16,8 @@ _logger = logging.getLogger(__name__)
 def on_app_startup(app: FastAPI) -> Callable[[], Coroutine[Any, Any, None]]:
     async def start_scheduler() -> None:
         with log_context(_logger, level=logging.INFO, msg=f"starting {MODULE_NAME_SCHEDULER}"):
-            await setup_releaser(app)
             await setup_worker(app)
+            await setup_releaser(app)
             await setup_manager(app)
 
     return start_scheduler
@@ -27,8 +27,8 @@ def on_app_shutdown(app: FastAPI) -> Callable[[], Coroutine[Any, Any, None]]:
     async def stop_scheduler() -> None:
         with log_context(_logger, level=logging.INFO, msg=f"stopping {MODULE_NAME_SCHEDULER}"):
             await shutdown_manager(app)
-            await shutdown_worker(app)
             await shutdown_releaser(app)
+            await shutdown_worker(app)
 
     return stop_scheduler
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_worker.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_worker.py
@@ -60,6 +60,8 @@ async def _handle_apply_distributed_schedule(app: FastAPI, data: bytes) -> bool:
 
 
 async def setup_worker(app: FastAPI) -> None:
+    app.state.scheduler_worker = create_scheduler(app)
+
     app_settings = get_application_settings(app)
     rabbitmq_client = get_rabbitmq_client(app)
     app.state.scheduler_worker_consumers = await asyncio.gather(
@@ -72,8 +74,6 @@ async def setup_worker(app: FastAPI) -> None:
             for _ in range(app_settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_SCHEDULING_CONCURRENCY)
         )
     )
-
-    app.state.scheduler_worker = create_scheduler(app)
 
 
 async def shutdown_worker(app: FastAPI) -> None:

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -8,7 +8,7 @@
 # pylint: disable=too-many-statements
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 from unittest import mock
 
@@ -19,6 +19,7 @@ from models_library.computations import CollectionRunID
 from pytest_mock import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
+from servicelib.rabbitmq._client import RabbitMQClient
 from settings_library.rabbit import RabbitSettings
 from simcore_service_director_v2.models.comp_runs import RunMetadataDict
 from simcore_service_director_v2.modules import comp_scheduler
@@ -148,11 +149,22 @@ def with_scheduling_concurrency(
     )
 
 
+@pytest.fixture
+async def queue_name(
+    create_rabbitmq_client: Callable[[str], RabbitMQClient],
+    mocker: MockerFixture,
+    scheduling_concurrency: int,
+) -> AsyncIterator[str]:
+    queue_name = f"{SchedulePipelineRabbitMessage.get_channel_name()}.{scheduling_concurrency}"
+    mocker.patch.object(SchedulePipelineRabbitMessage, "get_channel_name", return_value=queue_name)
+    yield queue_name
+    await create_rabbitmq_client("scheduler-parallelism-cleanup").unsubscribe(queue_name)
+
+
 @pytest.mark.parametrize("scheduling_concurrency", [1, 50, 100])
-@pytest.mark.parametrize("queue_name", [SchedulePipelineRabbitMessage.get_channel_name()])
 async def test_worker_scheduling_parallelism(
     rabbit_service: RabbitSettings,
-    ensure_parametrized_queue_is_empty: None,
+    queue_name: str,
     scheduling_concurrency: int,
     with_scheduling_concurrency: EnvVarsDict,
     with_disabled_auto_scheduling: mock.Mock,

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -74,6 +74,22 @@ async def test_worker_is_initialized_before_subscribing(mocker: MockerFixture):
     mocked_setup_manager.assert_awaited_once_with(app)
 
 
+async def test_scheduler_shutdown_order(mocker: MockerFixture):
+    app = FastAPI()
+    shutdown_calls = mocker.Mock()
+    shutdown_calls.attach_mock(mocker.patch(f"{comp_scheduler.__name__}.shutdown_manager"), "manager")
+    shutdown_calls.attach_mock(mocker.patch(f"{comp_scheduler.__name__}.shutdown_releaser"), "releaser")
+    shutdown_calls.attach_mock(mocker.patch(f"{comp_scheduler.__name__}.shutdown_worker"), "worker")
+
+    await comp_scheduler.on_app_shutdown(app)()
+
+    assert shutdown_calls.mock_calls == [
+        mocker.call.manager(app),
+        mocker.call.releaser(app),
+        mocker.call.worker(app),
+    ]
+
+
 @pytest.fixture
 def mock_schedule_pipeline(mocker: MockerFixture) -> mock.Mock:
     mock_scheduler_worker = mock.Mock()

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -28,7 +28,6 @@ from simcore_service_director_v2.modules.comp_scheduler._models import (
     SchedulePipelineRabbitMessage,
 )
 from simcore_service_director_v2.modules.comp_scheduler._worker import _get_scheduler_worker
-from tenacity import retry, stop_after_delay, wait_fixed
 
 pytest_simcore_core_services_selection = ["postgres", "rabbit", "redis"]
 pytest_simcore_ops_services_selection = ["adminer"]
@@ -168,12 +167,14 @@ async def test_worker_scheduling_parallelism(
 
     release_scheduler_calls = asyncio.Event()
     scheduler_calls_completed = asyncio.Event()
+    scheduler_calls_started = asyncio.Event()
     scheduler_calls_in_flight = 0
 
     async def _side_effect(*args, **kwargs):
         nonlocal scheduler_calls_in_flight
         scheduler_calls_in_flight += 1
-        scheduler_calls_completed.clear()
+        if scheduler_calls_in_flight == scheduling_concurrency:
+            scheduler_calls_started.set()
         try:
             await release_scheduler_calls.wait()
         finally:
@@ -197,15 +198,10 @@ async def test_worker_scheduling_parallelism(
 
     # whatever scheduling concurrency we call in here, we shall always see the same number of calls to the scheduler
     await asyncio.gather(*(_project_pipeline_creation_workflow() for _ in range(scheduling_concurrency)))
-    # the call to run the pipeline is async so we need to wait here
-    mocked_scheduler_api.assert_called()
-
-    @retry(stop=stop_after_delay(5), reraise=True, wait=wait_fixed(0.5))
-    def _assert_expected_called() -> None:
-        assert mocked_scheduler_api.call_count == scheduling_concurrency
 
     try:
-        _assert_expected_called()
+        await asyncio.wait_for(scheduler_calls_started.wait(), timeout=5)
+        assert mocked_scheduler_api.call_count == scheduling_concurrency
     finally:
         release_scheduler_calls.set()
         await asyncio.wait_for(scheduler_calls_completed.wait(), timeout=5)

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -71,7 +71,6 @@ async def test_worker_is_initialized_before_subscribing(mocker: MockerFixture):
     await comp_scheduler.on_app_startup(app)()
 
     assert _get_scheduler_worker(app) is scheduler
-    assert rabbitmq_client.subscribe.await_count > 1
     mocked_setup_manager.assert_awaited_once_with(app)
 
 

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -27,6 +27,7 @@ from simcore_service_director_v2.modules.comp_scheduler._models import (
 )
 from simcore_service_director_v2.modules.comp_scheduler._worker import (
     _get_scheduler_worker,
+    setup_worker,
 )
 from tenacity import retry, stop_after_delay, wait_fixed
 
@@ -36,6 +37,36 @@ pytest_simcore_ops_services_selection = ["adminer"]
 
 async def test_worker_starts_and_stops(initialized_app: FastAPI):
     assert _get_scheduler_worker(initialized_app) is not None
+
+
+async def test_worker_is_initialized_before_subscribing(mocker: MockerFixture):
+    app = FastAPI()
+    scheduler = mocker.Mock()
+    rabbitmq_client = mocker.Mock()
+
+    async def _subscribe(*args: Any, **kwargs: Any) -> tuple[str, str]:
+        assert _get_scheduler_worker(app) is scheduler
+        return ("queue", "consumer")
+
+    rabbitmq_client.subscribe = mocker.AsyncMock(side_effect=_subscribe)
+    app_settings = mocker.Mock()
+    app_settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_SCHEDULING_CONCURRENCY = 1
+    mocker.patch(
+        "simcore_service_director_v2.modules.comp_scheduler._worker.get_application_settings",
+        return_value=app_settings,
+    )
+    mocker.patch(
+        "simcore_service_director_v2.modules.comp_scheduler._worker.get_rabbitmq_client",
+        return_value=rabbitmq_client,
+    )
+    mocker.patch(
+        "simcore_service_director_v2.modules.comp_scheduler._worker.create_scheduler",
+        return_value=scheduler,
+    )
+
+    await setup_worker(app)
+
+    assert _get_scheduler_worker(app) is scheduler
 
 
 @pytest.fixture

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -21,15 +21,13 @@ from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.rabbit import RabbitSettings
 from simcore_service_director_v2.models.comp_runs import RunMetadataDict
-from simcore_service_director_v2.modules.comp_scheduler import _scheduler_base, _worker
+from simcore_service_director_v2.modules import comp_scheduler
+from simcore_service_director_v2.modules.comp_scheduler import _releaser, _scheduler_base, _worker
 from simcore_service_director_v2.modules.comp_scheduler._manager import run_new_pipeline
 from simcore_service_director_v2.modules.comp_scheduler._models import (
     SchedulePipelineRabbitMessage,
 )
-from simcore_service_director_v2.modules.comp_scheduler._worker import (
-    _get_scheduler_worker,
-    setup_worker,
-)
+from simcore_service_director_v2.modules.comp_scheduler._worker import _get_scheduler_worker
 from tenacity import retry, stop_after_delay, wait_fixed
 
 pytest_simcore_core_services_selection = ["postgres", "rabbit", "redis"]
@@ -61,13 +59,20 @@ async def test_worker_is_initialized_before_subscribing(mocker: MockerFixture):
         return_value=rabbitmq_client,
     )
     mocker.patch(
+        f"{_releaser.__name__}.get_rabbitmq_client",
+        return_value=rabbitmq_client,
+    )
+    mocker.patch(
         f"{_worker.__name__}.create_scheduler",
         return_value=scheduler,
     )
+    mocked_setup_manager = mocker.patch(f"{comp_scheduler.__name__}.setup_manager")
 
-    await setup_worker(app)
+    await comp_scheduler.on_app_startup(app)()
 
     assert _get_scheduler_worker(app) is scheduler
+    assert rabbitmq_client.subscribe.await_count > 1
+    mocked_setup_manager.assert_awaited_once_with(app)
 
 
 @pytest.fixture

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -166,8 +166,20 @@ async def test_worker_scheduling_parallelism(
 ):
     with_disabled_auto_scheduling.assert_called_once()
 
+    release_scheduler_calls = asyncio.Event()
+    scheduler_calls_completed = asyncio.Event()
+    scheduler_calls_in_flight = 0
+
     async def _side_effect(*args, **kwargs):
-        await asyncio.sleep(10)
+        nonlocal scheduler_calls_in_flight
+        scheduler_calls_in_flight += 1
+        scheduler_calls_completed.clear()
+        try:
+            await release_scheduler_calls.wait()
+        finally:
+            scheduler_calls_in_flight -= 1
+            if scheduler_calls_in_flight == 0:
+                scheduler_calls_completed.set()
 
     mocked_scheduler_api.side_effect = _side_effect
 
@@ -192,4 +204,8 @@ async def test_worker_scheduling_parallelism(
     def _assert_expected_called() -> None:
         assert mocked_scheduler_api.call_count == scheduling_concurrency
 
-    _assert_expected_called()
+    try:
+        _assert_expected_called()
+    finally:
+        release_scheduler_calls.set()
+        await asyncio.wait_for(scheduler_calls_completed.wait(), timeout=5)

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -23,7 +23,7 @@ from servicelib.rabbitmq._client import RabbitMQClient
 from settings_library.rabbit import RabbitSettings
 from simcore_service_director_v2.models.comp_runs import RunMetadataDict
 from simcore_service_director_v2.modules import comp_scheduler
-from simcore_service_director_v2.modules.comp_scheduler import _releaser, _scheduler_base, _worker
+from simcore_service_director_v2.modules.comp_scheduler import _scheduler_base, _worker
 from simcore_service_director_v2.modules.comp_scheduler._manager import run_new_pipeline
 from simcore_service_director_v2.modules.comp_scheduler._models import (
     SchedulePipelineRabbitMessage,
@@ -38,55 +38,28 @@ async def test_worker_starts_and_stops(initialized_app: FastAPI):
     assert _get_scheduler_worker(initialized_app) is not None
 
 
-async def test_worker_is_initialized_before_subscribing(mocker: MockerFixture):
-    app = FastAPI()
-    scheduler = mocker.Mock()
-    rabbitmq_client = mocker.Mock()
+async def test_scheduler_lifecycle_order(initialized_app: FastAPI, mocker: MockerFixture):
+    lifecycle_calls = mocker.Mock()
+    for function_name in (
+        "setup_manager",
+        "setup_releaser",
+        "setup_worker",
+        "shutdown_manager",
+        "shutdown_releaser",
+        "shutdown_worker",
+    ):
+        lifecycle_calls.attach_mock(mocker.patch(f"{comp_scheduler.__name__}.{function_name}"), function_name)
 
-    async def _subscribe(*args: Any, **kwargs: Any) -> tuple[str, str]:
-        assert _get_scheduler_worker(app) is scheduler
-        return ("queue", "consumer")
+    await comp_scheduler.on_app_startup(initialized_app)()
+    await comp_scheduler.on_app_shutdown(initialized_app)()
 
-    rabbitmq_client.subscribe = mocker.AsyncMock(side_effect=_subscribe)
-    app_settings = mocker.Mock()
-    app_settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_SCHEDULING_CONCURRENCY = 1
-    mocker.patch(
-        f"{_worker.__name__}.get_application_settings",
-        return_value=app_settings,
-    )
-    mocker.patch(
-        f"{_worker.__name__}.get_rabbitmq_client",
-        return_value=rabbitmq_client,
-    )
-    mocker.patch(
-        f"{_releaser.__name__}.get_rabbitmq_client",
-        return_value=rabbitmq_client,
-    )
-    mocker.patch(
-        f"{_worker.__name__}.create_scheduler",
-        return_value=scheduler,
-    )
-    mocked_setup_manager = mocker.patch(f"{comp_scheduler.__name__}.setup_manager")
-
-    await comp_scheduler.on_app_startup(app)()
-
-    assert _get_scheduler_worker(app) is scheduler
-    mocked_setup_manager.assert_awaited_once_with(app)
-
-
-async def test_scheduler_shutdown_order(mocker: MockerFixture):
-    app = FastAPI()
-    shutdown_calls = mocker.Mock()
-    shutdown_calls.attach_mock(mocker.patch(f"{comp_scheduler.__name__}.shutdown_manager"), "manager")
-    shutdown_calls.attach_mock(mocker.patch(f"{comp_scheduler.__name__}.shutdown_releaser"), "releaser")
-    shutdown_calls.attach_mock(mocker.patch(f"{comp_scheduler.__name__}.shutdown_worker"), "worker")
-
-    await comp_scheduler.on_app_shutdown(app)()
-
-    assert shutdown_calls.mock_calls == [
-        mocker.call.manager(app),
-        mocker.call.releaser(app),
-        mocker.call.worker(app),
+    assert lifecycle_calls.mock_calls == [
+        mocker.call.setup_worker(initialized_app),
+        mocker.call.setup_releaser(initialized_app),
+        mocker.call.setup_manager(initialized_app),
+        mocker.call.shutdown_manager(initialized_app),
+        mocker.call.shutdown_releaser(initialized_app),
+        mocker.call.shutdown_worker(initialized_app),
     ]
 
 

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -21,6 +21,7 @@ from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
 from settings_library.rabbit import RabbitSettings
 from simcore_service_director_v2.models.comp_runs import RunMetadataDict
+from simcore_service_director_v2.modules.comp_scheduler import _scheduler_base, _worker
 from simcore_service_director_v2.modules.comp_scheduler._manager import run_new_pipeline
 from simcore_service_director_v2.modules.comp_scheduler._models import (
     SchedulePipelineRabbitMessage,
@@ -52,15 +53,15 @@ async def test_worker_is_initialized_before_subscribing(mocker: MockerFixture):
     app_settings = mocker.Mock()
     app_settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_SCHEDULING_CONCURRENCY = 1
     mocker.patch(
-        "simcore_service_director_v2.modules.comp_scheduler._worker.get_application_settings",
+        f"{_worker.__name__}.get_application_settings",
         return_value=app_settings,
     )
     mocker.patch(
-        "simcore_service_director_v2.modules.comp_scheduler._worker.get_rabbitmq_client",
+        f"{_worker.__name__}.get_rabbitmq_client",
         return_value=rabbitmq_client,
     )
     mocker.patch(
-        "simcore_service_director_v2.modules.comp_scheduler._worker.create_scheduler",
+        f"{_worker.__name__}.create_scheduler",
         return_value=scheduler,
     )
 
@@ -83,7 +84,7 @@ def mocked_get_scheduler_worker(
 ) -> mock.Mock:
     # Mock `_get_scheduler_worker` to return our mock scheduler
     return mocker.patch(
-        "simcore_service_director_v2.modules.comp_scheduler._worker._get_scheduler_worker",
+        f"{_worker.__name__}._get_scheduler_worker",
         return_value=mock_schedule_pipeline,
     )
 
@@ -115,7 +116,7 @@ async def test_worker_properly_autocalls_scheduler_api(
 
 @pytest.fixture
 async def mocked_scheduler_api(mocker: MockerFixture) -> mock.Mock:
-    return mocker.patch("simcore_service_director_v2.modules.comp_scheduler._scheduler_base.BaseCompScheduler.apply")
+    return mocker.patch(f"{_scheduler_base.__name__}.BaseCompScheduler.apply")
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull-request prevents RabbitMQ consumers from processing scheduler messages before the scheduler worker is available.

- Creates the scheduler worker before registering consumers.
- Starts the worker before the task-result releaser.
- Shuts them down in reverse dependency order.

<img width="1280" height="538" alt="image" src="https://github.com/user-attachments/assets/449dc313-1455-4da2-ae04-6f8ce9c5a99d" />

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->

## How to test
```sh
cd services/director-v2
make install-dev
pytest tests/unit/with_dbs/comp_scheduler/test_worker.py -v --keep-docker-up
```
<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
- No changes.