### PR TITLE
🎨Director-v2: add metrics for currently running services

### DIFF
--- a/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_warm_buffer_machines_pool_core.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/cluster_scaling/_warm_buffer_machines_pool_core.py
@@ -20,6 +20,7 @@ from typing import cast
 
 import arrow
 from aws_library.ec2 import (
+    PRODUCT_NAME_TAG_KEY,
     EC2InstanceConfig,
     EC2InstanceData,
     EC2InstanceType,
@@ -67,7 +68,8 @@ def _record_instance_ready_metrics(app: FastAPI, *, instance: EC2InstanceData) -
     """Record metrics for instances ready to pull images."""
     if has_instrumentation(app):
         get_instrumentation(app).buffer_machines_pools_metrics.instances_ready_to_pull_seconds.labels(
-            instance_type=instance.type
+            instance_type=instance.type,
+            product_name=f"{instance.tags.get(PRODUCT_NAME_TAG_KEY)}",
         ).observe((arrow.utcnow().datetime - instance.launch_time).total_seconds())
 
 
@@ -353,7 +355,8 @@ async def _handle_pool_image_pulling(
                         get_instrumentation(
                             app
                         ).buffer_machines_pools_metrics.instances_completed_pulling_seconds.labels(
-                            instance_type=instance.type
+                            instance_type=instance.type,
+                            product_name=f"{instance.tags.get(PRODUCT_NAME_TAG_KEY)}",
                         ).observe((ssm_command.finish_time - ssm_command.start_time).total_seconds())
                     instances_to_stop.add(instance)
                 case "InProgress" | "Pending":

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_constants.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_constants.py
@@ -5,7 +5,7 @@ from servicelib.instrumentation import get_metrics_namespace
 from ..._meta import APP_NAME
 
 METRICS_NAMESPACE: Final[str] = get_metrics_namespace(APP_NAME)
-EC2_INSTANCE_LABELS: Final[tuple[str, ...]] = ("instance_type",)
+EC2_INSTANCE_LABELS: Final[tuple[str, ...]] = ("instance_type", "product_name")
 
 CLUSTER_METRICS_DEFINITIONS: Final[dict[str, tuple[str, tuple[str, ...]]]] = {
     "active_nodes": (
@@ -45,7 +45,8 @@ CLUSTER_METRICS_DEFINITIONS: Final[dict[str, tuple[str, tuple[str, ...]]]] = {
         EC2_INSTANCE_LABELS,
     ),
     "retired_nodes": (
-        "Number of EC2-backed docker nodes that were actively retired and waiting for draining and termination or re-use",
+        "Number of EC2-backed docker nodes that were actively retired and "
+        "waiting for draining and termination or re-use",
         EC2_INSTANCE_LABELS,
     ),
     "terminated_instances": (

--- a/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_utils.py
+++ b/services/autoscaling/src/simcore_service_autoscaling/modules/instrumentation/_utils.py
@@ -1,12 +1,12 @@
-from aws_library.ec2 import EC2InstanceData, TrackedGauge
+from aws_library.ec2 import PRODUCT_NAME_TAG_KEY, EC2InstanceData, TrackedGauge
 from aws_library.ec2 import create_gauge as _create_gauge
 from prometheus_client import CollectorRegistry
 
 from ._constants import METRICS_NAMESPACE
 
 
-def _instance_type_label(instance: EC2InstanceData) -> tuple[str]:
-    return (f"{instance.type}",)
+def _instance_labels(instance: EC2InstanceData) -> tuple[str, str]:
+    return (f"{instance.type}", f"{instance.tags.get(PRODUCT_NAME_TAG_KEY)}")
 
 
 def create_gauge(
@@ -22,5 +22,5 @@ def create_gauge(
         namespace=METRICS_NAMESPACE,
         subsystem=subsystem,
         registry=registry,
-        label_extractor=_instance_type_label,
+        label_extractor=_instance_labels,
     )

--- a/services/autoscaling/tests/unit/test_modules_instrumentation_utils.py
+++ b/services/autoscaling/tests/unit/test_modules_instrumentation_utils.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 
-from aws_library.ec2._models import EC2InstanceData
+from aws_library.ec2._models import PRODUCT_NAME_TAG_KEY, EC2InstanceData
 from prometheus_client import CollectorRegistry
 from simcore_service_autoscaling.modules.instrumentation._constants import (
     EC2_INSTANCE_LABELS,
@@ -13,7 +13,8 @@ def test_create_gauge_labels_instances_by_instance_type(
 ):
     # NOTE: TrackedGauge's own bookkeeping (e.g. resetting stale label combos to 0) is
     # tested once, generically, in aws-library's test_ec2_instrumentation.py. Here we only
-    # check that this service's create_gauge() wrapper feeds it the expected instance_type label.
+    # check that this service's create_gauge() wrapper feeds it the expected instance_type/
+    # product_name labels.
     registry = CollectorRegistry()
     tracked_gauge = create_gauge(
         field_name="example_gauge",
@@ -22,10 +23,10 @@ def test_create_gauge_labels_instances_by_instance_type(
         registry=registry,
     )
 
-    instance = fake_ec2_instance_data()
+    instance = fake_ec2_instance_data(tags={f"{PRODUCT_NAME_TAG_KEY}": "osparc"})
     tracked_gauge.update_from_instances([instance])
 
     sample = next(iter(tracked_gauge.gauge.collect())).samples[0]
     assert sample.name == "simcore_service_autoscaling_whatever_example_gauge"
     assert sample.value == 1
-    assert sample.labels == {"instance_type": instance.type}
+    assert sample.labels == {"instance_type": instance.type, "product_name": "osparc"}

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/instrumentation/_constants.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/instrumentation/_constants.py
@@ -5,7 +5,12 @@ from servicelib.instrumentation import get_metrics_namespace
 from ..._meta import APP_NAME
 
 METRICS_NAMESPACE: Final[str] = get_metrics_namespace(APP_NAME)
-PRIMARY_INSTANCE_LABELS: Final[tuple[str, ...]] = ("instance_type", "user_id", "wallet_id")
+PRIMARY_INSTANCE_LABELS: Final[tuple[str, ...]] = (
+    "instance_type",
+    "user_id",
+    "wallet_id",
+    "product_name",
+)
 
 PRIMARY_INSTANCES_METRICS_DEFINITIONS: Final[dict[str, tuple[str, tuple[str, ...]]]] = {
     "starting_instances": (

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/instrumentation/_utils.py
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/modules/instrumentation/_utils.py
@@ -1,4 +1,4 @@
-from aws_library.ec2 import EC2InstanceData, TrackedGauge
+from aws_library.ec2 import PRODUCT_NAME_TAG_KEY, EC2InstanceData, TrackedGauge
 from aws_library.ec2 import create_gauge as _create_gauge
 from prometheus_client import CollectorRegistry
 
@@ -6,11 +6,12 @@ from ...utils.ec2 import user_id_from_instance_tags, wallet_id_from_instance_tag
 from ._constants import METRICS_NAMESPACE
 
 
-def _instance_labels(instance: EC2InstanceData) -> tuple[str, str, str]:
+def _instance_labels(instance: EC2InstanceData) -> tuple[str, str, str, str]:
     return (
         f"{instance.type}",
         f"{user_id_from_instance_tags(instance.tags)}",
         f"{wallet_id_from_instance_tags(instance.tags)}",
+        f"{instance.tags.get(PRODUCT_NAME_TAG_KEY)}",
     )
 
 

--- a/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
+++ b/services/clusters-keeper/tests/unit/test_modules_clusters_management_core.py
@@ -270,8 +270,15 @@ async def test_cluster_management_core_removes_long_starting_clusters_after_some
     mocked_dask_ping_scheduler.is_scheduler_busy.assert_not_called()
 
 
-def _gauge_value(gauge, *, instance_type: str, user_id: UserID, wallet_id: WalletID | None) -> float:
-    return gauge.labels(instance_type=instance_type, user_id=f"{user_id}", wallet_id=f"{wallet_id}")._value.get()  # noqa: SLF001
+def _gauge_value(
+    gauge, *, instance_type: str, user_id: UserID, wallet_id: WalletID | None, product_name: ProductName
+) -> float:
+    return gauge.labels(  # noqa: SLF001
+        instance_type=instance_type,
+        user_id=f"{user_id}",
+        wallet_id=f"{wallet_id}",
+        product_name=f"{product_name}",
+    )._value.get()
 
 
 async def test_cluster_management_core_updates_primary_instances_metrics(
@@ -294,7 +301,12 @@ async def test_cluster_management_core_updates_primary_instances_metrics(
     )
     assert len(created_clusters) == 1
     the_cluster = created_clusters[0]
-    labels = {"instance_type": the_cluster.type, "user_id": user_id, "wallet_id": wallet_id}
+    labels = {
+        "instance_type": the_cluster.type,
+        "user_id": user_id,
+        "wallet_id": wallet_id,
+        "product_name": product_name,
+    }
 
     await check_clusters(initialized_app)
     assert _gauge_value(primary_metrics.starting_instances.gauge, **labels) == 1

--- a/services/clusters-keeper/tests/unit/test_modules_instrumentation_utils.py
+++ b/services/clusters-keeper/tests/unit/test_modules_instrumentation_utils.py
@@ -3,7 +3,7 @@
 
 from collections.abc import Callable
 
-from aws_library.ec2._models import EC2InstanceData
+from aws_library.ec2._models import PRODUCT_NAME_TAG_KEY, EC2InstanceData
 from prometheus_client import CollectorRegistry
 from simcore_service_clusters_keeper.constants import USER_ID_TAG_KEY, WALLET_ID_TAG_KEY
 from simcore_service_clusters_keeper.modules.instrumentation._constants import (
@@ -18,7 +18,7 @@ def test_create_gauge_labels_instances_by_instance_type_user_id_and_wallet_id(
     # NOTE: TrackedGauge's own bookkeeping (e.g. resetting stale label combos to 0) is
     # tested once, generically, in aws-library's test_ec2_instrumentation.py. Here we only
     # check that this service's create_gauge() wrapper feeds it the expected instance_type/
-    # user_id/wallet_id labels (derived from EC2 instance tags).
+    # user_id/wallet_id/product_name labels (derived from EC2 instance tags).
     registry = CollectorRegistry()
     tracked_gauge = create_gauge(
         field_name="example_gauge",
@@ -27,7 +27,13 @@ def test_create_gauge_labels_instances_by_instance_type_user_id_and_wallet_id(
         registry=registry,
     )
 
-    instance = fake_ec2_instance_data(tags={f"{USER_ID_TAG_KEY}": "12", f"{WALLET_ID_TAG_KEY}": "None"})
+    instance = fake_ec2_instance_data(
+        tags={
+            f"{USER_ID_TAG_KEY}": "12",
+            f"{WALLET_ID_TAG_KEY}": "None",
+            f"{PRODUCT_NAME_TAG_KEY}": "osparc",
+        }
+    )
     tracked_gauge.update_from_instances([instance])
 
     sample = next(iter(tracked_gauge.gauge.collect())).samples[0]
@@ -37,4 +43,5 @@ def test_create_gauge_labels_instances_by_instance_type_user_id_and_wallet_id(
         "instance_type": instance.type,
         "user_id": "12",
         "wallet_id": "None",
+        "product_name": "osparc",
     }

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
@@ -56,6 +56,7 @@ from .....modules.instrumentation import (
     get_instrumentation,
     get_metrics_labels,
     get_rate,
+    get_running_services_labels,
 )
 from .....utils.db import get_repository
 from ...api_client import SidecarsClient, get_sidecars_client
@@ -552,6 +553,9 @@ class Scheduler(  # pylint: disable=too-many-instance-attributes, too-many-publi
             async with self._lock:
                 for service_name in self._to_observe:
                     self._enqueue_observation_from_service_name(service_name)
+                get_instrumentation(self.app).dynamic_sidecar_metrics.update_running_services_count(
+                    get_running_services_labels(scheduler_data) for scheduler_data in self._to_observe.values()
+                )
         except Exception:  # pylint: disable=broad-except
             _logger.exception("Unexpected error while scheduling sidecars observation")
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/__init__.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/__init__.py
@@ -1,10 +1,11 @@
 from ._setup import configure_instrumentation, get_instrumentation
-from ._utils import get_metrics_labels, get_rate, track_duration
+from ._utils import get_metrics_labels, get_rate, get_running_services_labels, track_duration
 
 __all__: tuple[str, ...] = (
     "configure_instrumentation",
     "get_instrumentation",
     "get_metrics_labels",
     "get_rate",
+    "get_running_services_labels",
     "track_duration",
 )

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
@@ -1,7 +1,9 @@
+import collections
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Final
 
-from prometheus_client import CollectorRegistry, Histogram
+from prometheus_client import CollectorRegistry, Gauge, Histogram
 from pydantic import ByteSize, TypeAdapter
 from servicelib.db_asyncpg_pool_metrics import DbPoolMetrics
 from servicelib.instrumentation import MetricsBase, get_metrics_namespace
@@ -51,6 +53,9 @@ _RATE_BPS_BUCKETS: Final[tuple[float, ...]] = tuple(
 
 @dataclass(slots=True, kw_only=True)
 class DynamiSidecarMetrics(MetricsBase):
+    running_services_count: Gauge = field(init=False)
+    _running_services_seen_labels: set[tuple[str, ...]] = field(init=False, default_factory=set)
+
     start_time_duration: Histogram = field(init=False)
     stop_time_duration: Histogram = field(init=False)
     pull_user_services_images_duration: Histogram = field(init=False)
@@ -66,6 +71,14 @@ class DynamiSidecarMetrics(MetricsBase):
     push_service_state_rate: Histogram = field(init=False)
 
     def __post_init__(self) -> None:
+        self.running_services_count = Gauge(
+            "running_services_count",
+            "number of dynamic services currently running",
+            labelnames=_INSTRUMENTATION_LABELS,
+            namespace=_METRICS_NAMESPACE,
+            subsystem=self.subsystem,
+            registry=self.registry,
+        )
         self.start_time_duration = Histogram(
             "start_time_duration_seconds",
             "time to start dynamic service (from start request in dv-2 till service "
@@ -133,6 +146,19 @@ class DynamiSidecarMetrics(MetricsBase):
             subsystem=self.subsystem,
             registry=self.registry,
         )
+
+    def update_running_services_count(self, all_labels: Iterable[Mapping[str, str]]) -> None:
+        """Recomputes the gauge from the current set of tracked services (self-healing snapshot,
+        instead of incremental inc/dec which can drift on crashes/manual-intervention/error paths)."""
+        label_tuples = [tuple(labels[name] for name in _INSTRUMENTATION_LABELS) for labels in all_labels]
+        counts = collections.Counter(label_tuples)
+        current_labels = set(counts)
+        for label_tuple, count in counts.items():
+            self.running_services_count.labels(*label_tuple).set(count)
+        # drop combinations no longer present, instead of leaving zeroed series forever
+        for label_tuple in self._running_services_seen_labels - current_labels:
+            self.running_services_count.remove(*label_tuple)
+        self._running_services_seen_labels = current_labels
 
 
 @dataclass(slots=True, kw_only=True)

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
@@ -16,6 +16,7 @@ _INSTRUMENTATION_LABELS: Final[tuple[str, ...]] = (
     "wallet_id",
     "service_key",
     "service_version",
+    "product_name",
 )
 
 _MINUTE: Final[int] = 60

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_utils.py
@@ -16,6 +16,7 @@ def get_metrics_labels(scheduler_data: "SchedulerData") -> dict[str, str]:
         "wallet_id": (f"{scheduler_data.wallet_info.wallet_id}" if scheduler_data.wallet_info else ""),
         "service_key": scheduler_data.key,
         "service_version": scheduler_data.version,
+        "product_name": scheduler_data.product_name,
     }
 
 
@@ -26,6 +27,7 @@ def get_running_services_labels(scheduler_data: "SchedulerData") -> dict[str, st
         "wallet_id": f"{scheduler_data.wallet_info.wallet_id if scheduler_data.wallet_info else None}",
         "service_key": scheduler_data.key,
         "service_version": scheduler_data.version,
+        "product_name": scheduler_data.product_name,
     }
 
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_utils.py
@@ -19,6 +19,16 @@ def get_metrics_labels(scheduler_data: "SchedulerData") -> dict[str, str]:
     }
 
 
+def get_running_services_labels(scheduler_data: "SchedulerData") -> dict[str, str]:
+    # NOTE: matches clusters-keeper/autoscaling convention (f"{None}" == "None") instead of ""
+    return {
+        "user_id": f"{scheduler_data.user_id}",
+        "wallet_id": f"{scheduler_data.wallet_info.wallet_id if scheduler_data.wallet_info else None}",
+        "service_key": scheduler_data.key,
+        "service_version": scheduler_data.version,
+    }
+
+
 def get_rate(size: NonNegativeFloat | None, duration: NonNegativeFloat) -> NonNegativeFloat:
     if size is None or size <= 0:
         size = _EPSILON

--- a/services/director-v2/tests/unit/test_modules_instrumentation__models.py
+++ b/services/director-v2/tests/unit/test_modules_instrumentation__models.py
@@ -1,0 +1,45 @@
+from prometheus_client import CollectorRegistry
+from prometheus_client.metrics import Gauge
+from simcore_service_director_v2.modules.instrumentation._models import (
+    DynamiSidecarMetrics,
+)
+
+
+def _samples(gauge: Gauge) -> dict[tuple[tuple[str, str], ...], float]:
+    return {
+        tuple(sorted(sample.labels.items())): sample.value for family in gauge.collect() for sample in family.samples
+    }
+
+
+def test_update_running_services_count_sets_and_removes_stale_labels() -> None:
+    metrics = DynamiSidecarMetrics(  # pylint: disable=unexpected-keyword-arg
+        subsystem="dynamic_services", registry=CollectorRegistry()
+    )
+
+    labels_1 = {
+        "user_id": "1",
+        "wallet_id": "None",
+        "service_key": "simcore/services/dynamic/foo",
+        "service_version": "1.0.0",
+    }
+    labels_2 = {
+        "user_id": "2",
+        "wallet_id": "5",
+        "service_key": "simcore/services/dynamic/bar",
+        "service_version": "2.0.0",
+    }
+
+    metrics.update_running_services_count([labels_1, labels_1, labels_2])
+    samples = _samples(metrics.running_services_count)
+    assert samples[tuple(sorted(labels_1.items()))] == 2
+    assert samples[tuple(sorted(labels_2.items()))] == 1
+
+    # labels_2 no longer present -> removed entirely, not just zeroed
+    metrics.update_running_services_count([labels_1])
+    samples = _samples(metrics.running_services_count)
+    assert samples[tuple(sorted(labels_1.items()))] == 1
+    assert tuple(sorted(labels_2.items())) not in samples
+
+    # nothing running anymore -> no samples left at all
+    metrics.update_running_services_count([])
+    assert _samples(metrics.running_services_count) == {}

--- a/services/director-v2/tests/unit/test_modules_instrumentation__models.py
+++ b/services/director-v2/tests/unit/test_modules_instrumentation__models.py
@@ -21,12 +21,14 @@ def test_update_running_services_count_sets_and_removes_stale_labels() -> None:
         "wallet_id": "None",
         "service_key": "simcore/services/dynamic/foo",
         "service_version": "1.0.0",
+        "product_name": "osparc",
     }
     labels_2 = {
         "user_id": "2",
         "wallet_id": "5",
         "service_key": "simcore/services/dynamic/bar",
         "service_version": "2.0.0",
+        "product_name": "s4l",
     }
 
     metrics.update_running_services_count([labels_1, labels_1, labels_2])

--- a/services/director-v2/tests/unit/test_modules_instrumentation__utils.py
+++ b/services/director-v2/tests/unit/test_modules_instrumentation__utils.py
@@ -32,6 +32,7 @@ def test_get_metrics_labels_with_wallet(scheduler_data: SchedulerData) -> None:
     assert labels["user_id"] == f"{scheduler_data.user_id}"
     assert labels["service_key"] == scheduler_data.key
     assert labels["service_version"] == scheduler_data.version
+    assert labels["product_name"] == scheduler_data.product_name
 
 
 def test_get_running_services_labels_uses_none_string_for_missing_wallet(
@@ -48,3 +49,4 @@ def test_get_running_services_labels_with_wallet(scheduler_data: SchedulerData) 
     labels = get_running_services_labels(scheduler_data)
 
     assert labels["wallet_id"] == f"{scheduler_data.wallet_info.wallet_id}"
+    assert labels["product_name"] == scheduler_data.product_name

--- a/services/director-v2/tests/unit/test_modules_instrumentation__utils.py
+++ b/services/director-v2/tests/unit/test_modules_instrumentation__utils.py
@@ -1,6 +1,11 @@
 import time
 
-from simcore_service_director_v2.modules.instrumentation._utils import track_duration
+from simcore_service_director_v2.models.dynamic_services_scheduler import SchedulerData
+from simcore_service_director_v2.modules.instrumentation._utils import (
+    get_metrics_labels,
+    get_running_services_labels,
+    track_duration,
+)
 
 
 def test_track_duration():
@@ -8,3 +13,38 @@ def test_track_duration():
         time.sleep(0.1)
 
     assert duration.to_float() > 0.1
+
+
+def test_get_metrics_labels_uses_empty_string_for_missing_wallet(
+    scheduler_data: SchedulerData,
+) -> None:
+    scheduler_data.wallet_info = None
+
+    assert get_metrics_labels(scheduler_data)["wallet_id"] == ""
+
+
+def test_get_metrics_labels_with_wallet(scheduler_data: SchedulerData) -> None:
+    assert scheduler_data.wallet_info
+
+    labels = get_metrics_labels(scheduler_data)
+
+    assert labels["wallet_id"] == f"{scheduler_data.wallet_info.wallet_id}"
+    assert labels["user_id"] == f"{scheduler_data.user_id}"
+    assert labels["service_key"] == scheduler_data.key
+    assert labels["service_version"] == scheduler_data.version
+
+
+def test_get_running_services_labels_uses_none_string_for_missing_wallet(
+    scheduler_data: SchedulerData,
+) -> None:
+    scheduler_data.wallet_info = None
+
+    assert get_running_services_labels(scheduler_data)["wallet_id"] == "None"
+
+
+def test_get_running_services_labels_with_wallet(scheduler_data: SchedulerData) -> None:
+    assert scheduler_data.wallet_info
+
+    labels = get_running_services_labels(scheduler_data)
+
+    assert labels["wallet_id"] == f"{scheduler_data.wallet_info.wallet_id}"


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

### Motivation
In prometheus it is currently a headache to find out what is currently running. This would help for the dynamic services.

### probable side issue
in observation, maybe the histogram are responsible of the memory leak and might have to be removed.

### New metric

- **`running_services_count`** (Gauge, director-v2, subsystem `dynamic_services`)
  Number of dynamic services currently running.
  Labels: `user_id`, `wallet_id`, `service_key`, `service_version`, `product_name`.
  - Recomputed every scheduler tick (`DIRECTOR_V2_DYNAMIC_SCHEDULER_INTERVAL`, default 5s) directly from `Scheduler._to_observe` — the scheduler's own authoritative tracked-services dict — instead of incremental `inc()`/`dec()` at start/stop code paths, so it self-heals within one tick regardless of *how* a service disappears (clean stop, crash, manual intervention, restart).
  - Label combinations that drop to zero are fully `.remove()`d from the registry (not left as permanent `0` series), keeping memory bounded by currently-active services only.
  - `wallet_id` uses the `"None"` string convention (matching autoscaling/clusters-keeper) rather than empty string.

### Modified metrics

**director-v2** — `product_name` label added to all existing `dynamic_services` Histograms (previously `user_id`, `wallet_id`, `service_key`, `service_version` only):
  - `start_time_duration_seconds`
  - `stop_time_duration_seconds`
  - `pull_user_services_images_duration_seconds`
  - `output_ports_pull_rate_bps`
  - `input_ports_pull_rate_bps`
  - `pull_service_state_rate_bps`
  - `push_service_state_rate_bps`

**autoscaling** — `EC2_INSTANCE_LABELS` extended from `(instance_type,)` to `(instance_type, product_name)`, affecting:
  - Gauges: `active_nodes`, `pending_nodes`, `drained_nodes`, `hot_buffer_drained_nodes`, `pending_ec2s`, `broken_ec2s`, `warm_buffer_ec2s`, `disconnected_nodes`, `terminating_nodes`, `retired_nodes`, `terminated_instances`, `ready_instances`, `pending_instances`, `waiting_to_pull_instances`, `waiting_to_stop_instances`, `pulling_instances`, `stopping_instances`, `broken_instances`
  - Histograms: `instances_ready_to_pull_duration_seconds`, `instances_completed_pulling_duration_seconds`

**clusters-keeper** — `PRIMARY_INSTANCE_LABELS` extended from `(instance_type, user_id, wallet_id)` to `(instance_type, user_id, wallet_id, product_name)`, affecting:
  - Gauges: `starting_instances`, `connected_instances`, `busy_instances`, `broken_instances`

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
