### PR TITLE
🐛 instrumentation can now be disabled in `director-v2`

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_user_services.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_user_services.py
@@ -18,7 +18,11 @@ from .....core.dynamic_services_settings.scheduler import (
 )
 from .....models.dynamic_services_scheduler import SchedulerData
 from .....modules.catalog import CatalogClient
-from .....modules.instrumentation import get_instrumentation, get_metrics_labels
+from .....modules.instrumentation import (
+    get_instrumentation,
+    get_metrics_labels,
+    has_instrumentation,
+)
 from .....utils.db import get_repository
 from ....db.repositories.groups_extra_properties import GroupsExtraPropertiesRepository
 from ....db.repositories.projects import ProjectsRepository
@@ -220,7 +224,7 @@ async def create_user_services(  # pylint: disable=too-many-statements
     await sidecars_client.pull_service_input_ports(dynamic_sidecar_endpoint)
 
     start_duration = scheduler_data.dynamic_sidecar.instrumentation.elapsed_since_start_request()
-    if start_duration is not None:
+    if start_duration is not None and has_instrumentation(app):
         get_instrumentation(app).dynamic_sidecar_metrics.start_time_duration.labels(
             **get_metrics_labels(scheduler_data)
         ).observe(start_duration)

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_events_utils.py
@@ -71,6 +71,7 @@ from ....instrumentation import (
     get_instrumentation,
     get_metrics_labels,
     get_rate,
+    has_instrumentation,
     track_duration,
 )
 from ....long_running_tasks import get_long_running_client_helper
@@ -265,7 +266,7 @@ async def service_save_state(
 
     with track_duration() as duration:
         size = await sidecars_client.save_service_state(scheduler_data.endpoint, progress_callback=progress_callback)
-    if size and size > 0:
+    if size and size > 0 and has_instrumentation(app):
         get_instrumentation(app).dynamic_sidecar_metrics.push_service_state_rate.labels(
             **get_metrics_labels(scheduler_data)
         ).observe(get_rate(size, duration.to_float()))
@@ -470,7 +471,7 @@ async def attempt_pod_removal_and_data_saving(app: FastAPI, scheduler_data: Sche
     # metrics
 
     stop_duration = scheduler_data.dynamic_sidecar.instrumentation.elapsed_since_close_request()
-    if stop_duration is not None:
+    if stop_duration is not None and has_instrumentation(app):
         get_instrumentation(app).dynamic_sidecar_metrics.stop_time_duration.labels(
             **get_metrics_labels(scheduler_data)
         ).observe(stop_duration)
@@ -552,7 +553,7 @@ async def prepare_services_environment(app: FastAPI, scheduler_data: SchedulerDa
     async def _pull_output_ports_with_metrics() -> None:
         with track_duration() as duration:
             size: int = await sidecars_client.pull_service_output_ports(dynamic_sidecar_endpoint)
-        if size and size > 0:
+        if size and size > 0 and has_instrumentation(app):
             get_instrumentation(app).dynamic_sidecar_metrics.output_ports_pull_rate.labels(
                 **get_metrics_labels(scheduler_data)
             ).observe(get_rate(size, duration.to_float()))
@@ -561,15 +562,16 @@ async def prepare_services_environment(app: FastAPI, scheduler_data: SchedulerDa
         with track_duration() as duration:
             await sidecars_client.pull_user_services_images(dynamic_sidecar_endpoint)
 
-        get_instrumentation(app).dynamic_sidecar_metrics.pull_user_services_images_duration.labels(
-            **get_metrics_labels(scheduler_data)
-        ).observe(duration.to_float())
+        if has_instrumentation(app):
+            get_instrumentation(app).dynamic_sidecar_metrics.pull_user_services_images_duration.labels(
+                **get_metrics_labels(scheduler_data)
+            ).observe(duration.to_float())
 
     async def _restore_service_state_with_metrics() -> None:
         with track_duration() as duration:
             size = await sidecars_client.restore_service_state(dynamic_sidecar_endpoint)
 
-        if size and size > 0:
+        if size and size > 0 and has_instrumentation(app):
             get_instrumentation(app).dynamic_sidecar_metrics.pull_service_state_rate.labels(
                 **get_metrics_labels(scheduler_data)
             ).observe(get_rate(size, duration.to_float()))

--- a/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dynamic_sidecar/scheduler/_core/_scheduler.py
@@ -57,6 +57,7 @@ from .....modules.instrumentation import (
     get_metrics_labels,
     get_rate,
     get_running_services_labels,
+    has_instrumentation,
 )
 from .....utils.db import get_repository
 from ...api_client import SidecarsClient, get_sidecars_client
@@ -434,7 +435,7 @@ class Scheduler(  # pylint: disable=too-many-instance-attributes, too-many-publi
         transferred_bytes = await sidecars_client.pull_service_input_ports(dynamic_sidecar_endpoint, port_keys)
         duration = time.time() - started
 
-        if transferred_bytes and transferred_bytes > 0:
+        if transferred_bytes and transferred_bytes > 0 and has_instrumentation(self.app):
             get_instrumentation(self.app).dynamic_sidecar_metrics.input_ports_pull_rate.labels(
                 **get_metrics_labels(scheduler_data)
             ).observe(get_rate(transferred_bytes, duration))
@@ -553,9 +554,10 @@ class Scheduler(  # pylint: disable=too-many-instance-attributes, too-many-publi
             async with self._lock:
                 for service_name in self._to_observe:
                     self._enqueue_observation_from_service_name(service_name)
-                get_instrumentation(self.app).dynamic_sidecar_metrics.update_running_services_count(
-                    get_running_services_labels(scheduler_data) for scheduler_data in self._to_observe.values()
-                )
+                if has_instrumentation(self.app):
+                    get_instrumentation(self.app).dynamic_sidecar_metrics.update_running_services_count(
+                        get_running_services_labels(scheduler_data) for scheduler_data in self._to_observe.values()
+                    )
         except Exception:  # pylint: disable=broad-except
             _logger.exception("Unexpected error while scheduling sidecars observation")
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/__init__.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/__init__.py
@@ -1,4 +1,4 @@
-from ._setup import configure_instrumentation, get_instrumentation
+from ._setup import configure_instrumentation, get_instrumentation, has_instrumentation
 from ._utils import get_metrics_labels, get_rate, get_running_services_labels, track_duration
 
 __all__: tuple[str, ...] = (
@@ -7,5 +7,6 @@ __all__: tuple[str, ...] = (
     "get_metrics_labels",
     "get_rate",
     "get_running_services_labels",
+    "has_instrumentation",
     "track_duration",
 )

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_setup.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_setup.py
@@ -20,6 +20,10 @@ def configure_instrumentation(app: FastAPI, app_lifespan: LifespanManager) -> No
 
 
 def get_instrumentation(app: FastAPI) -> DirectorV2Instrumentation:
-    if not app.state.instrumentation:
+    if not has_instrumentation(app):
         raise ConfigurationError(msg="Instrumentation not setup. Please check the configuration.")
     return cast(DirectorV2Instrumentation, app.state.instrumentation)
+
+
+def has_instrumentation(app: FastAPI) -> bool:
+    return hasattr(app.state, "instrumentation")

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_setup.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_setup.py
@@ -21,7 +21,7 @@ def configure_instrumentation(app: FastAPI, app_lifespan: LifespanManager) -> No
 
 def get_instrumentation(app: FastAPI) -> DirectorV2Instrumentation:
     if not has_instrumentation(app):
-        raise ConfigurationError(msg="Instrumentation not setup. Please check the configuration.")
+        raise ConfigurationError(msg="Instrumentation is not set up. Please check the configuration.")
     return cast(DirectorV2Instrumentation, app.state.instrumentation)
 
 

--- a/services/director-v2/tests/unit/test_modules_instrumentation__setup.py
+++ b/services/director-v2/tests/unit/test_modules_instrumentation__setup.py
@@ -1,0 +1,39 @@
+# pylint: disable=redefined-outer-name
+
+import pytest
+from fastapi import FastAPI
+from prometheus_client import CollectorRegistry
+from simcore_service_director_v2.core.errors import ConfigurationError
+from simcore_service_director_v2.modules.instrumentation import (
+    get_instrumentation,
+    has_instrumentation,
+)
+from simcore_service_director_v2.modules.instrumentation._models import (
+    DirectorV2Instrumentation,
+)
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    return FastAPI()
+
+
+@pytest.fixture
+def instrumentation() -> DirectorV2Instrumentation:
+    return DirectorV2Instrumentation(registry=CollectorRegistry())
+
+
+def test_has_instrumentation_is_false_when_not_configured(app: FastAPI):
+    assert has_instrumentation(app) is False
+
+
+def test_get_instrumentation_raises_configuration_error_when_not_configured(app: FastAPI):
+    with pytest.raises(ConfigurationError):
+        get_instrumentation(app)
+
+
+def test_get_instrumentation_when_configured(app: FastAPI, instrumentation: DirectorV2Instrumentation):
+    app.state.instrumentation = instrumentation
+
+    assert has_instrumentation(app) is True
+    assert get_instrumentation(app) is instrumentation


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->

### What

Fixes a crash in `director-v2` that happened when Prometheus instrumentation is turned off (`DIRECTOR_V2_PROMETHEUS_INSTRUMENTATION_ENABLED=0`).

### Why

With metrics disabled, the service still tried to record them. This raised an error that interrupted the dynamic services observation loop, so starting a dynamic service could fail on deployments where instrumentation is off.

### How

Metrics recording is now skipped when instrumentation is disabled, instead of failing. This follows the same approach already used by the `autoscaling` and `clusters-keeper` services. When instrumentation is enabled, nothing changes and all metrics are still collected as before.

Also added unit tests covering both the enabled and disabled configurations.Autopilot continued: The response is technical and does not provide a short non-technical PR description as requested.Here's a plainer, jargon-free version:


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- https://github.com/ITISFoundation/private-issues/issues/646

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
