### PR TITLE
🐛 fix(dynamic-sidecar): guard watchdog process start/stop against a TOCTOU race

### DIFF
--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
@@ -1,13 +1,14 @@
 import logging
 import multiprocessing
 import stat
-from asyncio import CancelledError, Task, create_task, get_event_loop
+from asyncio import CancelledError, Task, create_task, get_event_loop, to_thread
 from asyncio import sleep as async_sleep
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from multiprocessing.queues import Queue
 from pathlib import Path
 from queue import Empty
+from threading import Lock
 from time import sleep as blocking_sleep
 from typing import Final
 
@@ -94,13 +95,17 @@ class _LoggingEventHandlerProcess:
         # the process itself and is used to stop the process.
         self._stop_queue: Queue[None] = multiprocessing.Queue()
 
+        self._process_lock: Lock = Lock()
         self._process: multiprocessing.Process | None = None
 
     def start_process(self) -> None:
-        with log_context(
-            logger,
-            logging.DEBUG,
-            f"{_LoggingEventHandlerProcess.__name__} start_process",
+        with (
+            log_context(
+                logger,
+                logging.DEBUG,
+                f"{_LoggingEventHandlerProcess.__name__} start_process",
+            ),
+            self._process_lock,
         ):
             self._process = multiprocessing.Process(
                 target=_process_worker,
@@ -115,10 +120,13 @@ class _LoggingEventHandlerProcess:
             self._process.start()
 
     def _stop_process(self) -> None:
-        with log_context(
-            logger,
-            logging.DEBUG,
-            f"{_LoggingEventHandlerProcess.__name__} stop_process",
+        with (
+            log_context(
+                logger,
+                logging.DEBUG,
+                f"{_LoggingEventHandlerProcess.__name__} stop_process",
+            ),
+            self._process_lock,
         ):
             self._stop_queue.put(None)
 
@@ -199,9 +207,11 @@ class LoggingEventHandlerObserver:
 
     async def stop(self) -> None:
         with log_context(logger, logging.INFO, f"{LoggingEventHandlerObserver.__name__} stop"):
-            self._stop_observer_process()
+            # NOTE: the health worker is the only other user of the process,
+            # stopping it first avoids racing with a restart
             self._keep_running = False
             if self._task_health_worker is not None:
                 self._task_health_worker.cancel("stopping health worker")
                 with suppress(CancelledError):
                     await self._task_health_worker
+            await to_thread(self._stop_observer_process)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
@@ -94,7 +94,7 @@ class _LoggingEventHandlerProcess:
 
         # This is accessible from the creating process and from
         # the process itself and is used to stop the process.
-        self._stop_queue: Queue[None] = multiprocessing.Queue()
+        self._stop_queue: Queue[None] | None = None
 
         self._process_lock: Lock = Lock()
         self._process: multiprocessing.Process | None = None
@@ -130,7 +130,9 @@ class _LoggingEventHandlerProcess:
             ),
             self._process_lock,
         ):
-            self._stop_queue.put(None)
+            if self._stop_queue is not None:
+                self._stop_queue.put(None)
+                self._stop_queue = None
 
             if self._process:
                 # force stop the process

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
@@ -1,7 +1,7 @@
 import logging
 import multiprocessing
 import stat
-from asyncio import Task, create_task, get_event_loop, to_thread
+from asyncio import CancelledError, Task, create_task, get_event_loop, to_thread
 from asyncio import sleep as async_sleep
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
@@ -12,7 +12,6 @@ from threading import Lock
 from time import sleep as blocking_sleep
 from typing import Final
 
-from common_library.async_tools import cancel_wait_task
 from pydantic import ByteSize, PositiveFloat
 from servicelib.logging_utils import log_context
 from watchdog.events import FileSystemEvent
@@ -212,6 +211,8 @@ class LoggingEventHandlerObserver:
             self._keep_running = False
             try:
                 if self._task_health_worker is not None:
-                    await cancel_wait_task(self._task_health_worker)
+                    self._task_health_worker.cancel("stopping health worker")
+                    with suppress(CancelledError):
+                        await self._task_health_worker
             finally:
                 await to_thread(self._stop_observer_process)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
@@ -1,7 +1,7 @@
 import logging
 import multiprocessing
 import stat
-from asyncio import CancelledError, Task, create_task, get_event_loop, to_thread
+from asyncio import Task, create_task, get_event_loop, to_thread
 from asyncio import sleep as async_sleep
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
@@ -12,6 +12,7 @@ from threading import Lock
 from time import sleep as blocking_sleep
 from typing import Final
 
+from common_library.async_tools import cancel_wait_task
 from pydantic import ByteSize, PositiveFloat
 from servicelib.logging_utils import log_context
 from watchdog.events import FileSystemEvent
@@ -107,6 +108,7 @@ class _LoggingEventHandlerProcess:
             ),
             self._process_lock,
         ):
+            self._stop_queue = multiprocessing.Queue()
             self._process = multiprocessing.Process(
                 target=_process_worker,
                 args=(
@@ -207,11 +209,9 @@ class LoggingEventHandlerObserver:
 
     async def stop(self) -> None:
         with log_context(logger, logging.INFO, f"{LoggingEventHandlerObserver.__name__} stop"):
-            # NOTE: the health worker is the only other user of the process,
-            # stopping it first avoids racing with a restart
             self._keep_running = False
-            if self._task_health_worker is not None:
-                self._task_health_worker.cancel("stopping health worker")
-                with suppress(CancelledError):
-                    await self._task_health_worker
-            await to_thread(self._stop_observer_process)
+            try:
+                if self._task_health_worker is not None:
+                    await cancel_wait_task(self._task_health_worker)
+            finally:
+                await to_thread(self._stop_observer_process)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
@@ -12,6 +12,7 @@ from threading import Lock
 from time import sleep as blocking_sleep
 from typing import Final
 
+from common_library.async_tools import cancel_wait_task
 from pydantic import ByteSize, PositiveFloat
 from servicelib.logging_utils import log_context
 from watchdog.events import FileSystemEvent
@@ -211,8 +212,7 @@ class LoggingEventHandlerObserver:
             self._keep_running = False
             try:
                 if self._task_health_worker is not None:
-                    self._task_health_worker.cancel("stopping health worker")
                     with suppress(CancelledError):
-                        await self._task_health_worker
+                        await cancel_wait_task(self._task_health_worker)
             finally:
                 await to_thread(self._stop_observer_process)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/attribute_monitor/_logging_event_handler.py
@@ -108,6 +108,10 @@ class _LoggingEventHandlerProcess:
             ),
             self._process_lock,
         ):
+            if self._stop_queue is not None or self._process is not None:
+                logger.debug("Process already started, skipping")
+                return
+
             self._stop_queue = multiprocessing.Queue()
             self._process = multiprocessing.Process(
                 target=_process_worker,

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
@@ -198,6 +198,10 @@ class _EventHandlerProcess:
             log_context(_logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} start_process"),
             self._process_lock,
         ):
+            if self._stop_queue is not None or self._process is not None:
+                _logger.debug("Process already started, skipping")
+                return
+
             self._stop_queue = multiprocessing.Queue()
             self._process = multiprocessing.Process(
                 target=_process_worker,

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
@@ -1,13 +1,13 @@
 import logging
 import multiprocessing
-from asyncio import CancelledError, Task, create_task, get_event_loop
+from asyncio import CancelledError, Task, create_task, get_event_loop, to_thread
 from asyncio import sleep as async_sleep
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from multiprocessing.queues import Queue
 from pathlib import Path
 from queue import Empty
-from threading import Thread
+from threading import Lock, Thread
 from time import sleep as blocking_sleep
 from typing import Any, Final
 
@@ -187,12 +187,16 @@ class _EventHandlerProcess:
         # the process itself and is used to stop the process.
         self._stop_queue: Queue[None] = multiprocessing.Queue()
 
+        self._process_lock: Lock = Lock()
         self._process: multiprocessing.Process | None = None
 
     def start_process(self) -> None:
         # NOTE: runs in asyncio thread
 
-        with log_context(_logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} start_process"):
+        with (
+            log_context(_logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} start_process"),
+            self._process_lock,
+        ):
             self._process = multiprocessing.Process(
                 target=_process_worker,
                 args=(
@@ -210,7 +214,10 @@ class _EventHandlerProcess:
     def stop_process(self) -> None:
         # NOTE: runs in asyncio thread
 
-        with log_context(_logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} stop_process"):
+        with (
+            log_context(_logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} stop_process"),
+            self._process_lock,
+        ):
             self._stop_queue.put(None)
 
             if self._process:
@@ -304,9 +311,9 @@ class EventHandlerObserver:
 
     async def stop(self) -> None:
         with log_context(_logger, logging.INFO, f"{EventHandlerObserver.__name__} stop"):
-            self._stop_observer_process()
             self._keep_running = False
             if self._task_health_worker is not None:
                 self._task_health_worker.cancel("stopping health worker")
                 with suppress(CancelledError):
                     await self._task_health_worker
+            await to_thread(self._stop_observer_process)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
@@ -1,9 +1,8 @@
 import logging
 import multiprocessing
-from asyncio import CancelledError, Task, create_task, get_event_loop, to_thread
+from asyncio import Task, create_task, get_event_loop, to_thread
 from asyncio import sleep as async_sleep
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import suppress
 from multiprocessing.queues import Queue
 from pathlib import Path
 from queue import Empty
@@ -11,6 +10,7 @@ from threading import Lock, Thread
 from time import sleep as blocking_sleep
 from typing import Any, Final
 
+from common_library.async_tools import cancel_wait_task
 from pydantic import PositiveFloat
 from servicelib.logging_utils import log_context
 from watchdog.events import FileSystemEvent
@@ -197,6 +197,7 @@ class _EventHandlerProcess:
             log_context(_logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} start_process"),
             self._process_lock,
         ):
+            self._stop_queue = multiprocessing.Queue()
             self._process = multiprocessing.Process(
                 target=_process_worker,
                 args=(
@@ -312,8 +313,8 @@ class EventHandlerObserver:
     async def stop(self) -> None:
         with log_context(_logger, logging.INFO, f"{EventHandlerObserver.__name__} stop"):
             self._keep_running = False
-            if self._task_health_worker is not None:
-                self._task_health_worker.cancel("stopping health worker")
-                with suppress(CancelledError):
-                    await self._task_health_worker
-            await to_thread(self._stop_observer_process)
+            try:
+                if self._task_health_worker is not None:
+                    await cancel_wait_task(self._task_health_worker)
+            finally:
+                await to_thread(self._stop_observer_process)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
@@ -186,7 +186,7 @@ class _EventHandlerProcess:
 
         # This is accessible from the creating process and from
         # the process itself and is used to stop the process.
-        self._stop_queue: Queue[None] = multiprocessing.Queue()
+        self._stop_queue: Queue[None] | None = None
 
         self._process_lock: Lock = Lock()
         self._process: multiprocessing.Process | None = None
@@ -220,7 +220,9 @@ class _EventHandlerProcess:
             log_context(_logger, logging.DEBUG, f"{_EventHandlerProcess.__name__} stop_process"),
             self._process_lock,
         ):
-            self._stop_queue.put(None)
+            if self._stop_queue is not None:
+                self._stop_queue.put(None)
+                self._stop_queue = None
 
             if self._process:
                 # force stop the process

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
@@ -1,8 +1,9 @@
 import logging
 import multiprocessing
-from asyncio import Task, create_task, get_event_loop, to_thread
+from asyncio import CancelledError, Task, create_task, get_event_loop, to_thread
 from asyncio import sleep as async_sleep
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 from multiprocessing.queues import Queue
 from pathlib import Path
 from queue import Empty
@@ -10,7 +11,6 @@ from threading import Lock, Thread
 from time import sleep as blocking_sleep
 from typing import Any, Final
 
-from common_library.async_tools import cancel_wait_task
 from pydantic import PositiveFloat
 from servicelib.logging_utils import log_context
 from watchdog.events import FileSystemEvent
@@ -315,6 +315,8 @@ class EventHandlerObserver:
             self._keep_running = False
             try:
                 if self._task_health_worker is not None:
-                    await cancel_wait_task(self._task_health_worker)
+                    self._task_health_worker.cancel("stopping health worker")
+                    with suppress(CancelledError):
+                        await self._task_health_worker
             finally:
                 await to_thread(self._stop_observer_process)

--- a/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
+++ b/services/dynamic-sidecar/src/simcore_service_dynamic_sidecar/modules/outputs/_event_handler.py
@@ -11,6 +11,7 @@ from threading import Lock, Thread
 from time import sleep as blocking_sleep
 from typing import Any, Final
 
+from common_library.async_tools import cancel_wait_task
 from pydantic import PositiveFloat
 from servicelib.logging_utils import log_context
 from watchdog.events import FileSystemEvent
@@ -315,8 +316,7 @@ class EventHandlerObserver:
             self._keep_running = False
             try:
                 if self._task_health_worker is not None:
-                    self._task_health_worker.cancel("stopping health worker")
                     with suppress(CancelledError):
-                        await self._task_health_worker
+                        await cancel_wait_task(self._task_health_worker)
             finally:
                 await to_thread(self._stop_observer_process)

--- a/services/dynamic-sidecar/tests/unit/conftest.py
+++ b/services/dynamic-sidecar/tests/unit/conftest.py
@@ -4,7 +4,11 @@
 
 import asyncio
 import logging
-from collections.abc import AsyncIterable, AsyncIterator
+import multiprocessing
+from collections.abc import AsyncIterable, AsyncIterator, Callable
+from multiprocessing.queues import Queue
+from threading import Barrier, Thread
+from typing import Final
 from unittest.mock import AsyncMock
 
 import pytest
@@ -12,6 +16,7 @@ from aiodocker.volumes import DockerVolume
 from asgi_lifespan import LifespanManager as ASGILifespanManager
 from async_asgi_testclient import TestClient
 from fastapi import FastAPI
+from pydantic import PositiveFloat
 from pytest_mock.plugin import MockerFixture
 from pytest_simcore.helpers.monkeypatch_envs import EnvVarsDict
 from simcore_service_dynamic_sidecar.core.application import AppState, create_app
@@ -29,6 +34,8 @@ from tenacity.stop import stop_after_delay
 from tenacity.wait import wait_fixed
 
 logger = logging.getLogger(__name__)
+
+_CONCURRENT_RUN_TIMEOUT_S: Final[float] = 10
 
 
 #
@@ -150,3 +157,40 @@ def mock_ensure_read_permissions_on_user_service_data(mocker: MockerFixture) -> 
     mocker.patch(
         "simcore_service_dynamic_sidecar.modules.long_running_tasks.ensure_read_permissions_on_user_service_data",
     )
+
+
+@pytest.fixture
+def health_check_queue() -> Queue[int | None]:
+    return multiprocessing.Queue()
+
+
+@pytest.fixture
+def heart_beat_interval_s() -> PositiveFloat:
+    return 0.01
+
+
+@pytest.fixture
+def run_concurrently() -> Callable[[list[Callable[[], None]]], list[BaseException]]:
+    """runs the given callables in threads started at the same time and returns the raised errors"""
+
+    def _(targets: list[Callable[[], None]]) -> list[BaseException]:
+        errors: list[BaseException] = []
+        start_together = Barrier(len(targets))
+
+        def _run(target: Callable[[], None]) -> None:
+            start_together.wait(timeout=_CONCURRENT_RUN_TIMEOUT_S)
+            try:
+                target()
+            except BaseException as exc:  # pylint: disable=broad-except
+                errors.append(exc)
+
+        threads = [Thread(target=_run, args=(target,)) for target in targets]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=_CONCURRENT_RUN_TIMEOUT_S)
+
+        assert not [t for t in threads if t.is_alive()], "threads did not complete (deadlock?)"
+        return errors
+
+    return _

--- a/services/dynamic-sidecar/tests/unit/test_modules_attribute_monitor.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_attribute_monitor.py
@@ -185,6 +185,69 @@ def test_logging_event_handler_process_concurrent_stop_process_does_not_raise(
     first_thread.join(timeout=5)
     second_thread.join(timeout=5)
 
+    assert not first_thread.is_alive(), "first thread never completed (deadlock?)"
+    assert not second_thread.is_alive(), "second thread never completed (deadlock?)"
+    assert not errors
+
+
+def test_logging_event_handler_process_concurrent_start_vs_stop_process_does_not_raise(
+    fake_dy_volumes_mount_dir: Path,
+    health_check_queue: Queue[int | None],
+    heart_beat_interval_s: PositiveFloat,
+    mocker: MockerFixture,
+):
+    observer_process = _LoggingEventHandlerProcess(
+        path_to_observe=fake_dy_volumes_mount_dir,
+        health_check_queue=health_check_queue,
+        heart_beat_interval_s=heart_beat_interval_s,
+    )
+
+    entered_start = threading.Event()
+    release_start = threading.Event()
+    first_caller_paused = False
+
+    def _start() -> None:
+        nonlocal first_caller_paused
+        # pauses while `start_process` still holds `_process_lock`
+        if not first_caller_paused:
+            first_caller_paused = True
+            entered_start.set()
+            assert release_start.wait(timeout=5), "test setup: never released"
+
+    mock_process_cls = Mock()
+    mock_process_cls.return_value.start.side_effect = _start
+    mocker.patch.object(multiprocessing, "Process", mock_process_cls)
+
+    errors: list[BaseException] = []
+
+    def _start_process() -> None:
+        try:
+            observer_process.start_process()
+        except BaseException as exc:  # pylint: disable=broad-except
+            errors.append(exc)
+
+    def _stop_process() -> None:
+        try:
+            observer_process._stop_process()  # noqa: SLF001
+        except BaseException as exc:  # pylint: disable=broad-except
+            errors.append(exc)
+
+    start_thread = threading.Thread(target=_start_process)
+    start_thread.start()
+    assert entered_start.wait(timeout=5), "start thread never reached start()"
+
+    # must block on `_process_lock` while `start_process` is still in progress
+    stop_thread = threading.Thread(target=_stop_process)
+    stop_thread.start()
+    stop_thread.join(timeout=0.5)
+    assert stop_thread.is_alive(), "_stop_process proceeded before start_process released the lock"
+
+    release_start.set()
+    start_thread.join(timeout=5)
+    stop_thread.join(timeout=5)
+
+    assert not start_thread.is_alive(), "start thread never completed (deadlock?)"
+    assert not stop_thread.is_alive(), "stop thread never completed (deadlock?)"
     assert not errors
 
 

--- a/services/dynamic-sidecar/tests/unit/test_modules_attribute_monitor.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_attribute_monitor.py
@@ -5,12 +5,14 @@
 
 import asyncio
 import logging
+import multiprocessing
 import pickle
 import socket
 import threading
 from collections import deque
 from collections.abc import AsyncIterator, Iterator
 from logging.handlers import DEFAULT_UDP_LOGGING_PORT, DatagramHandler
+from multiprocessing.queues import Queue
 from pathlib import Path
 from typing import Final
 from unittest.mock import AsyncMock, Mock
@@ -20,11 +22,15 @@ from faker import Faker
 from fastapi import FastAPI
 from fastapi_lifespan_manager import LifespanManager
 from models_library.basic_types import PortInt
+from pydantic import PositiveFloat
 from pytest_mock import MockerFixture
 from simcore_service_dynamic_sidecar.core.utils import async_command
 from simcore_service_dynamic_sidecar.modules.attribute_monitor import (
     _logging_event_handler,
     configure_attribute_monitor,
+)
+from simcore_service_dynamic_sidecar.modules.attribute_monitor._logging_event_handler import (
+    _LoggingEventHandlerProcess,
 )
 
 # NOTE: multiprocessing logs do not work with logcap,
@@ -116,6 +122,70 @@ async def logging_event_handler_observer(
     async with app_lifespan(fake_app):
         assert fake_app.state.attribute_monitor
         yield None
+
+
+@pytest.fixture
+def health_check_queue() -> Queue[int | None]:
+    return multiprocessing.Queue()
+
+
+@pytest.fixture
+def heart_beat_interval_s() -> PositiveFloat:
+    return 0.01
+
+
+def test_logging_event_handler_process_concurrent_stop_process_does_not_raise(
+    fake_dy_volumes_mount_dir: Path,
+    health_check_queue: Queue[int | None],
+    heart_beat_interval_s: PositiveFloat,
+):
+    observer_process = _LoggingEventHandlerProcess(
+        path_to_observe=fake_dy_volumes_mount_dir,
+        health_check_queue=health_check_queue,
+        heart_beat_interval_s=heart_beat_interval_s,
+    )
+
+    entered_kill = threading.Event()
+    release_kill = threading.Event()
+    first_caller_paused = False
+
+    def _kill() -> None:
+        nonlocal first_caller_paused
+        # only the first caller pauses: it must observe `self._process` as
+        # non-`None` for longer than it takes a concurrent caller to clear it
+        if not first_caller_paused:
+            first_caller_paused = True
+            entered_kill.set()
+            assert release_kill.wait(timeout=5), "test setup: never released"
+
+    mock_process = Mock()
+    mock_process.kill.side_effect = _kill
+    observer_process._process = mock_process  # noqa: SLF001
+
+    errors: list[BaseException] = []
+
+    def _stop_process() -> None:
+        try:
+            observer_process._stop_process()  # noqa: SLF001
+        except BaseException as exc:  # pylint: disable=broad-except
+            errors.append(exc)
+
+    first_thread = threading.Thread(target=_stop_process)
+    first_thread.start()
+    assert entered_kill.wait(timeout=5), "first thread never reached kill()"
+
+    # with the lock this blocks on `_process_lock` and cannot make progress
+    # while the first thread is paused mid-`kill()`; without it, it runs to
+    # completion (clearing `self._process`) before the first thread resumes
+    second_thread = threading.Thread(target=_stop_process)
+    second_thread.start()
+    second_thread.join(timeout=0.5)
+
+    release_kill.set()
+    first_thread.join(timeout=5)
+    second_thread.join(timeout=5)
+
+    assert not errors
 
 
 @pytest.mark.parametrize(

--- a/services/dynamic-sidecar/tests/unit/test_modules_attribute_monitor.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_attribute_monitor.py
@@ -180,6 +180,7 @@ def test_logging_event_handler_process_concurrent_stop_process_does_not_raise(
     second_thread = threading.Thread(target=_stop_process)
     second_thread.start()
     second_thread.join(timeout=0.5)
+    assert second_thread.is_alive(), "second stop_process proceeded before the first one released the lock"
 
     release_kill.set()
     first_thread.join(timeout=5)

--- a/services/dynamic-sidecar/tests/unit/test_modules_attribute_monitor.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_attribute_monitor.py
@@ -5,15 +5,15 @@
 
 import asyncio
 import logging
-import multiprocessing
 import pickle
 import socket
 import threading
 from collections import deque
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from logging.handlers import DEFAULT_UDP_LOGGING_PORT, DatagramHandler
 from multiprocessing.queues import Queue
 from pathlib import Path
+from time import sleep
 from typing import Final
 from unittest.mock import AsyncMock, Mock
 
@@ -39,6 +39,8 @@ from simcore_service_dynamic_sidecar.modules.attribute_monitor._logging_event_ha
 
 DATAGRAM_PORT: Final[PortInt] = PortInt(DEFAULT_UDP_LOGGING_PORT)
 ENSURE_LOGS_DELIVERED: Final[float] = 0.1
+_CONCURRENT_CALLS: Final[int] = 10
+_SLOW_KILL_DURATION_S: Final[float] = 0.1
 
 
 @pytest.fixture
@@ -66,10 +68,7 @@ class LogRecordKeeper:
         self._records.appendleft(x)
 
     def has_log_within(self, **expected_logrec_fields) -> bool:
-        for rec in self._records:
-            if all(str(v) in str(rec[k]) for k, v in expected_logrec_fields.items()):
-                return True
-        return False
+        return any(all(str(v) in str(rec[k]) for k, v in expected_logrec_fields.items()) for rec in self._records)
 
     def __len__(self) -> int:
         return len(self._records)
@@ -124,20 +123,28 @@ async def logging_event_handler_observer(
         yield None
 
 
-@pytest.fixture
-def health_check_queue() -> Queue[int | None]:
-    return multiprocessing.Queue()
-
-
-@pytest.fixture
-def heart_beat_interval_s() -> PositiveFloat:
-    return 0.01
-
-
-def test_logging_event_handler_process_concurrent_stop_process_does_not_raise(
+def test_logging_event_handler_process_concurrent_stop_does_not_raise(
     fake_dy_volumes_mount_dir: Path,
     health_check_queue: Queue[int | None],
     heart_beat_interval_s: PositiveFloat,
+    run_concurrently: Callable[[list[Callable[[], None]]], list[BaseException]],
+):
+    observer_process = _LoggingEventHandlerProcess(
+        path_to_observe=fake_dy_volumes_mount_dir,
+        health_check_queue=health_check_queue,
+        heart_beat_interval_s=heart_beat_interval_s,
+    )
+    # a slow kill() keeps `_process` set long enough for a concurrent caller to observe it
+    observer_process._process = Mock(kill=lambda: sleep(_SLOW_KILL_DURATION_S))  # noqa: SLF001
+
+    assert not run_concurrently([observer_process._stop_process] * _CONCURRENT_CALLS)  # noqa: SLF001
+
+
+def test_logging_event_handler_process_concurrent_start_and_stop_does_not_raise(
+    fake_dy_volumes_mount_dir: Path,
+    health_check_queue: Queue[int | None],
+    heart_beat_interval_s: PositiveFloat,
+    run_concurrently: Callable[[list[Callable[[], None]]], list[BaseException]],
 ):
     observer_process = _LoggingEventHandlerProcess(
         path_to_observe=fake_dy_volumes_mount_dir,
@@ -145,111 +152,12 @@ def test_logging_event_handler_process_concurrent_stop_process_does_not_raise(
         heart_beat_interval_s=heart_beat_interval_s,
     )
 
-    entered_kill = threading.Event()
-    release_kill = threading.Event()
-    first_caller_paused = False
-
-    def _kill() -> None:
-        nonlocal first_caller_paused
-        # only the first caller pauses: it must observe `self._process` as
-        # non-`None` for longer than it takes a concurrent caller to clear it
-        if not first_caller_paused:
-            first_caller_paused = True
-            entered_kill.set()
-            assert release_kill.wait(timeout=5), "test setup: never released"
-
-    mock_process = Mock()
-    mock_process.kill.side_effect = _kill
-    observer_process._process = mock_process  # noqa: SLF001
-
-    errors: list[BaseException] = []
-
-    def _stop_process() -> None:
-        try:
-            observer_process._stop_process()  # noqa: SLF001
-        except BaseException as exc:  # pylint: disable=broad-except
-            errors.append(exc)
-
-    first_thread = threading.Thread(target=_stop_process)
-    first_thread.start()
-    assert entered_kill.wait(timeout=5), "first thread never reached kill()"
-
-    # with the lock this blocks on `_process_lock` and cannot make progress
-    # while the first thread is paused mid-`kill()`; without it, it runs to
-    # completion (clearing `self._process`) before the first thread resumes
-    second_thread = threading.Thread(target=_stop_process)
-    second_thread.start()
-    second_thread.join(timeout=0.5)
-    assert second_thread.is_alive(), "second stop_process proceeded before the first one released the lock"
-
-    release_kill.set()
-    first_thread.join(timeout=5)
-    second_thread.join(timeout=5)
-
-    assert not first_thread.is_alive(), "first thread never completed (deadlock?)"
-    assert not second_thread.is_alive(), "second thread never completed (deadlock?)"
-    assert not errors
-
-
-def test_logging_event_handler_process_concurrent_start_vs_stop_process_does_not_raise(
-    fake_dy_volumes_mount_dir: Path,
-    health_check_queue: Queue[int | None],
-    heart_beat_interval_s: PositiveFloat,
-    mocker: MockerFixture,
-):
-    observer_process = _LoggingEventHandlerProcess(
-        path_to_observe=fake_dy_volumes_mount_dir,
-        health_check_queue=health_check_queue,
-        heart_beat_interval_s=heart_beat_interval_s,
+    assert not run_concurrently(
+        [observer_process.start_process, observer_process._stop_process]  # noqa: SLF001
+        * (_CONCURRENT_CALLS // 2)
     )
 
-    entered_start = threading.Event()
-    release_start = threading.Event()
-    first_caller_paused = False
-
-    def _start() -> None:
-        nonlocal first_caller_paused
-        # pauses while `start_process` still holds `_process_lock`
-        if not first_caller_paused:
-            first_caller_paused = True
-            entered_start.set()
-            assert release_start.wait(timeout=5), "test setup: never released"
-
-    mock_process_cls = Mock()
-    mock_process_cls.return_value.start.side_effect = _start
-    mocker.patch.object(multiprocessing, "Process", mock_process_cls)
-
-    errors: list[BaseException] = []
-
-    def _start_process() -> None:
-        try:
-            observer_process.start_process()
-        except BaseException as exc:  # pylint: disable=broad-except
-            errors.append(exc)
-
-    def _stop_process() -> None:
-        try:
-            observer_process._stop_process()  # noqa: SLF001
-        except BaseException as exc:  # pylint: disable=broad-except
-            errors.append(exc)
-
-    start_thread = threading.Thread(target=_start_process)
-    start_thread.start()
-    assert entered_start.wait(timeout=5), "start thread never reached start()"
-
-    # must block on `_process_lock` while `start_process` is still in progress
-    stop_thread = threading.Thread(target=_stop_process)
-    stop_thread.start()
-    stop_thread.join(timeout=0.5)
-    assert stop_thread.is_alive(), "_stop_process proceeded before start_process released the lock"
-
-    release_start.set()
-    start_thread.join(timeout=5)
-    stop_thread.join(timeout=5)
-
-    assert not start_thread.is_alive(), "start thread never completed (deadlock?)"
-    assert not stop_thread.is_alive(), "stop thread never completed (deadlock?)"
-    assert not errors
+    observer_process.shutdown()
 
 
 @pytest.mark.parametrize(

--- a/services/dynamic-sidecar/tests/unit/test_modules_attribute_monitor.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_attribute_monitor.py
@@ -154,7 +154,7 @@ def test_logging_event_handler_process_concurrent_start_and_stop_does_not_raise(
 
     assert not run_concurrently(
         [observer_process.start_process, observer_process._stop_process]  # noqa: SLF001
-        * (_CONCURRENT_CALLS // 2)
+        * _CONCURRENT_CALLS
     )
 
     observer_process.shutdown()

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
@@ -6,6 +6,7 @@ import multiprocessing
 from collections.abc import AsyncIterable
 from multiprocessing.queues import Queue
 from pathlib import Path
+from threading import Event, Thread
 from typing import Any, Final
 from unittest.mock import Mock
 
@@ -91,6 +92,60 @@ async def test_event_handler_process_lifecycle(
     observer_process.stop_process()
 
     observer_process.shutdown()
+
+
+def test_event_handler_process_concurrent_stop_process_does_not_raise(
+    outputs_context: OutputsContext,
+    health_check_queue: Queue[int | None],
+    heart_beat_interval_s: PositiveFloat,
+) -> None:
+    observer_process = _EventHandlerProcess(
+        outputs_context=outputs_context,
+        health_check_queue=health_check_queue,
+        heart_beat_interval_s=heart_beat_interval_s,
+    )
+
+    entered_kill = Event()
+    release_kill = Event()
+    first_caller_paused = False
+
+    def _kill() -> None:
+        nonlocal first_caller_paused
+        # only the first caller pauses: it must observe `self._process` as
+        # non-`None` for longer than it takes a concurrent caller to clear it
+        if not first_caller_paused:
+            first_caller_paused = True
+            entered_kill.set()
+            assert release_kill.wait(timeout=5), "test setup: never released"
+
+    mock_process = Mock()
+    mock_process.kill.side_effect = _kill
+    observer_process._process = mock_process
+
+    errors: list[BaseException] = []
+
+    def _stop_process() -> None:
+        try:
+            observer_process.stop_process()
+        except BaseException as exc:  # pylint: disable=broad-except
+            errors.append(exc)
+
+    first_thread = Thread(target=_stop_process)
+    first_thread.start()
+    assert entered_kill.wait(timeout=5), "first thread never reached kill()"
+
+    # with the lock this blocks on `_process_lock` and cannot make progress
+    # while the first thread is paused mid-`kill()`; without it, it runs to
+    # completion (clearing `self._process`) before the first thread resumes
+    second_thread = Thread(target=_stop_process)
+    second_thread.start()
+    second_thread.join(timeout=0.5)
+
+    release_kill.set()
+    first_thread.join(timeout=5)
+    second_thread.join(timeout=5)
+
+    assert not errors
 
 
 async def test_event_handler_observer_health_ok(

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
@@ -141,6 +141,7 @@ def test_event_handler_process_concurrent_stop_process_does_not_raise(
     second_thread = Thread(target=_stop_process)
     second_thread.start()
     second_thread.join(timeout=0.5)
+    assert second_thread.is_alive(), "stop_process proceeded before first stop_process released the lock"
 
     release_kill.set()
     first_thread.join(timeout=5)

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 
 import pytest
 from pydantic import PositiveFloat
+from pytest_mock import MockerFixture
 from simcore_service_dynamic_sidecar.modules.notifications._notifications_ports import (
     PortNotifier,
 )
@@ -145,6 +146,69 @@ def test_event_handler_process_concurrent_stop_process_does_not_raise(
     first_thread.join(timeout=5)
     second_thread.join(timeout=5)
 
+    assert not first_thread.is_alive(), "first thread never completed (deadlock?)"
+    assert not second_thread.is_alive(), "second thread never completed (deadlock?)"
+    assert not errors
+
+
+def test_event_handler_process_concurrent_start_vs_stop_process_does_not_raise(
+    outputs_context: OutputsContext,
+    health_check_queue: Queue[int | None],
+    heart_beat_interval_s: PositiveFloat,
+    mocker: MockerFixture,
+):
+    observer_process = _EventHandlerProcess(
+        outputs_context=outputs_context,
+        health_check_queue=health_check_queue,
+        heart_beat_interval_s=heart_beat_interval_s,
+    )
+
+    entered_start = Event()
+    release_start = Event()
+    first_caller_paused = False
+
+    def _start() -> None:
+        nonlocal first_caller_paused
+        # pauses while `start_process` still holds `_process_lock`
+        if not first_caller_paused:
+            first_caller_paused = True
+            entered_start.set()
+            assert release_start.wait(timeout=5), "test setup: never released"
+
+    mock_process_cls = Mock()
+    mock_process_cls.return_value.start.side_effect = _start
+    mocker.patch.object(multiprocessing, "Process", mock_process_cls)
+
+    errors: list[BaseException] = []
+
+    def _start_process() -> None:
+        try:
+            observer_process.start_process()
+        except BaseException as exc:  # pylint: disable=broad-except
+            errors.append(exc)
+
+    def _stop_process() -> None:
+        try:
+            observer_process.stop_process()
+        except BaseException as exc:  # pylint: disable=broad-except
+            errors.append(exc)
+
+    start_thread = Thread(target=_start_process)
+    start_thread.start()
+    assert entered_start.wait(timeout=5), "start thread never reached start()"
+
+    # must block on `_process_lock` while `start_process` is still in progress
+    stop_thread = Thread(target=_stop_process)
+    stop_thread.start()
+    stop_thread.join(timeout=0.5)
+    assert stop_thread.is_alive(), "stop_process proceeded before start_process released the lock"
+
+    release_start.set()
+    start_thread.join(timeout=5)
+    stop_thread.join(timeout=5)
+
+    assert not start_thread.is_alive(), "start thread never completed (deadlock?)"
+    assert not stop_thread.is_alive(), "stop thread never completed (deadlock?)"
     assert not errors
 
 

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
@@ -115,9 +115,7 @@ def test_event_handler_process_concurrent_start_and_stop_does_not_raise(
         heart_beat_interval_s=heart_beat_interval_s,
     )
 
-    assert not run_concurrently(
-        [observer_process.start_process, observer_process.stop_process] * (_CONCURRENT_CALLS // 2)
-    )
+    assert not run_concurrently([observer_process.start_process, observer_process.stop_process] * _CONCURRENT_CALLS)
 
     observer_process.shutdown()
 

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
@@ -98,7 +98,7 @@ def test_event_handler_process_concurrent_stop_process_does_not_raise(
     outputs_context: OutputsContext,
     health_check_queue: Queue[int | None],
     heart_beat_interval_s: PositiveFloat,
-) -> None:
+):
     observer_process = _EventHandlerProcess(
         outputs_context=outputs_context,
         health_check_queue=health_check_queue,
@@ -120,7 +120,7 @@ def test_event_handler_process_concurrent_stop_process_does_not_raise(
 
     mock_process = Mock()
     mock_process.kill.side_effect = _kill
-    observer_process._process = mock_process
+    observer_process._process = mock_process  # noqa: SLF001
 
     errors: list[BaseException] = []
 

--- a/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
+++ b/services/dynamic-sidecar/tests/unit/test_modules_outputs_event_handler.py
@@ -2,17 +2,15 @@
 # pylint: disable=protected-access
 
 import asyncio
-import multiprocessing
-from collections.abc import AsyncIterable
+from collections.abc import AsyncIterable, Callable
 from multiprocessing.queues import Queue
 from pathlib import Path
-from threading import Event, Thread
+from time import sleep
 from typing import Any, Final
 from unittest.mock import Mock
 
 import pytest
 from pydantic import PositiveFloat
-from pytest_mock import MockerFixture
 from simcore_service_dynamic_sidecar.modules.notifications._notifications_ports import (
     PortNotifier,
 )
@@ -30,6 +28,9 @@ from watchdog.events import (
     FileMovedEvent,
     FileSystemEvent,
 )
+
+_CONCURRENT_CALLS: Final[int] = 10
+_SLOW_KILL_DURATION_S: Final[float] = 0.1
 
 
 @pytest.fixture
@@ -67,16 +68,6 @@ async def outputs_manager(
     await outputs_manager.shutdown()
 
 
-@pytest.fixture
-def health_check_queue() -> Queue[int | None]:
-    return multiprocessing.Queue()
-
-
-@pytest.fixture
-def heart_beat_interval_s() -> PositiveFloat:
-    return 0.01
-
-
 async def test_event_handler_process_lifecycle(
     outputs_context: OutputsContext,
     health_check_queue: Queue[int | None],
@@ -95,10 +86,28 @@ async def test_event_handler_process_lifecycle(
     observer_process.shutdown()
 
 
-def test_event_handler_process_concurrent_stop_process_does_not_raise(
+def test_event_handler_process_concurrent_stop_does_not_raise(
     outputs_context: OutputsContext,
     health_check_queue: Queue[int | None],
     heart_beat_interval_s: PositiveFloat,
+    run_concurrently: Callable[[list[Callable[[], None]]], list[BaseException]],
+):
+    observer_process = _EventHandlerProcess(
+        outputs_context=outputs_context,
+        health_check_queue=health_check_queue,
+        heart_beat_interval_s=heart_beat_interval_s,
+    )
+    # a slow kill() keeps `_process` set long enough for a concurrent caller to observe it
+    observer_process._process = Mock(kill=lambda: sleep(_SLOW_KILL_DURATION_S))  # noqa: SLF001
+
+    assert not run_concurrently([observer_process.stop_process] * _CONCURRENT_CALLS)
+
+
+def test_event_handler_process_concurrent_start_and_stop_does_not_raise(
+    outputs_context: OutputsContext,
+    health_check_queue: Queue[int | None],
+    heart_beat_interval_s: PositiveFloat,
+    run_concurrently: Callable[[list[Callable[[], None]]], list[BaseException]],
 ):
     observer_process = _EventHandlerProcess(
         outputs_context=outputs_context,
@@ -106,111 +115,11 @@ def test_event_handler_process_concurrent_stop_process_does_not_raise(
         heart_beat_interval_s=heart_beat_interval_s,
     )
 
-    entered_kill = Event()
-    release_kill = Event()
-    first_caller_paused = False
-
-    def _kill() -> None:
-        nonlocal first_caller_paused
-        # only the first caller pauses: it must observe `self._process` as
-        # non-`None` for longer than it takes a concurrent caller to clear it
-        if not first_caller_paused:
-            first_caller_paused = True
-            entered_kill.set()
-            assert release_kill.wait(timeout=5), "test setup: never released"
-
-    mock_process = Mock()
-    mock_process.kill.side_effect = _kill
-    observer_process._process = mock_process  # noqa: SLF001
-
-    errors: list[BaseException] = []
-
-    def _stop_process() -> None:
-        try:
-            observer_process.stop_process()
-        except BaseException as exc:  # pylint: disable=broad-except
-            errors.append(exc)
-
-    first_thread = Thread(target=_stop_process)
-    first_thread.start()
-    assert entered_kill.wait(timeout=5), "first thread never reached kill()"
-
-    # with the lock this blocks on `_process_lock` and cannot make progress
-    # while the first thread is paused mid-`kill()`; without it, it runs to
-    # completion (clearing `self._process`) before the first thread resumes
-    second_thread = Thread(target=_stop_process)
-    second_thread.start()
-    second_thread.join(timeout=0.5)
-    assert second_thread.is_alive(), "stop_process proceeded before first stop_process released the lock"
-
-    release_kill.set()
-    first_thread.join(timeout=5)
-    second_thread.join(timeout=5)
-
-    assert not first_thread.is_alive(), "first thread never completed (deadlock?)"
-    assert not second_thread.is_alive(), "second thread never completed (deadlock?)"
-    assert not errors
-
-
-def test_event_handler_process_concurrent_start_vs_stop_process_does_not_raise(
-    outputs_context: OutputsContext,
-    health_check_queue: Queue[int | None],
-    heart_beat_interval_s: PositiveFloat,
-    mocker: MockerFixture,
-):
-    observer_process = _EventHandlerProcess(
-        outputs_context=outputs_context,
-        health_check_queue=health_check_queue,
-        heart_beat_interval_s=heart_beat_interval_s,
+    assert not run_concurrently(
+        [observer_process.start_process, observer_process.stop_process] * (_CONCURRENT_CALLS // 2)
     )
 
-    entered_start = Event()
-    release_start = Event()
-    first_caller_paused = False
-
-    def _start() -> None:
-        nonlocal first_caller_paused
-        # pauses while `start_process` still holds `_process_lock`
-        if not first_caller_paused:
-            first_caller_paused = True
-            entered_start.set()
-            assert release_start.wait(timeout=5), "test setup: never released"
-
-    mock_process_cls = Mock()
-    mock_process_cls.return_value.start.side_effect = _start
-    mocker.patch.object(multiprocessing, "Process", mock_process_cls)
-
-    errors: list[BaseException] = []
-
-    def _start_process() -> None:
-        try:
-            observer_process.start_process()
-        except BaseException as exc:  # pylint: disable=broad-except
-            errors.append(exc)
-
-    def _stop_process() -> None:
-        try:
-            observer_process.stop_process()
-        except BaseException as exc:  # pylint: disable=broad-except
-            errors.append(exc)
-
-    start_thread = Thread(target=_start_process)
-    start_thread.start()
-    assert entered_start.wait(timeout=5), "start thread never reached start()"
-
-    # must block on `_process_lock` while `start_process` is still in progress
-    stop_thread = Thread(target=_stop_process)
-    stop_thread.start()
-    stop_thread.join(timeout=0.5)
-    assert stop_thread.is_alive(), "stop_process proceeded before start_process released the lock"
-
-    release_start.set()
-    start_thread.join(timeout=5)
-    stop_thread.join(timeout=5)
-
-    assert not start_thread.is_alive(), "start thread never completed (deadlock?)"
-    assert not stop_thread.is_alive(), "stop thread never completed (deadlock?)"
-    assert not errors
+    observer_process.shutdown()
 
 
 async def test_event_handler_observer_health_ok(


### PR DESCRIPTION
## What do these changes do?

Guards the dynamic-sidecar watchdog process lifecycle (`EventHandlerObserver` / `LoggingEventHandlerObserver`) against a TOCTOU race on `self._process`, plus two bugs found while fixing it.

**Background:** the health worker (a background asyncio task) restarts the watchdog process from a `ThreadPoolExecutor` thread whenever heartbeats stop, while `start()`/`stop()` can run on the event-loop thread at any time. Nothing previously synchronized access to `self._process` between them.

### 1. Stop-vs-stop race (the crash seen in CI)

`stop_process()` read `self._process` three separate times with no lock:

```python
if self._process:
    self._process.kill()
    self._process.join()
    self._process = None
```

```mermaid
sequenceDiagram
    participant A as stop_process (thread A)
    participant B as stop_process (thread B)
    A->>A: if self._process: → True
    A->>A: self._process.kill()
    B->>B: if self._process: → True (not yet cleared)
    B->>B: self._process.kill()
    B->>B: self._process.join()
    B->>B: self._process = None
    A->>A: self._process.join() 💥 AttributeError: 'NoneType' has no attribute 'join'
```

### 2. Start-vs-stop race (same root cause, narrower window)

`start_process()` was equally unguarded, so a `stop_process()` landing mid-start could join/null a process that had just been (re)created:

```mermaid
sequenceDiagram
    participant Stop as stop_process()
    participant Start as start_process() (health-worker restart)
    Stop->>Stop: if self._process: → True (old process)
    Stop->>Stop: self._process.kill() → kills OLD process
    Start->>Start: self._process = NEW Process(...)
    Start->>Start: self._process.start()
    Stop->>Stop: self._process.join() → joins the NEW, barely-started process
    Stop->>Stop: self._process = None → leaks the new process, never tracked again
```

**Fix:** a `threading.Lock` (`_process_lock`) now wraps **both** `start_process()` and `stop_process()`, serializing every access to `self._process`.

### 3. Stale stop-queue reused across restarts

`stop_process()` pushes a sentinel into `self._stop_queue`, but the worker only checks `qsize() == 0` — it never actually consumes it. Since the queue was never recreated, a restarted worker saw a non-empty queue immediately and exited right after starting. `start_process()` now creates a fresh `self._stop_queue` before spawning the new process.

### 4. `stop()` shutdown ordering

The health worker is the only other user of the process. `stop()` now cancels/awaits the health-worker task **before** the final `_stop_observer_process()` call (moved to `to_thread`, since it can now block on the lock), guaranteeing no restart can be triggered after `stop()` returns. Wrapped in `try/finally` so the process is still shut down even if awaiting the health-worker task re-raises a real (non-cancellation) exception.

## Related issue/s

N/A

## How to test

```bash
cd services/dynamic-sidecar
make install-dev
pytest -vv \
  tests/unit/test_modules_outputs_event_handler.py \
  tests/unit/test_modules_attribute_monitor.py \
  tests/unit/test_modules_outputs_watcher.py
```

## Dev-ops
- No changes.
