### PR TITLE
⬆️ Maintenance: migrate redis 6.2.6 to valkey 7.2 

### DIFF
--- a/packages/common-library/src/common_library/basic_types.py
+++ b/packages/common-library/src/common_library/basic_types.py
@@ -31,7 +31,6 @@ class BootModeEnum(StrEnum):
     DEVELOPMENT = "development"
 
     def is_devel_mode(self) -> bool:
-        """returns True if this boot mode is used for development"""
         return self in {self.DEBUG, self.DEVELOPMENT, self.LOCAL}
 
 

--- a/packages/service-library/src/servicelib/docker_utils.py
+++ b/packages/service-library/src/servicelib/docker_utils.py
@@ -260,9 +260,8 @@ async def _parse_pull_information(  # noqa: C901
                 ).downloaded = parsed_progress.progress_detail.current
         case "verifying checksum" | "download complete":
             assert parsed_progress.id  # nosec
-            layer_id_to_size.setdefault(parsed_progress.id, _PulledStatus(0)).downloaded = layer_id_to_size.setdefault(
-                parsed_progress.id, _PulledStatus(0)
-            ).size
+            pulled_status = layer_id_to_size.setdefault(parsed_progress.id, _PulledStatus(0))
+            pulled_status.downloaded = pulled_status.size
         case "extracting":
             _handle_extracting_progress(
                 parsed_progress,
@@ -272,17 +271,13 @@ async def _parse_pull_information(  # noqa: C901
             )
         case "pull complete":
             assert parsed_progress.id  # nosec
-            layer_id_to_size.setdefault(parsed_progress.id, _PulledStatus(0)).extracted = layer_id_to_size[
-                parsed_progress.id
-            ].size
+            pulled_status = layer_id_to_size.setdefault(parsed_progress.id, _PulledStatus(0))
+            pulled_status.extracted = pulled_status.size
         case "already exists":
             assert parsed_progress.id  # nosec
-            layer_id_to_size.setdefault(parsed_progress.id, _PulledStatus(0)).extracted = layer_id_to_size[
-                parsed_progress.id
-            ].size
-            layer_id_to_size.setdefault(parsed_progress.id, _PulledStatus(0)).downloaded = layer_id_to_size[
-                parsed_progress.id
-            ].size
+            pulled_status = layer_id_to_size.setdefault(parsed_progress.id, _PulledStatus(0))
+            pulled_status.extracted = pulled_status.size
+            pulled_status.downloaded = pulled_status.size
         case progress_status if any(
             msg in progress_status
             for msg in [

--- a/packages/service-library/tests/fastapi/test_docker_utils.py
+++ b/packages/service-library/tests/fastapi/test_docker_utils.py
@@ -229,9 +229,13 @@ async def test_pull_image_without_layer_information(
 
     # check there were no warnings
     # NOTE: this would pop up in case docker changes its pulling statuses
-    expected_warning = "pulling image without layer information"
+    # NOTE: since the extraction might go very fast on a local machine vs EC2 we skip that warning here
+    expected_warnings = ["pulling image without layer information", "Estimated extraction for"]
     assert not [
-        r.message for r in caplog.records if r.levelname == "WARNING" and not r.message.startswith(expected_warning)
+        r.message
+        for r in caplog.records
+        if r.levelname == "WARNING"
+        and not any(r.message.startswith(expected_warning) for expected_warning in expected_warnings)
     ]
 
     # pull a second time should, the image is already there, but the progress is then 0
@@ -247,7 +251,10 @@ async def test_pull_image_without_layer_information(
     _assert_progress_report_values(mocked_progress_cb, total=1)
     # check there were no warnings
     assert not [
-        r.message for r in caplog.records if r.levelname == "WARNING" and not r.message.startswith(expected_warning)
+        r.message
+        for r in caplog.records
+        if r.levelname == "WARNING"
+        and not any(r.message.startswith(expected_warning) for expected_warning in expected_warnings)
     ]
 
 

--- a/services/autoscaling/tests/manual/docker-compose.yml
+++ b/services/autoscaling/tests/manual/docker-compose.yml
@@ -19,13 +19,13 @@ services:
       start_period: 5s
 
   redis:
-    image: "redis:6.2.6@sha256:4bed291aa5efb9f0d77b76ff7d4ab71eee410962965d052552db1fb80576431d"
+    image: "valkey/valkey:7.2@sha256:1bbb912679bea3ec2c1b21af3860beb4397774e9118eddad4ae50d8e97fabb99"
     init: true
     hostname: "{{.Node.Hostname}}-{{.Service.Name}}-{{.Task.Slot}}"
     # ports:
     #   - "6379:6379"
     healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 5s
       timeout: 30s
       retries: 50

--- a/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
+++ b/services/clusters-keeper/src/simcore_service_clusters_keeper/data/docker-compose.yml
@@ -150,11 +150,11 @@ services:
 
   redis:
     # NOTE: currently autoscaling requires redis to run
-    image: "redis:6.2.6@sha256:4bed291aa5efb9f0d77b76ff7d4ab71eee410962965d052552db1fb80576431d"
+    image: "valkey/valkey:7.2@sha256:1bbb912679bea3ec2c1b21af3860beb4397774e9118eddad4ae50d8e97fabb99"
     init: true
     hostname: "{{.Node.Hostname}}-{{.Task.Slot}}"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 5s
       timeout: 30s
       retries: 50

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -173,7 +173,7 @@ services:
       ]
 
   redis:
-    image: "redis:6.2.6@sha256:4bed291aa5efb9f0d77b76ff7d4ab71eee410962965d052552db1fb80576431d"
+    image: "redis:8.10.1@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5"
     init: true
     hostname: "{{.Node.Hostname}}-{{.Task.Slot}}"
     command:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -173,7 +173,7 @@ services:
       ]
 
   redis:
-    image: "redis:8.10.1@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5"
+    image: "redis:6.2.6@sha256:4bed291aa5efb9f0d77b76ff7d4ab71eee410962965d052552db1fb80576431d"
     init: true
     hostname: "{{.Node.Hostname}}-{{.Task.Slot}}"
     command:

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -135,7 +135,10 @@ services:
           "--dbname",
           "${POSTGRES_DB}",
         ]
+      start_period: 15s
+      start_interval: 1s
       interval: 5s
+      timeout: 30s
       retries: 5
     # NOTES: this is not yet compatible with portainer deployment but could work also for other containers
     # works with Docker 19.03 and not yet with Portainer 1.23.0 (see https://github.com/portainer/portainer/issues/3551)
@@ -173,24 +176,29 @@ services:
       ]
 
   redis:
-    image: "redis:6.2.6@sha256:4bed291aa5efb9f0d77b76ff7d4ab71eee410962965d052552db1fb80576431d"
+    image: "valkey/valkey:7.2@sha256:1bbb912679bea3ec2c1b21af3860beb4397774e9118eddad4ae50d8e97fabb99"
     init: true
     hostname: "{{.Node.Hostname}}-{{.Task.Slot}}"
-    command:
-      # redis server will write a backup every 60 seconds if at least 1 key was changed
-      # also aof (append only) is also enabled such that we get full durability at the expense
-      # of backup size. The backup is written into /data.
-      # https://redis.io/topics/persistence
-      [
-        "redis-server",
+    command: [
+        "valkey-server",
+
+        # RDB snapshot if at least one key changed in 60 seconds.
         "--save",
         "60 1",
+
         "--loglevel",
         "verbose",
         "--databases",
         "12",
+
+        # Persist mutations in AOF as well.
         "--appendonly",
         "yes",
+
+        # State the intended durability policy explicitly.
+        "--appendfsync",
+        "everysec",
+
         "--requirepass",
         "${REDIS_PASSWORD}",
       ]
@@ -201,10 +209,24 @@ services:
     volumes:
       - redis-data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      test:
+        [
+          "CMD",
+          "valkey-cli",
+          "--no-auth-warning",
+          "--pass",
+          "$${REDIS_PASSWORD}",
+          "ping",
+          "|",
+          "grep",
+          "-qx",
+          "PONG",
+        ]
+      start_period: 15s
+      start_interval: 1s
       interval: 5s
       timeout: 30s
-      retries: 50
+      retries: 5
 
   rabbit:
     image: itisfoundation/rabbitmq:4.1.6-management

--- a/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
@@ -48,7 +48,7 @@ services:
     depends_on:
       - postgres
   redis:
-    image: "redis:6.2.6@sha256:4bed291aa5efb9f0d77b76ff7d4ab71eee410962965d052552db1fb80576431d"
+    image: "valkey/valkey:7.2@sha256:1bbb912679bea3ec2c1b21af3860beb4397774e9118eddad4ae50d8e97fabb99"
     init: true
     ports:
       - "6379:6379"
@@ -57,7 +57,7 @@ services:
       TEST_REDIS_PASSWORD: ${TEST_REDIS_PASSWORD:-adminadminadmin}
     command:
       [
-        "redis-server",
+        "valkey-server",
         "--loglevel",
         "verbose",
         "--databases",

--- a/services/web/server/tests/unit/with_dbs/docker-compose.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "-c"
       - "fsync=off"
   redis:
-    image: "redis:6.2.6@sha256:4bed291aa5efb9f0d77b76ff7d4ab71eee410962965d052552db1fb80576431d"
+    image: "valkey/valkey:7.2@sha256:1bbb912679bea3ec2c1b21af3860beb4397774e9118eddad4ae50d8e97fabb99"
     init: true
     ports:
       - "6379:6379"
@@ -42,7 +42,7 @@ services:
       TEST_REDIS_PASSWORD: ${TEST_REDIS_PASSWORD:-adminadminadmin}
     command:
       [
-        "redis-server",
+        "valkey-server",
         "--loglevel",
         "verbose",
         "--databases",


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
for info current 6.2.6 is end of life since 2025.

due to license issues, we migrate from redis to valkey following this: https://valkey.io/topics/migration/

valkey is a fork of redis and is evolving now. Also AWS seems to support valkey instead of Redis.

if this proves stable then we can upgrade further.

NOTE: redis name is kept in docker-compose so that DNS still resolve as usual.


<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
