### PR TITLE
✅ test(web-server): fix flaky `test_create_and_delete_many_nodes_in_parallel`

### DIFF
--- a/services/web/server/tests/unit/with_dbs/conftest.py
+++ b/services/web/server/tests/unit/with_dbs/conftest.py
@@ -471,6 +471,11 @@ async def mocked_dynamic_services_interface(
         autospec=True,
         return_value=False,
     )
+    mock["director_v2.api.get_computation_task"] = mocker.patch(
+        f"{director_v2_service.__name__}.get_computation_task",
+        autospec=True,
+        return_value=None,
+    )
     mock["director_v2.api.stop_pipeline"] = mocker.patch(
         f"{director_v2_service.__name__}.stop_pipeline",
         autospec=True,
@@ -558,7 +563,7 @@ def postgres_db(postgres_dsn: dict, postgres_service: str) -> Iterator[sa.engine
     pg_cli.discover.callback(**kwargs)
     assert pg_cli.upgrade.callback
     pg_cli.upgrade.callback("head")
-    # Uses syncrounous engine for that
+    # Uses synchronous engine for that
     sync_engine = sa.create_engine(url, isolation_level="AUTOCOMMIT")
 
     yield sync_engine


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?
`test_create_and_delete_many_nodes_in_parallel` was failing randomly in CI with a 500 error, even though nothing was wrong with the code it tests.

The reason: one director-v2 function (`get_computation_task`) was missing from the shared mock fixture. So every one of the 150 node creations tried to call the real director-v2 service, which doesn't exist during unit tests. The call failed, got retried after a random 0–1 second pause, and then the error was quietly ignored — so the test still passed, it just became much slower.

Those random pauses added up to ~90 seconds. The test has a 300-second limit, so on a fast
machine it passed and on a busy CI runner it ran out of time and returned a 500.

The fix simply adds the missing function to the mock. Nothing about the tested behaviour changes — the mock returns exactly what the real call was already returning — but the test no longer waits on failing network calls.

Result: the test went from ~110 seconds to ~37 seconds, and no longer depends on how busy the machine is.

## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test
```console
cd services/web/server
pytest tests/unit/with_dbs/02 -q
```

## Dev-ops
- No changes.