### PR TITLE
🐛 🔒️ fix(simcore-sdk): sanitize sensitive credentials in rclone command logging

### DIFF
--- a/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_utils.py
+++ b/packages/simcore-sdk/src/simcore_sdk/node_ports_common/r_clone_utils.py
@@ -15,6 +15,42 @@ from ._utils import BaseLogParser
 
 _logger = logging.getLogger(__name__)
 
+_PLACEHOLDER: Final[str] = "*" * 8
+_SENSITIVE_RCLONE_FLAGS: Final[set[str]] = {
+    "--pass",
+    "--password",
+    "--secret-access-key",
+    "--access-key-id",
+    "--auth",
+    "--api-key",
+    "--bearer-token",
+    "--client-secret",
+    "--client-id",
+}
+
+
+def _sanitize_rclone_command(command: list[str]) -> list[str]:
+    """Sanitize rclone command by masking sensitive credentials before logging."""
+    skip_indices = set()
+    result = []
+
+    for i, arg in enumerate(command):
+        if i in skip_indices:
+            continue
+
+        if "=" in arg:
+            flag_part = arg.split("=", 1)[0]
+            result.append(f"{flag_part}={_PLACEHOLDER}" if flag_part in _SENSITIVE_RCLONE_FLAGS else arg)
+        elif arg in _SENSITIVE_RCLONE_FLAGS:
+            result.append(arg)
+            if i + 1 < len(command) and not command[i + 1].startswith("-"):
+                result.append(_PLACEHOLDER)
+                skip_indices.add(i + 1)
+        else:
+            result.append(arg)
+
+    return result
+
 
 class _RCloneSyncMessageBase(BaseModel):
     level: str = Field(..., description="log level")
@@ -144,7 +180,7 @@ def overwrite_command(source_command: list[str], *, edit: EditArguments, remove:
             _logger.warning(
                 "cannot remove entry='%s' as it does not exist in command='%s'",
                 search_entry,
-                source_command,
+                _sanitize_rclone_command(source_command),
             )
 
     return new_command
@@ -160,12 +196,13 @@ def get_effective_vfs_write_back_seconds(resolved_command: list[str]) -> int:
         ValueError: If the flag is missing or has no value
     """
     if _VFS_WRITE_BACK_FLAG not in resolved_command:
-        msg = f"'{_VFS_WRITE_BACK_FLAG}' not found in resolved command={resolved_command}"
+        msg = f"'{_VFS_WRITE_BACK_FLAG}' not found in resolved command={_sanitize_rclone_command(resolved_command)}"
         raise ValueError(msg)
 
     idx = resolved_command.index(_VFS_WRITE_BACK_FLAG)
     if idx + 1 >= len(resolved_command):
-        msg = f"'{_VFS_WRITE_BACK_FLAG}' is missing its value in resolved command={resolved_command}"
+        sanitized_cmd = _sanitize_rclone_command(resolved_command)
+        msg = f"'{_VFS_WRITE_BACK_FLAG}' is missing its value in resolved command={sanitized_cmd}"
         raise ValueError(msg)
 
     value_str = resolved_command[idx + 1]
@@ -175,7 +212,7 @@ def get_effective_vfs_write_back_seconds(resolved_command: list[str]) -> int:
             "could not parse value '%s' for '%s' in resolved command='%s'",
             value_str,
             _VFS_WRITE_BACK_FLAG,
-            resolved_command,
+            _sanitize_rclone_command(resolved_command),
         )
     return total
 

--- a/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_utils.py
+++ b/packages/simcore-sdk/tests/unit/test_node_ports_common_r_clone_utils.py
@@ -13,6 +13,7 @@ from simcore_sdk.node_ports_common.r_clone_utils import (
     _RCloneSyncTransferCompletedMessage,
     _RCloneSyncTransferringMessage,
     _RCloneSyncUpdatedMessage,
+    _sanitize_rclone_command,
     overwrite_command,
 )
 
@@ -158,3 +159,130 @@ _SOURCE_COMMAND: Final[list[str]] = [
 )
 def test_overwrite_command(edit: EditArguments, remove: RemoveArguments, expected_command: list[str]) -> None:
     assert overwrite_command(_SOURCE_COMMAND, edit=edit, remove=remove) == expected_command
+
+
+@pytest.mark.parametrize(
+    "command,expected_sanitized",
+    [
+        pytest.param(
+            [
+                "rclone",
+                "--config",
+                "/path/to/config",
+                "--transfers",
+                "16",
+            ],
+            [
+                "rclone",
+                "--config",
+                "/path/to/config",
+                "--transfers",
+                "16",
+            ],
+            id="no-sensitive-data",
+        ),
+        pytest.param(
+            [
+                "rclone",
+                "--pass",
+                "my-secret-password",
+                "sync",
+                "source",
+                "dest",
+            ],
+            [
+                "rclone",
+                "--pass",
+                "********",
+                "sync",
+                "source",
+                "dest",
+            ],
+            id="mask-pass-flag",
+        ),
+        pytest.param(
+            [
+                "rclone",
+                "--password=my-secret-password",
+                "sync",
+            ],
+            [
+                "rclone",
+                "--password=********",
+                "sync",
+            ],
+            id="mask-password-embedded",
+        ),
+        pytest.param(
+            [
+                "rclone",
+                "--secret-access-key",
+                "AKIA1234567890ABCDEF",
+                "--access-key-id",
+                "AKIAIOSFODNN7EXAMPLE",
+            ],
+            [
+                "rclone",
+                "--secret-access-key",
+                "********",
+                "--access-key-id",
+                "********",
+            ],
+            id="mask-aws-credentials",
+        ),
+        pytest.param(
+            [
+                "rclone",
+                "--api-key",
+                "sk_test_123456789",
+                "--bearer-token=some_token_value",
+            ],
+            [
+                "rclone",
+                "--api-key",
+                "********",
+                "--bearer-token=********",
+            ],
+            id="mask-api-keys",
+        ),
+        pytest.param(
+            [
+                "rclone",
+                "--auth",
+                "user:password",
+                "--client-secret",
+                "client_secret_value",
+                "--config",
+                "/etc/rclone.conf",
+            ],
+            [
+                "rclone",
+                "--auth",
+                "********",
+                "--client-secret",
+                "********",
+                "--config",
+                "/etc/rclone.conf",
+            ],
+            id="mask-auth-and-client-secret",
+        ),
+        pytest.param(
+            [
+                "rclone",
+                "--client-id=my_id",
+                "--pass=secret",
+                "sync",
+            ],
+            [
+                "rclone",
+                "--client-id=********",
+                "--pass=********",
+                "sync",
+            ],
+            id="mask-multiple-embedded-flags",
+        ),
+    ],
+)
+def test_sanitize_rclone_command(command: list[str], expected_sanitized: list[str]) -> None:
+    """Test that sensitive data in rclone commands is properly masked."""
+    assert _sanitize_rclone_command(command) == expected_sanitized


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request introduces a utility to sanitize sensitive credentials in `rclone` commands before they are logged, improving security and privacy. The main changes include the implementation of the `_sanitize_rclone_command` function, integration of this sanitizer into existing logging and error reporting, and comprehensive unit tests to verify its behavior.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
- No changes.