### PR TITLE
🐛 fix(director-v2): prevent dask client crash on non-str scheduler metric keys

### DIFF
--- a/packages/common-library/src/common_library/json_serialization.py
+++ b/packages/common-library/src/common_library/json_serialization.py
@@ -140,6 +140,24 @@ def representation_encoder(obj: Any):
         return str(obj)
 
 
+# Types orjson.OPT_NON_STR_KEYS already accepts as dict keys (IntEnum is a subclass of int)
+_JSON_KEY_SAFE_TYPES = (str, int, float, bool, type(None), datetime.datetime, datetime.date, datetime.time, UUID)
+
+
+def _sanitize_non_str_keys(obj: Any) -> Any:
+    """Recursively replaces dict keys unsupported by OPT_NON_STR_KEYS (e.g. tuples) with `str(key)`."""
+    if isinstance(obj, dict):
+        return {
+            (key if isinstance(key, _JSON_KEY_SAFE_TYPES) else str(key)): _sanitize_non_str_keys(value)
+            for key, value in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_sanitize_non_str_keys(item) for item in obj]
+    if isinstance(obj, tuple):
+        return tuple(_sanitize_non_str_keys(item) for item in obj)
+    return obj
+
+
 def json_dumps(
     obj: Any,
     *,
@@ -147,6 +165,7 @@ def json_dumps(
     sort_keys: bool = False,
     indent: int | None = None,
     separators: SeparatorTuple | tuple[str, str] | None = None,
+    sanitize_keys: bool = False,
 ) -> str:
     """json.dumps-like API implemented with orjson.dumps in the core
 
@@ -167,6 +186,12 @@ def json_dumps(
         # some examples with time-stamps that were corrupted because of this replacement.
         msg = f"Only {_orjson_default_separator} supported, got {separators}"
         raise ValueError(msg)
+
+    if sanitize_keys:
+        # NOTE: OPT_NON_STR_KEYS only supports a fixed set of key types (see below) and there is
+        # no `default`-like hook for keys, so any other key type (e.g. a tuple) raises unconditionally.
+        # Opt-in only: existing callers are unaffected and keep getting a hard failure on unexpected keys.
+        obj = _sanitize_non_str_keys(obj)
 
     # serialize
     result: str = orjson.dumps(obj, default=default, option=option).decode("utf-8")

--- a/packages/common-library/src/common_library/json_serialization.py
+++ b/packages/common-library/src/common_library/json_serialization.py
@@ -140,7 +140,6 @@ def representation_encoder(obj: Any):
         return str(obj)
 
 
-# Types orjson.OPT_NON_STR_KEYS already accepts as dict keys (IntEnum is a subclass of int)
 _JSON_KEY_SAFE_TYPES = (str, int, float, bool, type(None), datetime.datetime, datetime.date, datetime.time, UUID)
 
 
@@ -188,9 +187,6 @@ def json_dumps(
         raise ValueError(msg)
 
     if sanitize_keys:
-        # NOTE: OPT_NON_STR_KEYS only supports a fixed set of key types (see below) and there is
-        # no `default`-like hook for keys, so any other key type (e.g. a tuple) raises unconditionally.
-        # Opt-in only: existing callers are unaffected and keep getting a hard failure on unexpected keys.
         obj = _sanitize_non_str_keys(obj)
 
     # serialize

--- a/packages/common-library/tests/test_json_serialization.py
+++ b/packages/common-library/tests/test_json_serialization.py
@@ -4,7 +4,7 @@
 
 import json
 from copy import deepcopy
-from typing import Annotated, Any, TypeAlias
+from typing import Annotated, Any
 from uuid import uuid4
 
 import pytest
@@ -18,6 +18,8 @@ from common_library.json_serialization import (
 from faker import Faker
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, HttpUrl, TypeAdapter
 from pydantic.json import pydantic_encoder
+
+type ConstrainedFloat = Annotated[float, Field(ge=0.0, le=1.0)]
 
 
 @pytest.fixture
@@ -53,7 +55,19 @@ def test_serialized_non_str_dict_keys():
     json_dumps({1: "foo"})
 
 
-ConstrainedFloat: TypeAlias = Annotated[float, Field(ge=0.0, le=1.0)]
+def test_serialized_tuple_dict_keys_raises_without_sanitize_keys():
+    # OPT_NON_STR_KEYS does not cover tuple keys (e.g. distributed's digest metrics)
+    with pytest.raises(TypeError, match="Dict key must"):
+        json_dumps({("a", "b"): "foo"})
+
+
+def test_serialized_tuple_dict_keys_with_sanitize_keys():
+    assert json_dumps({("a", "b"): "foo", "nested": {("c",): 1}}, sanitize_keys=True) == json_dumps(
+        {
+            "('a', 'b')": "foo",
+            "nested": {"('c',)": 1},
+        }
+    )
 
 
 def test_serialized_constraint_floats():

--- a/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/dask_client.py
@@ -158,7 +158,7 @@ class DaskClient:
                     )
                     _logger.info(
                         "Scheduler info:\n%s",
-                        json_dumps(await get_scheduler_details(backend.client), indent=2),
+                        json_dumps(await get_scheduler_details(backend.client), indent=2, sanitize_keys=True),
                     )
                     return instance
         # this is to satisfy pylance

--- a/services/director-v2/tests/unit/test_modules_dask_client.py
+++ b/services/director-v2/tests/unit/test_modules_dask_client.py
@@ -223,6 +223,44 @@ async def dask_client(
     return client
 
 
+async def test_create_dask_client_recovers_from_scheduler_info_with_non_str_keys(
+    _minimal_dask_config: None,
+    dask_spec_local_cluster: distributed.SpecCluster,
+    minimal_app: FastAPI,
+    tasks_file_link_type: FileLinkType,
+    mocker: MockerFixture,
+):
+    original_get_scheduler_details = get_scheduler_details
+
+    async def _get_scheduler_details_with_non_str_keys(client: distributed.Client):
+        info = await original_get_scheduler_details(client)
+        return {
+            **info,
+            "workers": {
+                **info["workers"],
+                "fake-worker": {
+                    "metrics": {("execute", "prefix", "thread-noncpu", "seconds"): 1.23},
+                },
+            },
+        }
+
+    mocker.patch(
+        "simcore_service_director_v2.modules.dask_client.get_scheduler_details",
+        side_effect=_get_scheduler_details_with_non_str_keys,
+    )
+
+    client = await DaskClient.create(
+        app=minimal_app,
+        settings=minimal_app.state.settings.DIRECTOR_V2_COMPUTATIONAL_BACKEND,
+        endpoint=TypeAdapter(AnyUrl).validate_python(dask_spec_local_cluster.scheduler_address),
+        authentication=NoAuthentication(),
+        tasks_file_link_type=tasks_file_link_type,
+        cluster_type=ClusterTypeInModel.ON_PREMISE,
+    )
+    assert client
+    await client.delete()
+
+
 @pytest.fixture
 def project_id() -> ProjectID:
     return uuid4()


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request introduces improved handling of non-string dictionary keys during JSON serialization, particularly to address cases where keys such as tuples are present (which are not natively supported by orjson's `OPT_NON_STR_KEYS`). The changes add an optional mechanism to sanitize such keys, preventing serialization errors and improving robustness in cases like Dask scheduler info logging. Comprehensive tests are included to ensure correct behavior.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
- No changes.