### PR TITLE
🐛Director-v2: disallow PENDING tasks with no job_id attached

### DIFF
--- a/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/utils.py
+++ b/packages/dask-task-models-library/src/dask_task_models_library/container_tasks/utils.py
@@ -1,5 +1,4 @@
 from typing import Final
-from uuid import uuid4
 
 from models_library.projects import ProjectID
 from models_library.projects_nodes_io import NodeID
@@ -15,14 +14,13 @@ def generate_dask_job_id(
     user_id: UserID,
     project_id: ProjectID,
     node_id: NodeID,
+    run_id: int,
 ) -> DaskJobID:
-    """creates a dask job id:
-    The job ID shall contain the user_id, project_id, node_id
-    Also, it must be unique
-    and it is shown in the Dask scheduler dashboard website
+    """creates a deterministic dask job id:
+    The job ID shall contain the user_id, project_id, node_id and run_id
     """
     return DaskJobID(
-        f"{service_key}:{service_version}:userid_{user_id}:projectid_{project_id}:nodeid_{node_id}:uuid_{uuid4()}"
+        f"{service_key}:{service_version}:userid_{user_id}:projectid_{project_id}:nodeid_{node_id}:runid_{run_id}"
     )
 
 

--- a/packages/dask-task-models-library/tests/container_tasks/test_utils.py
+++ b/packages/dask-task-models-library/tests/container_tasks/test_utils.py
@@ -41,14 +41,20 @@ def node_id(faker: Faker) -> NodeID:
     return NodeID(faker.uuid4())
 
 
+@pytest.fixture
+def run_id(faker: Faker) -> int:
+    return faker.pyint(min_value=1)
+
+
 def test_dask_job_id_serialization(
     service_key: ServiceKey,
     service_version: ServiceVersion,
     user_id: UserID,
     project_id: ProjectID,
     node_id: NodeID,
+    run_id: int,
 ):
-    dask_job_id = generate_dask_job_id(service_key, service_version, user_id, project_id, node_id)
+    dask_job_id = generate_dask_job_id(service_key, service_version, user_id, project_id, node_id, run_id=run_id)
     (
         parsed_service_key,
         parsed_service_version,
@@ -56,6 +62,67 @@ def test_dask_job_id_serialization(
         parsed_project_id,
         parsed_node_id,
     ) = parse_dask_job_id(dask_job_id)
+    assert service_key == parsed_service_key
+    assert service_version == parsed_service_version
+    assert user_id == parsed_user_id
+    assert project_id == parsed_project_id
+    assert node_id == parsed_node_id
+
+
+def test_dask_job_id_with_run_id_is_deterministic(
+    service_key: ServiceKey,
+    service_version: ServiceVersion,
+    user_id: UserID,
+    project_id: ProjectID,
+    node_id: NodeID,
+    faker: Faker,
+):
+    run_id = faker.pyint(min_value=1)
+    dask_job_id = generate_dask_job_id(service_key, service_version, user_id, project_id, node_id, run_id=run_id)
+    # same (node, run) resubmission reuses the exact same dask key
+    assert dask_job_id == generate_dask_job_id(
+        service_key, service_version, user_id, project_id, node_id, run_id=run_id
+    )
+    # a different run must get a different dask key
+    assert dask_job_id != generate_dask_job_id(
+        service_key, service_version, user_id, project_id, node_id, run_id=run_id + 1
+    )
+    # still parses the same way regardless of the run_id suffix
+    (
+        parsed_service_key,
+        parsed_service_version,
+        parsed_user_id,
+        parsed_project_id,
+        parsed_node_id,
+    ) = parse_dask_job_id(dask_job_id)
+    assert service_key == parsed_service_key
+    assert service_version == parsed_service_version
+    assert user_id == parsed_user_id
+    assert project_id == parsed_project_id
+    assert node_id == parsed_node_id
+
+
+def test_parse_dask_job_id_is_compatible_with_old_uuid_style_job_id(
+    service_key: ServiceKey,
+    service_version: ServiceVersion,
+    user_id: UserID,
+    project_id: ProjectID,
+    node_id: NodeID,
+    faker: Faker,
+):
+    """job ids generated before run_id existed used a random uuid as the last segment
+    instead of runid_<int>; parse_dask_job_id must keep parsing those (jobs already
+    in flight when this change is deployed)."""
+    old_style_job_id = (
+        f"{service_key}:{service_version}:userid_{user_id}:projectid_{project_id}:nodeid_{node_id}:uuid_{faker.uuid4()}"
+    )
+    (
+        parsed_service_key,
+        parsed_service_version,
+        parsed_user_id,
+        parsed_project_id,
+        parsed_node_id,
+    ) = parse_dask_job_id(old_style_job_id)
     assert service_key == parsed_service_key
     assert service_version == parsed_service_version
     assert user_id == parsed_user_id

--- a/services/autoscaling/tests/unit/conftest.py
+++ b/services/autoscaling/tests/unit/conftest.py
@@ -898,6 +898,7 @@ def fake_dask_job_id(
             user_id=user_id,
             project_id=project_id,
             node_id=faker.uuid4(cast_to=None),
+            run_id=faker.pyint(min_value=1),
         )
 
     return _

--- a/services/autoscaling/tests/unit/test_utils_rabbitmq.py
+++ b/services/autoscaling/tests/unit/test_utils_rabbitmq.py
@@ -127,8 +127,11 @@ def dask_task(
     user_id: UserID,
     project_id: ProjectID,
     node_id: NodeID,
+    faker: Faker,
 ) -> DaskTask:
-    dask_key = generate_dask_job_id(service_key, service_version, user_id, project_id, node_id)
+    dask_key = generate_dask_job_id(
+        service_key, service_version, user_id, project_id, node_id, run_id=faker.pyint(min_value=1)
+    )
     return DaskTask(task_id=dask_key, required_resources={})
 
 
@@ -163,7 +166,8 @@ async def test_post_task_empty_tasks(
         async for attempt in AsyncRetrying(**_TENACITY_STABLE_RETRY_PARAMS):
             with attempt:
                 print(
-                    f"--> checking for message in rabbit exchange {LoggerRabbitMessage.get_channel_name()}, {attempt.retry_state.retry_object.statistics}"
+                    f"--> checking for message in rabbit exchange {LoggerRabbitMessage.get_channel_name()}, "
+                    f"{attempt.retry_state.retry_object.statistics}"
                 )
 
                 logs_rabbitmq_consumer.assert_not_called()
@@ -192,7 +196,8 @@ async def test_post_task_log_message_docker(
     async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
         with attempt:
             print(
-                f"--> checking for message in rabbit exchange {LoggerRabbitMessage.get_channel_name()}, {attempt.retry_state.retry_object.statistics}"
+                f"--> checking for message in rabbit exchange {LoggerRabbitMessage.get_channel_name()}, "
+                f"{attempt.retry_state.retry_object.statistics}"
             )
             logs_rabbitmq_consumer.assert_called_once_with(
                 LoggerRabbitMessage(
@@ -229,7 +234,8 @@ async def test_post_task_log_message_dask(
     async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
         with attempt:
             print(
-                f"--> checking for message in rabbit exchange {LoggerRabbitMessage.get_channel_name()}, {attempt.retry_state.retry_object.statistics}"
+                f"--> checking for message in rabbit exchange {LoggerRabbitMessage.get_channel_name()}, "
+                f"{attempt.retry_state.retry_object.statistics}"
             )
             logs_rabbitmq_consumer.assert_called_once_with(
                 LoggerRabbitMessage(
@@ -274,7 +280,8 @@ async def test_post_task_progress_message_docker(
     async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
         with attempt:
             print(
-                f"--> checking for message in rabbit exchange {ProgressRabbitMessageNode.get_channel_name()}, {attempt.retry_state.retry_object.statistics}"
+                f"--> checking for message in rabbit exchange {ProgressRabbitMessageNode.get_channel_name()}, "
+                f"{attempt.retry_state.retry_object.statistics}"
             )
             progress_rabbitmq_consumer.assert_called_once_with(
                 ProgressRabbitMessageNode(
@@ -316,7 +323,8 @@ async def test_post_task_progress_message_dask(
     async for attempt in AsyncRetrying(**_TENACITY_RETRY_PARAMS):
         with attempt:
             print(
-                f"--> checking for message in rabbit exchange {ProgressRabbitMessageNode.get_channel_name()}, {attempt.retry_state.retry_object.statistics}"
+                f"--> checking for message in rabbit exchange {ProgressRabbitMessageNode.get_channel_name()}, "
+                f"{attempt.retry_state.retry_object.statistics}"
             )
             progress_rabbitmq_consumer.assert_called_once_with(
                 ProgressRabbitMessageNode(

--- a/services/director-v2/src/simcore_service_director_v2/core/errors.py
+++ b/services/director-v2/src/simcore_service_director_v2/core/errors.py
@@ -71,6 +71,10 @@ class ComputationalTaskNotFoundError(DirectorError):
     msg_template = "Computational task {node_id} not found"
 
 
+class ComputationalTaskJobIdAlreadySetError(DirectorError):
+    msg_template = "Computational task {node_id} in project {project_id} already has a job_id set"
+
+
 class WalletNotEnoughCreditsError(DirectorError):
     msg_template = "Wallet '{wallet_name}' has {wallet_credit_amount} credits."
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -320,6 +320,37 @@ class BaseCompScheduler(ABC):
             for task in running_tasks:
                 await comp_tasks_repo.update_project_task_last_heartbeat(project_id, task.node_id, run_id, utc_now)
 
+    async def _fix_tasks_stuck_pending_without_job_id(
+        self,
+        project_id: ProjectID,
+        run_id: RunID,
+        comp_tasks: dict[NodeIDStr, CompTaskAtDB],
+    ) -> dict[NodeIDStr, CompTaskAtDB]:
+        """safety-net for https://github.com/ITISFoundation/private-issues/issues/648:
+        resets tasks stuck in PENDING without a job_id back to PUBLISHED so they get restarted."""
+        stuck_node_ids = [
+            NodeID(node_id)
+            for node_id, task in comp_tasks.items()
+            if task.state is RunningState.PENDING and task.job_id is None
+        ]
+        if not stuck_node_ids:
+            return comp_tasks
+
+        _logger.warning(
+            "found %d task(s) stuck in PENDING without a job_id, resetting them to PUBLISHED so they get restarted: %s",
+            len(stuck_node_ids),
+            stuck_node_ids,
+        )
+        await CompTasksRepository.instance(self.db_engine).update_project_tasks_state(
+            project_id,
+            run_id,
+            stuck_node_ids,
+            RunningState.PUBLISHED,
+        )
+        for node_id in stuck_node_ids:
+            comp_tasks[f"{node_id}"].state = RunningState.PUBLISHED
+        return comp_tasks
+
     async def _get_changed_tasks_from_backend(
         self,
         user_id: UserID,
@@ -566,6 +597,8 @@ class BaseCompScheduler(ABC):
                 await self._update_states_from_comp_backend(user_id, project_id, iteration, dag, comp_run)
                 # 1.1. get the updated tasks NOTE: we need to get them again as some states might have changed
                 comp_tasks = await self._get_pipeline_tasks(project_id, dag)
+                # 1.2. safety-net: repair any task stuck PENDING without a job_id (see docstring)
+                comp_tasks = await self._fix_tasks_stuck_pending_without_job_id(project_id, comp_run.run_id, comp_tasks)
                 # 2. timeout if waiting for cluster has been there for more than X minutes
                 comp_tasks = await self._timeout_if_waiting_for_cluster_too_long(
                     user_id, project_id, comp_run, comp_tasks

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -908,14 +908,13 @@ class BaseCompScheduler(ABC):
                 comp_tasks[f"{task}"].state = RunningState.WAITING_FOR_CLUSTER
 
         except ComputationalTaskJobIdAlreadySetError as exc:
-            # NOTE: should never happen (see https://github.com/ITISFoundation/private-issues/issues/648).
-            # Do not mark tasks_ready_to_start as FAILED here: some may already be legitimately running.
             _logger.exception(
                 **create_troubleshooting_log_kwargs(
                     "Unexpected: a task selected to start already had a job_id set. Left untouched, "
                     "will be re-evaluated on the next scheduling pass.",
                     error=exc,
                     error_context=log_error_context,
+                    tip="This is likely a transient issue. The task will be re-evaluated on the next scheduling cycle.",
                 )
             )
         except Exception as exc:

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_base.py
@@ -45,6 +45,7 @@ from ...core.errors import (
     ComputationalBackendOnDemandNotReadyError,
     ComputationalRunNotFoundError,
     ComputationalSchedulerChangedError,
+    ComputationalTaskJobIdAlreadySetError,
     DaskClientAcquisisitonError,
     InvalidPipelineError,
 )
@@ -774,7 +775,7 @@ class BaseCompScheduler(ABC):
 
         return comp_tasks
 
-    async def _schedule_tasks_to_start(
+    async def _schedule_tasks_to_start(  # noqa: C901
         self,
         user_id: UserID,
         project_id: ProjectID,
@@ -906,6 +907,17 @@ class BaseCompScheduler(ABC):
             for task in tasks_ready_to_start:
                 comp_tasks[f"{task}"].state = RunningState.WAITING_FOR_CLUSTER
 
+        except ComputationalTaskJobIdAlreadySetError as exc:
+            # NOTE: should never happen (see https://github.com/ITISFoundation/private-issues/issues/648).
+            # Do not mark tasks_ready_to_start as FAILED here: some may already be legitimately running.
+            _logger.exception(
+                **create_troubleshooting_log_kwargs(
+                    "Unexpected: a task selected to start already had a job_id set. Left untouched, "
+                    "will be re-evaluated on the next scheduling pass.",
+                    error=exc,
+                    error_context=log_error_context,
+                )
+            )
         except Exception as exc:
             _logger.exception(
                 **create_troubleshooting_log_kwargs(

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_scheduler_dask.py
@@ -163,21 +163,12 @@ class DaskScheduler(BaseCompScheduler):
             run_id=comp_run.run_id,
             run_metadata=comp_run.metadata,
         ) as client:
-            # Change the tasks state to PENDING
             comp_tasks_repo = CompTasksRepository.instance(self.db_engine)
-            await comp_tasks_repo.update_project_tasks_state(
-                project_id,
-                comp_run.run_id,
-                list(scheduled_tasks.keys()),
-                RunningState.PENDING,
-                clear_errors=False,
-            )
-            # each task is started independently
-
             for node_id, task in scheduled_tasks.items():
                 published_tasks = await client.send_computation_tasks(
                     user_id=user_id,
                     project_id=project_id,
+                    run_id=comp_run.run_id,
                     tasks={node_id: task.image},
                     hardware_info=task.hardware_info,
                     callback=wake_up_callback,
@@ -190,9 +181,7 @@ class DaskScheduler(BaseCompScheduler):
                 # update the database so we do have the correct job_ids there
                 await limited_gather(
                     *(
-                        comp_tasks_repo.update_project_task_job_id(
-                            project_id, task.node_id, comp_run.run_id, task.job_id
-                        )
+                        comp_tasks_repo.set_task_job_id(project_id, task.node_id, comp_run.run_id, task.job_id)
                         for task in published_tasks
                     ),
                     log=_logger,

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -78,7 +78,7 @@ from ..core.errors import (
     TaskSchedulingError,
 )
 from ..core.settings import AppSettings, ComputationalBackendSettings
-from ..models.comp_runs import RunMetadataDict
+from ..models.comp_runs import RunID, RunMetadataDict
 from ..models.comp_tasks import Image
 from ..modules.storage import StorageClient
 from ..utils import dask as dask_utils
@@ -251,7 +251,17 @@ class DaskClient:
             # NOTE: the callback is running in a secondary thread, and takes a future as arg
             task_future.add_done_callback(lambda _: callback())
 
-            await dask_utils.wrap_client_async_routine(self.backend.client.publish_dataset(task_future, name=job_id))
+            try:
+                await dask_utils.wrap_client_async_routine(
+                    self.backend.client.publish_dataset(task_future, name=job_id)
+                )
+            except KeyError as exc:
+                if "already exists" not in f"{exc}":
+                    raise
+                # NOTE: job_id (stable per run_id) was already published -> resubmission is a no-op.
+                _logger.warning(
+                    "dask task %s was already published, this should not happen but is harmless", f"{job_id=}"
+                )
 
             _logger.info(
                 "Dask task %s started [%s] with encryption [%s]",
@@ -277,9 +287,12 @@ class DaskClient:
         metadata: RunMetadataDict,
         hardware_info: HardwareInfo,
         resource_tracking_run_id: ServiceRunID,
+        run_id: RunID,
     ) -> list[PublishedComputationTask]:
         """actually sends the function remote_fct to be remotely executed. if None is kept then the default
         function that runs container will be started.
+
+        `run_id` makes the job_id stable for a given (project_id, node_id, run_id), enabling idempotent resubmission.
 
         Raises:
           - ComputationalBackendNoS3AccessError when storage is not accessible
@@ -299,6 +312,7 @@ class DaskClient:
                 user_id=user_id,
                 project_id=project_id,
                 node_id=node_id,
+                run_id=run_id,
             )
             assert node_image.node_requirements  # nosec
             dask_resources = dask_utils.from_node_reqs_to_dask_resources(node_image.node_requirements)

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -259,9 +259,7 @@ class DaskClient:
                 if "already exists" not in f"{exc}":
                     raise
                 # NOTE: job_id (stable per run_id) was already published -> resubmission is a no-op.
-                _logger.warning(
-                    "dask task %s was already published, this should not happen but is harmless", f"{job_id=}"
-                )
+                _logger.info("dask task %s was already published, this should not happen but is harmless", f"{job_id=}")
 
             _logger.info(
                 "Dask task %s started [%s] with encryption [%s]",

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -240,6 +240,7 @@ class CompTasksRepository(BaseRepository):
         """sets the task's job_id and atomically moves it to PENDING.
 
         Raises:
+            ComputationalTaskNotFoundError: if the task does not exist
             ComputationalTaskJobIdAlreadySetError: if the task already has a job_id
         """
         task_kwargs = {"job_id": job_id, "state": RUNNING_STATE_TO_DB[RunningState.PENDING]}
@@ -255,6 +256,13 @@ class CompTasksRepository(BaseRepository):
                 .returning(literal_column("*"))
             )
             if result.one_or_none() is None:
+                task_exists = await conn.scalar(
+                    sa.select(comp_tasks.c.node_id).where(
+                        (comp_tasks.c.project_id == f"{project_id}") & (comp_tasks.c.node_id == f"{task}")
+                    )
+                )
+                if task_exists is None:
+                    raise ComputationalTaskNotFoundError(node_id=task)
                 raise ComputationalTaskJobIdAlreadySetError(project_id=project_id, node_id=task)
             # Sync with comp_run_snapshot_tasks table
             await conn.execute(

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -17,7 +17,10 @@ from servicelib.rabbitmq import RabbitMQRPCClient
 from sqlalchemy import CursorResult, literal_column
 from sqlalchemy.dialects.postgresql import insert
 
-from .....core.errors import ComputationalTaskNotFoundError
+from .....core.errors import (
+    ComputationalTaskJobIdAlreadySetError,
+    ComputationalTaskNotFoundError,
+)
 from .....models.comp_runs import RunID
 from .....models.comp_tasks import CompTaskAtDB, ComputationTaskForRpcDBGet
 from .....modules.resource_usage_tracker_client import ResourceUsageTrackerClient
@@ -233,8 +236,36 @@ class CompTasksRepository(BaseRepository):
                 row = result.one()
                 return CompTaskAtDB.model_validate(row)
 
-    async def update_project_task_job_id(self, project_id: ProjectID, task: NodeID, run_id: RunID, job_id: str) -> None:
-        await self._update_task(project_id, task, run_id, job_id=job_id)
+    async def set_task_job_id(self, project_id: ProjectID, task: NodeID, run_id: RunID, job_id: str) -> None:
+        """sets the task's job_id and atomically moves it to PENDING.
+
+        Raises:
+            ComputationalTaskJobIdAlreadySetError: if the task already has a job_id
+        """
+        task_kwargs = {"job_id": job_id, "state": RUNNING_STATE_TO_DB[RunningState.PENDING]}
+        async with self.db_engine.begin() as conn:
+            result: CursorResult = await conn.execute(
+                sa.update(comp_tasks)
+                .where(
+                    (comp_tasks.c.project_id == f"{project_id}")
+                    & (comp_tasks.c.node_id == f"{task}")
+                    & (comp_tasks.c.job_id.is_(None))
+                )
+                .values(**task_kwargs)
+                .returning(literal_column("*"))
+            )
+            if result.one_or_none() is None:
+                raise ComputationalTaskJobIdAlreadySetError(project_id=project_id, node_id=task)
+            # Sync with comp_run_snapshot_tasks table
+            await conn.execute(
+                sa.update(comp_run_snapshot_tasks)
+                .where(
+                    (comp_run_snapshot_tasks.c.run_id == run_id)
+                    & (comp_run_snapshot_tasks.c.project_id == f"{project_id}")
+                    & (comp_run_snapshot_tasks.c.node_id == f"{task}")
+                )
+                .values(**task_kwargs)
+            )
 
     async def reset_task_for_resubmission(
         self,

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -72,6 +72,7 @@ from simcore_service_director_v2.core.errors import (
 )
 from simcore_service_director_v2.models.comp_runs import (
     JobEncryptionRunMetadataDict,
+    RunID,
     RunMetadataDict,
 )
 from simcore_service_director_v2.models.comp_tasks import Image
@@ -499,6 +500,7 @@ async def test_send_computation_task(
         metadata=comp_run_metadata,
         hardware_info=empty_hardware_info,
         resource_tracking_run_id=resource_tracking_run_id,
+        run_id=RunID(1),
     )
     assert node_id_to_job_ids
     assert len(node_id_to_job_ids) == 1
@@ -602,6 +604,7 @@ async def test_send_computation_task_propagates_encryption_context(
         metadata=metadata_with_encryption,
         hardware_info=empty_hardware_info,
         resource_tracking_run_id=resource_tracking_run_id,
+        run_id=RunID(1),
     )
     assert len(node_id_to_job_ids) == 1
     published_computation_task = node_id_to_job_ids[0]
@@ -666,6 +669,7 @@ async def test_computation_task_is_persisted_on_dask_scheduler(
         metadata=comp_run_metadata,
         hardware_info=empty_hardware_info,
         resource_tracking_run_id=resource_tracking_run_id,
+        run_id=RunID(1),
     )
     assert published_computation_task
     assert len(published_computation_task) == 1
@@ -702,6 +706,76 @@ async def test_computation_task_is_persisted_on_dask_scheduler(
     assert task_result.get("some_output_key") == 123
     # try to create another future and this one is already done
     assert distributed.Future(published_computation_task[0].job_id, client=dask_client.backend.client).done()
+
+
+async def test_resubmitting_same_run_id_does_not_recompute_the_task(
+    dask_client: DaskClient,
+    user_id: UserID,
+    project_id: ProjectID,
+    image_params: ImageParams,
+    _mocked_node_ports: None,
+    mocked_user_completed_cb: mock.AsyncMock,
+    mocked_storage_service_api: respx.MockRouter,
+    faker: Faker,
+    comp_run_metadata: RunMetadataDict,
+    empty_hardware_info: HardwareInfo,
+    resource_tracking_run_id: ServiceRunID,
+):
+    """Regression test for https://github.com/ITISFoundation/private-issues/issues/648:
+    resubmitting the same (node, run_id) must reuse the same dask key and must NOT
+    recompute the task, since generate_dask_job_id makes the key deterministic for that
+    purpose."""
+    _DASK_COUNTER_NAME = faker.pystr()
+    counter_var = distributed.Variable(_DASK_COUNTER_NAME, client=dask_client.backend.client)
+    await counter_var.set(0)  # type: ignore
+
+    # NOTE: this must be inlined so that the test works,
+    # the dask-worker must be able to import the function
+    def fake_remote_fct(
+        task_parameters: ContainerTaskParameters,
+        docker_auth: DockerBasicAuth,
+        log_file_url: LogFileUploadURL,
+        s3_settings: S3Settings | None,
+        encryption: JobEncryptionContext | None,
+    ) -> TaskOutputData:
+        var = distributed.Variable(_DASK_COUNTER_NAME)
+        var.set(var.get() + 1)
+        return TaskOutputData.model_validate({"some_output_key": 123})
+
+    run_id = RunID(1)
+    first_submission = await dask_client.send_computation_tasks(
+        user_id=user_id,
+        project_id=project_id,
+        tasks=image_params.fake_tasks,
+        callback=mocked_user_completed_cb,
+        remote_fct=fake_remote_fct,
+        metadata=comp_run_metadata,
+        hardware_info=empty_hardware_info,
+        resource_tracking_run_id=resource_tracking_run_id,
+        run_id=run_id,
+    )
+    assert len(first_submission) == 1
+    await _assert_wait_for_task_status(first_submission[0].job_id, dask_client, RunningState.SUCCESS)
+
+    # NOTE: same node/user/project/run_id -> same deterministic job_id (simulates a retry
+    # after e.g. a DB write failure that happened right after a successful dask submission)
+    second_submission = await dask_client.send_computation_tasks(
+        user_id=user_id,
+        project_id=project_id,
+        tasks=image_params.fake_tasks,
+        callback=mocked_user_completed_cb,
+        remote_fct=fake_remote_fct,
+        metadata=comp_run_metadata,
+        hardware_info=empty_hardware_info,
+        resource_tracking_run_id=resource_tracking_run_id,
+        run_id=run_id,
+    )
+    assert len(second_submission) == 1
+    assert second_submission[0].job_id == first_submission[0].job_id
+    await _assert_wait_for_task_status(second_submission[0].job_id, dask_client, RunningState.SUCCESS)
+
+    # the remote function must have executed exactly once: dask deduplicated the resubmission by key
+    assert await counter_var.get() == 1  # type: ignore
 
 
 async def test_abort_computation_tasks(
@@ -756,6 +830,7 @@ async def test_abort_computation_tasks(
         metadata=comp_run_metadata,
         hardware_info=empty_hardware_info,
         resource_tracking_run_id=resource_tracking_run_id,
+        run_id=RunID(1),
     )
     assert published_computation_task
     assert len(published_computation_task) == 1
@@ -833,6 +908,7 @@ async def test_failed_task_returns_exceptions(
         metadata=comp_run_metadata,
         hardware_info=empty_hardware_info,
         resource_tracking_run_id=resource_tracking_run_id,
+        run_id=RunID(1),
     )
     assert published_computation_task
     assert len(published_computation_task) == 1
@@ -915,6 +991,7 @@ async def test_send_computation_task_with_missing_resources_raises(
             metadata=comp_run_metadata,
             hardware_info=empty_hardware_info,
             resource_tracking_run_id=resource_tracking_run_id,
+            run_id=RunID(1),
         )
     mocked_user_completed_cb.assert_not_called()
 
@@ -944,6 +1021,7 @@ async def test_send_computation_task_with_hardware_info_raises(
             metadata=comp_run_metadata,
             hardware_info=hardware_info,
             resource_tracking_run_id=resource_tracking_run_id,
+            run_id=RunID(1),
         )
     mocked_user_completed_cb.assert_not_called()
 
@@ -984,6 +1062,7 @@ async def test_too_many_resources_send_computation_task(
             metadata=comp_run_metadata,
             hardware_info=empty_hardware_info,
             resource_tracking_run_id=resource_tracking_run_id,
+            run_id=RunID(1),
         )
 
     mocked_user_completed_cb.assert_not_called()
@@ -1014,6 +1093,7 @@ async def test_disconnected_backend_raises_exception(
             metadata=comp_run_metadata,
             hardware_info=empty_hardware_info,
             resource_tracking_run_id=resource_tracking_run_id,
+            run_id=RunID(1),
         )
     mocked_user_completed_cb.assert_not_called()
 
@@ -1060,6 +1140,7 @@ async def test_changed_scheduler_raises_exception(
                 metadata=comp_run_metadata,
                 hardware_info=empty_hardware_info,
                 resource_tracking_run_id=resource_tracking_run_id,
+                run_id=RunID(1),
             )
     mocked_user_completed_cb.assert_not_called()
 
@@ -1107,6 +1188,7 @@ async def test_get_tasks_status(
         metadata=comp_run_metadata,
         hardware_info=empty_hardware_info,
         resource_tracking_run_id=resource_tracking_run_id,
+        run_id=RunID(1),
     )
     assert published_computation_task
     assert len(published_computation_task) == 1
@@ -1188,6 +1270,7 @@ async def test_dask_sub_handlers(
         metadata=comp_run_metadata,
         hardware_info=empty_hardware_info,
         resource_tracking_run_id=resource_tracking_run_id,
+        run_id=RunID(1),
     )
     assert published_computation_task
     assert len(published_computation_task) == 1

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -64,6 +64,7 @@ from simcore_service_director_v2.core.errors import (
     ComputationalBackendTaskResultsNotReadyError,
     ComputationalSchedulerChangedError,
     ComputationalSchedulerError,
+    ComputationalTaskJobIdAlreadySetError,
     DaskClientAcquisisitonError,
     InvalidPipelineError,
 )
@@ -273,6 +274,7 @@ async def _assert_publish_in_dask_backend(
                 metadata=mock.ANY,
                 hardware_info=mock.ANY,
                 resource_tracking_run_id=mock.ANY,
+                run_id=mock.ANY,
             )
             for p in expected_pending_tasks
         ],
@@ -737,6 +739,7 @@ async def test_proper_pipeline_is_scheduled(  # noqa: PLR0915
         metadata=mock.ANY,
         hardware_info=mock.ANY,
         resource_tracking_run_id=mock.ANY,
+        run_id=mock.ANY,
     )
     mocked_dask_client.send_computation_tasks.reset_mock()
     mocked_dask_client.get_tasks_status.assert_has_calls(
@@ -3096,3 +3099,56 @@ async def test_computational_run_not_found_error_does_not_release_resources(
     mocked_safe_release_resources.assert_not_called()
     # no comp_run row should exist (was deleted before apply)
     await assert_comp_runs_empty(sqlalchemy_async_engine)
+
+
+async def test_task_job_id_already_set_error_does_not_fail_other_tasks(
+    with_disabled_auto_scheduling: mock.Mock,
+    with_disabled_scheduler_publisher: mock.Mock,
+    initialized_app: FastAPI,
+    mocked_dask_client: mock.MagicMock,
+    scheduler_api: BaseCompScheduler,
+    sqlalchemy_async_engine: AsyncEngine,
+    published_project: PublishedProject,
+    run_metadata: RunMetadataDict,
+    computational_pipeline_rabbit_client_parser: mock.AsyncMock,
+    fake_collection_run_id: CollectionRunID,
+    mocker: MockerFixture,
+):
+    """If _start_tasks unexpectedly raises ComputationalTaskJobIdAlreadySetError (see
+    https://github.com/ITISFoundation/private-issues/issues/648), scheduling must handle it
+    gracefully: not crash, and not mark the tasks to start as FAILED (some might already be
+    legitimately running with their job_id already persisted)."""
+    _with_mock_send_computation_tasks(published_project.tasks, mocked_dask_client)
+    run_in_db, expected_published_tasks = await _assert_start_pipeline(
+        initialized_app,
+        sqlalchemy_async_engine=sqlalchemy_async_engine,
+        published_project=published_project,
+        run_metadata=run_metadata,
+        computational_pipeline_rabbit_client_parser=computational_pipeline_rabbit_client_parser,
+        collection_run_id=fake_collection_run_id,
+    )
+
+    mocker.patch.object(
+        scheduler_api,
+        "_start_tasks",
+        side_effect=ComputationalTaskJobIdAlreadySetError(
+            project_id=run_in_db.project_uuid, node_id=expected_published_tasks[0].node_id
+        ),
+    )
+
+    # scheduling must not raise
+    await scheduler_api.apply(
+        user_id=run_in_db.user_id,
+        project_id=run_in_db.project_uuid,
+        iteration=run_in_db.iteration,
+    )
+
+    # tasks must remain untouched (still PUBLISHED), not forced to FAILED
+    await assert_comp_tasks_and_comp_run_snapshot_tasks(
+        sqlalchemy_async_engine,
+        project_uuid=published_project.project.uuid,
+        task_ids=[t.node_id for t in expected_published_tasks],
+        expected_state=RunningState.PUBLISHED,
+        expected_progress=None,
+        run_id=run_in_db.run_id,
+    )

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -54,7 +54,7 @@ from pytest_mock.plugin import MockerFixture
 from servicelib.rabbitmq import RabbitMQClient
 from servicelib.rabbitmq._constants import BIND_TO_ALL_TOPICS
 from simcore_postgres_database.models.comp_runs import comp_runs
-from simcore_postgres_database.models.comp_tasks import NodeClass
+from simcore_postgres_database.models.comp_tasks import NodeClass, comp_tasks
 from simcore_sdk.node_ports_common.exceptions import S3InvalidPathError
 from simcore_service_director_v2.core.errors import (
     ClustersKeeperNotAvailableError,
@@ -3151,4 +3151,50 @@ async def test_task_job_id_already_set_error_does_not_fail_other_tasks(
         expected_state=RunningState.PUBLISHED,
         expected_progress=None,
         run_id=run_in_db.run_id,
+    )
+
+
+async def test_fix_tasks_stuck_pending_without_job_id_resets_to_published(
+    with_disabled_auto_scheduling: mock.Mock,
+    with_disabled_scheduler_publisher: mock.Mock,
+    mocked_dask_client: mock.MagicMock,
+    sqlalchemy_async_engine: AsyncEngine,
+    running_project: RunningProject,
+    scheduler_api: BaseCompScheduler,
+):
+    """Safety-net regression test for https://github.com/ITISFoundation/private-issues/issues/648:
+    a task stuck PENDING with no job_id must be reset to PUBLISHED so it gets restarted."""
+    comp_run = running_project.runs
+    # tasks[2] depends on tasks[1] (not yet SUCCESS), so once reset to PUBLISHED it is not
+    # immediately eligible to (re)start in the same apply() call
+    stuck_task = running_project.tasks[2]
+
+    # simulate the invalid state: PENDING with no job_id
+    async with sqlalchemy_async_engine.begin() as conn:
+        await conn.execute(
+            comp_tasks.update()
+            .where(comp_tasks.c.project_id == f"{stuck_task.project_id}")
+            .where(comp_tasks.c.node_id == f"{stuck_task.node_id}")
+            .values(state=RunningState.PENDING.value, job_id=None)
+        )
+
+    async def mocked_get_tasks_status(job_ids: list[str]) -> list[RunningState]:
+        return [RunningState.STARTED for _ in job_ids]
+
+    mocked_dask_client.get_tasks_status.side_effect = mocked_get_tasks_status
+    assert running_project.project.prj_owner
+    await scheduler_api.apply(
+        user_id=running_project.project.prj_owner,
+        project_id=running_project.project.uuid,
+        iteration=comp_run.iteration,
+    )
+
+    mocked_dask_client.send_computation_tasks.assert_not_called()
+    await assert_comp_tasks_and_comp_run_snapshot_tasks(
+        sqlalchemy_async_engine,
+        project_uuid=stuck_task.project_id,
+        task_ids=[stuck_task.node_id],
+        expected_state=RunningState.PUBLISHED,
+        expected_progress=stuck_task.progress,
+        run_id=comp_run.run_id,
     )

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_scheduler_dask.py
@@ -29,8 +29,9 @@ from _helpers import (
 )
 from dask_task_models_library.container_tasks.errors import ServiceRuntimeError, TaskCancelledError
 from dask_task_models_library.container_tasks.events import TaskProgressEvent
-from dask_task_models_library.container_tasks.io import TaskOutputData
+from dask_task_models_library.container_tasks.io import TaskInputData, TaskOutputData, TaskOutputDataSchema
 from dask_task_models_library.container_tasks.protocol import TaskOwner
+from distributed import SpecCluster
 from faker import Faker
 from fastapi.applications import FastAPI
 from models_library.computations import CollectionRunID
@@ -49,8 +50,9 @@ from models_library.rabbitmq_messages import (
     SimcorePlatformStatus,
 )
 from models_library.users import UserID
-from pydantic import TypeAdapter
+from pydantic import AnyUrl, TypeAdapter
 from pytest_mock.plugin import MockerFixture
+from pytest_simcore.helpers.typing_env import EnvVarsDict
 from servicelib.rabbitmq import RabbitMQClient
 from servicelib.rabbitmq._constants import BIND_TO_ALL_TOPICS
 from simcore_postgres_database.models.comp_runs import comp_runs
@@ -82,6 +84,7 @@ from simcore_service_director_v2.modules.comp_scheduler._scheduler_dask import (
 from simcore_service_director_v2.modules.comp_scheduler._utils import COMPLETED_STATES
 from simcore_service_director_v2.modules.comp_scheduler._worker import _get_scheduler_worker
 from simcore_service_director_v2.modules.dask_client import DaskJobID, PublishedComputationTask
+from simcore_service_director_v2.modules.dask_clients_pool import DaskClientsPool
 from simcore_service_director_v2.modules.osparc_variables._errors import (
     OsparcVariableResolveError,
     OsparcVariableResolveTimeoutError,
@@ -3198,3 +3201,115 @@ async def test_fix_tasks_stuck_pending_without_job_id_resets_to_published(
         expected_progress=stuck_task.progress,
         run_id=comp_run.run_id,
     )
+
+
+@pytest.fixture
+def with_real_dask_cluster_url(
+    mock_env: EnvVarsDict,
+    dask_spec_local_cluster: SpecCluster,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPUTATIONAL_BACKEND_DASK_CLIENT_ENABLED", "1")
+    monkeypatch.setenv("COMPUTATIONAL_BACKEND_DEFAULT_CLUSTER_URL", dask_spec_local_cluster.scheduler_address)
+
+
+@pytest.fixture
+def with_mocked_node_ports_and_storage(
+    mock_env: EnvVarsDict, mocker: MockerFixture, mocked_storage_service_api: Any
+) -> None:
+    # file-transfer machinery is out of scope here: only dask job submission/idempotency is under test
+    mocker.patch(
+        "simcore_service_director_v2.modules.dask_client.dask_utils.create_node_ports",
+        return_value=None,
+    )
+    mocker.patch(
+        "simcore_service_director_v2.modules.dask_client.dask_utils.compute_input_data",
+        return_value=TaskInputData.model_validate({}),
+    )
+    mocker.patch(
+        "simcore_service_director_v2.modules.dask_client.dask_utils.compute_output_data_schema",
+        return_value=TaskOutputDataSchema.model_validate({}),
+    )
+    mocker.patch(
+        "simcore_service_director_v2.modules.dask_client.dask_utils.compute_service_log_file_upload_link",
+        return_value=TypeAdapter(AnyUrl).validate_python("file://undefined"),
+    )
+
+
+async def test_start_tasks_retry_after_db_write_failure_does_not_duplicate_dask_job(
+    with_disabled_auto_scheduling: mock.Mock,
+    with_disabled_scheduler_publisher: mock.Mock,
+    with_real_dask_cluster_url: None,
+    with_mocked_node_ports_and_storage: None,
+    initialized_app: FastAPI,
+    scheduler_api: BaseCompScheduler,
+    sqlalchemy_async_engine: AsyncEngine,
+    published_project: PublishedProject,
+    run_metadata: RunMetadataDict,
+    computational_pipeline_rabbit_client_parser: mock.AsyncMock,
+    fake_collection_run_id: CollectionRunID,
+):
+    """End-to-end regression test with a REAL dask cluster for
+    https://github.com/ITISFoundation/private-issues/issues/648: dask accepts the job, but the DB
+    write of (job_id, PENDING) never gets committed (e.g. the process crashes right after). The task
+    is found back in PUBLISHED with no job_id, so the next apply() resubmits it. Thanks to the
+    deterministic job_id, dask must not end up with two jobs for the same task."""
+    run_in_db, published_tasks = await _assert_start_pipeline(
+        initialized_app,
+        sqlalchemy_async_engine=sqlalchemy_async_engine,
+        published_project=published_project,
+        run_metadata=run_metadata,
+        computational_pipeline_rabbit_client_parser=computational_pipeline_rabbit_client_parser,
+        collection_run_id=fake_collection_run_id,
+    )
+    task_to_start = published_tasks[1]
+
+    # 1. the scheduler submits the job to the (real) dask cluster and persists (job_id, PENDING)
+    await scheduler_api.apply(
+        user_id=run_in_db.user_id,
+        project_id=run_in_db.project_uuid,
+        iteration=run_in_db.iteration,
+    )
+    persisted_tasks, _ = await assert_comp_tasks_and_comp_run_snapshot_tasks(
+        sqlalchemy_async_engine,
+        project_uuid=published_project.project.uuid,
+        task_ids=[task_to_start.node_id],
+        expected_state=RunningState.PENDING,
+        expected_progress=None,
+        run_id=run_in_db.run_id,
+    )
+    job_id = persisted_tasks[0].job_id
+    assert job_id
+
+    # 2. simulate the DB write never being committed: the task is found back in PUBLISHED
+    # with no job_id, even though dask already accepted the job
+    async with sqlalchemy_async_engine.begin() as conn:
+        await conn.execute(
+            comp_tasks.update()
+            .where(comp_tasks.c.project_id == f"{task_to_start.project_id}")
+            .where(comp_tasks.c.node_id == f"{task_to_start.node_id}")
+            .values(state=RunningState.PUBLISHED.value, job_id=None)
+        )
+
+    # 3. the next scheduling pass picks it up again and resubmits it with the same deterministic job_id
+    await scheduler_api.apply(
+        user_id=run_in_db.user_id,
+        project_id=run_in_db.project_uuid,
+        iteration=run_in_db.iteration,
+    )
+    persisted_tasks, _ = await assert_comp_tasks_and_comp_run_snapshot_tasks(
+        sqlalchemy_async_engine,
+        project_uuid=published_project.project.uuid,
+        task_ids=[task_to_start.node_id],
+        expected_state=RunningState.PENDING,
+        expected_progress=None,
+        run_id=run_in_db.run_id,
+    )
+    assert persisted_tasks[0].job_id == job_id
+
+    # 4. the critical assertion: only ONE dask job exists, despite 2 submission attempts
+    dask_clients_pool = DaskClientsPool.instance(initialized_app)
+    default_cluster = initialized_app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.default_cluster
+    async with dask_clients_pool.acquire(default_cluster, ref="test-verify-single-dask-job") as dask_client:
+        published_datasets = await dask_client.backend.client.list_datasets()  # type: ignore
+    assert published_datasets.count(job_id) == 1

--- a/services/director-v2/tests/unit/with_dbs/conftest.py
+++ b/services/director-v2/tests/unit/with_dbs/conftest.py
@@ -52,12 +52,12 @@ async def create_pipeline(
 
 # states from which a task has a job_id (see CompTasksRepository.set_task_job_id)
 _STATES_WITH_JOB_ID = {
+    StateType.ABORTED,
+    StateType.FAILED,
     StateType.PENDING,
-    StateType.WAITING_FOR_RESOURCES,
     StateType.RUNNING,
     StateType.SUCCESS,
-    StateType.FAILED,
-    StateType.ABORTED,
+    StateType.WAITING_FOR_RESOURCES,
 }
 
 

--- a/services/director-v2/tests/unit/with_dbs/conftest.py
+++ b/services/director-v2/tests/unit/with_dbs/conftest.py
@@ -31,6 +31,7 @@ from simcore_service_director_v2.models.comp_pipelines import CompPipelineAtDB
 from simcore_service_director_v2.models.comp_runs import (
     CompRunsAtDB,
     ProjectMetadataDict,
+    RunID,
     RunMetadataDict,
 )
 from simcore_service_director_v2.models.comp_tasks import CompTaskAtDB, Image
@@ -49,11 +50,26 @@ async def create_pipeline(
     return _
 
 
+# states from which a task has a job_id (see CompTasksRepository.set_task_job_id)
+_STATES_WITH_JOB_ID = {
+    StateType.PENDING,
+    StateType.WAITING_FOR_RESOURCES,
+    StateType.RUNNING,
+    StateType.SUCCESS,
+    StateType.FAILED,
+    StateType.ABORTED,
+}
+
+
 @pytest.fixture
 async def create_tasks_from_project(
     create_comp_task: Callable[..., Awaitable[dict[str, Any]]],
 ) -> Callable[..., Awaitable[list[CompTaskAtDB]]]:
-    async def _(user: dict[str, Any], project: ProjectAtDB, **overrides_kwargs) -> list[CompTaskAtDB]:
+    async def _(
+        user: dict[str, Any], project: ProjectAtDB, run_id: RunID | None = None, **overrides_kwargs
+    ) -> list[CompTaskAtDB]:
+        if run_id is None:
+            run_id = RunID(1)
         created_tasks: list[CompTaskAtDB] = []
         for internal_id, (node_id, node_data) in enumerate(project.workbench.items()):
             task_config = {
@@ -87,14 +103,16 @@ async def create_tasks_from_project(
                 "image": Image(name=node_data.key, tag=node_data.version).model_dump(by_alias=True, exclude_unset=True),
                 "node_class": to_node_class(node_data.key),
                 "internal_id": internal_id + 1,
-                "job_id": generate_dask_job_id(
+            }
+            if overrides_kwargs.get("state") in _STATES_WITH_JOB_ID:
+                task_config["job_id"] = generate_dask_job_id(
                     service_key=node_data.key,
                     service_version=node_data.version,
                     user_id=user["id"],
                     project_id=project.uuid,
                     node_id=NodeID(node_id),
-                ),
-            }
+                    run_id=run_id,
+                )
             task_config.update(**overrides_kwargs)
             task_dict = await create_comp_task(**task_config)
             new_task = CompTaskAtDB.model_validate(task_dict)
@@ -230,6 +248,7 @@ async def create_comp_run_snapshot_tasks(
                     user_id=user["id"],
                     project_id=project.uuid,
                     node_id=NodeID(node_id),
+                    run_id=run_id,
                 ),
                 "state": StateType.PUBLISHED.value,
             }
@@ -320,6 +339,7 @@ async def running_project(
         tasks=await create_tasks_from_project(
             user=user,
             project=created_project,
+            run_id=_comp_run.run_id,
             state=StateType.RUNNING,
             progress=0.0,
             start=now_time,
@@ -370,6 +390,7 @@ async def running_project_mark_for_cancellation(
         tasks=await create_tasks_from_project(
             user=user,
             project=created_project,
+            run_id=_comp_run.run_id,
             state=StateType.RUNNING,
             progress=0.0,
             start=now_time,

--- a/services/director-v2/tests/unit/with_dbs/test_modules_db_repositories_comp_tasks.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_db_repositories_comp_tasks.py
@@ -1,0 +1,64 @@
+# pylint: disable=redefined-outer-name
+# pylint: disable=unused-argument
+
+import pytest
+import sqlalchemy as sa
+from _helpers import PublishedProject
+from faker import Faker
+from fastapi import FastAPI
+from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
+from pytest_simcore.helpers.typing_env import EnvVarsDict
+from simcore_service_director_v2.core.errors import ComputationalTaskJobIdAlreadySetError
+from simcore_service_director_v2.models.comp_runs import RunID
+from simcore_service_director_v2.modules.db.repositories.comp_tasks import (
+    CompTasksRepository,
+)
+from simcore_service_director_v2.utils.db import get_repository
+
+pytest_simcore_core_services_selection = [
+    "postgres",
+]
+pytest_simcore_ops_services_selection = [
+    "adminer",
+]
+
+
+@pytest.fixture
+def mock_env(
+    monkeypatch: pytest.MonkeyPatch,
+    postgres_host_config: dict[str, str],
+    mock_env: EnvVarsDict,
+    postgres_db: sa.engine.Engine,
+    faker: Faker,
+) -> EnvVarsDict:
+    """overrides unit/conftest:mock_env fixture"""
+    env_vars = mock_env.copy()
+    env_vars.update(
+        {
+            "S3_ACCESS_KEY": "12345678",
+            "S3_BUCKET_NAME": "simcore",
+            "S3_ENDPOINT": "http://172.17.0.1:9001",
+            "S3_REGION": faker.pystr(),
+            "S3_SECRET_KEY": "12345678",
+            "POSTGRES_HOST": postgres_host_config["host"],
+            "POSTGRES_USER": postgres_host_config["user"],
+            "POSTGRES_PASSWORD": postgres_host_config["password"],
+            "POSTGRES_DB": postgres_host_config["database"],
+        }
+    )
+    setenvs_from_dict(monkeypatch, env_vars)
+    return env_vars
+
+
+async def test_set_task_job_id_raises_if_already_set(
+    initialized_app: FastAPI,
+    published_project: PublishedProject,
+):
+    """set_task_job_id must never silently overwrite an existing job_id
+    (see https://github.com/ITISFoundation/private-issues/issues/648)."""
+    comp_tasks_repo = get_repository(initialized_app, CompTasksRepository)
+    task = published_project.tasks[0]
+    run_id = RunID(1)
+    await comp_tasks_repo.set_task_job_id(task.project_id, task.node_id, run_id, "job-id-1")
+    with pytest.raises(ComputationalTaskJobIdAlreadySetError):
+        await comp_tasks_repo.set_task_job_id(task.project_id, task.node_id, run_id, "job-id-2")

--- a/services/director-v2/tests/unit/with_dbs/test_modules_db_repositories_comp_tasks.py
+++ b/services/director-v2/tests/unit/with_dbs/test_modules_db_repositories_comp_tasks.py
@@ -6,9 +6,13 @@ import sqlalchemy as sa
 from _helpers import PublishedProject
 from faker import Faker
 from fastapi import FastAPI
+from models_library.projects_nodes_io import NodeID
 from pytest_simcore.helpers.monkeypatch_envs import setenvs_from_dict
 from pytest_simcore.helpers.typing_env import EnvVarsDict
-from simcore_service_director_v2.core.errors import ComputationalTaskJobIdAlreadySetError
+from simcore_service_director_v2.core.errors import (
+    ComputationalTaskJobIdAlreadySetError,
+    ComputationalTaskNotFoundError,
+)
 from simcore_service_director_v2.models.comp_runs import RunID
 from simcore_service_director_v2.modules.db.repositories.comp_tasks import (
     CompTasksRepository,
@@ -62,3 +66,15 @@ async def test_set_task_job_id_raises_if_already_set(
     await comp_tasks_repo.set_task_job_id(task.project_id, task.node_id, run_id, "job-id-1")
     with pytest.raises(ComputationalTaskJobIdAlreadySetError):
         await comp_tasks_repo.set_task_job_id(task.project_id, task.node_id, run_id, "job-id-2")
+
+
+async def test_set_task_job_id_raises_not_found_if_task_does_not_exist(
+    initialized_app: FastAPI,
+    published_project: PublishedProject,
+    faker: Faker,
+):
+    comp_tasks_repo = get_repository(initialized_app, CompTasksRepository)
+    task = published_project.tasks[0]
+    run_id = RunID(1)
+    with pytest.raises(ComputationalTaskNotFoundError):
+        await comp_tasks_repo.set_task_job_id(task.project_id, NodeID(f"{faker.uuid4()}"), run_id, "job-id-1")

--- a/services/director-v2/tests/unit/with_dbs/test_utils_dask.py
+++ b/services/director-v2/tests/unit/with_dbs/test_utils_dask.py
@@ -91,7 +91,7 @@ async def mocked_node_ports_filemanager_fcts(
         "get_upload_links_from_s3": mocker.patch(
             "simcore_service_director_v2.utils.dask.port_utils.filemanager.get_upload_links_from_s3",
             autospec=True,
-            side_effect=lambda **kwargs: (
+            side_effect=lambda **kwargs: (  # noqa: ARG005
                 0,
                 FileUploadSchema(
                     urls=[
@@ -198,6 +198,7 @@ async def test_parse_output_data(
     fake_io_schema: dict[str, dict[str, str]],
     fake_task_output_data: TaskOutputData,
     mocker: MockerFixture,
+    faker: Faker,
 ):
     # need some fakes set in the DB
     sleeper_task: CompTaskAtDB = published_project.tasks[1]
@@ -213,6 +214,7 @@ async def test_parse_output_data(
         user_id,
         published_project.project.uuid,
         sleeper_task.node_id,
+        run_id=faker.pyint(min_value=1),
     )
     await parse_output_data(sqlalchemy_async_engine, dask_job_id, fake_task_output_data)
 
@@ -395,7 +397,8 @@ async def test_clean_task_output_and_log_files_if_invalid(
         mock.call(
             user_id=user_id,
             store_id=0,
-            s3_object=f"{published_project.project.uuid}/{sleeper_task.node_id}/{next(iter(fake_io_schema[key].get('fileToKeyMap', {key: key})))}",
+            s3_object=f"{published_project.project.uuid}/{sleeper_task.node_id}/"
+            f"{next(iter(fake_io_schema[key].get('fileToKeyMap', {key: key})))}",
         )
         for key in fake_outputs
     ] + [


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
In deployments such as #master that re-deploy often it was found that computational tasks set to `PENDING` state with no attached dask `job_id` were saved in `comp_tasks` DB table. This most probably happens when a re-deploys happens and the starting of the job is stopped mid-air.
This would lead to having computational pipeline wrongly in `RUNNING` state. The dv-2 computational cluster would not check that the single tasks were actually not properly started (shown by the fact that no dask-job ID was found) and the dv-2 computational cluster was relying only on the task state.
The system was made to only submit once (hence the `PENDING` state was set beforehand) to prevent multiple expensive job submissions. The job_id was written in the DB only afterwards (which is what failed now).

This PR changes this in the following ways:
- there is a fix that will check that the PENDING tasks in a a pipeline all have a dask job ID, if not these tasks will be set back to PUBLISHED (e.g. so they will get re-submitted or cancelled depending on the wished run state)
- there is a fix that ensures the `PENDING` state and dask `job_id` are both written to the DB together so in case something bad happen while connecting to the DB they will both have the correct expected state
- The changes above would make it possible to do multiple submissions of the same computational job which is NOT acceptable.
- there is a fix that makes publishing to dask idempotent. the dask job ID was always unique until now. This is now deterministic and the same task will produce the same dask job_id. The dask backend recognizes a dask that was already submitted, which was unknown until now.
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->

Bonus:
- also refactors and bring in https://github.com/ITISFoundation/osparc-simcore/pull/9587 thanks to @giancarloromeo 
## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/private-issues/issues/648

## How to test
```bash
cd services/director-v2
make install-dev
make test-unit-dev
```
<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
