### PR TITLE
🐛 Webserver: ensure project-logs unsubscription always runs on disconnect/close

### DIFF
--- a/services/web/server/src/simcore_service_webserver/projects/_controller/projects_slot.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_controller/projects_slot.py
@@ -69,12 +69,14 @@ async def _on_user_disconnected(
 
     assert len(projects) <= 1, "At the moment, at most one project per session"  # nosec
 
+    # NOTE: both groups of tasks run concurrently and independently (reraise=False) so a
+    # failure notifying the project-locked state (e.g. an RPC timeout) can never prevent
+    # the log-unsubscription from running, which would otherwise leak a topic binding
     await logged_gather(
-        *[retrieve_and_notify_project_locked_state(user_id, prj, app, notify_only_prj_user=True) for prj in projects]
+        *[retrieve_and_notify_project_locked_state(user_id, prj, app, notify_only_prj_user=True) for prj in projects],
+        *[conditionally_unsubscribe_project_logs_across_replicas(app, ProjectID(prj), user_id) for prj in projects],
+        reraise=False,
     )
-
-    for _project_id in projects:  # At the moment, only 1 is expected
-        await conditionally_unsubscribe_project_logs_across_replicas(app, ProjectID(_project_id), user_id)
 
 
 def setup_project_observer_events(app: web.Application) -> None:

--- a/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
+++ b/services/web/server/src/simcore_service_webserver/projects/_projects_service.py
@@ -1863,31 +1863,34 @@ async def close_project_for_user(
     # check it is not opened by someone else
     all_user_sessions_with_project.remove(current_user_session)
     _logger.debug("remaining user_to_session_ids: %s", all_user_sessions_with_project)
-    if not all_user_sessions_with_project:
-        # NOTE: depending on the garbage collector speed, it might already be removing it
-        remove_services_task = remove_project_dynamic_services(
-            user_id, project_uuid, app, simcore_user_agent, product_name
-        )
-        if wait_for_service_closed:
-            # wait for the task to finish
-            await remove_services_task
-        else:
-            fire_and_forget_task(
-                remove_services_task,
-                task_suffix_name=f"remove_project_dynamic_services_{user_id=}_{project_uuid=}",
-                fire_and_forget_tasks_collection=app[APP_FIRE_AND_FORGET_TASKS_KEY],
+    try:
+        if not all_user_sessions_with_project:
+            # NOTE: depending on the garbage collector speed, it might already be removing it
+            remove_services_task = remove_project_dynamic_services(
+                user_id, project_uuid, app, simcore_user_agent, product_name
             )
-    else:
-        # when the project is still opened by other users, we just notify the project state update
-        project = await get_project_for_user(
-            app,
-            f"{project_uuid}",
-            user_id,
-            include_state=True,
-        )
-        await notify_project_state_update(app, project)
-
-    await conditionally_unsubscribe_project_logs_across_replicas(app, project_uuid, user_id)
+            if wait_for_service_closed:
+                # wait for the task to finish
+                await remove_services_task
+            else:
+                fire_and_forget_task(
+                    remove_services_task,
+                    task_suffix_name=f"remove_project_dynamic_services_{user_id=}_{project_uuid=}",
+                    fire_and_forget_tasks_collection=app[APP_FIRE_AND_FORGET_TASKS_KEY],
+                )
+        else:
+            # when the project is still opened by other users, we just notify the project state update
+            project = await get_project_for_user(
+                app,
+                f"{project_uuid}",
+                user_id,
+                include_state=True,
+            )
+            await notify_project_state_update(app, project)
+    finally:
+        # NOTE: always unsubscribe, even if the above raised (e.g. an RPC timeout), so a
+        # failure here can never leak this project's log topic binding on this replica
+        await conditionally_unsubscribe_project_logs_across_replicas(app, project_uuid, user_id)
 
 
 async def _get_project_share_state(

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_nodes_handler.py
@@ -355,7 +355,6 @@ def standard_user_role() -> tuple[str, tuple]:
     return (all_roles[0], (pytest.param(*all_roles[1][2], id="standard user role"),))
 
 
-@pytest.mark.flaky(max_runs=3)
 @pytest.mark.parametrize(*standard_user_role())
 async def test_create_and_delete_many_nodes_in_parallel(
     mock_dynamic_scheduler: None,

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_service_conditionally_unsubscribe_from_project_logs.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_service_conditionally_unsubscribe_from_project_logs.py
@@ -13,6 +13,7 @@ from collections.abc import Awaitable, Callable
 import pytest
 import socketio
 from aiohttp.test_utils import TestClient
+from models_library.projects import ProjectID
 from pytest_mock import MockerFixture, MockType
 from pytest_simcore.helpers.webserver_login import log_client_in
 from pytest_simcore.helpers.webserver_parametrizations import (
@@ -75,7 +76,7 @@ async def test_conditionally_unsubscribe_from_project_logs(
     client_2 = client_on_running_server_factory()
 
     # 1. user 1 opens project
-    sio1, client_id1, sio1_handlers = await create_socketio_connection_with_handlers(None, client_1)
+    _sio1, client_id1, _sio1_handlers = await create_socketio_connection_with_handlers(None, client_1)
     await _open_project(
         client_1,
         client_id1,
@@ -84,13 +85,13 @@ async def test_conditionally_unsubscribe_from_project_logs(
     )
 
     # 2. create a separate client now and log in user2, open the same shared project
-    user_2 = await log_client_in(
+    _user_2 = await log_client_in(
         client_2,
         {"role": user_role.name},
         enable_check=True,
         exit_stack=exit_stack,
     )
-    sio2, client_id2, sio2_handlers = await create_socketio_connection_with_handlers(None, client_2)
+    _sio2, client_id2, _sio2_handlers = await create_socketio_connection_with_handlers(None, client_2)
     await _open_project(
         client_2,
         client_id2,
@@ -105,3 +106,118 @@ async def test_conditionally_unsubscribe_from_project_logs(
     # 4. user 2 closes the project (now unsubscribe should happen)
     await _close_project(client_2, client_id2, shared_project, status.HTTP_204_NO_CONTENT)
     assert mocked_publish_unsubscribe_from_project_logs_event.called
+
+
+@pytest.mark.parametrize(
+    "user_role,expected",
+    [
+        (UserRole.USER, status.HTTP_200_OK),
+    ],
+)
+async def test_close_project_for_user_still_unsubscribes_when_notify_state_update_fails(
+    max_number_of_user_sessions: int,
+    with_enabled_rtc_collaboration: None,
+    client: TestClient,
+    client_on_running_server_factory: Callable[[], TestClient],
+    logged_user: dict,
+    shared_project: dict,
+    user_role: UserRole,
+    expected: ExpectedResponse,
+    exit_stack: contextlib.AsyncExitStack,
+    create_socketio_connection_with_handlers: Callable[
+        [str | None, TestClient],
+        Awaitable[tuple[socketio.AsyncClient, str, SocketHandlers]],
+    ],
+    mocked_dynamic_services_interface: dict[str, MockType],
+    mocked_conditionally_unsubscribe_project_logs: MockType,
+    mock_catalog_api: dict[str, MockType],
+    osparc_product_name: str,
+    mocker: MockerFixture,
+):
+    # Regression test: a failure while notifying the still-connected user's project state
+    # (e.g. an RPC timeout) must not prevent the log-unsubscription cleanup from running.
+    client_1 = client
+    client_2 = client_on_running_server_factory()
+
+    _sio1, client_id1, _sio1_handlers = await create_socketio_connection_with_handlers(None, client_1)
+    await _open_project(client_1, client_id1, shared_project, status.HTTP_200_OK)
+
+    await log_client_in(
+        client_2,
+        {"role": user_role.name},
+        enable_check=True,
+        exit_stack=exit_stack,
+    )
+    _sio2, client_id2, _sio2_handlers = await create_socketio_connection_with_handlers(None, client_2)
+    await _open_project(client_2, client_id2, shared_project, status.HTTP_200_OK)
+
+    # user 2 remains connected, so closing for user 1 takes the "notify state update" branch
+    mocker.patch(
+        "simcore_service_webserver.projects._projects_service.notify_project_state_update",
+        autospec=True,
+        side_effect=RuntimeError("injected failure"),
+    )
+
+    from simcore_service_webserver.projects._projects_service import (  # noqa: PLC0415
+        close_project_for_user,
+    )
+
+    with pytest.raises(RuntimeError, match="injected failure"):
+        await close_project_for_user(
+            user_id=logged_user["id"],
+            project_uuid=ProjectID(shared_project["uuid"]),
+            client_session_id=client_id1,
+            app=client_1.app,
+            simcore_user_agent="pytest",
+            product_name=osparc_product_name,
+        )
+
+    # despite the failure above, the log-unsubscription must still have been attempted
+    mocked_conditionally_unsubscribe_project_logs.assert_called_once()
+
+
+@pytest.mark.parametrize("user_role", [UserRole.USER])
+async def test_on_user_disconnected_still_unsubscribes_when_locked_state_notification_fails(
+    user_role: UserRole,
+    with_enabled_rtc_collaboration: None,
+    client: TestClient,
+    logged_user: dict,
+    shared_project: dict,
+    create_socketio_connection_with_handlers: Callable[
+        [str | None, TestClient],
+        Awaitable[tuple[socketio.AsyncClient, str, SocketHandlers]],
+    ],
+    mocked_dynamic_services_interface: dict[str, MockType],
+    mock_catalog_api: dict[str, MockType],
+    osparc_product_name: str,
+    mocker: MockerFixture,
+):
+    # Regression test: a failure notifying the project-locked state (e.g. an RPC timeout)
+    # must not prevent the log-unsubscription from running for the disconnecting session.
+    client_1 = client
+    _sio1, client_id1, _sio1_handlers = await create_socketio_connection_with_handlers(None, client_1)
+    await _open_project(client_1, client_id1, shared_project, status.HTTP_200_OK)
+
+    mocker.patch(
+        "simcore_service_webserver.projects._controller.projects_slot.retrieve_and_notify_project_locked_state",
+        autospec=True,
+        side_effect=RuntimeError("injected failure"),
+    )
+    mocked_unsubscribe = mocker.patch(
+        "simcore_service_webserver.projects._controller.projects_slot.conditionally_unsubscribe_project_logs_across_replicas",
+        autospec=True,
+    )
+
+    from simcore_service_webserver.projects._controller.projects_slot import (  # noqa: PLC0415
+        _on_user_disconnected,
+    )
+
+    # logged_gather(..., reraise=False) swallows the injected failure: this must not raise
+    await _on_user_disconnected(
+        user_id=logged_user["id"],
+        client_session_id=client_id1,
+        app=client_1.app,
+        product_name=osparc_product_name,
+    )
+
+    mocked_unsubscribe.assert_called_once()

--- a/services/web/server/tests/unit/with_dbs/02/test_projects_service_conditionally_unsubscribe_from_project_logs.py
+++ b/services/web/server/tests/unit/with_dbs/02/test_projects_service_conditionally_unsubscribe_from_project_logs.py
@@ -22,6 +22,12 @@ from pytest_simcore.helpers.webserver_parametrizations import (
 )
 from servicelib.aiohttp import status
 from simcore_service_webserver.db.models import UserRole
+from simcore_service_webserver.projects._controller.projects_slot import (
+    _on_user_disconnected,
+)
+from simcore_service_webserver.projects._projects_service import (
+    close_project_for_user,
+)
 from test_projects_states_handlers import _close_project, _open_project
 
 
@@ -158,10 +164,6 @@ async def test_close_project_for_user_still_unsubscribes_when_notify_state_updat
         side_effect=RuntimeError("injected failure"),
     )
 
-    from simcore_service_webserver.projects._projects_service import (  # noqa: PLC0415
-        close_project_for_user,
-    )
-
     with pytest.raises(RuntimeError, match="injected failure"):
         await close_project_for_user(
             user_id=logged_user["id"],
@@ -206,10 +208,6 @@ async def test_on_user_disconnected_still_unsubscribes_when_locked_state_notific
     mocked_unsubscribe = mocker.patch(
         "simcore_service_webserver.projects._controller.projects_slot.conditionally_unsubscribe_project_logs_across_replicas",
         autospec=True,
-    )
-
-    from simcore_service_webserver.projects._controller.projects_slot import (  # noqa: PLC0415
-        _on_user_disconnected,
     )
 
     # logged_gather(..., reraise=False) swallows the injected failure: this must not raise


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Follow-up to the RabbitMQ logs-queue incident : 2 code paths could silently skip unsubscribing a user's session from a project's live-log topic RabbitMQ Queue binding.

Both bugs share the same shape: a fallible RPC-dependent step (a lock-state notification / a dynamic-service-removal or project-state fetch — all of which can time out when RabbitMQ or the dynamic-scheduler is under stress) ran **before** the log-unsubscription step, with no isolation between them, so a failure in the first step prevented the second from ever running.

1. **`_on_user_disconnected`** (`projects/_controller/projects_slot.py`, socket disconnect path): the project-locked-state notification and the log-unsubscription were two separate sequential steps — a failure in one can no longer block the other.
2. **`close_project_for_user`** (`projects/_projects_service.py`, REST `close_project` + garbage-collector path): now the log unsubscription always runs.
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- https://git.speag.com/oSparc/osparc-infra/-/issues/107

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
