### PR TITLE
🎨Director-v2: adds simcore_user_agent in metrics to allow filtering in prometheus

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_models.py
@@ -17,6 +17,7 @@ _INSTRUMENTATION_LABELS: Final[tuple[str, ...]] = (
     "service_key",
     "service_version",
     "product_name",
+    "simcore_user_agent",
 )
 
 _MINUTE: Final[int] = 60

--- a/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_utils.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/instrumentation/_utils.py
@@ -17,6 +17,7 @@ def get_metrics_labels(scheduler_data: "SchedulerData") -> dict[str, str]:
         "service_key": scheduler_data.key,
         "service_version": scheduler_data.version,
         "product_name": scheduler_data.product_name,
+        "simcore_user_agent": scheduler_data.request_simcore_user_agent,
     }
 
 
@@ -28,6 +29,7 @@ def get_running_services_labels(scheduler_data: "SchedulerData") -> dict[str, st
         "service_key": scheduler_data.key,
         "service_version": scheduler_data.version,
         "product_name": scheduler_data.product_name,
+        "simcore_user_agent": scheduler_data.request_simcore_user_agent,
     }
 
 

--- a/services/director-v2/tests/unit/test_modules_instrumentation__models.py
+++ b/services/director-v2/tests/unit/test_modules_instrumentation__models.py
@@ -22,6 +22,7 @@ def test_update_running_services_count_sets_and_removes_stale_labels() -> None:
         "service_key": "simcore/services/dynamic/foo",
         "service_version": "1.0.0",
         "product_name": "osparc",
+        "simcore_user_agent": "undefined",
     }
     labels_2 = {
         "user_id": "2",
@@ -29,6 +30,7 @@ def test_update_running_services_count_sets_and_removes_stale_labels() -> None:
         "service_key": "simcore/services/dynamic/bar",
         "service_version": "2.0.0",
         "product_name": "s4l",
+        "simcore_user_agent": "e2e-playwright",
     }
 
     metrics.update_running_services_count([labels_1, labels_1, labels_2])

--- a/services/director-v2/tests/unit/test_modules_instrumentation__utils.py
+++ b/services/director-v2/tests/unit/test_modules_instrumentation__utils.py
@@ -33,6 +33,7 @@ def test_get_metrics_labels_with_wallet(scheduler_data: SchedulerData) -> None:
     assert labels["service_key"] == scheduler_data.key
     assert labels["service_version"] == scheduler_data.version
     assert labels["product_name"] == scheduler_data.product_name
+    assert labels["simcore_user_agent"] == scheduler_data.request_simcore_user_agent
 
 
 def test_get_running_services_labels_uses_none_string_for_missing_wallet(
@@ -49,4 +50,5 @@ def test_get_running_services_labels_with_wallet(scheduler_data: SchedulerData) 
     labels = get_running_services_labels(scheduler_data)
 
     assert labels["wallet_id"] == f"{scheduler_data.wallet_info.wallet_id}"
+    assert labels["simcore_user_agent"] == scheduler_data.request_simcore_user_agent
     assert labels["product_name"] == scheduler_data.product_name


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
- adds `simcore_user_agent` to the running services metrics
--> Allows to properly filter e2e tests in grafana dashboards
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
