### PR TITLE
🐛 Fix director-v2 memory leak from unbounded user_id/wallet_id metric l…

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_user_services.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_user_services.py
@@ -221,8 +221,9 @@ async def create_user_services(  # pylint: disable=too-many-statements
 
     start_duration = scheduler_data.dynamic_sidecar.instrumentation.elapsed_since_start_request()
     if start_duration is not None:
-        get_instrumentation(app).dynamic_sidecar_metrics.start_time_duration.labels(
-            **get_metrics_labels(scheduler_data)
+        dynamic_sidecar_metrics = get_instrumentation(app).dynamic_sidecar_metrics
+        dynamic_sidecar_metrics.start_time_duration.labels(
+            **dynamic_sidecar_metrics.record_labels(get_metrics_labels(scheduler_data))
         ).observe(start_duration)
 
     _logger.info("Internal state after creating user services %s", scheduler_data)

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
@@ -266,8 +266,9 @@ async def service_save_state(
     with track_duration() as duration:
         size = await sidecars_client.save_service_state(scheduler_data.endpoint, progress_callback=progress_callback)
     if size and size > 0:
-        get_instrumentation(app).dynamic_sidecar_metrics.push_service_state_rate.labels(
-            **get_metrics_labels(scheduler_data)
+        dynamic_sidecar_metrics = get_instrumentation(app).dynamic_sidecar_metrics
+        dynamic_sidecar_metrics.push_service_state_rate.labels(
+            **dynamic_sidecar_metrics.record_labels(get_metrics_labels(scheduler_data))
         ).observe(get_rate(size, duration.to_float()))
 
     await sidecars_client.update_volume_state(
@@ -471,8 +472,9 @@ async def attempt_pod_removal_and_data_saving(app: FastAPI, scheduler_data: Sche
 
     stop_duration = scheduler_data.dynamic_sidecar.instrumentation.elapsed_since_close_request()
     if stop_duration is not None:
-        get_instrumentation(app).dynamic_sidecar_metrics.stop_time_duration.labels(
-            **get_metrics_labels(scheduler_data)
+        dynamic_sidecar_metrics = get_instrumentation(app).dynamic_sidecar_metrics
+        dynamic_sidecar_metrics.stop_time_duration.labels(
+            **dynamic_sidecar_metrics.record_labels(get_metrics_labels(scheduler_data))
         ).observe(stop_duration)
 
 
@@ -553,16 +555,18 @@ async def prepare_services_environment(app: FastAPI, scheduler_data: SchedulerDa
         with track_duration() as duration:
             size: int = await sidecars_client.pull_service_output_ports(dynamic_sidecar_endpoint)
         if size and size > 0:
-            get_instrumentation(app).dynamic_sidecar_metrics.output_ports_pull_rate.labels(
-                **get_metrics_labels(scheduler_data)
+            dynamic_sidecar_metrics = get_instrumentation(app).dynamic_sidecar_metrics
+            dynamic_sidecar_metrics.output_ports_pull_rate.labels(
+                **dynamic_sidecar_metrics.record_labels(get_metrics_labels(scheduler_data))
             ).observe(get_rate(size, duration.to_float()))
 
     async def _pull_user_services_images_with_metrics() -> None:
         with track_duration() as duration:
             await sidecars_client.pull_user_services_images(dynamic_sidecar_endpoint)
 
-        get_instrumentation(app).dynamic_sidecar_metrics.pull_user_services_images_duration.labels(
-            **get_metrics_labels(scheduler_data)
+        dynamic_sidecar_metrics = get_instrumentation(app).dynamic_sidecar_metrics
+        dynamic_sidecar_metrics.pull_user_services_images_duration.labels(
+            **dynamic_sidecar_metrics.record_labels(get_metrics_labels(scheduler_data))
         ).observe(duration.to_float())
 
     async def _restore_service_state_with_metrics() -> None:
@@ -570,8 +574,9 @@ async def prepare_services_environment(app: FastAPI, scheduler_data: SchedulerDa
             size = await sidecars_client.restore_service_state(dynamic_sidecar_endpoint)
 
         if size and size > 0:
-            get_instrumentation(app).dynamic_sidecar_metrics.pull_service_state_rate.labels(
-                **get_metrics_labels(scheduler_data)
+            dynamic_sidecar_metrics = get_instrumentation(app).dynamic_sidecar_metrics
+            dynamic_sidecar_metrics.pull_service_state_rate.labels(
+                **dynamic_sidecar_metrics.record_labels(get_metrics_labels(scheduler_data))
             ).observe(get_rate(size, duration.to_float()))
 
     tasks = [

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
@@ -434,8 +434,9 @@ class Scheduler(  # pylint: disable=too-many-instance-attributes, too-many-publi
         duration = time.time() - started
 
         if transferred_bytes and transferred_bytes > 0:
-            get_instrumentation(self.app).dynamic_sidecar_metrics.input_ports_pull_rate.labels(
-                **get_metrics_labels(scheduler_data)
+            dynamic_sidecar_metrics = get_instrumentation(self.app).dynamic_sidecar_metrics
+            dynamic_sidecar_metrics.input_ports_pull_rate.labels(
+                **dynamic_sidecar_metrics.record_labels(get_metrics_labels(scheduler_data))
             ).observe(get_rate(transferred_bytes, duration))
 
         if scheduler_data.restart_policy == RestartPolicy.ON_INPUTS_DOWNLOADED:

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+from collections.abc import Iterator
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Final
 
@@ -15,6 +18,12 @@ _INSTRUMENTATION_LABELS: Final[tuple[str, ...]] = (
     "service_key",
     "service_version",
 )
+# NOTE: user_id/wallet_id are unbounded values: every distinct combination ever
+# observed would otherwise be retained forever in the process' registry, causing
+# an unbounded memory leak (see incident: director-v2 slow memory growth). Bound
+# it with LRU eviction so recent per-user/per-wallet labels are kept while total
+# memory stays capped regardless of how many users/wallets are seen over time.
+_MAX_TRACKED_LABEL_COMBINATIONS: Final[int] = 2000
 
 _MINUTE: Final[int] = 60
 _BUCKETS_TIME_S: Final[tuple[float, ...]] = (
@@ -64,6 +73,8 @@ class DynamiSidecarMetrics(MetricsBase):
     # NOTE: input ports are never pushed
     # NOTE: output ports are pushed by the dy-sidecar, upon change making recovering the metric very complicated
     push_service_state_rate: Histogram = field(init=False)
+
+    _lru_label_combinations: "OrderedDict[tuple[str, ...], None]" = field(init=False, default_factory=OrderedDict)
 
     def __post_init__(self) -> None:
         self.start_time_duration = Histogram(
@@ -133,6 +144,34 @@ class DynamiSidecarMetrics(MetricsBase):
             subsystem=self.subsystem,
             registry=self.registry,
         )
+
+    def _iter_histograms(self) -> Iterator[Histogram]:
+        yield self.start_time_duration
+        yield self.stop_time_duration
+        yield self.pull_user_services_images_duration
+        yield self.output_ports_pull_rate
+        yield self.input_ports_pull_rate
+        yield self.pull_service_state_rate
+        yield self.push_service_state_rate
+
+    def record_labels(self, labels: dict[str, str]) -> dict[str, str]:
+        """Tracks usage of this (user_id, wallet_id, service_key, service_version) combination.
+
+        Evicts the least-recently-used combination from all histograms once
+        _MAX_TRACKED_LABEL_COMBINATIONS is exceeded, bounding memory usage.
+        """
+        key = tuple(labels[name] for name in _INSTRUMENTATION_LABELS)
+        if key in self._lru_label_combinations:
+            self._lru_label_combinations.move_to_end(key)
+            return labels
+
+        self._lru_label_combinations[key] = None
+        if len(self._lru_label_combinations) > _MAX_TRACKED_LABEL_COMBINATIONS:
+            oldest, _ = self._lru_label_combinations.popitem(last=False)
+            for histogram in self._iter_histograms():
+                with suppress(KeyError):
+                    histogram.remove(*oldest)
+        return labels
 
 
 @dataclass(slots=True, kw_only=True)


### PR DESCRIPTION
## What do these changes do?

I asked Sonnet 5 for memory leaks in dv2 based on the osparc master logs. @GitHK, I created a draft PR with a possible fix. That don't know if this is the main memory leak you've been looking for, but this definitely would decrease the memory buildup in osparc-master.

Another solution is to drop the user_id/wallet_id from the metrics instead of using an LRU.

<img width="571" height="135" alt="Screenshot 2026-08-24 at 17 53 19" src="https://github.com/user-attachments/assets/b6721a8c-31a5-4ee7-ad54-c765855cc433" />


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
