### PR TITLE
🐛Director-v2: prevent scheduler startup race

### DIFF
--- a/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
+++ b/packages/pytest-simcore/src/pytest_simcore/rabbit_service.py
@@ -4,6 +4,7 @@
 # pylint: disable=protected-access
 
 import asyncio
+import contextlib
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 
@@ -132,11 +133,21 @@ async def ensure_parametrized_queue_is_empty(
     rabbitmq_client = create_rabbitmq_client("pytest-purger")
 
     async def _queue_messages_purger() -> None:
-        assert rabbitmq_client._channel_pool  # noqa: SLF001
-        async with rabbitmq_client._channel_pool.acquire() as channel:  # noqa: SLF001
+        # NOTE: a passive get_queue() on a non-existing queue makes the broker close the
+        # channel (ChannelNotFoundEntity), which would poison the client's channel pool if
+        # that channel got reused. So we use a dedicated channel here and always close it,
+        # instead of going through `rabbitmq_client._channel_pool.acquire()`.
+        channel = await rabbitmq_client._get_channel()  # noqa: SLF001
+        try:
             assert isinstance(channel, aio_pika.RobustChannel)
             queue = await channel.get_queue(queue_name)
             await queue.purge()
+        except aio_pika.exceptions.ChannelNotFoundEntity:
+            # queue does not exist (yet): nothing to purge
+            pass
+        finally:
+            with contextlib.suppress(Exception):
+                await channel.close()
 
     await _queue_messages_purger()
     yield

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/__init__.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/__init__.py
@@ -47,8 +47,8 @@ def configure_comp_scheduler(app_lifespan: LifespanManager) -> None:
     # NOTE: each resource is registered as its own lifespan so that, if a later one fails to
     # start, the LifespanManager only tears down the resources that were actually started (in
     # reverse order), instead of leaving them dangling.
-    app_lifespan.add(_releaser_lifespan)
     app_lifespan.add(_worker_lifespan)
+    app_lifespan.add(_releaser_lifespan)
     app_lifespan.add(_manager_lifespan)
 
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_worker.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_worker.py
@@ -62,6 +62,10 @@ async def _handle_apply_distributed_schedule(app: FastAPI, data: bytes) -> bool:
 async def setup_worker(app: FastAPI) -> None:
     app_settings = get_application_settings(app)
     rabbitmq_client = get_rabbitmq_client(app)
+
+    # scheduler must exist before consumers start, since messages may arrive right after subscribing
+    app.state.scheduler_worker = create_scheduler(app)
+
     app.state.scheduler_worker_consumers = await asyncio.gather(
         *(
             rabbitmq_client.subscribe(
@@ -72,8 +76,6 @@ async def setup_worker(app: FastAPI) -> None:
             for _ in range(app_settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND.COMPUTATIONAL_BACKEND_SCHEDULING_CONCURRENCY)
         )
     )
-
-    app.state.scheduler_worker = create_scheduler(app)
 
 
 async def shutdown_worker(app: FastAPI) -> None:

--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_worker.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_worker.py
@@ -62,10 +62,7 @@ async def _handle_apply_distributed_schedule(app: FastAPI, data: bytes) -> bool:
 async def setup_worker(app: FastAPI) -> None:
     app_settings = get_application_settings(app)
     rabbitmq_client = get_rabbitmq_client(app)
-
-    # scheduler must exist before consumers start, since messages may arrive right after subscribing
     app.state.scheduler_worker = create_scheduler(app)
-
     app.state.scheduler_worker_consumers = await asyncio.gather(
         *(
             rabbitmq_client.subscribe(

--- a/services/director-v2/tests/unit/test_modules_comp_scheduler_lifespan.py
+++ b/services/director-v2/tests/unit/test_modules_comp_scheduler_lifespan.py
@@ -11,15 +11,15 @@ from simcore_service_director_v2.modules.comp_scheduler import configure_comp_sc
 async def test_partial_startup_failure_only_tears_down_started_resources(mocker: MockerFixture):
     """If `setup_worker` fails, the releaser (already started) must be shut down while the
     manager (never started) must not."""
-    setup_releaser = mocker.patch("simcore_service_director_v2.modules.comp_scheduler.setup_releaser", autospec=True)
-    shutdown_releaser = mocker.patch(
-        "simcore_service_director_v2.modules.comp_scheduler.shutdown_releaser", autospec=True
-    )
-    setup_worker = mocker.patch(
-        "simcore_service_director_v2.modules.comp_scheduler.setup_worker",
+    setup_releaser = mocker.patch(
+        "simcore_service_director_v2.modules.comp_scheduler.setup_releaser",
         autospec=True,
         side_effect=RuntimeError("boom"),
     )
+    shutdown_releaser = mocker.patch(
+        "simcore_service_director_v2.modules.comp_scheduler.shutdown_releaser", autospec=True
+    )
+    setup_worker = mocker.patch("simcore_service_director_v2.modules.comp_scheduler.setup_worker", autospec=True)
     shutdown_worker = mocker.patch("simcore_service_director_v2.modules.comp_scheduler.shutdown_worker", autospec=True)
     setup_manager = mocker.patch("simcore_service_director_v2.modules.comp_scheduler.setup_manager", autospec=True)
     shutdown_manager = mocker.patch(
@@ -34,12 +34,12 @@ async def test_partial_startup_failure_only_tears_down_started_resources(mocker:
         async with app_lifespan(app):
             pytest.fail("lifespan should have failed to start")
 
-    setup_releaser.assert_called_once_with(app)
     setup_worker.assert_called_once_with(app)
+    setup_releaser.assert_called_once_with(app)
     setup_manager.assert_not_called()
 
-    shutdown_releaser.assert_called_once_with(app)
-    shutdown_worker.assert_not_called()
+    shutdown_worker.assert_called_once_with(app)
+    shutdown_releaser.assert_not_called()
     shutdown_manager.assert_not_called()
 
 

--- a/services/director-v2/tests/unit/test_modules_comp_scheduler_lifespan.py
+++ b/services/director-v2/tests/unit/test_modules_comp_scheduler_lifespan.py
@@ -85,10 +85,10 @@ async def test_full_startup_and_shutdown_order(mocker: MockerFixture):
         pass
 
     assert calls == [
-        "setup_releaser",
         "setup_worker",
+        "setup_releaser",
         "setup_manager",
         "shutdown_manager",
-        "shutdown_worker",
         "shutdown_releaser",
+        "shutdown_worker",
     ]

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -28,7 +28,6 @@ from simcore_service_director_v2.modules.comp_scheduler._models import (
 from simcore_service_director_v2.modules.comp_scheduler._worker import (
     _get_scheduler_worker,
 )
-from tenacity import retry, stop_after_delay, wait_fixed
 
 pytest_simcore_core_services_selection = ["postgres", "rabbit", "redis"]
 pytest_simcore_ops_services_selection = ["adminer"]
@@ -114,8 +113,28 @@ async def test_worker_scheduling_parallelism(
 ):
     with_disabled_auto_scheduling.assert_called_once()
 
+    # NOTE: rendezvous barrier instead of a fixed sleep: each call blocks until
+    # `scheduling_concurrency` calls are simultaneously in-flight, which deterministically
+    # proves they run concurrently (not queued up one at a time) and, since it resolves as
+    # soon as that is true, is neither slower nor flakier than reality allows - unlike a
+    # fixed sleep, it does not need to guess a "long enough" duration.
+    concurrent_calls = 0
+    peak_concurrent_calls = 0
+    completed_calls = 0
+    all_running_concurrently = asyncio.Event()
+    all_calls_returned = asyncio.Event()
+
     async def _side_effect(*args, **kwargs):
-        await asyncio.sleep(10)
+        nonlocal concurrent_calls, peak_concurrent_calls, completed_calls
+        concurrent_calls += 1
+        peak_concurrent_calls = max(peak_concurrent_calls, concurrent_calls)
+        if peak_concurrent_calls == scheduling_concurrency:
+            all_running_concurrently.set()
+        await all_running_concurrently.wait()
+        concurrent_calls -= 1
+        completed_calls += 1
+        if completed_calls == scheduling_concurrency:
+            all_calls_returned.set()
 
     mocked_scheduler_api.side_effect = _side_effect
 
@@ -133,11 +152,18 @@ async def test_worker_scheduling_parallelism(
 
     # whatever scheduling concurrency we call in here, we shall always see the same number of calls to the scheduler
     await asyncio.gather(*(_project_pipeline_creation_workflow() for _ in range(scheduling_concurrency)))
-    # the call to run the pipeline is async so we need to wait here
-    mocked_scheduler_api.assert_called()
 
-    @retry(stop=stop_after_delay(5), reraise=True, wait=wait_fixed(0.5))
-    def _assert_expected_called() -> None:
-        assert mocked_scheduler_api.call_count == scheduling_concurrency
-
-    _assert_expected_called()
+    # NOTE: the messages are only acked once the handler (i.e. `apply`, including its own
+    # lock-release cleanup) fully returns. If the test returned earlier, the app/rabbitmq
+    # connection would be torn down while those messages are still un-acked, which makes the
+    # broker requeue them. Since the queue name is shared across all the parametrized runs of
+    # this test, that leftover message would then be redelivered to (and counted by) the *next*
+    # parametrized test, causing flaky off-by-one failures there. So we wait for every call to
+    # have actually returned (not just started), which also fails fast instead of hanging if the
+    # worker is not actually running the calls concurrently.
+    await asyncio.wait_for(all_calls_returned.wait(), timeout=10)
+    # small grace period for `apply`'s own post-return cleanup (lock release, message ack) to
+    # flush, so a late/duplicate call would still be observed by the assertions below
+    await asyncio.sleep(0.5)
+    assert mocked_scheduler_api.call_count == scheduling_concurrency
+    assert peak_concurrent_calls == scheduling_concurrency

--- a/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
+++ b/services/director-v2/tests/unit/with_dbs/comp_scheduler/test_worker.py
@@ -118,6 +118,12 @@ async def test_worker_scheduling_parallelism(
     # proves they run concurrently (not queued up one at a time) and, since it resolves as
     # soon as that is true, is neither slower nor flakier than reality allows - unlike a
     # fixed sleep, it does not need to guess a "long enough" duration.
+    # NOTE: this queue is durable and shared by the whole comp_scheduler test suite (other
+    # tests in test_manager.py/test_scheduler_dask.py also publish real messages on it), so a
+    # stray message from a completely unrelated test can occasionally be delivered to this
+    # test's own consumer(s). We only track/synchronize on calls for the (user_id, project_id)
+    # pairs *we* actually scheduled below; anything else is such a stray and is simply ignored.
+    our_project_keys: set[tuple[int, str]] = set()
     concurrent_calls = 0
     peak_concurrent_calls = 0
     completed_calls = 0
@@ -126,6 +132,8 @@ async def test_worker_scheduling_parallelism(
 
     async def _side_effect(*args, **kwargs):
         nonlocal concurrent_calls, peak_concurrent_calls, completed_calls
+        if (kwargs.get("user_id"), f"{kwargs.get('project_id')}") not in our_project_keys:
+            return
         concurrent_calls += 1
         peak_concurrent_calls = max(peak_concurrent_calls, concurrent_calls)
         if peak_concurrent_calls == scheduling_concurrency:
@@ -141,6 +149,7 @@ async def test_worker_scheduling_parallelism(
     async def _project_pipeline_creation_workflow() -> None:
         published_project = await publish_project()
         assert published_project.project.prj_owner
+        our_project_keys.add((published_project.project.prj_owner, f"{published_project.project.uuid}"))
         await run_new_pipeline(
             initialized_app,
             user_id=published_project.project.prj_owner,
@@ -165,5 +174,5 @@ async def test_worker_scheduling_parallelism(
     # small grace period for `apply`'s own post-return cleanup (lock release, message ack) to
     # flush, so a late/duplicate call would still be observed by the assertions below
     await asyncio.sleep(0.5)
-    assert mocked_scheduler_api.call_count == scheduling_concurrency
+    assert completed_calls == scheduling_concurrency
     assert peak_concurrent_calls == scheduling_concurrency


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
all credits to @giancarloromeo 


<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- replaces https://github.com/ITISFoundation/osparc-simcore/pull/9587

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
