### PR TITLE
🎨 enh(storage): enable localization of task progress messages

### DIFF
--- a/packages/common-library/src/common_library/locale/es_ES/LC_MESSAGES/messages.po
+++ b/packages/common-library/src/common_library/locale/es_ES/LC_MESSAGES/messages.po
@@ -3590,3 +3590,15 @@ msgstr ""
 #~ msgstr ""
 #~ "No se pudo encontrar al propietario del proyecto en los derechos de acceso "
 #~ "del proyecto."
+
+# CTX-INTERPRETATION: This string appears in the context of a file copying
+# operation.
+#: services/storage/src/simcore_service_storage/api/_worker_tasks/_simcore_s3.py:36
+msgid "Copying files"
+msgstr "Copiando archivos"
+
+# CTX-INTERPRETATION: This string appears in the context of creating an
+# export archive.
+#: services/storage/src/simcore_service_storage/api/_worker_tasks/_simcore_s3.py:37
+msgid "Creating export archive"
+msgstr "Creando el archivo de exportación"

--- a/packages/common-library/src/common_library/locale/ko_KR/LC_MESSAGES/messages.po
+++ b/packages/common-library/src/common_library/locale/ko_KR/LC_MESSAGES/messages.po
@@ -3044,3 +3044,15 @@ msgid ""
 "We apologize for the inconvenience. The issue has been recorded, please "
 "report it if it persists."
 msgstr "불편을 드려 죄송합니다. 문제가 기록되었으며, 지속되면 보고해 주시기 바랍니다."
+
+# CTX-INTERPRETATION: This string appears in the context of a file copying
+# operation.
+#: services/storage/src/simcore_service_storage/api/_worker_tasks/_simcore_s3.py:36
+msgid "Copying files"
+msgstr "파일 복사 중"
+
+# CTX-INTERPRETATION: This string appears in the context of creating an
+# export archive.
+#: services/storage/src/simcore_service_storage/api/_worker_tasks/_simcore_s3.py:37
+msgid "Creating export archive"
+msgstr "내보내기 아카이브 생성"

--- a/packages/common-library/src/common_library/locale/zh_CN/LC_MESSAGES/messages.po
+++ b/packages/common-library/src/common_library/locale/zh_CN/LC_MESSAGES/messages.po
@@ -2896,3 +2896,15 @@ msgstr "我们对给您带来的不便深表歉意。问题已被记录，如果
 # settings.
 #~ msgid "The project owner could not be found in the project's access rights."
 #~ msgstr "在项目的访问权限中找不到项目所有者。"
+
+# CTX-INTERPRETATION: This string appears in the context of a file copying
+# operation.
+#: services/storage/src/simcore_service_storage/api/_worker_tasks/_simcore_s3.py:36
+msgid "Copying files"
+msgstr "正在复制文件"
+
+# CTX-INTERPRETATION: This string appears in the context of creating an
+# export archive.
+#: services/storage/src/simcore_service_storage/api/_worker_tasks/_simcore_s3.py:37
+msgid "Creating export archive"
+msgstr "创建导出存档"

--- a/scripts/i18n/Makefile
+++ b/scripts/i18n/Makefile
@@ -68,6 +68,7 @@ I18N_DIRS := \
   services/director-v2 \
   services/api-server \
   services/notifications \
+  services/storage \
   packages/service-library \
   packages/dask-task-models-library \
   packages/common-library

--- a/services/static-webserver/client/source/class/osparc/data/PollTask.js
+++ b/services/static-webserver/client/source/class/osparc/data/PollTask.js
@@ -131,7 +131,11 @@ qx.Class.define("osparc.data.PollTask", {
 
     __pollTaskState: function() {
       const statusPath = this.self().extractPathname(this.getStatusHref());
-      fetch(statusPath)
+      fetch(statusPath, {
+        headers: {
+          "X-Simcore-Language": osparc.utils.LanguageManager.getBackendLocale()
+        }
+      })
         .then(resp => {
           if (this.__aborting || this.getDone()) {
             return null;

--- a/services/storage/src/simcore_service_storage/api/_worker_tasks/_simcore_s3.py
+++ b/services/storage/src/simcore_service_storage/api/_worker_tasks/_simcore_s3.py
@@ -1,11 +1,12 @@
 import datetime
 import functools
 import logging
-from typing import Any
+from typing import Any, Final
 
 from aws_library.s3._models import S3ObjectKey
 from celery import Task  # type: ignore[import-untyped]
 from celery_library.worker.app_server import get_app_server
+from common_library.user_messages import user_message
 from models_library.api_schemas_storage.search_async_jobs import SearchResultItem
 from models_library.api_schemas_storage.storage_schemas import (
     UNDEFINED_SIZE,
@@ -32,6 +33,9 @@ from ...simcore_s3_dsm import SimcoreS3DataManager
 
 _logger = logging.getLogger(__name__)
 
+_MSG_COPYING_FILES: Final[str] = user_message("Copying files", _version=1)
+_MSG_CREATING_EXPORT_ARCHIVE: Final[str] = user_message("Creating export archive", _version=1)
+
 
 async def _task_progress_cb(task: Task, task_key: TaskKey, report: ProgressReport) -> None:
     worker = get_app_server(task.app).task_manager
@@ -54,7 +58,7 @@ async def deep_copy_files_from_project(
         assert isinstance(dsm, SimcoreS3DataManager)  # nosec
         async with ProgressBarData(
             num_steps=1,
-            description="copying files",
+            description=_MSG_COPYING_FILES,
             progress_report_cb=functools.partial(_task_progress_cb, task, task_key),
         ) as task_progress:
             await dsm.deep_copy_project_simcore_s3(
@@ -101,7 +105,7 @@ async def export_data(
 
         async with ProgressBarData(
             num_steps=1,
-            description=f"'{task_key}' export data",
+            description=_MSG_CREATING_EXPORT_ARCHIVE,
             progress_report_cb=_progress_cb,
         ) as progress_bar:
             return await dsm.create_s3_export(

--- a/services/web/server/src/simcore_service_webserver/tasks/_controller/_rest.py
+++ b/services/web/server/src/simcore_service_webserver/tasks/_controller/_rest.py
@@ -20,6 +20,7 @@ from servicelib.long_running_tasks import lrt_api
 
 from ..._meta import API_VTAG
 from ...celery import get_task_manager
+from ...locale import translate_message
 from ...login.decorators import login_required
 from ...long_running_tasks.plugin import webserver_request_context_decorator
 from ...models import AuthenticatedRequestContext, WebServerOwnerMetadata
@@ -110,12 +111,13 @@ async def get_async_job_status(request: web.Request) -> web.Response:
 
     _task_id = f"{task_status.job_id}"
     _progress = task_status.progress
+    _message = translate_message(_progress.message.description, request) if _progress.message else ""
     return create_data_response(
         TaskStatus(
             task_progress=TaskProgress(
                 task_id=_task_id,
                 percent=_progress.percent_value,
-                message=_progress.message.description if _progress.message else "",
+                message=_message,
             ),
             done=task_status.done,
             started=None,


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
This pull request introduces internationalization (i18n) improvements for user-facing task progress messages, ensuring that status updates such as "Copying files" and "Creating export archive" are displayed in the user's preferred language. It also updates the backend and frontend to support and use these localized messages, and adds new translations for Spanish, Korean, and Chinese.

### Example of download
<img width="376" height="175" alt="image" src="https://github.com/user-attachments/assets/70ae57eb-e1fa-4bd7-9048-709dfe94d2b8" />

## Related issue/s
- fixes https://github.com/ITISFoundation/osparc-simcore/issues/9678

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
- No changes.