### PR TITLE
⬆️ Bumped postgres to 14.23 (⚠️ DevOPS)

### DIFF
--- a/packages/postgres-database/tests/docker-compose.yml
+++ b/packages/postgres-database/tests/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
+    image: "postgres:14.23@sha256:2f439458ab6a57a925825ae14f9d06910e4fe4a41c8d4a0ae06397e65b707e1b"
     init: true
     environment:
       POSTGRES_USER: test

--- a/services/api-server/tests/unit/_with_db/data/docker-compose.yml
+++ b/services/api-server/tests/unit/_with_db/data/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
+    image: "postgres:14.23@sha256:2f439458ab6a57a925825ae14f9d06910e4fe4a41c8d4a0ae06397e65b707e1b"
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-test}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-test}
@@ -20,7 +20,7 @@ services:
         "-c",
         "log_duration=true",
         "-c",
-        "log_line_prefix=[%p] [%a] [%c] [%x] "
+        "log_line_prefix=[%p] [%a] [%c] [%x] ",
       ]
   adminer:
     image: adminer

--- a/services/director-v2/docker-compose-extra.yml
+++ b/services/director-v2/docker-compose-extra.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
+    image: "postgres:14.23@sha256:2f439458ab6a57a925825ae14f9d06910e4fe4a41c8d4a0ae06397e65b707e1b"
     init: true
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-test}
@@ -21,7 +21,7 @@ services:
         "-c",
         "log_duration=true",
         "-c",
-        "log_line_prefix=[%p] [%a] [%c] [%x] "
+        "log_line_prefix=[%p] [%a] [%c] [%x] ",
       ]
   rabbit:
     image: itisfoundation/rabbitmq:4.1.6-management

--- a/services/director/tests/unit/test_producer.py
+++ b/services/director/tests/unit/test_producer.py
@@ -353,9 +353,9 @@ async def test_get_service_key_version_from_docker_service(
 @pytest.mark.parametrize(
     "fake_service_str",
     [
-        "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc",
-        "/simcore/postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc",
-        "itisfoundation/postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc",
+        "postgres:14.23@sha256:2f439458ab6a57a925825ae14f9d06910e4fe4a41c8d4a0ae06397e65b707e1b",
+        "/simcore/postgres:14.23@sha256:2f439458ab6a57a925825ae14f9d06910e4fe4a41c8d4a0ae06397e65b707e1b",
+        "itisfoundation/postgres:14.23@sha256:2f439458ab6a57a925825ae14f9d06910e4fe4a41c8d4a0ae06397e65b707e1b",
         "/simcore/services/stuff/postgres:10.11",
     ],
 )

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -109,7 +109,7 @@ services:
   ###########################
 
   postgres:
-    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
+    image: "postgres:14.23@sha256:2f439458ab6a57a925825ae14f9d06910e4fe4a41c8d4a0ae06397e65b707e1b"
     init: true
     hostname: "{{.Node.Hostname}}-{{.Task.Slot}}"
     environment:

--- a/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose-devel.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
+    image: "postgres:14.23@sha256:2f439458ab6a57a925825ae14f9d06910e4fe4a41c8d4a0ae06397e65b707e1b"
     restart: always
     init: true
     environment:

--- a/services/web/server/tests/unit/with_dbs/docker-compose.yml
+++ b/services/web/server/tests/unit/with_dbs/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: "postgres:14.8-alpine@sha256:150dd39ccb7ae6c7ba6130c3582c39a30bb5d3d22cb08ad0ba37001e3f829abc"
+    image: "postgres:14.23@sha256:2f439458ab6a57a925825ae14f9d06910e4fe4a41c8d4a0ae06397e65b707e1b"
     restart: always
     init: true
     environment:


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
Bumps postgres from 14.8 to 14.23 (in sync with AWS)
<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->
- fixes https://github.com/ITISFoundation/osparc-ops-environments/issues/1533

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops
- a backup of the DB prior to deploying might be a good idea

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
