### PR TITLE
♻️ ⚰️ chore(dynamic-sidecar): remove `aioprocessing`

### DIFF
--- a/services/dynamic-sidecar/requirements/_base.in
+++ b/services/dynamic-sidecar/requirements/_base.in
@@ -28,7 +28,6 @@
 aio-pika
 aiodocker
 aiofiles
-aioprocessing
 psutil
 pydantic
 python-magic # file type identification library. See 'magic.from_file(...)' NOTE: requires `libmagic`` installed

--- a/services/dynamic-sidecar/requirements/_base.txt
+++ b/services/dynamic-sidecar/requirements/_base.txt
@@ -26,8 +26,6 @@ aiohttp==3.14.3
     #   -c requirements/../../../requirements/constraints.txt
     #   -r requirements/../../../packages/simcore-sdk/requirements/_base.in
     #   aiodocker
-aioprocessing==2.0.1
-    # via -r requirements/_base.in
 aiormq==6.8.1
     # via aio-pika
 aiosignal==1.4.0

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
@@ -1,17 +1,16 @@
 import logging
+import multiprocessing
 import stat
 from asyncio import CancelledError, Task, create_task, get_event_loop
 from asyncio import sleep as async_sleep
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
+from multiprocessing.queues import Queue
 from pathlib import Path
 from queue import Empty
 from time import sleep as blocking_sleep
 from typing import Final
 
-import aioprocessing  # type: ignore[import-untyped]
-from aioprocessing.process import AioProcess  # type: ignore[import-untyped]
-from aioprocessing.queues import AioQueue  # type: ignore[import-untyped]
 from pydantic import ByteSize, PositiveFloat
 from servicelib.logging_utils import log_context
 from watchdog.events import FileSystemEvent
@@ -41,23 +40,61 @@ class _LoggingEventHandler(SafeFileSystemEventHandler):
             )
 
 
+def _process_worker(
+    path_to_observe: Path,
+    health_check_queue: Queue[int | None],
+    stop_queue: Queue[None],
+    heart_beat_interval_s: PositiveFloat,
+) -> None:
+    # NOTE: module level and only receives pickleable arguments,
+    # so that it is compatible with any multiprocessing start method
+
+    observer = ExtendedInotifyObserver()
+    file_system_event_handler = _LoggingEventHandler()
+    watch = None
+
+    try:
+        watch = observer.schedule(
+            event_handler=file_system_event_handler,
+            path=f"{path_to_observe.absolute()}",
+            recursive=True,
+        )
+        observer.start()
+
+        while stop_queue.qsize() == 0:
+            # NOTE: watchdog handles events internally every 1 second.
+            # While doing so it will block this thread briefly.
+            # Health check delivery may be delayed.
+
+            health_check_queue.put(_HEART_BEAT_MARK)
+            blocking_sleep(heart_beat_interval_s)
+
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Unexpected error")
+    finally:
+        if watch:
+            observer.remove_handler_for_watch(file_system_event_handler, watch)
+        observer.stop()
+
+        logger.warning("%s exited", _LoggingEventHandlerProcess.__name__)
+
+
 class _LoggingEventHandlerProcess:
     def __init__(
         self,
         path_to_observe: Path,
-        health_check_queue: AioQueue,
+        health_check_queue: Queue[int | None],
         heart_beat_interval_s: PositiveFloat,
     ) -> None:
         self.path_to_observe: Path = path_to_observe
-        self.health_check_queue: AioQueue = health_check_queue
+        self.health_check_queue: Queue[int | None] = health_check_queue
         self.heart_beat_interval_s: PositiveFloat = heart_beat_interval_s
 
         # This is accessible from the creating process and from
         # the process itself and is used to stop the process.
-        self._stop_queue: AioQueue = aioprocessing.AioQueue()
+        self._stop_queue: Queue[None] = multiprocessing.Queue()
 
-        self._file_system_event_handler: _LoggingEventHandler | None = None
-        self._process: AioProcess | None = None
+        self._process: multiprocessing.Process | None = None
 
     def start_process(self) -> None:
         with log_context(
@@ -65,8 +102,17 @@ class _LoggingEventHandlerProcess:
             logging.DEBUG,
             f"{_LoggingEventHandlerProcess.__name__} start_process",
         ):
-            self._process = aioprocessing.AioProcess(target=self._process_worker, daemon=True)
-            self._process.start()  # pylint:disable=no-member
+            self._process = multiprocessing.Process(
+                target=_process_worker,
+                args=(
+                    self.path_to_observe,
+                    self.health_check_queue,
+                    self._stop_queue,
+                    self.heart_beat_interval_s,
+                ),
+                daemon=True,
+            )
+            self._process.start()
 
     def _stop_process(self) -> None:
         with log_context(
@@ -74,16 +120,13 @@ class _LoggingEventHandlerProcess:
             logging.DEBUG,
             f"{_LoggingEventHandlerProcess.__name__} stop_process",
         ):
-            self._stop_queue.put(None)  # pylint:disable=no-member
+            self._stop_queue.put(None)
 
             if self._process:
                 # force stop the process
-                self._process.kill()  # pylint:disable=no-member
-                self._process.join()  # pylint:disable=no-member
+                self._process.kill()
+                self._process.join()
                 self._process = None
-
-            # cleanup whatever remains
-            self._file_system_event_handler = None
 
     def shutdown(self) -> None:
         with log_context(logger, logging.DEBUG, f"{_LoggingEventHandlerProcess.__name__} shutdown"):
@@ -91,36 +134,6 @@ class _LoggingEventHandlerProcess:
 
             # signal queue observers to finish
             self.health_check_queue.put(None)
-
-    def _process_worker(self) -> None:
-        observer = ExtendedInotifyObserver()
-        self._file_system_event_handler = _LoggingEventHandler()
-        watch = None
-
-        try:
-            watch = observer.schedule(
-                event_handler=self._file_system_event_handler,
-                path=f"{self.path_to_observe.absolute()}",
-                recursive=True,
-            )
-            observer.start()
-
-            while self._stop_queue.qsize() == 0:  # pylint:disable=no-member
-                # NOTE: watchdog handles events internally every 1 second.
-                # While doing so it will block this thread briefly.
-                # Health check delivery may be delayed.
-
-                self.health_check_queue.put(_HEART_BEAT_MARK)
-                blocking_sleep(self.heart_beat_interval_s)
-
-        except Exception:  # pylint: disable=broad-except
-            logger.exception("Unexpected error")
-        finally:
-            if watch:
-                observer.remove_handler_for_watch(self._file_system_event_handler, watch)
-            observer.stop()
-
-            logger.warning("%s exited", _LoggingEventHandlerProcess.__name__)
 
 
 class LoggingEventHandlerObserver:
@@ -140,7 +153,7 @@ class LoggingEventHandlerObserver:
         self._heart_beat_interval_s: PositiveFloat = heart_beat_interval_s
         self.max_heart_beat_wait_interval_s: PositiveFloat = max_heart_beat_wait_interval_s
 
-        self._health_check_queue = aioprocessing.AioQueue()
+        self._health_check_queue: Queue[int | None] = multiprocessing.Queue()
         self._logging_event_handler_process = _LoggingEventHandlerProcess(
             path_to_observe=self.path_to_observe,
             health_check_queue=self._health_check_queue,
@@ -161,7 +174,7 @@ class LoggingEventHandlerObserver:
             heart_beat_count = 0
             while True:
                 try:
-                    self._health_check_queue.get_nowait()  # pylint:disable=no-member
+                    self._health_check_queue.get_nowait()
                     heart_beat_count += 1
                 except Empty:
                     break

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_context.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_context.py
@@ -1,9 +1,11 @@
+import multiprocessing
+from asyncio import to_thread
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
+from multiprocessing.queues import Queue
 from pathlib import Path
+from typing import Any
 
-import aioprocessing  # type: ignore[import-untyped]
-from aioprocessing.queues import AioQueue  # type: ignore[import-untyped]
 from fastapi import FastAPI
 from fastapi_lifespan_manager import LifespanManager
 
@@ -15,10 +17,10 @@ class OutputsContext:
     outputs_path: Path
 
     # _PortKeysEventHandler (generates) -> EventFilter (receives)
-    port_key_events_queue: AioQueue = field(default_factory=aioprocessing.AioQueue)
+    port_key_events_queue: Queue[str | None] = field(default_factory=multiprocessing.Queue)
 
     # OutputsContext (generates) -> _EventHandlerProcess(receives)
-    file_system_event_handler_queue: AioQueue = field(default_factory=aioprocessing.AioQueue)
+    file_system_event_handler_queue: Queue[dict[str, Any] | None] = field(default_factory=multiprocessing.Queue)
 
     # contains port types such as int, str, bool
     non_file_type_port_keys: list[str] = field(default_factory=list)
@@ -28,19 +30,21 @@ class OutputsContext:
 
     async def set_file_type_port_keys(self, file_type_port_keys: list[str]) -> None:
         self._file_type_port_keys = file_type_port_keys
-        await self.file_system_event_handler_queue.coro_put(  # pylint:disable=no-member
+        await to_thread(
+            self.file_system_event_handler_queue.put,
             {
                 "method_name": "handle_set_outputs_port_keys",
                 "kwargs": {"outputs_port_keys": self._file_type_port_keys},
-            }
+            },
         )
 
     async def toggle_event_propagation(self, *, is_enabled: bool) -> None:
-        await self.file_system_event_handler_queue.coro_put(  # pylint:disable=no-member
+        await to_thread(
+            self.file_system_event_handler_queue.put,
             {
                 "method_name": "handle_toggle_event_propagation",
                 "kwargs": {"is_enabled": is_enabled},
-            }
+            },
         )
 
     @property

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
@@ -1,17 +1,16 @@
 import logging
+import multiprocessing
 from asyncio import CancelledError, Task, create_task, get_event_loop
 from asyncio import sleep as async_sleep
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
+from multiprocessing.queues import Queue
 from pathlib import Path
 from queue import Empty
 from threading import Thread
 from time import sleep as blocking_sleep
 from typing import Any, Final
 
-import aioprocessing  # type: ignore [import-untyped]
-from aioprocessing.process import AioProcess  # type: ignore [import-untyped]
-from aioprocessing.queues import AioQueue  # type: ignore [import-untyped]
 from pydantic import PositiveFloat
 from servicelib.logging_utils import log_context
 from watchdog.events import FileSystemEvent
@@ -32,12 +31,12 @@ def _get_first_entry_or_none(data: list[str]) -> str | None:
 class _PortKeysEventHandler(SafeFileSystemEventHandler):
     # NOTE: runs in the created process
 
-    def __init__(self, outputs_path: Path, port_key_events_queue: AioQueue):
+    def __init__(self, outputs_path: Path, port_key_events_queue: Queue[str | None]):
         super().__init__()
 
         self._is_event_propagation_enabled: bool = False
         self.outputs_path: Path = outputs_path
-        self.port_key_events_queue: AioQueue = port_key_events_queue
+        self.port_key_events_queue: Queue[str | None] = port_key_events_queue
         self._outputs_port_keys: set[str] = set()
 
     def handle_set_outputs_port_keys(self, *, outputs_port_keys: set[str]) -> None:
@@ -89,47 +88,136 @@ class _PortKeysEventHandler(SafeFileSystemEventHandler):
             self.port_key_events_queue.put(port_key_candidate)
 
 
+def _thread_worker_update_outputs_port_keys(
+    file_system_event_handler_queue: Queue[dict[str, Any] | None],
+    file_system_event_handler: _PortKeysEventHandler,
+) -> None:
+    # NOTE: runs as a thread in the created process
+
+    # Propagate `outputs_port_keys` changes to the `_PortKeysEventHandler`.
+    while True:
+        message: dict[str, Any] | None = file_system_event_handler_queue.get()
+        _logger.debug("received message %s", message)
+
+        # no more messages quitting
+        if message is None:
+            break
+
+        # handle events
+        method_kwargs: dict[str, Any] = message["kwargs"]
+        method_name = message["method_name"]
+        method_to_call = getattr(file_system_event_handler, method_name)
+        method_to_call(**method_kwargs)
+
+
+def _process_worker(
+    outputs_path: Path,
+    port_key_events_queue: Queue[str | None],
+    file_system_event_handler_queue: Queue[dict[str, Any] | None],
+    health_check_queue: Queue[int | None],
+    stop_queue: Queue[None],
+    heart_beat_interval_s: PositiveFloat,
+) -> None:
+    # NOTE: module level and only receives pickleable arguments,
+    # so that it is compatible with any multiprocessing start method
+
+    observer = ExtendedInotifyObserver()
+    file_system_event_handler = _PortKeysEventHandler(
+        outputs_path=outputs_path,
+        port_key_events_queue=port_key_events_queue,
+    )
+    watch = None
+
+    thread_update_outputs_port_keys = Thread(
+        target=_thread_worker_update_outputs_port_keys,
+        args=(file_system_event_handler_queue, file_system_event_handler),
+        daemon=True,
+    )
+    thread_update_outputs_port_keys.start()
+
+    try:
+        watch = observer.schedule(
+            event_handler=file_system_event_handler,
+            path=f"{outputs_path.absolute()}",
+            recursive=True,
+        )
+        observer.start()
+
+        while stop_queue.qsize() == 0:
+            # watchdog internally uses 1 sec interval to detect events
+            # sleeping for less is useless.
+            # If this value is bigger then the DEFAULT_OBSERVER_TIMEOUT
+            # the result will not be as expected. Keep sleep to 1 second
+
+            # NOTE: watchdog will block this thread for some period of
+            # time while handling inotify events
+            # the health_check sending could be delayed
+
+            health_check_queue.put(_HEART_BEAT_MARK)
+            blocking_sleep(heart_beat_interval_s)
+
+    except Exception:  # pylint: disable=broad-except
+        _logger.exception("Unexpected error")
+    finally:
+        if watch:
+            observer.remove_handler_for_watch(file_system_event_handler, watch)
+        observer.stop()
+
+        # stop created thread
+        file_system_event_handler_queue.put(None)
+        thread_update_outputs_port_keys.join()
+
+        _logger.warning("%s exited", _EventHandlerProcess.__name__)
+
+
 class _EventHandlerProcess:
     def __init__(
         self,
         outputs_context: OutputsContext,
-        health_check_queue: AioQueue,
+        health_check_queue: Queue[int | None],
         heart_beat_interval_s: PositiveFloat,
     ) -> None:
         # NOTE: runs in asyncio thread
 
         self.outputs_context: OutputsContext = outputs_context
-        self.health_check_queue: AioQueue = health_check_queue
+        self.health_check_queue: Queue[int | None] = health_check_queue
         self.heart_beat_interval_s: PositiveFloat = heart_beat_interval_s
 
         # This is accessible from the creating process and from
         # the process itself and is used to stop the process.
-        self._stop_queue: AioQueue = aioprocessing.AioQueue()
+        self._stop_queue: Queue[None] = multiprocessing.Queue()
 
-        self._file_system_event_handler: _PortKeysEventHandler | None = None
-        self._process: AioProcess | None = None
+        self._process: multiprocessing.Process | None = None
 
     def start_process(self) -> None:
         # NOTE: runs in asyncio thread
 
         with log_context(_logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} start_process"):
-            self._process = aioprocessing.AioProcess(target=self._process_worker, daemon=True)
-            self._process.start()  # pylint:disable=no-member
+            self._process = multiprocessing.Process(
+                target=_process_worker,
+                args=(
+                    self.outputs_context.outputs_path,
+                    self.outputs_context.port_key_events_queue,
+                    self.outputs_context.file_system_event_handler_queue,
+                    self.health_check_queue,
+                    self._stop_queue,
+                    self.heart_beat_interval_s,
+                ),
+                daemon=True,
+            )
+            self._process.start()
 
     def stop_process(self) -> None:
         # NOTE: runs in asyncio thread
 
         with log_context(_logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} stop_process"):
-            self._stop_queue.put(None)  # pylint:disable=no-member
+            self._stop_queue.put(None)
 
             if self._process:
                 # force stop the process
-                self._process.kill()  # pylint:disable=no-member
-                self._process.join()  # pylint:disable=no-member
+                self._process.kill()
+                self._process.join()
                 self._process = None
-
-            # cleanup whatever remains
-            self._file_system_event_handler = None
 
     def shutdown(self) -> None:
         # NOTE: runs in asyncio thread
@@ -138,81 +226,8 @@ class _EventHandlerProcess:
             self.stop_process()
 
             # signal queue observers to finish
-            self.outputs_context.port_key_events_queue.put(None)  # pylint:disable=no-member
-            self.health_check_queue.put(None)  # pylint:disable=no-member
-
-    def _thread_worker_update_outputs_port_keys(self) -> None:
-        # NOTE: runs as a thread in the created process
-
-        # Propagate `outputs_port_keys` changes to the `_PortKeysEventHandler`.
-        while True:
-            message: dict[str, Any] | None = self.outputs_context.file_system_event_handler_queue.get()  # pylint:disable=no-member
-            _logger.debug("received message %s", message)
-
-            # no more messages quitting
-            if message is None:
-                break
-
-            # do nothing
-            if self._file_system_event_handler is None:
-                continue
-
-            # handle events
-            method_kwargs: dict[str, Any] = message["kwargs"]
-            method_name = message["method_name"]
-            method_to_call = getattr(self._file_system_event_handler, method_name)
-            method_to_call(**method_kwargs)
-
-    def _process_worker(self) -> None:
-        # NOTE: runs in the created process
-
-        observer = ExtendedInotifyObserver()
-        self._file_system_event_handler = _PortKeysEventHandler(
-            outputs_path=self.outputs_context.outputs_path,
-            port_key_events_queue=self.outputs_context.port_key_events_queue,
-        )
-        watch = None
-
-        thread_update_outputs_port_keys = Thread(target=self._thread_worker_update_outputs_port_keys, daemon=True)
-        thread_update_outputs_port_keys.start()
-
-        try:
-            watch = observer.schedule(
-                event_handler=self._file_system_event_handler,
-                path=f"{self.outputs_context.outputs_path.absolute()}",
-                recursive=True,
-            )
-            observer.start()
-
-            while self._stop_queue.qsize() == 0:  # pylint:disable=no-member
-                # watchdog internally uses 1 sec interval to detect events
-                # sleeping for less is useless.
-                # If this value is bigger then the DEFAULT_OBSERVER_TIMEOUT
-                # the result will not be as expected. Keep sleep to 1 second
-
-                # NOTE: watchdog will block this thread for some period of
-                # time while handling inotify events
-                # the health_check sending could be delayed
-
-                self.health_check_queue.put(  # pylint:disable=no-member
-                    _HEART_BEAT_MARK
-                )
-                blocking_sleep(self.heart_beat_interval_s)
-
-        except Exception:  # pylint: disable=broad-except
-            _logger.exception("Unexpected error")
-        finally:
-            if watch:
-                observer.remove_handler_for_watch(self._file_system_event_handler, watch)
-            observer.stop()
-
-            # stop created thread
-            self.outputs_context.file_system_event_handler_queue.put(  # pylint:disable=no-member
-                None
-            )
-            thread_update_outputs_port_keys.join()
-
-            _logger.warning("%s exited", _EventHandlerProcess.__name__)
+            self.outputs_context.port_key_events_queue.put(None)
+            self.health_check_queue.put(None)
 
 
 class EventHandlerObserver:
@@ -234,7 +249,7 @@ class EventHandlerObserver:
         self.heart_beat_interval_s: PositiveFloat = heart_beat_interval_s
         self.max_heart_beat_wait_interval_s: PositiveFloat = max_heart_beat_wait_interval_s
 
-        self._health_check_queue: AioQueue = aioprocessing.AioQueue()
+        self._health_check_queue: Queue[int | None] = multiprocessing.Queue()
         self._event_handler_process: _EventHandlerProcess = _EventHandlerProcess(
             outputs_context=outputs_context,
             health_check_queue=self._health_check_queue,
@@ -255,7 +270,7 @@ class EventHandlerObserver:
             heart_beat_count = 0
             while True:
                 try:
-                    self._health_check_queue.get_nowait()  # pylint:disable=no-member
+                    self._health_check_queue.get_nowait()
                     heart_beat_count += 1
                 except Empty:
                     break

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_watcher.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_watcher.py
@@ -1,5 +1,5 @@
 import logging
-from asyncio import CancelledError, Task, create_task
+from asyncio import CancelledError, Task, create_task, to_thread
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, suppress
 
@@ -31,7 +31,7 @@ class OutputsWatcher:
 
     async def _worker_events(self) -> None:
         while True:
-            event: str | None = await self.outputs_context.port_key_events_queue.coro_get()
+            event: str | None = await to_thread(self.outputs_context.port_key_events_queue.get)
             if event is None:
                 break
 

--- a/services/dynamic-sidecar/tests/unit/api/rest/test_containers.py
+++ b/services/dynamic-sidecar/tests/unit/api/rest/test_containers.py
@@ -328,27 +328,24 @@ def mock_event_filter_enqueue(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> 
 
 
 @pytest.fixture
-async def mocked_port_key_events_queue_coro_get(app: FastAPI, mocker: MockerFixture) -> Mock:
+async def mocked_port_key_events_queue_get(app: FastAPI, mocker: MockerFixture) -> Mock:
     outputs_context: OutputsContext = app.state.outputs_context
 
-    target = getattr(outputs_context.port_key_events_queue, "coro_get")  # noqa: B009
+    target = outputs_context.port_key_events_queue.get
 
     mock_result_tracker = Mock()
 
-    async def _wrapped_coroutine() -> Any:
-        # NOTE: coro_get returns a future, naming is unfortunate
-        # and can cause confusion, normally an async def function
-        # will return a coroutine not a future object.
-        future: asyncio.Future = target()
-        result = await future
+    def _wrapped() -> Any:
+        # NOTE: runs in the thread used by `asyncio.to_thread`
+        result = target()
         mock_result_tracker(result)
 
         return result
 
     mocker.patch.object(
         outputs_context.port_key_events_queue,
-        "coro_get",
-        side_effect=_wrapped_coroutine,
+        "get",
+        side_effect=_wrapped,
     )
 
     return mock_result_tracker
@@ -445,7 +442,7 @@ async def test_container_docker_error(
 
 async def test_outputs_watcher_disabling(
     test_client: TestClient,
-    mocked_port_key_events_queue_coro_get: Mock,
+    mocked_port_key_events_queue_get: Mock,
     mock_event_filter_enqueue: AsyncMock,
 ):
     assert isinstance(test_client.application, FastAPI)
@@ -469,9 +466,7 @@ async def test_outputs_watcher_disabling(
             with attempt:
                 # check events were triggered after generation
                 events_in_dir: list[str] = [
-                    c.args[0]
-                    for c in mocked_port_key_events_queue_coro_get.call_args_list
-                    if c.args[0] == random_subdir
+                    c.args[0] for c in mocked_port_key_events_queue_get.call_args_list if c.args[0] == random_subdir
                 ]
 
                 if is_propagation_enabled:

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
@@ -2,14 +2,14 @@
 # pylint: disable=protected-access
 
 import asyncio
+import multiprocessing
 from collections.abc import AsyncIterable
+from multiprocessing.queues import Queue
 from pathlib import Path
 from typing import Any, Final
 from unittest.mock import Mock
 
-import aioprocessing
 import pytest
-from aioprocessing.queues import AioQueue
 from pydantic import PositiveFloat
 from simcore_service_dynamic_sidecar.modules.notifications._notifications_ports import (
     PortNotifier,
@@ -66,8 +66,8 @@ async def outputs_manager(
 
 
 @pytest.fixture
-def health_check_queue() -> AioQueue:
-    return aioprocessing.AioQueue()
+def health_check_queue() -> Queue[int | None]:
+    return multiprocessing.Queue()
 
 
 @pytest.fixture
@@ -77,7 +77,7 @@ def heart_beat_interval_s() -> PositiveFloat:
 
 async def test_event_handler_process_lifecycle(
     outputs_context: OutputsContext,
-    health_check_queue: AioQueue,
+    health_check_queue: Queue[int | None],
     heart_beat_interval_s: PositiveFloat,
 ):
     observer_process = _EventHandlerProcess(
@@ -141,7 +141,7 @@ def mock_state_path() -> Path:
     return _STATE_PATH
 
 
-class _MockAioQueue:
+class _MockQueue:
     def __init__(self) -> None:
         self.items: list[Any] = []
 
@@ -228,7 +228,7 @@ class _MockAioQueue:
 def test_port_keys_event_handler_triggers_for_events(
     mock_state_path: Path, event: FileSystemEvent, expected_port_key: str | None
 ) -> None:
-    queue = _MockAioQueue()
+    queue = _MockQueue()
 
     event_handler = _PortKeysEventHandler(mock_state_path, queue)
     event_handler.handle_set_outputs_port_keys(outputs_port_keys={"output_1"})


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Removes the `aioprocessing` dependency from the `dynamic-sidecar` and replaces it with the standard library `multiprocessing` + `asyncio.to_thread`.

**Why:** `aioprocessing` is not compatible with Python 3.14 and is blocking the Python upgrade. On POSIX, Python 3.14 changes the default `multiprocessing` start method from `fork` to `forkserver`, which requires process targets and their arguments to be **pickleable**. `aioprocessing`'s `AioProcess`/`AioQueue` were used with bound-method targets (`self._process_worker`), which fails at `Process.start()` with:

    _pickle.PicklingError: Can't pickle local object ... when serializing dict item '_target'

On top of that, `aioprocessing` is effectively unmaintained (last release 2.0.1) and untyped (required `# type: ignore[import-untyped]` everywhere).

## Related PR/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- allows https://github.com/ITISFoundation/osparc-simcore/pull/9624

## How to test
```sh
cd services/dynamic-sidecar
make install-dev
pytest -vv --pdb tests/unit/test_modules_outputs_event_handler.py
```

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
- No changes.