### PR TITLE
⬆️Maintenance: upgrade local jaeger to latest

### DIFF
--- a/.renovaterc.jsonc
+++ b/.renovaterc.jsonc
@@ -6,8 +6,8 @@
   ],
   "dependencyDashboard": true,
   "prCreation": "approval",
-  "platformAutomerge": false,
-  "automerge": false,
+  "platformAutomerge": true,
+  "automerge": true,
   // Pinned explicitly (matches the default) so CI can gate on this exact prefix,
   // e.g. .github/workflows/renovate-fix-lockfiles.yml
   "branchPrefix": "renovate/",
@@ -64,7 +64,7 @@
       "minimumReleaseAge": "3 days",
       "dependencyDashboardApproval": true,
       "prCreation": "approval",
-      "automerge": false
+      "automerge": true
     },
     {
       "description": "Services: upgrade slower / more conservative",
@@ -75,7 +75,7 @@
       "minimumReleaseAge": "14 days",
       "dependencyDashboardApproval": true,
       "prCreation": "approval",
-      "automerge": false
+      "automerge": true
     },
     {
       "description": "These requirements.txt are pip-compile outputs; let pip-compile own them (avoid double updates)",
@@ -103,7 +103,7 @@
       "groupName": "docker images",
       "dependencyDashboardApproval": true,
       "prCreation": "approval",
-      "automerge": false
+      "automerge": true
     }
   ]
 }

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -98,6 +98,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
   "PT019",   # user pytest.mark.usefixture
   "PLR2004", # use of magic values
   "PLR0913", # too many arguments
+  "PLR0917", # too many keyword arguments
   "N806",    # Uppercase variables in functions
   "PT001",   # use pytest.fixture over pytest.fixture() whatsoever
   "ERA001",  # found commented out code

--- a/packages/service-library/tests/test_async_utils.py
+++ b/packages/service-library/tests/test_async_utils.py
@@ -58,6 +58,9 @@ def _compensate_for_slow_systems(number: float) -> float:
     return number * 10
 
 
+type ContextKey = tuple[int, int, int]
+
+
 @pytest.mark.no_leaks
 async def test_context_aware_dispatch(
     sleep_duration: float, ensure_run_in_sequence_context_is_empty: None, faker: Faker
@@ -80,7 +83,12 @@ async def test_context_aware_dispatch(
             "c3": faker.random_int(0, 10),
         }
 
-    contexts = [make_context() for _ in range(10)]
+    rng = random.Random(0xC0FFEE)  # noqa: S311
+    context_keys: set[ContextKey] = set()
+    while len(context_keys) < 10:
+        context_keys.add((rng.randrange(1_000_000), rng.randrange(1_000_000), rng.randrange(1_000_000)))
+
+    contexts = [{"c1": key[0], "c2": key[1], "c3": key[2]} for key in context_keys]
 
     locked_stores = {}
     expected_outcomes = {}
@@ -91,7 +99,7 @@ async def test_context_aware_dispatch(
 
     tasks = deque()
     for control in range(1000):
-        context = random.choice(contexts)
+        context = random.choice(contexts)  # noqa: S311
         key = make_key_from_context(context)
         expected_outcomes[key].append(control)
 
@@ -101,33 +109,34 @@ async def test_context_aware_dispatch(
         task = asyncio.get_event_loop().create_task(orderly(**params))
         tasks.append(task)
 
-    for task in tasks:
-        await task
+    await asyncio.wait_for(asyncio.gather(*tasks), timeout=30)
 
     for context in contexts:
         key = make_key_from_context(context)
         assert list(expected_outcomes[key]) == await locked_stores[key].get_all()
+
+    await asyncio.sleep(0)  # allow any remaining tasks to complete
 
 
 @pytest.mark.no_leaks
 async def test_context_aware_function_sometimes_fails(
     ensure_run_in_sequence_context_is_empty: None,
 ) -> None:
-    class DidFailException(Exception):
+    class DidFailError(Exception):
         pass
 
     @run_sequentially_in_context(target_args=["will_fail"])
     async def sometimes_failing(will_fail: bool) -> bool:
         if will_fail:
             msg = "I was instructed to fail"
-            raise DidFailException(msg)
+            raise DidFailError(msg)
         return True
 
     for x in range(100):
         raise_error = x % 2 == 0
 
         if raise_error:
-            with pytest.raises(DidFailException):
+            with pytest.raises(DidFailError):
                 await sometimes_failing(raise_error)
         else:
             assert await sometimes_failing(raise_error) is True
@@ -143,7 +152,7 @@ async def test_context_aware_wrong_target_args_name(
     async def target_function(the_param: Any) -> None:
         return None
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:  # noqa: PT011
         await target_function("something")
 
     message = f"Expected '{expected_param_name}' in '{target_function.__name__}' arguments."

--- a/services/docker-compose-ops.yml
+++ b/services/docker-compose-ops.yml
@@ -55,23 +55,19 @@ services:
       start_period: 10s
 
   jaeger:
-    image: jaegertracing/all-in-one:1.47
+    image: jaegertracing/jaeger:latest
     networks:
       - simcore_default
     ports:
       - "16686:16686" # Jaeger UI
-      - "14268:14268" # Jaeger HTTP Thrift
-      - "14250:14250" # Jaeger gRPC
       - "43017:4317" # opentelemetry GRPC default port
       - "43018:4318" # opentelemetry HTTP default port
-    environment:
-      COLLECTOR_OTLP_ENABLED: "true"
   portainer:
     image: portainer/portainer-ce
     init: true
     ports:
       - "9000:9000"
-    command: -H unix:///var/run/docker.sock
+    command: ["-H", "unix:///var/run/docker.sock", "--no-setup-token"]
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - portainer_data:/data


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
upgrades localy used jaeger to latest version (2.20.0)

NOTE: this is only used for local dev, therefore no pinning (same as portainer)

BONUS:
- maybe fixes one flaky test.
- let renovate merge when there are enough approvals

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
