### PR TITLE
🐛 fix: avoid raise on exception handling and localization config added to the `statics` endpoint

### DIFF
--- a/packages/service-library/src/servicelib/aiohttp/client_session.py
+++ b/packages/service-library/src/servicelib/aiohttp/client_session.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from aiohttp import ClientSession, ClientTimeout, web
@@ -13,7 +13,7 @@ from .application_keys import APP_CLIENT_SESSION_KEY
 
 
 @asynccontextmanager
-async def persistent_client_session(app: web.Application) -> AsyncIterator[None]:
+async def persistent_client_session(app: web.Application) -> AsyncGenerator[None]:
     """Ensures a single client session per application
 
     IMPORTANT: Use this function ONLY in cleanup context , i.e.

--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/storage_client.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/storage_client.py
@@ -112,7 +112,7 @@ async def retry_request(
             async with _session_method(session, method, url, **kwargs) as response:
                 if response.status != expected_status:
                     # this is a more precise raise_for_status()
-                    error_msg = await response.json()
+                    error_msg = await response.text()
                     response.release()
                     raise ClientResponseError(
                         response.request_info,

--- a/services/dynamic-sidecar/tests/unit/api/rest/test_containers_long_running_tasks.py
+++ b/services/dynamic-sidecar/tests/unit/api/rest/test_containers_long_running_tasks.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import json
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Iterator
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import Any, Final, NamedTuple
@@ -117,7 +117,7 @@ def mock_tasks(mocker: MockerFixture) -> Iterator[None]:
 
 
 @asynccontextmanager
-async def auto_remove_task(http_client: HttpClient, task_id: TaskId) -> AsyncIterator[None]:
+async def auto_remove_task(http_client: HttpClient, task_id: TaskId) -> AsyncGenerator[None]:
     """cleanup pending tasks"""
     try:
         yield

--- a/services/web/server/src/simcore_service_webserver/application_settings.py
+++ b/services/web/server/src/simcore_service_webserver/application_settings.py
@@ -282,7 +282,7 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
     ]
 
     WEBSERVER_LICENSES: Annotated[
-        LicensesSettings | None | bool,
+        LicensesSettings | bool | None,
         Field(
             json_schema_extra={"auto_default_from_env": True},
             # NOTE: `bool` is to keep backwards compatibility
@@ -595,6 +595,7 @@ class ApplicationSettings(BaseApplicationSettings, MixinLoggingSettings):
                 "SIMCORE_VCS_RELEASE_URL": True,
                 "SWARM_STACK_NAME": True,
                 "WEBSERVER_DEV_FEATURES_ENABLED": True,
+                "WEBSERVER_LOCALIZED_MESSAGES_ENABLED": True,
                 "WEBSERVER_LOGIN": {
                     "LOGIN_ACCOUNT_DELETION_RETENTION_DAYS",
                     "LOGIN_2FA_REQUIRED",

--- a/services/web/server/tests/unit/isolated/test_application_settings.py
+++ b/services/web/server/tests/unit/isolated/test_application_settings.py
@@ -111,6 +111,7 @@ def test_settings_to_client_statics_plugins(
 
     assert "webserverLicenses" not in statics
     assert "webserverDevFeaturesEnabled" in statics
+    assert "webserverLocalizedMessagesEnabled" in statics
 
     assert (
         statics["webserverLogin"]["LOGIN_ACCOUNT_DELETION_RETENTION_DAYS"]
@@ -228,8 +229,10 @@ def mock_service_environment(
     service_name: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> EnvVarsDict:
-    # NOTE: the name of the service in real deploys are not necessarily the ones we have here in the docker-compose
-    # Typically they include prefixes with the deployment name e.g. master-webserver or staging-webserver instead of just webserver
+    # NOTE: the name of the service in real deploys are not necessarily
+    # the ones we have here in the docker-compose
+    # Typically they include prefixes with the deployment name e.g.
+    # master-webserver or staging-webserver instead of just webserver
     _logger.info("Mocking envs for service: %s", service_name)
 
     assert docker_compose_service_environment_dict


### PR DESCRIPTION

  
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

Following up with a timeout in storage on the inhouse deploy, I found that the exception handling of it was raising since the response is not json

```
 File "/home/scu/.venv/lib/python3.13/site-packages/simcore_sdk/node_ports_common/storage_client.py", line 115, in retry_request
      error_msg = await response.json()
                  ^^^^^^^^^^^^^^^^^^^^^
    File "/home/scu/.venv/lib/python3.13/site-packages/aiohttp/client_reqrep.py", line 778, in json
      raise ContentTypeError(
      ...<7 lines>...
      )
  aiohttp.client_exceptions.ContentTypeError: 504, message='Attempt to decode JSON with unexpected mimetype: ', 
  
```  

## Extras

- @odeimaiz new field in `webserverLocalizedMessagesEnabled` in statics, corresponding to `WEBSERVER_LOCALIZED_MESSAGES_ENABLED` config in the backend
- fixed `asynccontextmanager` deprecation warning (causes most of the noise) in a trial to reduce the number of ongoing warning


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
