### PR TITLE
🐛 fix(service-library): mark RabbitMQ clients unhealthy on connection loss

### DIFF
--- a/packages/service-library/src/servicelib/rabbitmq/_client_base.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_base.py
@@ -52,7 +52,7 @@ class RabbitMQClientBase:
                         error_context={"sender": sender},
                     )
                 )
-                self._healthy_state = False
+            self._healthy_state = False
 
     def _channel_close_callback(
         self,

--- a/packages/service-library/src/servicelib/rabbitmq/_client_base.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_base.py
@@ -52,50 +52,65 @@ class RabbitMQClientBase:
         sender: Any,  # pylint: disable=unused-argument
         exc: BaseException | None,
     ) -> None:
-        if exc:
-            if isinstance(exc, asyncio.CancelledError | aiormq.exceptions.ConnectionClosed):
-                _logger.info(
-                    **create_troubleshooting_log_kwargs(
-                        "RabbitMQ connection closed",
-                        error=exc,
-                        error_context={"sender": sender},
-                    )
+        if not exc:
+            return
+
+        if isinstance(exc, asyncio.CancelledError):
+            _logger.info(
+                **create_troubleshooting_log_kwargs(
+                    "RabbitMQ connection cancelled",
+                    error=exc,
+                    error_context={"sender": sender},
                 )
-            else:
-                _logger.error(
-                    **create_troubleshooting_log_kwargs(
-                        "RabbitMQ connection closed with unexpected error",
-                        error=exc,
-                        error_context={"sender": sender},
-                    )
-                )
-            self._mark_unhealthy()
+            )
+            return
+
+        _logger.error(
+            **create_troubleshooting_log_kwargs(
+                "RabbitMQ connection closed",
+                error=exc,
+                error_context={"sender": sender},
+            )
+        )
+        self._mark_unhealthy()
 
     def _channel_close_callback(
         self,
         sender: Any,
         exc: BaseException | None,
     ) -> None:
-        if exc:
-            if isinstance(exc, asyncio.CancelledError | aiormq.exceptions.ChannelClosed) or (
-                isinstance(exc, aiormq.exceptions.ConnectionClosed) and _AWS_MAINTENANCE_MODE_MESSAGE in f"{exc}"
-            ):
-                _logger.info(
-                    **create_troubleshooting_log_kwargs(
-                        "RabbitMQ channel closed gracefully (maintenance mode)",
-                        error=exc,
-                        error_context={"sender": sender},
-                    )
+        if not exc:
+            return
+
+        if isinstance(exc, asyncio.CancelledError):
+            _logger.info(
+                **create_troubleshooting_log_kwargs(
+                    "RabbitMQ channel cancelled",
+                    error=exc,
+                    error_context={"sender": sender},
                 )
-            else:
-                _logger.error(
-                    **create_troubleshooting_log_kwargs(
-                        "RabbitMQ channel closed with unexpected error",
-                        error=exc,
-                        error_context={"sender": sender},
-                    )
+            )
+            return
+
+        if isinstance(exc, aiormq.exceptions.ChannelClosed) or (
+            isinstance(exc, aiormq.exceptions.ConnectionClosed) and _AWS_MAINTENANCE_MODE_MESSAGE in f"{exc}"
+        ):
+            _logger.info(
+                **create_troubleshooting_log_kwargs(
+                    "RabbitMQ channel closed gracefully (maintenance mode)",
+                    error=exc,
+                    error_context={"sender": sender},
                 )
-            self._mark_unhealthy()
+            )
+        else:
+            _logger.error(
+                **create_troubleshooting_log_kwargs(
+                    "RabbitMQ channel closed with unexpected error",
+                    error=exc,
+                    error_context={"sender": sender},
+                )
+            )
+        self._mark_unhealthy()
 
     def _connection_reconnect_callback(
         self,

--- a/packages/service-library/src/servicelib/rabbitmq/_client_base.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_base.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
+import time
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Final
 
 import aio_pika
@@ -12,6 +13,11 @@ from settings_library.rabbit import RabbitSettings
 from ..logging_utils import log_catch
 
 _DEFAULT_RABBITMQ_SERVER_HEARTBEAT_S: Final[int] = 60
+
+# How long a disconnect is tolerated (e.g. AWS MQ maintenance restarts) before
+# `healthy` reports False. Avoids flapping unhealthy for brief, self-healing
+# reconnects handled transparently by aio_pika's RobustConnection.
+_DEFAULT_HEALTH_GRACE_PERIOD_S: Final[float] = 10
 
 _logger = logging.getLogger(__name__)
 
@@ -27,8 +33,19 @@ class RabbitMQClientBase:
     client_name: str
     settings: RabbitSettings
     heartbeat: int = _DEFAULT_RABBITMQ_SERVER_HEARTBEAT_S
+    grace_period_s: float = _DEFAULT_HEALTH_GRACE_PERIOD_S
 
     _healthy_state: bool = True
+    _unhealthy_since: float | None = field(default=None, init=False, repr=False)
+
+    def _mark_unhealthy(self) -> None:
+        self._healthy_state = False
+        if self._unhealthy_since is None:
+            self._unhealthy_since = time.monotonic()
+
+    def _mark_healthy(self) -> None:
+        self._healthy_state = True
+        self._unhealthy_since = None
 
     def _connection_close_callback(
         self,
@@ -52,7 +69,7 @@ class RabbitMQClientBase:
                         error_context={"sender": sender},
                     )
                 )
-            self._healthy_state = False
+            self._mark_unhealthy()
 
     def _channel_close_callback(
         self,
@@ -78,7 +95,7 @@ class RabbitMQClientBase:
                         error_context={"sender": sender},
                     )
                 )
-                self._healthy_state = False
+            self._mark_unhealthy()
 
     def _connection_reconnect_callback(
         self,
@@ -88,11 +105,15 @@ class RabbitMQClientBase:
             "RabbitMQ (re)connected (%s): restoring healthy state",
             self.client_name,
         )
-        self._healthy_state = True
+        self._mark_healthy()
 
     @property
     def healthy(self) -> bool:
-        return self._healthy_state
+        if self._healthy_state:
+            return True
+        if self._unhealthy_since is None:
+            return False
+        return (time.monotonic() - self._unhealthy_since) < self.grace_period_s
 
     async def ping(self) -> bool:
         with log_catch(_logger, reraise=False):

--- a/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
+++ b/packages/service-library/src/servicelib/rabbitmq/_client_rpc.py
@@ -115,9 +115,9 @@ class RabbitMQRPCClient(RabbitMQClientBase):
                 async with self._surface_lock:
                     await self._rebuild_rpc_surface()
             except Exception:
-                self._healthy_state = False
+                self._mark_unhealthy()
                 raise
-            self._healthy_state = True
+            self._mark_healthy()
 
     async def close(self) -> None:
         with log_context(

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_client_base.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_client_base.py
@@ -101,15 +101,21 @@ def test_channel_close_callback_with_no_exception_stays_healthy(
 # ---------------------------------------------------------------------------
 
 
-def test_connection_close_callback_with_connection_closed_stays_healthy(
+def test_connection_close_callback_with_cancelled_error_marks_unhealthy(
     client_base: RabbitMQClientBase,
 ):
-    # Create a mock with __str__ method that includes the maintenance mode message
+    client_base._connection_close_callback(sender="1", exc=asyncio.CancelledError())
+    assert client_base.healthy is False
+
+
+def test_connection_close_callback_with_connection_closed_marks_unhealthy(
+    client_base: RabbitMQClientBase,
+):
     mock_reply = MagicMock(reply_code=320, reply_text="CONNECTION_FORCED - Node was put into maintenance mode")
     mock_reply.__str__.return_value = "CONNECTION_FORCED - Node was put into maintenance mode"
     exc = aiormq.exceptions.ConnectionClosed(mock_reply)
     client_base._connection_close_callback(sender="1", exc=exc)
-    assert client_base.healthy is True
+    assert client_base.healthy is False
 
 
 def test_connection_close_callback_with_unexpected_error_marks_unhealthy(

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_client_base.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_client_base.py
@@ -38,7 +38,8 @@ def client_base(rabbit_settings: RabbitSettings) -> RabbitMQClientBase:
         async def close(self) -> None:
             pass
 
-    return _Concrete(client_name="test-client", settings=rabbit_settings)
+    # grace_period_s=0 so these tests observe the raw state transition immediately
+    return _Concrete(client_name="test-client", settings=rabbit_settings, grace_period_s=0)
 
 
 # ---------------------------------------------------------------------------
@@ -46,37 +47,38 @@ def client_base(rabbit_settings: RabbitSettings) -> RabbitMQClientBase:
 # ---------------------------------------------------------------------------
 
 
-def test_channel_close_callback_with_connection_closed_stays_healthy(
+def test_channel_close_callback_with_connection_closed_marks_unhealthy(
     client_base: RabbitMQClientBase,
 ):
     """When the broker forces connection closure (AWS MQ maintenance, AMQP 320
     CONNECTION_FORCED), _channel_close_callback receives a ConnectionClosed
-    exception. This must NOT mark the client unhealthy — aio_pika's
-    RobustConnection handles reconnection automatically."""
+    exception. Any close marks the client unhealthy immediately; the
+    grace period (not exercised here, grace_period_s=0) is what tolerates
+    brief, self-healing reconnects handled by aio_pika's RobustConnection."""
     # Create a mock with __str__ method that includes the maintenance mode message
     reply_text = "CONNECTION_FORCED - Node was put into maintenance mode"
     mock_reply = MagicMock(reply_code=320, reply_text=reply_text)
     mock_reply.__str__.return_value = reply_text
     exc = aiormq.exceptions.ConnectionClosed(mock_reply)
     client_base._channel_close_callback(sender="1", exc=exc)
-    assert client_base.healthy is True
+    assert client_base.healthy is False
 
 
-def test_channel_close_callback_with_cancelled_error_stays_healthy(
+def test_channel_close_callback_with_cancelled_error_marks_unhealthy(
     client_base: RabbitMQClientBase,
 ):
-    """asyncio.CancelledError during shutdown must not mark the client unhealthy."""
+    """asyncio.CancelledError during shutdown still marks the client unhealthy."""
     client_base._channel_close_callback(sender="1", exc=asyncio.CancelledError())
-    assert client_base.healthy is True
+    assert client_base.healthy is False
 
 
-def test_channel_close_callback_with_channel_closed_stays_healthy(
+def test_channel_close_callback_with_channel_closed_marks_unhealthy(
     client_base: RabbitMQClientBase,
 ):
-    """A normal ChannelClosed (e.g. consumer cancel) must not mark the client unhealthy."""
+    """A normal ChannelClosed (e.g. consumer cancel) marks the client unhealthy."""
     exc = aiormq.exceptions.ChannelClosed(MagicMock(reply_code=404, reply_text="NOT_FOUND"))
     client_base._channel_close_callback(sender="1", exc=exc)
-    assert client_base.healthy is True
+    assert client_base.healthy is False
 
 
 def test_channel_close_callback_with_unexpected_error_marks_unhealthy(
@@ -142,3 +144,67 @@ def test_connection_reconnect_callback_restores_healthy_state(
 
     client_base._connection_reconnect_callback()
     assert client_base.healthy is True
+
+
+# ---------------------------------------------------------------------------
+# grace period — tolerate brief, self-healing disconnects
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client_base_with_grace_period(rabbit_settings: RabbitSettings) -> RabbitMQClientBase:
+    class _Concrete(RabbitMQClientBase):
+        async def close(self) -> None:
+            pass
+
+    return _Concrete(client_name="test-client", settings=rabbit_settings, grace_period_s=10)
+
+
+def test_disconnect_within_grace_period_stays_healthy(
+    client_base_with_grace_period: RabbitMQClientBase,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A disconnect must not be surfaced as unhealthy until it outlasts the
+    grace period, so brief AWS MQ maintenance blips don't trigger restarts."""
+    fake_now = 1_000.0
+    monkeypatch.setattr("servicelib.rabbitmq._client_base.time.monotonic", lambda: fake_now)
+
+    client_base_with_grace_period._connection_close_callback(sender="1", exc=RuntimeError("unexpected"))
+    assert client_base_with_grace_period.healthy is True
+
+    fake_now += 5  # still within the 10s grace period
+    assert client_base_with_grace_period.healthy is True
+
+
+def test_disconnect_beyond_grace_period_becomes_unhealthy(
+    client_base_with_grace_period: RabbitMQClientBase,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Once the disconnect outlasts the grace period, healthy must report False."""
+    fake_now = 1_000.0
+    monkeypatch.setattr("servicelib.rabbitmq._client_base.time.monotonic", lambda: fake_now)
+
+    client_base_with_grace_period._connection_close_callback(sender="1", exc=RuntimeError("unexpected"))
+    assert client_base_with_grace_period.healthy is True
+
+    fake_now += 11  # beyond the 10s grace period
+    assert client_base_with_grace_period.healthy is False
+
+
+def test_reconnect_within_grace_period_resets_timer(
+    client_base_with_grace_period: RabbitMQClientBase,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A successful reconnect clears the disconnect timer, so a later
+    disconnect starts its own grace period rather than reusing a stale one."""
+    fake_now = 1_000.0
+    monkeypatch.setattr("servicelib.rabbitmq._client_base.time.monotonic", lambda: fake_now)
+
+    client_base_with_grace_period._connection_close_callback(sender="1", exc=RuntimeError("unexpected"))
+    fake_now += 5
+    client_base_with_grace_period._connection_reconnect_callback()
+    assert client_base_with_grace_period.healthy is True
+
+    fake_now += 8  # would have exceeded the original grace window, but the timer was reset
+    client_base_with_grace_period._connection_close_callback(sender="1", exc=RuntimeError("unexpected"))
+    assert client_base_with_grace_period.healthy is True

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_client_base.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_client_base.py
@@ -64,12 +64,11 @@ def test_channel_close_callback_with_connection_closed_marks_unhealthy(
     assert client_base.healthy is False
 
 
-def test_channel_close_callback_with_cancelled_error_marks_unhealthy(
+def test_channel_close_callback_with_cancelled_error_stays_healthy(
     client_base: RabbitMQClientBase,
 ):
-    """asyncio.CancelledError during shutdown still marks the client unhealthy."""
     client_base._channel_close_callback(sender="1", exc=asyncio.CancelledError())
-    assert client_base.healthy is False
+    assert client_base.healthy is True
 
 
 def test_channel_close_callback_with_channel_closed_marks_unhealthy(
@@ -103,11 +102,11 @@ def test_channel_close_callback_with_no_exception_stays_healthy(
 # ---------------------------------------------------------------------------
 
 
-def test_connection_close_callback_with_cancelled_error_marks_unhealthy(
+def test_connection_close_callback_with_cancelled_error_stays_healthy(
     client_base: RabbitMQClientBase,
 ):
     client_base._connection_close_callback(sender="1", exc=asyncio.CancelledError())
-    assert client_base.healthy is False
+    assert client_base.healthy is True
 
 
 def test_connection_close_callback_with_connection_closed_marks_unhealthy(

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
@@ -320,6 +320,7 @@ async def test_rpc_client_recovers_after_broker_disruption(
 
 
 async def test_rpc_client_stays_unhealthy_when_rebuild_fails(rpc_client: RabbitMQRPCClient, mocker: MockerFixture):
+    rpc_client.grace_period_s = 0  # observe the raw state transition immediately
     mocker.patch.object(rpc_client, "_rebuild_rpc_surface", side_effect=RuntimeError("boom"))
     assert rpc_client.healthy is True
 

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
@@ -396,3 +396,38 @@ async def test_rpc_client_recovers_when_broker_closes_all_connections(
             assert rpc_client.healthy is True
             assert _get_rpc_result_queue_name(rpc_client) != queue_before
             assert await rpc_client.request(namespace, RPCMethodName(add_me.__name__), x=4, y=5) == 9
+
+
+@pytest.mark.no_cleanup_check_rabbitmq_server_has_no_errors
+async def test_rpc_client_recovers_after_broker_restart(rpc_client: RabbitMQRPCClient, namespace: RPCNamespace):
+    await rpc_client.register_handler(namespace, RPCMethodName(add_me.__name__), add_me)
+    assert await rpc_client.request(namespace, RPCMethodName(add_me.__name__), x=1, y=3) == 4
+    queue_before = _get_rpc_result_queue_name(rpc_client)
+
+    async with aiodocker.Docker() as docker_client:
+        containers = await docker_client.containers.list(filters={"name": ["rabbit"]})
+        assert len(containers) == 1, "missing rabbit container!"
+        rabbit_container = containers[0]
+        stop_instance = await rabbit_container.exec(["rabbitmqctl", "stop_app"])
+        stop_stream = stop_instance.start()
+        async with stop_stream:
+            while await stop_stream.read_out() is not None:
+                pass
+        assert (await stop_instance.inspect())["ExitCode"] == 0
+        try:
+            async for attempt in AsyncRetrying(stop=stop_after_delay(10), wait=wait_fixed(1), reraise=True):
+                with attempt:
+                    assert rpc_client.healthy is False
+        finally:
+            start_instance = await rabbit_container.exec(["rabbitmqctl", "start_app"])
+            start_stream = start_instance.start()
+            async with start_stream:
+                while await start_stream.read_out() is not None:
+                    pass
+            assert (await start_instance.inspect())["ExitCode"] == 0
+
+    async for attempt in AsyncRetrying(stop=stop_after_delay(60), wait=wait_fixed(1), reraise=True):
+        with attempt:
+            assert rpc_client.healthy is True
+            assert _get_rpc_result_queue_name(rpc_client) != queue_before
+            assert await rpc_client.request(namespace, RPCMethodName(add_me.__name__), x=4, y=5) == 9

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
@@ -415,7 +415,9 @@ async def test_rpc_client_recovers_after_broker_restart(rpc_client: RabbitMQRPCC
                 while await stop_stream.read_out() is not None:
                     pass
             assert (await stop_instance.inspect())["ExitCode"] == 0
-            async for attempt in AsyncRetrying(stop=stop_after_delay(10), wait=wait_fixed(1), reraise=True):
+            # allow for the client's health grace period (tolerates brief,
+            # self-healing disconnects) before it must report unhealthy
+            async for attempt in AsyncRetrying(stop=stop_after_delay(20), wait=wait_fixed(1), reraise=True):
                 with attempt:
                     assert rpc_client.healthy is False
         finally:

--- a/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
+++ b/packages/service-library/tests/rabbitmq/test_rabbitmq_rpc.py
@@ -409,12 +409,12 @@ async def test_rpc_client_recovers_after_broker_restart(rpc_client: RabbitMQRPCC
         assert len(containers) == 1, "missing rabbit container!"
         rabbit_container = containers[0]
         stop_instance = await rabbit_container.exec(["rabbitmqctl", "stop_app"])
-        stop_stream = stop_instance.start()
-        async with stop_stream:
-            while await stop_stream.read_out() is not None:
-                pass
-        assert (await stop_instance.inspect())["ExitCode"] == 0
         try:
+            stop_stream = stop_instance.start()
+            async with stop_stream:
+                while await stop_stream.read_out() is not None:
+                    pass
+            assert (await stop_instance.inspect())["ExitCode"] == 0
             async for attempt in AsyncRetrying(stop=stop_after_delay(10), wait=wait_fixed(1), reraise=True):
                 with attempt:
                     assert rpc_client.healthy is False


### PR DESCRIPTION
## What do these changes do?

RabbitMQ clients could continue reporting `healthy=True` after the broker closed their connection during maintenance or a restart. `_connection_close_callback` only cleared the health state for unexpected exceptions; `aiormq.exceptions.ConnectionClosed` and `asyncio.CancelledError` followed expected handling paths that skipped that transition. Health checks could therefore return a false positive while the RPC transport was unavailable.

This PR makes every exceptional connection **and channel** closure mark the client unhealthy (previously `_channel_close_callback` had the same gap — only "unexpected" channel errors flipped health, graceful ones like AWS MQ maintenance closes didn't). The existing reconnection lifecycle (`_connection_reconnect_callback` / `RabbitMQRPCClient._on_reconnect`) remains responsible for restoring the healthy state after the connection and RPC topology have been rebuilt.

Marking unhealthy on every close, including brief AWS MQ maintenance-mode restarts that `aio_pika`'s `RobustConnection` reconnects from automatically within seconds, risked unnecessary container restarts since these services' `/health` endpoint feeds a single Docker `HEALTHCHECK` (no separate liveness/readiness split). To avoid that regression, `RabbitMQClientBase` now tracks *when* it went unhealthy and only reports `healthy=False` once the disconnect has persisted past a `grace_period_s` (default 10s) — brief, self-healing reconnects stay invisible to health checks, while sustained outages (e.g. `rabbitmqctl stop_app`, a real broker crash) are surfaced correctly.

## Related issue/s

## How to test
```sh
cd packages/service-library
make "install-dev[all]"

pytest -vv tests/rabbitmq/test_rabbitmq_client_base.py tests/rabbitmq/test_rabbitmq_rpc.py
```

## Dev-ops
No changes.