### PR TITLE
⚡ perf(director-v2): optimize DB repositories

### DIFF
--- a/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_manager.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/comp_scheduler/_manager.py
@@ -14,6 +14,7 @@ from servicelib.logging_utils import log_context
 from servicelib.redis import CouldNotAcquireLockError, exclusive
 from servicelib.tracing import traced
 from servicelib.utils import limited_gather
+from simcore_postgres_database.utils_repos import pass_or_acquire_connection
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from ...core.errors import ComputationalRunNotFoundError
@@ -168,16 +169,22 @@ _LOST_TASKS_FACTOR: Final[int] = 10
 )
 async def schedule_all_pipelines(app: FastAPI) -> None:
     with log_context(_logger, logging.DEBUG, msg="scheduling pipelines"):
-        db_engine = get_db_engine(app)
-        runs_to_schedule = await CompRunsRepository.instance(db_engine).list_(
-            filter_by_state=SCHEDULED_STATES,
-            never_scheduled=True,
-            processed_since=SCHEDULER_INTERVAL,
-        )
-        possibly_lost_scheduled_pipelines = await CompRunsRepository.instance(db_engine).list_(
-            filter_by_state=SCHEDULED_STATES,
-            scheduled_since=SCHEDULER_INTERVAL * _LOST_TASKS_FACTOR,
-        )
+        engine = get_db_engine(app)
+        repo = CompRunsRepository.instance(get_db_engine(app))
+
+        async with pass_or_acquire_connection(engine) as conn:
+            runs_to_schedule = await repo.list_(
+                conn,
+                filter_by_state=SCHEDULED_STATES,
+                never_scheduled=True,
+                processed_since=SCHEDULER_INTERVAL,
+            )
+            possibly_lost_scheduled_pipelines = await repo.list_(
+                conn,
+                filter_by_state=SCHEDULED_STATES,
+                scheduled_since=SCHEDULER_INTERVAL * _LOST_TASKS_FACTOR,
+            )
+
         if possibly_lost_scheduled_pipelines:
             _logger.error(
                 "found %d lost pipelines, they will be re-scheduled now. '%s'",
@@ -191,7 +198,7 @@ async def schedule_all_pipelines(app: FastAPI) -> None:
                 *(
                     request_pipeline_scheduling(
                         rabbitmq_client,
-                        db_engine,
+                        get_db_engine(app),
                         user_id=run.user_id,
                         project_id=run.project_uuid,
                         iteration=run.iteration,

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_pipelines.py
@@ -4,6 +4,7 @@ import networkx as nx
 import sqlalchemy as sa
 from models_library.projects import ProjectID
 from models_library.projects_state import RunningState
+from simcore_postgres_database.utils_repos import transaction_context
 from sqlalchemy.dialects.postgresql import insert
 
 from ....core.errors import PipelineNotFoundError
@@ -44,9 +45,9 @@ class CompPipelinesRepository(BaseRepository):
                 exclude_unset=True,
             ),
         )
-        async with self.db_engine.begin() as conn:
+        async with transaction_context(self.db_engine) as conn:
             await conn.execute(on_update_stmt)
 
     async def delete_pipeline(self, project_id: ProjectID) -> None:
-        async with self.db_engine.begin() as conn:
-            await conn.execute(sa.delete(comp_pipeline).where(comp_pipeline.c.project_id == str(project_id)))
+        async with transaction_context(self.db_engine) as conn:
+            await conn.execute(sa.delete(comp_pipeline).where(comp_pipeline.c.project_id == f"{project_id}"))

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -316,7 +316,7 @@ class CompRunsRepository(BaseRepository):
 
         async with pass_or_acquire_connection(self.db_engine) as conn:
             total_count = await conn.scalar(count_query)
-
+            result = await conn.execute(list_query)
             items = [
                 ComputationRunRpcGet(
                     project_uuid=row.project_uuid,
@@ -327,7 +327,7 @@ class CompRunsRepository(BaseRepository):
                     started_at=row.started_at,
                     ended_at=row.ended_at,
                 )
-                async for row in await conn.stream(list_query)
+                for row in result
             ]
 
             return cast(int, total_count), items
@@ -369,7 +369,7 @@ class CompRunsRepository(BaseRepository):
 
         async with pass_or_acquire_connection(self.db_engine) as conn:
             total_count = await conn.scalar(count_query)
-
+            result = await conn.execute(list_query)
             items = [
                 ComputationRunRpcGet(
                     project_uuid=row.project_uuid,
@@ -380,7 +380,7 @@ class CompRunsRepository(BaseRepository):
                     started_at=row.started_at,
                     ended_at=row.ended_at,
                 )
-                async for row in await conn.stream(list_query)
+                for row in result
             ]
 
             return cast(int, total_count), items
@@ -391,7 +391,7 @@ class CompRunsRepository(BaseRepository):
         product_name: str,
         user_id: UserID,
     ) -> list[CollectionRunID]:
-        list_query = (
+        stmt = (
             sa.select(
                 comp_runs.c.collection_run_id,
             )
@@ -406,7 +406,8 @@ class CompRunsRepository(BaseRepository):
         )
 
         async with pass_or_acquire_connection(self.db_engine) as conn:
-            return [CollectionRunID(row[0]) async for row in await conn.stream(list_query)]
+            result = await conn.execute(stmt)
+            return [CollectionRunID(collection_run_id) for collection_run_id in result.scalars()]
 
     async def list_group_by_collection_run_id(
         self,

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -18,6 +18,7 @@ from models_library.projects_state import RunningState
 from models_library.rest_ordering import OrderBy, OrderDirection
 from models_library.users import UserID
 from models_library.utils.fastapi_encoders import jsonable_encoder
+from pydantic import TypeAdapter
 from simcore_postgres_database.utils_repos import (
     pass_or_acquire_connection,
     transaction_context,
@@ -236,15 +237,10 @@ class CompRunsRepository(BaseRepository):
         if scheduling_or_conditions:
             conditions.append(sa.or_(*scheduling_or_conditions))
 
-        async with self.db_engine.connect() as conn:
-            return [
-                CompRunsAtDB.model_validate(row)
-                async for row in await conn.stream(
-                    sa.select(comp_runs).where(
-                        sa.and_(True, *conditions)  # noqa: FBT003
-                    )
-                )
-            ]
+        async with pass_or_acquire_connection(self.db_engine) as conn:
+            result = await conn.execute(sa.select(comp_runs).where(sa.and_(*conditions)))
+            rows = result.mappings().all()
+            return TypeAdapter(list[CompRunsAtDB]).validate_python(rows)
 
     _COMPUTATION_RUNS_RPC_GET_COLUMNS = [  # noqa: RUF012
         comp_runs.c.project_uuid,

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -23,7 +23,6 @@ from simcore_postgres_database.utils_repos import (
     pass_or_acquire_connection,
     transaction_context,
 )
-from sqlalchemy import CursorResult
 from sqlalchemy.dialects.postgresql.asyncpg import AsyncAdapt_asyncpg_dbapi
 from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.sql import or_
@@ -491,7 +490,7 @@ class CompRunsRepository(BaseRepository):
                 if iteration is None:
                     iteration = await _get_next_iteration(conn, user_id, project_id)
 
-                result: CursorResult = await conn.execute(
+                result = await conn.execute(
                     comp_runs.insert()
                     .values(
                         user_id=user_id,
@@ -503,7 +502,7 @@ class CompRunsRepository(BaseRepository):
                         dag_adjacency_list=dag_adjacency_list,
                         collection_run_id=f"{collection_run_id}",
                     )
-                    .returning(literal_column("*"))
+                    .returning(*comp_runs.c)
                 )
                 row = result.one()
                 return CompRunsAtDB.model_validate(row)

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -460,21 +460,19 @@ class CompRunsRepository(BaseRepository):
 
         async with pass_or_acquire_connection(self.db_engine) as conn:
             total_count = await conn.scalar(count_query)
-            items = []
-            async for row in await conn.stream(list_query):
-                db_states = [DB_TO_RUNNING_STATE[s] for s in row.states]
-                resolved_state = _resolve_grouped_state(db_states)
-                items.append(
-                    ComputationCollectionRunRpcGet(
-                        collection_run_id=row.collection_run_id,
-                        project_ids=row.project_ids,
-                        state=resolved_state,
-                        info={} if row.info is None else row.info,
-                        submitted_at=row.submitted_at,
-                        started_at=row.started_at,
-                        ended_at=row.ended_at,
-                    )
+            result = await conn.execute(list_query)
+            items = [
+                ComputationCollectionRunRpcGet(
+                    collection_run_id=row.collection_run_id,
+                    project_ids=row.project_ids,
+                    state=_resolve_grouped_state([DB_TO_RUNNING_STATE[s] for s in row.states]),
+                    info={} if row.info is None else row.info,
+                    submitted_at=row.submitted_at,
+                    started_at=row.started_at,
+                    ended_at=row.ended_at,
                 )
+                for row in result
+            ]
             return cast(int, total_count), items
 
     async def create(

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -516,7 +516,7 @@ class CompRunsRepository(BaseRepository):
         self, user_id: UserID, project_id: ProjectID, iteration: Iteration, **values
     ) -> CompRunsAtDB | None:
         async with transaction_context(self.db_engine) as conn:
-            result: CursorResult = await conn.execute(
+            result = await conn.execute(
                 sa.update(comp_runs)
                 .where(
                     (comp_runs.c.project_uuid == f"{project_id}")
@@ -524,7 +524,7 @@ class CompRunsRepository(BaseRepository):
                     & (comp_runs.c.iteration == iteration)
                 )
                 .values(**values)
-                .returning(literal_column("*"))
+                .returning(*comp_runs.c)
             )
             row = result.one_or_none()
             return CompRunsAtDB.model_validate(row) if row else None

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs.py
@@ -185,6 +185,7 @@ class CompRunsRepository(BaseRepository):
 
     async def list_(
         self,
+        connection: AsyncConnection | None = None,
         *,
         filter_by_state: set[RunningState] | None = None,
         never_scheduled: bool = False,
@@ -237,7 +238,7 @@ class CompRunsRepository(BaseRepository):
         if scheduling_or_conditions:
             conditions.append(sa.or_(*scheduling_or_conditions))
 
-        async with pass_or_acquire_connection(self.db_engine) as conn:
+        async with pass_or_acquire_connection(self.db_engine, connection) as conn:
             result = await conn.execute(sa.select(comp_runs).where(sa.and_(*conditions)))
             rows = result.mappings().all()
             return TypeAdapter(list[CompRunsAtDB]).validate_python(rows)

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs_snapshot_tasks.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_runs_snapshot_tasks.py
@@ -98,9 +98,6 @@ class CompRunsSnapshotTasksRepository(BaseRepository):
 
         async with self.db_engine.connect() as conn:
             total_count = await conn.scalar(count_query)
-
-            items = [
-                CompRunSnapshotTaskDBGet.model_validate(row, from_attributes=True)
-                async for row in await conn.stream(list_query)
-            ]
+            result = await conn.execute(list_query)
+            items = [CompRunSnapshotTaskDBGet.model_validate(row, from_attributes=True) for row in result]
             return cast(int, total_count), items

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -14,6 +14,7 @@ from models_library.wallets import WalletInfo
 from pydantic import TypeAdapter
 from servicelib.logging_utils import log_context
 from servicelib.rabbitmq import RabbitMQRPCClient
+from simcore_postgres_database.utils_repos import pass_or_acquire_connection
 from sqlalchemy import CursorResult, literal_column
 from sqlalchemy.dialects.postgresql import insert
 
@@ -119,13 +120,12 @@ class CompTasksRepository(BaseRepository):
             return cast(int, total_count), items
 
     async def task_exists(self, project_id: ProjectID, node_id: NodeID) -> bool:
-        async with self.db_engine.connect() as conn:
-            nid: str | None = await conn.scalar(
-                sa.select(comp_tasks.c.node_id).where(
-                    (comp_tasks.c.project_id == f"{project_id}") & (comp_tasks.c.node_id == f"{node_id}")
-                )
+        async with pass_or_acquire_connection(self.db_engine) as conn:
+            stmt = sa.select(
+                sa.exists().where((comp_tasks.c.project_id == f"{project_id}") & (comp_tasks.c.node_id == f"{node_id}"))
             )
-            return nid is not None
+            result = await conn.execute(stmt)
+            return result.scalar_one()
 
     async def upsert_tasks_from_project(
         self,

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/comp_tasks/_core.py
@@ -112,11 +112,8 @@ class CompTasksRepository(BaseRepository):
 
         async with self.db_engine.connect() as conn:
             total_count = await conn.scalar(count_query)
-
-            items = [
-                ComputationTaskForRpcDBGet.model_validate(row, from_attributes=True)
-                async for row in await conn.stream(list_query)
-            ]
+            result = await conn.execute(list_query)
+            items = [ComputationTaskForRpcDBGet.model_validate(row, from_attributes=True) for row in result]
             return cast(int, total_count), items
 
     async def task_exists(self, project_id: ProjectID, node_id: NodeID) -> bool:

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class ProjectsRepository(BaseRepository):
     async def exists(self, project_id: ProjectID) -> bool:
         async with pass_or_acquire_connection(self.db_engine) as conn:
-            stmt = sa.select(sa.exists(sa.select(sa.literal(1)).where(projects.c.uuid == f"{project_id}")))
+            stmt = sa.select(sa.exists().where(projects.c.uuid == f"{project_id}"))
             result = await conn.execute(stmt)
             return result.scalar_one()
 

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
@@ -14,14 +14,14 @@ logger = logging.getLogger(__name__)
 class ProjectsRepository(BaseRepository):
     async def exists(self, project_id: ProjectID) -> bool:
         async with pass_or_acquire_connection(self.db_engine) as conn:
-            stmt = sa.select(sa.exists().where(projects.c.uuid == f"{project_id}"))
+            stmt = sa.select(sa.exists(sa.select(sa.literal(1)).where(projects.c.uuid == f"{project_id}")))
             result = await conn.execute(stmt)
             return result.scalar_one()
 
     async def get(self, project_id: ProjectID) -> ProjectAtDB:
         async with pass_or_acquire_connection(self.db_engine) as conn:
-            query = sa.select(projects).where(projects.c.uuid == f"{project_id}")
-            result = await conn.execute(query)
+            stmt = sa.select(projects).where(projects.c.uuid == f"{project_id}")
+            result = await conn.execute(stmt)
             row = result.one_or_none()
             if row is None:
                 raise ProjectNotFoundError(project_id=project_id)

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects.py
@@ -19,15 +19,8 @@ class ProjectsRepository(BaseRepository):
             return result.scalar_one()
 
     async def get(self, project_id: ProjectID) -> ProjectAtDB:
-        # Select all project columns except 'workbench' (deprecated).
-        # The workbench is no longer reconstructed here for performance reasons;
-        # callers that need the nodes must fetch them via ProjectsNodesRepository.
-        project_cols = [c for c in projects.c if c.name != "workbench"]
-
         async with pass_or_acquire_connection(self.db_engine) as conn:
-            query = sa.select(
-                *project_cols,
-            ).where(projects.c.uuid == str(project_id))
+            query = sa.select(projects).where(projects.c.uuid == f"{project_id}")
             result = await conn.execute(query)
             row = result.one_or_none()
             if row is None:

--- a/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects_nodes.py
+++ b/services/director-v2/src/simcore_service_director_v2/modules/db/repositories/projects_nodes.py
@@ -32,8 +32,7 @@ class ProjectsNodesRepository(BaseRepository):
         async with pass_or_acquire_connection(self.db_engine) as conn:
             stmt = sa.select(
                 sa.exists().where(
-                    projects_nodes.c.project_uuid == f"{project_id}",
-                    projects_nodes.c.node_id == f"{node_id}",
+                    (projects_nodes.c.project_uuid == f"{project_id}") & (projects_nodes.c.node_id == f"{node_id}")
                 )
             )
             result = await conn.execute(stmt)


### PR DESCRIPTION
<!-- Title Annotations:

  WIP: work in progress
  🐛    Fix a bug.
  ✨    Introduce new features.
  🎨    Enhance existing feature.
  ♻️    Refactor code.
  🚑️    Critical hotfix.
  ⚗️    Perform experiments.
  ⬆️    Upgrade dependencies.
  📝    Add or update documentation.
  🔨    Add or update development scripts.
  ✅    Add, update or pass tests.
  🔒️    Fix security issues.
  ⚠️    Changes in ops configuration etc. are required before deploying.
        [ Please add a link to the associated ops-issue or PR, such as in https://github.com/ITISFoundation/osparc-ops-environments or https://git.speag.com/oSparc/osparc-infra ]
  🗃️    Database table changed (relevant for devops).
  👽️    Public API changes (meaning: dev features are moved to being exposed in production)
  🚨    Do manual testing when deployed
  🤖    (partially-)AI generated PR

or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Badge to openapi specs (use for API changes)
URL structure: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/[GITHUB_USERNAME]/[REPO]/[COMMIT_HASH_OR_BRANCH]/[PATH_TO_FILE]#tag/[TAG_NAME]/operation/[OPERATION_ID]

Components:
- GITHUB_USERNAME: Your GitHub username (or 'ITISFoundation' if pushing directly)
- REPO: Repository name (osparc-simcore)
- COMMIT_HASH_OR_BRANCH: Full commit SHA or branch name (ensure file exists at this ref)
- PATH_TO_FILE: Path from repo root to openapi.json file
- TAG_NAME (optional): OpenAPI tag to filter by (e.g., 'admin')
- OPERATION_ID (optional): Specific operation to highlight (e.g., 'list_users_accounts')

Example with fragment pointing to specific operation:
[![ReDoc](https://img.shields.io/badge/OpenAPI-ReDoc-85ea2d?logo=openapiinitiative)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/pcrespov/osparc-simcore/b75927d3b3b90638a9b825cd17b1e1f17176a5ef/services/web/server/src/simcore_service_webserver/api/v0/openapi.json#tag/admin/operation/list_users_accounts)
-->


## Related issue/s
<!-- LINK to other issues and add prefix `closes`, `fixes`, `resolves`-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Dev-ops

<!--
- No changes /updated ENV. SEE https://git.speag.com/oSparc/osparc-ops-deployment-configuration/-/blob/configs/README.md?ref_type=heads#how-to-update-env-variables)
- SEE docs/devops-checklist.md
- 🤖 If AI tools were used, add: Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
  (see https://docs.kernel.org/process/coding-assistants.html#attribution)
-->
